### PR TITLE
Improve GitHub discovery surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-school.yml
+++ b/.github/ISSUE_TEMPLATE/add-school.yml
@@ -1,0 +1,59 @@
+name: Add or fix a school
+description: Share a Common Data Set URL or correction for a school we should track.
+title: "Add school: "
+labels:
+  - school-data
+  - discovery
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when collegedata.fyi is missing a school, has the wrong Common Data Set URL, or needs a sub-institutional CDS variant added.
+  - type: input
+    id: school_name
+    attributes:
+      label: School name
+      placeholder: Example University
+    validations:
+      required: true
+  - type: input
+    id: school_url
+    attributes:
+      label: School website
+      placeholder: https://www.example.edu
+    validations:
+      required: false
+  - type: input
+    id: ipeds_id
+    attributes:
+      label: IPEDS UNITID, if known
+      placeholder: "123456"
+    validations:
+      required: false
+  - type: input
+    id: cds_url
+    attributes:
+      label: Common Data Set URL
+      description: Link to the CDS landing page or a direct PDF/XLSX/DOCX/HTML file.
+      placeholder: https://www.example.edu/institutional-research/common-data-set
+    validations:
+      required: true
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: What needs to change?
+      options:
+        - Add a missing school
+        - Fix an existing school URL
+        - Add a historical CDS year
+        - Add a sub-institutional variant
+        - Mark school as not publishing CDS
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Include how you found the URL, whether it is official, and anything unusual about the page.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Browse collegedata.fyi
+    url: https://collegedata.fyi
+    about: Search the public Common Data Set archive and browser.
+  - name: API documentation
+    url: https://collegedata.fyi/api
+    about: Query the public PostgREST API and browser search endpoint.

--- a/.github/ISSUE_TEMPLATE/contribute-cleaner.yml
+++ b/.github/ISSUE_TEMPLATE/contribute-cleaner.yml
@@ -1,0 +1,56 @@
+name: Contribute an extractor or cleaner
+description: Propose a parser, cleaner, LLM repair, or extraction-quality improvement.
+title: "Cleaner proposal: "
+labels:
+  - extraction-quality
+  - cleaner
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for tooling that improves structured extraction from CDS PDFs, XLSX, DOCX, HTML, scans, or Docling output.
+  - type: input
+    id: project_url
+    attributes:
+      label: Tool or branch URL
+      description: Link to your repo, branch, package, notebook, or proof of concept.
+      placeholder: https://github.com/you/cds-cleaner
+    validations:
+      required: false
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target extraction surface
+      options:
+        - Tier 1 XLSX
+        - Tier 2 fillable PDF / AcroForm
+        - Tier 3 DOCX
+        - Tier 4 flattened PDF / Docling
+        - Tier 4 LLM fallback
+        - Tier 5 scanned PDF / OCR
+        - Tier 6 HTML
+        - Cross-tier validation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: fields
+    attributes:
+      label: Fields or sections improved
+      description: List CDS sections, field IDs, or examples such as C1 admissions, C9 SAT/ACT, H2A aid, or B1 enrollment.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include before/after field counts, ground-truth checks, schools tested, or failure modes fixed.
+    validations:
+      required: true
+  - type: textarea
+    id: integration
+    attributes:
+      label: Integration notes
+      description: Explain whether this is a deterministic parser, fallback overlay, validation rule, or external package.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/report-extraction-error.yml
+++ b/.github/ISSUE_TEMPLATE/report-extraction-error.yml
@@ -1,0 +1,61 @@
+name: Report bad extracted data
+description: Flag a Common Data Set value that appears wrong, missing, or stale.
+title: "Extraction issue: "
+labels:
+  - extraction-quality
+  - data-error
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the source CDS is correct but collegedata.fyi extracted, normalized, or displayed the wrong value.
+  - type: input
+    id: school_id
+    attributes:
+      label: School ID or school name
+      placeholder: yale or Yale University
+    validations:
+      required: true
+  - type: input
+    id: cds_year
+    attributes:
+      label: CDS year
+      placeholder: 2024-25
+    validations:
+      required: true
+  - type: input
+    id: page_url
+    attributes:
+      label: collegedata.fyi page URL
+      placeholder: https://www.collegedata.fyi/schools/yale/2024-25
+    validations:
+      required: false
+  - type: input
+    id: field_id
+    attributes:
+      label: CDS field ID, if known
+      description: Examples include C.116, C.901, B.2203, H.209.
+      placeholder: C.116
+    validations:
+      required: false
+  - type: textarea
+    id: observed
+    attributes:
+      label: What collegedata.fyi shows
+      placeholder: "Example: Applied = 3,210"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the source CDS shows
+      placeholder: "Example: Applied = 32,100 on page 8, section C1"
+    validations:
+      required: true
+  - type: textarea
+    id: source_evidence
+    attributes:
+      label: Source evidence
+      description: Page number, section, screenshot description, or link to the official source document.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **College facts pulled straight from each school's Common Data Set.**
 
