### PR TITLE
fix: align sitemap canonicals

### DIFF
--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,8 +1,10 @@
 import type { MetadataRoute } from "next";
 
+const SITE_URL = "https://www.collegedata.fyi";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },
-    sitemap: "https://collegedata.fyi/sitemap.xml",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,40 +1,49 @@
 import type { MetadataRoute } from "next";
 import { fetchManifest, aggregateSchools } from "@/lib/queries";
 
+const SITE_URL = "https://www.collegedata.fyi";
+
+function isAcademicYear(value: string | null | undefined): value is string {
+  if (!value) return false;
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  return Number(match[2]) === (Number(match[1]) + 1) % 100;
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const manifest = await fetchManifest();
   const schools = aggregateSchools(manifest);
 
   const staticPages: MetadataRoute.Sitemap = [
-    { url: "https://collegedata.fyi", changeFrequency: "daily", priority: 1 },
+    { url: SITE_URL, changeFrequency: "daily", priority: 1 },
     {
-      url: "https://collegedata.fyi/schools",
+      url: `${SITE_URL}/schools`,
       changeFrequency: "daily",
       priority: 0.9,
     },
     {
-      url: "https://collegedata.fyi/about",
+      url: `${SITE_URL}/about`,
       changeFrequency: "monthly",
       priority: 0.5,
     },
   ];
 
   const schoolPages: MetadataRoute.Sitemap = schools.map((s) => ({
-    url: `https://collegedata.fyi/schools/${s.school_id}`,
+    url: `${SITE_URL}/schools/${s.school_id}`,
     changeFrequency: "weekly" as const,
     priority: 0.8,
   }));
 
-  // Year detail pages for extracted documents only
+  // Exclude malformed year slugs from the sitemap until the upstream
+  // manifest rows are corrected. Google should only see stable canonicals.
   const yearPages: MetadataRoute.Sitemap = manifest
     .filter(
       (doc) =>
         doc.extraction_status === "extracted" &&
-        doc.canonical_year &&
-        doc.canonical_year !== "unknown"
+        isAcademicYear(doc.canonical_year)
     )
     .map((doc) => ({
-      url: `https://collegedata.fyi/schools/${doc.school_id}/${doc.canonical_year}`,
+      url: `${SITE_URL}/schools/${doc.school_id}/${doc.canonical_year}`,
       changeFrequency: "monthly" as const,
       priority: 0.7,
     }));


### PR DESCRIPTION
## Summary
- switch sitemap and robots output to the canonical `www.collegedata.fyi` host
- filter malformed academic-year slugs out of the sitemap so Google only sees stable canonical URLs

## Verification
- live-site spot check of canonical tags, robots, sitemap, and representative school/year pages
- `npm run build` could not run in this workspace because `next` is not installed locally (`next: command not found`)
