### PR TITLE
School detail page redesign

### DIFF
--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -198,7 +198,7 @@ async function DocumentVariant({
           <h2 className="text-lg font-semibold text-gray-900">
             Federal outcomes
           </h2>
-          <ScorecardVintageNote scorecard={scorecard} className="mt-1" />
+          <div className="mt-1"><ScorecardVintageNote scorecard={scorecard} /></div>
           <div className="mt-3">
             <OutcomesBand scorecard={scorecard} />
           </div>

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -177,14 +177,8 @@ export default async function SchoolDetailPage({
 
       {/* Header */}
       <header
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr auto",
-          gap: 32,
-          alignItems: "end",
-          paddingTop: 24,
-          paddingBottom: 8,
-        }}
+        className="cd-school-header"
+        style={{ paddingTop: 24, paddingBottom: 8 }}
       >
         <div>
           <div
@@ -264,11 +258,16 @@ export default async function SchoolDetailPage({
           </div>
         </div>
 
-        <div style={{ textAlign: "right" }}>
-          <div className="meta" style={{ marginBottom: 6 }}>
-            § {docs.length} document{docs.length !== 1 ? "s" : ""} archived
+        <div className="cd-school-header__aside">
+          <div className="meta cd-school-header__count">
+            <span className="cd-school-header__glyph">§</span>
+            <span>
+              {docs.length} document{docs.length !== 1 ? "s" : ""} archived
+            </span>
             {earliestYear && latestYear && earliestYear !== latestYear && (
-              <> · {earliestYear} – {latestYear}</>
+              <span className="cd-school-header__years">
+                {earliestYear}&ndash;{latestYear}
+              </span>
             )}
           </div>
           {history.length > 1 && (

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import {
   fetchSchoolDocuments,
   fetchScorecardByIpedsId,
 } from "@/lib/queries";
 import { DocumentCard } from "@/components/DocumentCard";
 import { OutcomesSection } from "@/components/OutcomesSection";
+import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
+import { Sparkline } from "@/components/Sparkline";
 import { yearRange } from "@/lib/format";
+import type { ManifestRow } from "@/lib/types";
 
 export const revalidate = 3600;
 
@@ -35,6 +39,47 @@ export async function generateMetadata({
   };
 }
 
+// Italicize a trailing institution-type word ("University", "College", etc.)
+// to give the serif headline a bit of editorial rhythm. Keeps the leading
+// proper noun in roman; falls back to roman-only for names without a known
+// suffix.
+function splitInstitutionalSuffix(name: string): {
+  head: string;
+  tail: string | null;
+} {
+  const SUFFIXES = [
+    "University",
+    "College",
+    "Institute",
+    "Polytechnic",
+    "Academy",
+    "School",
+    "Seminary",
+    "Conservatory",
+  ];
+  for (const s of SUFFIXES) {
+    if (name.endsWith(` ${s}`)) {
+      return { head: name.slice(0, -s.length - 1), tail: s };
+    }
+  }
+  return { head: name, tail: null };
+}
+
+// Ascending step series of the school's archived document count over time.
+// Drives the small forest sparkline next to the count. One step per CDS
+// year archived; if everything was added at once the line goes flat and
+// the sparkline collapses to a baseline (which is fine).
+function archiveHistory(docs: ManifestRow[]): number[] {
+  const years = docs
+    .map((d) => d.canonical_year)
+    .filter((y): y is string => y != null)
+    .sort();
+  if (years.length === 0) return [];
+  const series: number[] = [];
+  for (let i = 0; i < years.length; i++) series.push(i + 1);
+  return series.length === 1 ? [0, 1] : series;
+}
+
 export default async function SchoolDetailPage({
   params,
 }: {
@@ -53,16 +98,14 @@ export default async function SchoolDetailPage({
   const ipedsId = docs.find((d) => d.ipeds_id)?.ipeds_id ?? null;
   const scorecard = await fetchScorecardByIpedsId(ipedsId);
 
-  const name = docs[0].school_name;
+  const name = docs[0].school_name ?? "Unknown school";
+  const { head, tail } = splitInstitutionalSuffix(name);
   const years = docs
     .map((d) => d.canonical_year)
     .filter((y): y is string => y != null)
     .sort();
 
-  // Check if this school has sub-institutional variants
   const hasSubs = docs.some((d) => d.sub_institutional != null);
-
-  // Group by sub_institutional if applicable
   const groups: { label: string | null; docs: typeof docs }[] = [];
   if (hasSubs) {
     const subMap = new Map<string | null, typeof docs>();
@@ -81,6 +124,9 @@ export default async function SchoolDetailPage({
 
   const schoolUrl = `https://www.collegedata.fyi/schools/${school_id}`;
   const uniqueYears = Array.from(new Set(years));
+  const earliestYear = years.length > 0 ? years[0]?.split("-")[0] : null;
+  const latestYear =
+    years.length > 0 ? years[years.length - 1]?.split("-")[0] : null;
 
   const jsonLd = [
     {
@@ -98,9 +144,6 @@ export default async function SchoolDetailPage({
         { "@type": "ListItem", position: 2, name, item: schoolUrl },
       ],
     },
-    // DataCatalog enumerates every archived year as a Dataset reference.
-    // Gives LLMs and search engines a one-stop index of what's in the archive
-    // for this school.
     {
       "@context": "https://schema.org",
       "@type": "DataCatalog",
@@ -120,42 +163,170 @@ export default async function SchoolDetailPage({
     },
   ];
 
+  const history = archiveHistory(docs);
+  const carnegieCode = scorecard?.carnegie_basic;
+
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <div className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
         }}
       />
-      <h1 className="text-2xl font-bold text-gray-900">{name}</h1>
-      <p className="text-gray-600 mt-1">
-        {docs.length} document{docs.length !== 1 ? "s" : ""} archived
-        {years.length > 0 && `, ${yearRange(years[0], years[years.length - 1])}`}
-      </p>
 
-      {groups.map((group) => (
-        <div key={group.label ?? "main"} className="mt-6">
-          {group.label && (
-            <h2 className="text-lg font-semibold text-gray-800 mb-3">
-              {group.label}
-            </h2>
-          )}
-          <div className="space-y-2">
-            {group.docs.map((doc) => (
-              <DocumentCard key={doc.document_id} doc={doc} />
-            ))}
+      {/* Header */}
+      <header
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 32,
+          alignItems: "end",
+          paddingTop: 24,
+          paddingBottom: 8,
+        }}
+      >
+        <div>
+          <div
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: "var(--ink-3)",
+              letterSpacing: "0.08em",
+              marginBottom: 12,
+              textTransform: "uppercase",
+            }}
+          >
+            <Link
+              href="/schools"
+              style={{
+                color: "var(--ink-3)",
+                textDecoration: "none",
+              }}
+            >
+              SCHOOLS
+            </Link>{" "}
+            / <span style={{ color: "var(--ink)" }}>{name.toUpperCase()}</span>
+          </div>
+          <h1
+            className="serif"
+            style={{
+              fontWeight: 400,
+              fontSize: "clamp(40px, 6vw, 58px)",
+              margin: 0,
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+            }}
+          >
+            {tail ? (
+              <>
+                {head} <span style={{ fontStyle: "italic" }}>{tail}</span>
+              </>
+            ) : (
+              name
+            )}
+          </h1>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 22,
+              marginTop: 16,
+              alignItems: "baseline",
+              color: "var(--ink-2)",
+              fontSize: 14,
+            }}
+          >
+            {ipedsId && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 11.5,
+                  color: "var(--ink-3)",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                IPEDS {ipedsId}
+              </span>
+            )}
+            {carnegieCode != null && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 11.5,
+                  color: "var(--ink-3)",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                CARNEGIE {carnegieCode}
+              </span>
+            )}
           </div>
         </div>
-      ))}
+
+        <div style={{ textAlign: "right" }}>
+          <div className="meta" style={{ marginBottom: 6 }}>
+            § {docs.length} document{docs.length !== 1 ? "s" : ""} archived
+            {earliestYear && latestYear && earliestYear !== latestYear && (
+              <> · {earliestYear} – {latestYear}</>
+            )}
+          </div>
+          {history.length > 1 && (
+            <Sparkline data={history} w={120} h={26} color="var(--forest)" />
+          )}
+        </div>
+      </header>
+
+      {/* Documents ledger */}
+      <div className="rule-2" style={{ marginTop: 32, paddingTop: 20 }}>
+        {groups.map((group, gi) => (
+          <div key={group.label ?? "main"}>
+            {group.label && (
+              <h2
+                className="serif"
+                style={{
+                  fontSize: 18,
+                  margin: gi === 0 ? "0 0 8px" : "16px 0 8px",
+                  letterSpacing: "-0.005em",
+                }}
+              >
+                {group.label}
+              </h2>
+            )}
+            {group.docs.map((doc, i) => (
+              <DocumentCard
+                key={doc.document_id}
+                doc={doc}
+                isLast={
+                  gi === groups.length - 1 && i === group.docs.length - 1
+                }
+              />
+            ))}
+          </div>
+        ))}
+      </div>
 
       {scorecard ? (
         <OutcomesSection scorecard={scorecard} />
       ) : ipedsId ? (
-        <p className="mt-10 text-sm text-gray-500">
-          Federal outcomes data is not available for this institution.
+        <p
+          className="mono"
+          style={{
+            marginTop: 56,
+            fontSize: 12,
+            color: "var(--ink-3)",
+            letterSpacing: "0.05em",
+          }}
+        >
+          FEDERAL OUTCOMES DATA NOT AVAILABLE FOR THIS INSTITUTION.
         </p>
       ) : null}
+
+      {scorecard && (
+        <div style={{ marginTop: 24 }}>
+          <ScorecardVintageNote scorecard={scorecard} />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -79,6 +79,8 @@
 }
 .cd-chip--solid { background: var(--ink); color: var(--paper); border-color: var(--ink); }
 .cd-chip--forest { background: var(--forest); color: var(--paper); border-color: var(--forest); }
+.cd-chip--brick { background: transparent; color: var(--brick); border-color: var(--brick); }
+.cd-chip--ochre { background: transparent; color: var(--ochre); border-color: var(--ochre); }
 
 /* Buttons */
 .cd-btn {
@@ -141,4 +143,84 @@
 @media (max-width: 640px) {
   .cd-nav-row { flex-wrap: wrap; row-gap: 10px; }
   .cd-nav-links { width: 100%; justify-content: flex-start; gap: 18px; font-size: 13px; flex-wrap: wrap; }
+}
+
+/* School page header — desktop puts the count + sparkline on the right
+   gutter; mobile stacks under the title with a hairline rule and inline
+   row so "§", count, and year range stay on one line with breathing room. */
+.cd-school-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 32px;
+  align-items: end;
+}
+.cd-school-header__aside {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+.cd-school-header__count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.cd-school-header__glyph {
+  font-family: var(--serif);
+  font-size: 14px;
+  font-style: italic;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink-3);
+}
+.cd-school-header__years::before {
+  content: "·";
+  margin-right: 8px;
+  color: var(--ink-4);
+}
+@media (max-width: 640px) {
+  .cd-school-header { grid-template-columns: 1fr; gap: 18px; }
+  .cd-school-header__aside {
+    text-align: left;
+    align-items: flex-start;
+    padding-top: 14px;
+    border-top: 1px solid var(--rule);
+  }
+  .cd-school-header__count { justify-content: flex-start; }
+}
+
+/* Earnings distribution — full dollar labels at desktop, abbreviated $Xk
+   on narrow screens so adjacent ticks don't overlap. The tick wrapper
+   caps width to avoid bleed past its own column. */
+.cd-earnings-tick { max-width: 33%; }
+.cd-earnings-tick__value { font-size: 20px; margin-top: 2px; }
+.cd-earnings-tick__full { display: inline; }
+.cd-earnings-tick__short { display: none; }
+@media (max-width: 640px) {
+  .cd-earnings-tick__value { font-size: 16px; }
+  .cd-earnings-tick__full  { display: none; }
+  .cd-earnings-tick__short { display: inline; }
+}
+
+/* Net price by family income — fixed columns so the modal-bracket caption
+   never collides with the dollar value. The marker column reserves its
+   width even when the row is non-modal (visibility: hidden), so bars stay
+   aligned across rows. Collapses to a 2-row stack on narrow viewports. */
+.cd-price-row {
+  display: grid;
+  grid-template-columns: 170px 1fr 110px 90px;
+  gap: 20px;
+}
+@media (max-width: 640px) {
+  .cd-price-row {
+    grid-template-columns: 1fr 88px;
+    gap: 4px 14px;
+  }
+  .cd-price-band   { grid-column: 1; grid-row: 1; }
+  .cd-price-value  { grid-column: 2; grid-row: 1; }
+  .cd-price-bar    { grid-column: 1 / -1; grid-row: 2; }
+  .cd-price-marker { grid-column: 1 / -1; grid-row: 3; text-align: right; }
 }

--- a/web/src/components/DocumentCard.tsx
+++ b/web/src/components/DocumentCard.tsx
@@ -7,6 +7,22 @@ import {
 } from "@/lib/format";
 import type { ManifestRow } from "@/lib/types";
 
+// Map an extraction status to a chip variant. Only the success state gets
+// the forest pill; failures use brick (the alarm color in tokens.css);
+// pending/discovered stay neutral so they read as in-flight, not done.
+function statusChipClass(status: string): string {
+  switch (status) {
+    case "extracted":
+      return "cd-chip cd-chip--forest";
+    case "failed":
+      return "cd-chip cd-chip--brick";
+    case "extraction_pending":
+      return "cd-chip cd-chip--ochre";
+    default:
+      return "cd-chip";
+  }
+}
+
 // One row of the documents ledger. Year sits in display serif; the format
 // and status are mono chips; download/view actions are right-aligned. Last
 // row drops the dashed separator so the ledger ends on a hairline rule.
@@ -18,13 +34,13 @@ export function DocumentCard({
   isLast?: boolean;
 }) {
   const pdfUrl = storageUrl(doc.source_storage_path);
-  const isExtracted = doc.extraction_status === "extracted";
+  const sourceUrl = doc.source_url;
+  const status = doc.extraction_status ?? "discovered";
+  const isExtracted = status === "extracted";
   const canLink =
     isExtracted && doc.canonical_year && doc.canonical_year !== "unknown";
   const dqLabel = dataQualityLabel(doc.data_quality_flag ?? null);
-  const statusLabel = formatExtractionStatus(
-    doc.extraction_status ?? "discovered",
-  );
+  const statusLabel = formatExtractionStatus(status);
   const formatLabel = doc.source_format
     ? formatBadgeLabel(doc.source_format)
     : null;
@@ -58,13 +74,7 @@ export function DocumentCard({
         }}
       >
         {formatLabel && <span className="cd-chip">{formatLabel}</span>}
-        <span
-          className={
-            isExtracted ? "cd-chip cd-chip--forest" : "cd-chip"
-          }
-        >
-          {statusLabel}
-        </span>
+        <span className={statusChipClass(status)}>{statusLabel}</span>
         {dqLabel && (
           <span
             className="cd-chip"
@@ -100,11 +110,15 @@ export function DocumentCard({
             View fields →
           </Link>
         )}
-        {pdfUrl && (
+        {pdfUrl ? (
           <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
             Download PDF
           </a>
-        )}
+        ) : sourceUrl ? (
+          <a href={sourceUrl} target="_blank" rel="noopener noreferrer">
+            View source →
+          </a>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/DocumentCard.tsx
+++ b/web/src/components/DocumentCard.tsx
@@ -1,74 +1,111 @@
 import Link from "next/link";
-import { Badge } from "./Badge";
 import {
   formatBadgeLabel,
   formatExtractionStatus,
-  statusColor,
-  formatColor,
   storageUrl,
   dataQualityLabel,
-  dataQualityColor,
 } from "@/lib/format";
 import type { ManifestRow } from "@/lib/types";
 
-export function DocumentCard({ doc }: { doc: ManifestRow }) {
+// One row of the documents ledger. Year sits in display serif; the format
+// and status are mono chips; download/view actions are right-aligned. Last
+// row drops the dashed separator so the ledger ends on a hairline rule.
+export function DocumentCard({
+  doc,
+  isLast = false,
+}: {
+  doc: ManifestRow;
+  isLast?: boolean;
+}) {
   const pdfUrl = storageUrl(doc.source_storage_path);
   const isExtracted = doc.extraction_status === "extracted";
-  const canLink = isExtracted && doc.canonical_year && doc.canonical_year !== "unknown";
+  const canLink =
+    isExtracted && doc.canonical_year && doc.canonical_year !== "unknown";
   const dqLabel = dataQualityLabel(doc.data_quality_flag ?? null);
+  const statusLabel = formatExtractionStatus(
+    doc.extraction_status ?? "discovered",
+  );
+  const formatLabel = doc.source_format
+    ? formatBadgeLabel(doc.source_format)
+    : null;
+
+  const rowStyle: React.CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: "96px 1fr auto",
+    gap: 20,
+    alignItems: "center",
+    padding: "16px 0",
+    borderBottom: isLast
+      ? "1px solid var(--rule)"
+      : "1px dashed var(--rule)",
+  };
 
   return (
-    <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3 hover:bg-gray-50">
-      <div className="flex items-center gap-3 flex-wrap">
-        {canLink ? (
-          <Link
-            href={`/schools/${doc.school_id}/${doc.canonical_year}`}
-            className="text-blue-600 hover:text-blue-800 font-medium"
+    <div style={rowStyle}>
+      <span
+        className="serif nums"
+        style={{ fontSize: 24, letterSpacing: "-0.01em" }}
+      >
+        {doc.canonical_year ?? doc.cds_year}
+      </span>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        {formatLabel && <span className="cd-chip">{formatLabel}</span>}
+        <span
+          className={
+            isExtracted ? "cd-chip cd-chip--forest" : "cd-chip"
+          }
+        >
+          {statusLabel}
+        </span>
+        {dqLabel && (
+          <span
+            className="cd-chip"
+            style={{ borderColor: "var(--ochre)", color: "var(--ochre)" }}
           >
-            {doc.canonical_year}
-          </Link>
-        ) : (
-          <span className="font-medium text-gray-700">
-            {doc.canonical_year ?? doc.cds_year}
+            {dqLabel}
           </span>
         )}
-
         {doc.sub_institutional && (
-          <span className="text-xs text-gray-500">
+          <span
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: "var(--ink-3)",
+              letterSpacing: "0.05em",
+            }}
+          >
             {doc.sub_institutional}
           </span>
         )}
-
-        {doc.source_format && (
-          <Badge
-            label={formatBadgeLabel(doc.source_format)}
-            className={formatColor()}
-          />
-        )}
-
-        <Badge
-          label={formatExtractionStatus(doc.extraction_status ?? "discovered")}
-          className={statusColor(doc.extraction_status ?? "discovered")}
-        />
-
-        {dqLabel && (
-          <Badge
-            label={`Publisher issue: ${dqLabel}`}
-            className={dataQualityColor()}
-          />
-        )}
       </div>
 
-      {pdfUrl && (
-        <a
-          href={pdfUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shrink-0 ml-4 text-sm text-blue-600 hover:text-blue-800"
-        >
-          Download PDF
-        </a>
-      )}
+      <div
+        style={{
+          display: "flex",
+          gap: 18,
+          alignItems: "center",
+          fontSize: 13,
+        }}
+      >
+        {canLink && (
+          <Link href={`/schools/${doc.school_id}/${doc.canonical_year}`}>
+            View fields →
+          </Link>
+        )}
+        {pdfUrl && (
+          <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
+            Download PDF
+          </a>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/EarningsDistribution.tsx
+++ b/web/src/components/EarningsDistribution.tsx
@@ -86,6 +86,7 @@ export function EarningsDistribution({
         ].map((t) => (
           <div
             key={t.label}
+            className="cd-earnings-tick"
             style={{
               position: "absolute",
               top: 44,
@@ -104,8 +105,13 @@ export function EarningsDistribution({
             >
               {t.label.toUpperCase()}
             </div>
-            <div className="serif nums" style={{ fontSize: 20, marginTop: 2 }}>
-              ${t.v.toLocaleString("en-US")}
+            <div className="serif nums cd-earnings-tick__value">
+              <span className="cd-earnings-tick__full">
+                ${t.v.toLocaleString("en-US")}
+              </span>
+              <span className="cd-earnings-tick__short">
+                ${Math.round(t.v / 1000)}k
+              </span>
             </div>
           </div>
         ))}

--- a/web/src/components/EarningsDistribution.tsx
+++ b/web/src/components/EarningsDistribution.tsx
@@ -1,0 +1,133 @@
+import type { ScorecardSummary } from "@/lib/types";
+
+// Earnings spread as a flat scale: P25 and P75 are ink dots; the median is a
+// larger forest dot; a faint forest band fills the interquartile range.
+// Renders only when all three percentiles are present (graceful render
+// elsewhere strips the section if the data is missing).
+export function EarningsDistribution({
+  scorecard,
+}: {
+  scorecard: ScorecardSummary;
+}) {
+  const p25 = scorecard.earnings_10yr_p25;
+  const p50 = scorecard.earnings_10yr_median;
+  const p75 = scorecard.earnings_10yr_p75;
+  if (p25 == null || p50 == null || p75 == null) return null;
+
+  // Domain wide enough to hold ~99% of US schools; clamped per-school
+  // so visually shorter ranges still read as "tight" rather than "small".
+  const domainMin = 15000;
+  const domainMax = 85000;
+  const min = Math.min(domainMin, p25 - 5000);
+  const max = Math.max(domainMax, p75 + 5000);
+  const pct = (v: number) => ((v - min) / (max - min)) * 100;
+
+  const ticks = [20000, 40000, 60000, 80000].filter(
+    (t) => t >= min && t <= max,
+  );
+
+  return (
+    <div style={{ position: "relative", height: 120, marginTop: 24 }}>
+      <div style={{ position: "relative", height: 44 }}>
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: 22,
+            height: 1,
+            background: "var(--rule-strong)",
+          }}
+        />
+        {[p25, p75].map((v, i) => (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              top: 17,
+              left: `${pct(v)}%`,
+              transform: "translateX(-50%)",
+              width: 10,
+              height: 10,
+              background: "var(--ink)",
+              borderRadius: "50%",
+            }}
+          />
+        ))}
+        <div
+          style={{
+            position: "absolute",
+            top: 16,
+            left: `${pct(p25)}%`,
+            width: `${pct(p75) - pct(p25)}%`,
+            height: 12,
+            background: "var(--forest)",
+            opacity: 0.22,
+            borderRadius: 6,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 12,
+            left: `${pct(p50)}%`,
+            transform: "translateX(-50%)",
+            width: 18,
+            height: 18,
+            background: "var(--forest)",
+            borderRadius: "50%",
+            boxShadow: "0 0 0 3px var(--paper)",
+          }}
+        />
+        {[
+          { v: p25, label: "P25" },
+          { v: p50, label: "Median" },
+          { v: p75, label: "P75" },
+        ].map((t) => (
+          <div
+            key={t.label}
+            style={{
+              position: "absolute",
+              top: 44,
+              left: `${pct(t.v)}%`,
+              transform: "translateX(-50%)",
+              textAlign: "center",
+            }}
+          >
+            <div
+              className="mono"
+              style={{
+                fontSize: 10,
+                color: "var(--ink-3)",
+                letterSpacing: "0.06em",
+              }}
+            >
+              {t.label.toUpperCase()}
+            </div>
+            <div className="serif nums" style={{ fontSize: 20, marginTop: 2 }}>
+              ${t.v.toLocaleString("en-US")}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ position: "relative", marginTop: 60, height: 16 }}>
+        {ticks.map((v) => (
+          <div
+            key={v}
+            className="mono"
+            style={{
+              position: "absolute",
+              left: `${pct(v)}%`,
+              transform: "translateX(-50%)",
+              fontSize: 10,
+              color: "var(--ink-4)",
+              letterSpacing: "0.04em",
+            }}
+          >
+            ${v / 1000}k
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/NetPriceByIncome.tsx
+++ b/web/src/components/NetPriceByIncome.tsx
@@ -68,10 +68,8 @@ export function NetPriceByIncome({
           return (
             <div
               key={r.label}
+              className="cd-price-row"
               style={{
-                display: "grid",
-                gridTemplateColumns: "170px 1fr 90px",
-                gap: 20,
                 alignItems: "center",
                 padding: "14px 0",
                 borderBottom:
@@ -80,10 +78,14 @@ export function NetPriceByIncome({
                     : "1px dashed var(--rule)",
               }}
             >
-              <span style={{ fontSize: 14, color: "var(--ink-2)" }}>
+              <span
+                className="cd-price-band"
+                style={{ fontSize: 14, color: "var(--ink-2)" }}
+              >
                 {r.label}
               </span>
               <div
+                className="cd-price-bar"
                 style={{
                   height: 18,
                   background: "var(--paper-2)",
@@ -99,26 +101,22 @@ export function NetPriceByIncome({
                     background: r.isModal ? "var(--forest)" : "var(--ink)",
                   }}
                 />
-                {r.isModal && (
-                  <span
-                    className="mono"
-                    style={{
-                      position: "absolute",
-                      right: -94,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      fontSize: 10.5,
-                      color: "var(--forest)",
-                      letterSpacing: "0.05em",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    ← MODAL BRACKET
-                  </span>
-                )}
               </div>
               <span
-                className="mono nums"
+                className="mono cd-price-marker"
+                aria-hidden={!r.isModal}
+                style={{
+                  fontSize: 10.5,
+                  color: "var(--forest)",
+                  letterSpacing: "0.05em",
+                  whiteSpace: "nowrap",
+                  visibility: r.isModal ? "visible" : "hidden",
+                }}
+              >
+                ← MODAL BRACKET
+              </span>
+              <span
+                className="mono nums cd-price-value"
                 style={{ fontSize: 14, textAlign: "right" }}
               >
                 {formatCurrency(r.value)}

--- a/web/src/components/NetPriceByIncome.tsx
+++ b/web/src/components/NetPriceByIncome.tsx
@@ -4,29 +4,33 @@ import { formatCurrency } from "@/lib/format";
 type Bracket = {
   label: string;
   field: keyof ScorecardSummary;
+  low: number;
+  high: number;
 };
 
 const BRACKETS: Bracket[] = [
-  { label: "$0 – $30,000", field: "net_price_0_30k" },
-  { label: "$30,001 – $48,000", field: "net_price_30k_48k" },
-  { label: "$48,001 – $75,000", field: "net_price_48k_75k" },
-  { label: "$75,001 – $110,000", field: "net_price_75k_110k" },
-  { label: "$110,001 and up", field: "net_price_110k_plus" },
+  { label: "$0 – $30,000", field: "net_price_0_30k", low: 0, high: 30000 },
+  { label: "$30,001 – $48,000", field: "net_price_30k_48k", low: 30001, high: 48000 },
+  { label: "$48,001 – $75,000", field: "net_price_48k_75k", low: 48001, high: 75000 },
+  { label: "$75,001 – $110,000", field: "net_price_75k_110k", low: 75001, high: 110000 },
+  { label: "$110,001 and up", field: "net_price_110k_plus", low: 110001, high: Infinity },
 ];
 
-// Horizontal bars of the average net price (sticker minus grants) paid by
-// enrolled students at each family-income bracket. Bar width is relative to
-// the school's own max bracket so the spread is legible both for schools
-// with progressive pricing (Harvard: $2K → $53K) and flat pricing (most
-// state universities). Hides entirely if no brackets have data.
+// Horizontal bars of average net price (sticker minus grants) per income
+// bracket. Bars are ink; the bracket containing the school's median family
+// income is highlighted in forest as the modal bracket. Bar widths are scaled
+// to the row max so spread reads cleanly for both progressive and flat
+// pricing.
 export function NetPriceByIncome({
   scorecard,
 }: {
   scorecard: ScorecardSummary;
 }) {
+  const mfi = scorecard.median_family_income;
   const rows = BRACKETS.map((b) => ({
     label: b.label,
     value: scorecard[b.field] as number | null,
+    isModal: mfi != null && mfi >= b.low && mfi <= b.high,
   })).filter((r) => r.value != null);
 
   if (rows.length === 0) return null;
@@ -34,33 +38,95 @@ export function NetPriceByIncome({
   const max = Math.max(...rows.map((r) => r.value as number));
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-5">
-      <div className="flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold text-gray-900">
-          Net price by family income
-        </h3>
-        <p className="text-xs text-gray-500">Average cost after grants</p>
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <div className="meta" style={{ marginBottom: 6 }}>
+            §H · Net price by family income
+          </div>
+          <h3
+            className="serif"
+            style={{ fontSize: 22, margin: 0, letterSpacing: "-0.01em" }}
+          >
+            Average cost after grants
+          </h3>
+        </div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+          CDS H2A · {scorecard.scorecard_data_year}
+        </div>
       </div>
-      <dl className="mt-4 space-y-2.5">
-        {rows.map((r) => {
-          const widthPct =
-            max > 0 ? Math.max(4, ((r.value as number) / max) * 100) : 0;
+
+      <div className="rule-2" style={{ marginTop: 20, paddingTop: 14 }}>
+        {rows.map((r, i) => {
+          const widthPct = max > 0 ? Math.max(4, ((r.value as number) / max) * 100) : 0;
           return (
-            <div key={r.label} className="flex items-center gap-3 text-sm">
-              <dt className="w-40 shrink-0 text-gray-600">{r.label}</dt>
-              <div className="relative h-5 flex-1 overflow-hidden rounded bg-gray-100">
+            <div
+              key={r.label}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "170px 1fr 90px",
+                gap: 20,
+                alignItems: "center",
+                padding: "14px 0",
+                borderBottom:
+                  i === rows.length - 1
+                    ? "none"
+                    : "1px dashed var(--rule)",
+              }}
+            >
+              <span style={{ fontSize: 14, color: "var(--ink-2)" }}>
+                {r.label}
+              </span>
+              <div
+                style={{
+                  height: 18,
+                  background: "var(--paper-2)",
+                  position: "relative",
+                }}
+              >
                 <div
-                  className="h-full rounded bg-blue-500"
-                  style={{ width: `${widthPct}%` }}
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    right: "auto",
+                    width: `${widthPct}%`,
+                    background: r.isModal ? "var(--forest)" : "var(--ink)",
+                  }}
                 />
+                {r.isModal && (
+                  <span
+                    className="mono"
+                    style={{
+                      position: "absolute",
+                      right: -94,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      fontSize: 10.5,
+                      color: "var(--forest)",
+                      letterSpacing: "0.05em",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    ← MODAL BRACKET
+                  </span>
+                )}
               </div>
-              <dd className="w-20 shrink-0 text-right font-medium text-gray-900">
+              <span
+                className="mono nums"
+                style={{ fontSize: 14, textAlign: "right" }}
+              >
                 {formatCurrency(r.value)}
-              </dd>
+              </span>
             </div>
           );
         })}
-      </dl>
+      </div>
     </div>
   );
 }

--- a/web/src/components/OutcomesBand.tsx
+++ b/web/src/components/OutcomesBand.tsx
@@ -1,7 +1,7 @@
 import type { ScorecardSummary } from "@/lib/types";
 import { formatCurrency, formatPercent } from "@/lib/format";
 
-function StatCard({
+function Kpi({
   label,
   value,
   hint,
@@ -11,17 +11,31 @@ function StatCard({
   hint?: string;
 }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white px-4 py-3">
-      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
-      <p className="mt-1 text-xl font-semibold text-gray-900">{value}</p>
-      {hint && <p className="mt-1 text-xs text-gray-500">{hint}</p>}
+    <div>
+      <div className="meta" style={{ marginBottom: 8 }}>
+        {label}
+      </div>
+      <div
+        className="serif stat-num"
+        style={{ fontSize: 34, lineHeight: 1, letterSpacing: "-0.02em" }}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div
+          className="mono"
+          style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 6 }}
+        >
+          {hint}
+        </div>
+      )}
     </div>
   );
 }
 
 // Compact 4-card headline for federal Scorecard outcomes. Null fields drop
 // out, so a small school that doesn't report to Scorecard renders fewer
-// cards instead of a row of dashes.
+// cells instead of a row of dashes.
 export function OutcomesBand({ scorecard }: { scorecard: ScorecardSummary }) {
   const cards: { label: string; value: string; hint?: string }[] = [];
 
@@ -29,7 +43,7 @@ export function OutcomesBand({ scorecard }: { scorecard: ScorecardSummary }) {
     cards.push({
       label: "Median earnings",
       value: formatCurrency(scorecard.earnings_10yr_median),
-      hint: "10 years after enrollment",
+      hint: "10 yrs after enrollment",
     });
   }
   if (scorecard.graduation_rate_6yr != null) {
@@ -43,34 +57,32 @@ export function OutcomesBand({ scorecard }: { scorecard: ScorecardSummary }) {
     cards.push({
       label: "Average net price",
       value: formatCurrency(scorecard.avg_net_price),
-      hint: "Sticker minus grants",
+      hint: "sticker minus grants",
     });
   }
   if (scorecard.median_debt_completers != null) {
     cards.push({
-      label: "Median debt at graduation",
+      label: "Median debt at grad.",
       value: formatCurrency(scorecard.median_debt_completers),
-      hint: "Federal loans only",
+      hint: "federal loans only",
     });
   }
 
   if (cards.length === 0) return null;
 
-  // Tailwind JIT requires literal class names — can't interpolate grid cols.
-  // Pick the right class based on card count; 4 is the cap.
-  const colClass =
-    cards.length >= 4
-      ? "sm:grid-cols-4"
-      : cards.length === 3
-        ? "sm:grid-cols-3"
-        : cards.length === 2
-          ? "sm:grid-cols-2"
-          : "sm:grid-cols-1";
-
   return (
-    <div className={`grid grid-cols-2 gap-3 ${colClass}`}>
+    <div
+      className="rule-2"
+      style={{
+        marginTop: 20,
+        paddingTop: 24,
+        display: "grid",
+        gridTemplateColumns: `repeat(${cards.length}, 1fr)`,
+        gap: 32,
+      }}
+    >
       {cards.map((c) => (
-        <StatCard key={c.label} {...c} />
+        <Kpi key={c.label} {...c} />
       ))}
     </div>
   );

--- a/web/src/components/OutcomesSection.tsx
+++ b/web/src/components/OutcomesSection.tsx
@@ -1,16 +1,21 @@
 import type { ScorecardSummary } from "@/lib/types";
-import { formatCurrency, formatPercent } from "@/lib/format";
+import { formatPercent } from "@/lib/format";
 import { OutcomesBand } from "./OutcomesBand";
 import { NetPriceByIncome } from "./NetPriceByIncome";
-import { ScorecardVintageNote } from "./ScorecardVintageNote";
+import { EarningsDistribution } from "./EarningsDistribution";
 
-function MiniCard({ label, value }: { label: string; value: string }) {
+function SmallKpi({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded border border-gray-200 bg-white px-3 py-2">
-      <p className="text-[11px] text-gray-500 uppercase tracking-wide">
+    <div>
+      <div className="meta" style={{ marginBottom: 4 }}>
         {label}
-      </p>
-      <p className="mt-0.5 text-base font-semibold text-gray-900">{value}</p>
+      </div>
+      <div
+        className="serif stat-num"
+        style={{ fontSize: 26, lineHeight: 1, letterSpacing: "-0.02em" }}
+      >
+        {value}
+      </div>
     </div>
   );
 }
@@ -18,10 +23,9 @@ function MiniCard({ label, value }: { label: string; value: string }) {
 type Stat = { label: string; value: string };
 
 // Full federal-outcomes section for the school landing page. Composes the
-// compact 4-card band, the net-price-by-income widget, and two secondary
-// stat grids (completion / retention, and student profile). Every grid
-// filters out null fields so the section shrinks gracefully for schools
-// with partial data.
+// 4-cell headline band, earnings spread, net-price-by-income widget, and
+// the completion / retention strip. Every grid filters out null fields so
+// the section shrinks gracefully for schools with partial Scorecard data.
 export function OutcomesSection({
   scorecard,
 }: {
@@ -30,134 +34,124 @@ export function OutcomesSection({
   const completion: Stat[] = [];
   if (scorecard.graduation_rate_4yr != null)
     completion.push({
-      label: "4-year grad",
+      label: "4-yr grad",
       value: formatPercent(scorecard.graduation_rate_4yr, 0),
     });
   if (scorecard.graduation_rate_6yr != null)
     completion.push({
-      label: "6-year grad",
+      label: "6-yr grad",
       value: formatPercent(scorecard.graduation_rate_6yr, 0),
     });
   if (scorecard.graduation_rate_8yr != null)
     completion.push({
-      label: "8-year grad",
+      label: "8-yr grad",
       value: formatPercent(scorecard.graduation_rate_8yr, 0),
     });
   if (scorecard.retention_rate_ft != null)
     completion.push({
-      label: "Retention (FT)",
+      label: "Retention",
       value: formatPercent(scorecard.retention_rate_ft, 0),
     });
   if (scorecard.grad_rate_pell != null)
     completion.push({
-      label: "Pell grad rate",
+      label: "Pell grad",
       value: formatPercent(scorecard.grad_rate_pell, 0),
     });
   if (scorecard.transfer_out_rate != null)
     completion.push({
-      label: "Transfer out",
+      label: "Transfer",
       value: formatPercent(scorecard.transfer_out_rate, 0),
     });
 
-  const profile: Stat[] = [];
-  if (scorecard.pell_grant_rate != null)
-    profile.push({
-      label: "Pell recipients",
-      value: formatPercent(scorecard.pell_grant_rate, 0),
-    });
-  if (scorecard.federal_loan_rate != null)
-    profile.push({
-      label: "With federal loans",
-      value: formatPercent(scorecard.federal_loan_rate, 0),
-    });
-  if (scorecard.first_generation_share != null)
-    profile.push({
-      label: "First-generation",
-      value: formatPercent(scorecard.first_generation_share, 0),
-    });
-  if (scorecard.median_family_income != null)
-    profile.push({
-      label: "Median family income",
-      value: formatCurrency(scorecard.median_family_income),
-    });
-  if (scorecard.enrollment != null)
-    profile.push({
-      label: "Undergraduate enrollment",
-      value: scorecard.enrollment.toLocaleString("en-US"),
-    });
-
-  const earningsRange: Stat[] = [];
-  if (scorecard.earnings_10yr_p25 != null)
-    earningsRange.push({
-      label: "25th percentile",
-      value: formatCurrency(scorecard.earnings_10yr_p25),
-    });
-  if (scorecard.earnings_10yr_median != null)
-    earningsRange.push({
-      label: "Median",
-      value: formatCurrency(scorecard.earnings_10yr_median),
-    });
-  if (scorecard.earnings_10yr_p75 != null)
-    earningsRange.push({
-      label: "75th percentile",
-      value: formatCurrency(scorecard.earnings_10yr_p75),
-    });
+  const hasEarnings =
+    scorecard.earnings_10yr_p25 != null &&
+    scorecard.earnings_10yr_median != null &&
+    scorecard.earnings_10yr_p75 != null;
 
   return (
-    <section className="mt-10">
-      <h2 className="text-lg font-semibold text-gray-900">Federal outcomes</h2>
-      <ScorecardVintageNote scorecard={scorecard} className="mt-1" />
-
-      <div className="mt-5">
-        <OutcomesBand scorecard={scorecard} />
-      </div>
-
-      {earningsRange.length >= 2 && (
-        <div className="mt-6">
-          <h3 className="text-sm font-semibold text-gray-900">
-            Earnings distribution, 10 years after enrollment
-          </h3>
-          <p className="mt-1 text-xs text-gray-500">
-            Federal-worker-and-not-enrolled cohort, reported in{" "}
-            {scorecard.scorecard_data_year} dollars.
-          </p>
-          <div className="mt-2 grid grid-cols-3 gap-2">
-            {earningsRange.map((s) => (
-              <MiniCard key={s.label} {...s} />
-            ))}
+    <>
+      <section style={{ marginTop: 56 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 24,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <div className="meta" style={{ marginBottom: 6 }}>
+              § Federal outcomes
+            </div>
+            <h2
+              className="serif"
+              style={{ fontSize: 32, margin: 0, letterSpacing: "-0.015em" }}
+            >
+              What federal data says
+            </h2>
+          </div>
+          <div
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: "var(--ink-3)",
+              letterSpacing: "0.05em",
+              textAlign: "right",
+              maxWidth: 360,
+              lineHeight: 1.5,
+            }}
+          >
+            SRC · U.S. DEPT. OF ED., COLLEGE SCORECARD{" "}
+            {scorecard.scorecard_data_year}.<br />
+            OUTCOMES LAG THE CDS YEAR SHOWN ABOVE.
           </div>
         </div>
+
+        <OutcomesBand scorecard={scorecard} />
+      </section>
+
+      {hasEarnings && (
+        <section style={{ marginTop: 48 }}>
+          <div className="meta" style={{ marginBottom: 6 }}>
+            § Earnings distribution
+          </div>
+          <h3
+            className="serif"
+            style={{ fontSize: 22, margin: 0, letterSpacing: "-0.01em" }}
+          >
+            Ten years after enrollment, in {scorecard.scorecard_data_year}{" "}
+            dollars
+          </h3>
+          <EarningsDistribution scorecard={scorecard} />
+        </section>
       )}
 
-      <div className="mt-6">
+      <section style={{ marginTop: 48 }}>
         <NetPriceByIncome scorecard={scorecard} />
-      </div>
+      </section>
 
       {completion.length > 0 && (
-        <div className="mt-6">
-          <h3 className="text-sm font-semibold text-gray-900">
-            Completion and retention
-          </h3>
-          <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <section style={{ marginTop: 48 }}>
+          <div className="meta" style={{ marginBottom: 6 }}>
+            §B · Completion and retention
+          </div>
+          <div
+            className="rule-2"
+            style={{
+              marginTop: 14,
+              paddingTop: 20,
+              display: "grid",
+              gridTemplateColumns: `repeat(${Math.min(completion.length, 6)}, 1fr)`,
+              gap: 24,
+            }}
+          >
             {completion.map((s) => (
-              <MiniCard key={s.label} {...s} />
+              <SmallKpi key={s.label} {...s} />
             ))}
           </div>
-        </div>
+        </section>
       )}
-
-      {profile.length > 0 && (
-        <div className="mt-6">
-          <h3 className="text-sm font-semibold text-gray-900">
-            Student profile
-          </h3>
-          <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
-            {profile.map((s) => (
-              <MiniCard key={s.label} {...s} />
-            ))}
-          </div>
-        </div>
-      )}
-    </section>
+    </>
   );
 }

--- a/web/src/components/ScorecardVintageNote.tsx
+++ b/web/src/components/ScorecardVintageNote.tsx
@@ -2,19 +2,25 @@ import type { ScorecardSummary } from "@/lib/types";
 
 export function ScorecardVintageNote({
   scorecard,
-  className = "",
 }: {
   scorecard: ScorecardSummary;
-  className?: string;
 }) {
   return (
-    <p className={`text-xs italic text-gray-500 ${className}`}>
+    <p
+      className="serif"
+      style={{
+        fontStyle: "italic",
+        fontSize: 13,
+        color: "var(--ink-3)",
+        margin: 0,
+        lineHeight: 1.5,
+      }}
+    >
       Federal data from the U.S. Department of Education&apos;s{" "}
       <a
         href="https://collegescorecard.ed.gov/"
         target="_blank"
         rel="noopener noreferrer"
-        className="underline hover:text-gray-700"
       >
         College Scorecard
       </a>


### PR DESCRIPTION
## Summary

Rebuilds the school landing page in the archival voice from the Claude Design handoff (Newsreader serif + Geist + JetBrains Mono on paper/ink/forest).

- New `EarningsDistribution` chart: P25 / Median / P75 on a flat axis with a forest median dot and faint forest IQR band.
- New `NetPriceByIncome`: ink bars on a paper-2 track, with the bracket containing the school's median family income highlighted in forest as the "modal bracket" (caption now in its own column so it never overlaps the dollar value).
- Documents render as a ledger of rows (serif year, mono format/status chips) instead of cards. Status chip is variant-driven: extracted → forest, failed → brick, pending → ochre, otherwise neutral. Falls back to `source_url` (`View source →`) when no archived PDF is available.
- Header redesigned: mono breadcrumb, serif display name with italic institution suffix, IPEDS / Carnegie marginalia on the left; archive-growth sparkline + "§ N documents archived · YEAR–YEAR" on the right.
- Outcomes section rebuilt around `§` marginalia with a serif "What federal data says" heading and inline source citation.
- `cd-chip--brick` and `cd-chip--ochre` token variants added.
- Mobile layout: hero stacks under 640px with a hairline rule; net-price bars stack band/value over bar; earnings tick labels switch to `$Xk` abbreviations to avoid overlap.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified Harvard, Williams, Stanford at 1280×900 and 390×844 in Playwright; zero console errors
- [x] Confirmed FAILED (Williams) is brick, EXTRACTED is forest, no longer indistinguishable
- [x] Confirmed `← MODAL BRACKET` no longer overlaps the dollar value (Harvard $30k–$48k row)
- [x] Confirmed mobile earnings labels use abbreviated `$Xk` and don't collide
- [x] Confirmed `View source →` fallback path renders when storage path is null