+Open-source Common Data Set API, searchable college admissions dataset, and preservation archive for U.S. higher education data.
+
 An open, reproducible library of US college data. We find each school's Common Data Set document, extract it into a canonical schema, and publish both the raw source file and the structured extract alongside a queryable manifest. No hand-cleaned numbers, no opinionated schema of our own — we use the one the CDS Initiative already publishes. Just ground truth you can build on top of.
 
 > **Status: V1 live at [collegedata.fyi](https://collegedata.fyi).** 697 schools indexed, 3,924 archived CDS documents, structured extraction on 3,841 of them (98%). Five of six extraction tiers shipped: filled XLSX (template cell-position map), fillable PDF (AcroForm), flattened PDF (Docling + schema-targeting cleaner), image-only scan (force-OCR), and structured HTML (HTML normalizer reusing the Tier 4 cleaner). DOCX is the only remaining tier and is scoped in [PRD 007](docs/prd/007-tier3-docx-extraction.md). GT scorer 94% on hand-audited schools; C1 admissions fields at 50-60% Tier 4 coverage corpus-wide. See [`docs/extraction-quality.md`](docs/extraction-quality.md) for full coverage by section, [`docs/known-issues/`](docs/known-issues/) for per-school notes.
@@ -52,6 +54,19 @@ curl 'https://api.collegedata.fyi/rest/v1/cds_artifacts?document_id=eq.<uuid>&ki
 5. Community cleanup tools can register via `cleaners.yaml` and publish their own artifacts alongside the primary ones — see [ADR 0002](docs/decisions/0002-publish-raw-over-clean.md) for the rationale.
 
 Full architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## Ecosystem and related projects
+
+collegedata.fyi sits between official higher-education data systems and the document-processing tools needed to make decentralized CDS files queryable:
+
+- [Common Data Set Initiative](https://commondataset.org/) — the canonical CDS templates and field definitions this project follows.
+- [College Scorecard API](https://collegescorecard.ed.gov/data/api/) — federal outcomes, net-price, debt, completion, and earnings data; joined into `cds_scorecard`.
+- [IPEDS](https://nces.ed.gov/ipeds/) — federal postsecondary reporting system and the source of school identity metadata such as UNITID.
+- [Docling](https://github.com/docling-project/docling) — open-source document conversion toolkit used for flattened PDF, scanned PDF, and layout-aware extraction.
+- [UrbanInstitute/ipeds-scraper](https://github.com/UrbanInstitute/ipeds-scraper) — downloader for IPEDS complete data files.
+- [UrbanInstitute/education-data-package-r](https://github.com/UrbanInstitute/education-data-package-r) — R package for accessing education data including IPEDS and College Scorecard data.
+- [karllhughes/colleges](https://github.com/karllhughes/colleges) — open API of U.S. colleges and universities.
+- [kielni/ipeds-sql](https://github.com/kielni/ipeds-sql) — IPEDS data loaded into a SQL-friendly shape.
 
 ## Docs and decisions
 


### PR DESCRIPTION
## Summary
- add README search/discovery language for Common Data Set API and higher-ed data use cases
- add ecosystem links to related college data, IPEDS, College Scorecard, and Docling projects
- add GitHub issue templates for adding schools, reporting extraction errors, and contributing cleaners

## Verification
- issue template YAML parsed locally