### PR TITLE
Hint that GitHub nav link opens a new tab

### DIFF
--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -64,15 +64,29 @@ export function Nav() {
             href="https://github.com/bolewood/collegedata-fyi"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="GitHub (opens in new tab)"
             style={{
               textDecoration: "none",
               color: "var(--ink-3)",
               paddingBottom: 2,
               borderBottom: "1px solid transparent",
+              display: "inline-flex",
+              alignItems: "baseline",
+              gap: 4,
             }}
             className="nav-link"
           >
             GitHub
+            <span
+              aria-hidden="true"
+              style={{
+                fontSize: "0.75em",
+                color: "var(--ink-4)",
+                lineHeight: 1,
+              }}
+            >
+              ↗
+            </span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a faint ↗ glyph after "GitHub" in the top nav and an `aria-label` so screen readers announce "GitHub (opens in new tab)". Glyph renders at 0.75em in `var(--ink-4)` so it reads as a hint without competing with the section labels or the active-state underline.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified glyph renders next to "GitHub" at desktop, sized so it doesn't crowd "API"
- [x] Confirmed other nav links unchanged