### PR TITLE
Highlight active section in top nav

### DIFF
--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Wordmark } from "./Wordmark";
 
 const NAV_LINKS = [
@@ -9,7 +12,18 @@ const NAV_LINKS = [
   { href: "/api", label: "API" },
 ];
 
+// A nav link is "active" when the user is on that section. Section pages
+// (e.g. /recipes/acceptance-vs-yield) keep the parent (/recipes) lit so
+// the nav reads as "you are here" instead of "you are nowhere."
+function isActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
+  if (pathname === href) return true;
+  return pathname.startsWith(href + "/");
+}
+
 export function Nav() {
+  const pathname = usePathname();
+
   return (
     <nav
       style={{
@@ -25,21 +39,27 @@ export function Nav() {
           <Wordmark variant="dotted" size={20} />
         </Link>
         <div className="cd-nav-links">
-          {NAV_LINKS.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              style={{
-                textDecoration: "none",
-                color: "var(--ink-3)",
-                paddingBottom: 2,
-                borderBottom: "1px solid transparent",
-              }}
-              className="nav-link"
-            >
-              {l.label}
-            </Link>
-          ))}
+          {NAV_LINKS.map((l) => {
+            const active = isActive(pathname, l.href);
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                aria-current={active ? "page" : undefined}
+                style={{
+                  textDecoration: "none",
+                  color: active ? "var(--ink)" : "var(--ink-3)",
+                  paddingBottom: 2,
+                  borderBottom: active
+                    ? "1px solid var(--ink)"
+                    : "1px solid transparent",
+                }}
+                className="nav-link"
+              >
+                {l.label}
+              </Link>
+            );
+          })}
           <a
             href="https://github.com/bolewood/collegedata-fyi"
             target="_blank"


### PR DESCRIPTION
## Summary

The header nav rendered every link in the same gray (`var(--ink-3)`), so visitors landed on `/recipes/acceptance-vs-yield` or `/schools/harvard` with no visual indication of which section they were in. The reference `NavRow` in the Claude Design handoff highlights the active link in ink with a 1px ink underline; this restores that behavior.

- Sub-routes light up the parent: `/schools/harvard` keeps "Schools" lit, `/recipes/acceptance-vs-yield` keeps "Recipes" lit.
- Match logic is exact-href OR `href + "/"` prefix, so `/api` stays distinct from `/api-docs` if that ever lands.
- Adds `aria-current="page"` so screen readers pick up the active section.
- `Nav` switches to a client component because `usePathname` is only available at the client boundary.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified `/recipes/acceptance-vs-yield` highlights "Recipes"
- [x] Verified `/schools/harvard` highlights "Schools"
- [x] Verified other links remain in `var(--ink-3)` with transparent underline