### PR TITLE
Redesign FieldsView as textbook gutter

### DIFF
--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -192,6 +192,68 @@
   .cd-school-header__count { justify-content: flex-start; }
 }
 
+/* FieldsView textbook layout — sticky section/subsection index in the
+   left gutter, KV groups in the right body. Gutter collapses to a stacked
+   block on narrow viewports so the page still scans at phone widths. */
+.cd-fields__layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 36px;
+  margin-top: 20px;
+}
+/* Don't shrink the gutter cell to its content — sticky needs its parent
+   to be as tall as the body so the index stays pinned all the way down. */
+.cd-fields__gutter { align-self: stretch; }
+.cd-fields__gutter-sticky {
+  position: sticky;
+  top: 24px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+.cd-fields__gutter-section {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 4px;
+  margin-bottom: 6px;
+  letter-spacing: -0.005em;
+}
+.cd-fields__gutter-section:hover { color: var(--forest-ink); }
+.cd-fields__gutter-letter {
+  font-style: italic;
+  color: var(--forest);
+  width: 24px;
+  flex-shrink: 0;
+}
+.cd-fields__gutter-sub {
+  display: block;
+  padding: 2px 0 2px 32px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+  text-decoration: none;
+  line-height: 1.5;
+}
+.cd-fields__gutter-sub:hover { color: var(--ink); }
+@media (max-width: 800px) {
+  .cd-fields__layout { grid-template-columns: 1fr; gap: 18px; }
+  .cd-fields__gutter-sticky {
+    position: static;
+    max-height: 280px;
+    border: 1px solid var(--rule);
+    border-radius: 2px;
+    padding: 14px 16px;
+    background: #faf6ec;
+  }
+}
+
 /* Recipe page layouts — reader's-guide and quadrant/band grids stack
    under 720px so the marginalia label collapses above the body copy
    instead of getting squeezed into a 200px gutter. */

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -1,6 +1,13 @@
 import type { FieldValue } from "@/lib/types";
-import { SECTION_NAMES, FIELD_LABELS } from "@/lib/labels";
+import { FIELD_LABELS } from "@/lib/labels";
+import { groupBySection, type SubsectionGroup } from "@/lib/sections";
+import { formatFieldValue } from "@/lib/format";
 
+// FieldsView — textbook-gutter layout. Sticky section/subsection index on
+// the left, KV groups on the right. Each subsection renders the extracted
+// fields as a label/value list with dashed rules between rows; future work
+// can swap in reconstructed CDS tables for select subsections (B1, C9,
+// H2A, etc.) without changing the surrounding layout.
 export function FieldsView({
   values,
   totalFields,
@@ -8,64 +15,171 @@ export function FieldsView({
   values: Record<string, FieldValue>;
   totalFields?: number;
 }) {
-  const entries = Object.entries(values);
-
-  // Group fields by section (from the field value's own section metadata)
-  const grouped = new Map<string, { id: string; field: FieldValue }[]>();
-
-  for (const [id, field] of entries) {
-    const section = field.section ?? sectionLetterToName(id.split(".")[0]);
-    const group = grouped.get(section) ?? [];
-    group.push({ id, field });
-    grouped.set(section, group);
-  }
-
-  // Sort sections by the field ID prefix (A before B before C...)
-  const sortedSections = Array.from(grouped.entries()).sort(([, a], [, b]) => {
-    const aMin = a[0]?.id ?? "";
-    const bMin = b[0]?.id ?? "";
-    return aMin.localeCompare(bMin);
-  });
-
-  for (const [, fields] of sortedSections) {
-    fields.sort((a, b) => a.id.localeCompare(b.id));
-  }
+  const sections = groupBySection(values);
+  const totalExtracted = Object.keys(values).length;
 
   return (
-    <div>
-      {totalFields != null && (
-        <p className="mb-4 text-sm text-gray-500">
-          {entries.length} of ~{totalFields} fields extracted
-        </p>
-      )}
+    <div className="cd-fields">
+      <ProvenanceNote
+        totalExtracted={totalExtracted}
+        totalKnown={totalFields}
+      />
 
-      {sortedSections.map(([sectionName, fields]) => {
-        const letter = fields[0]?.id.split(".")[0] ?? "";
-        return (
-          <div key={sectionName} className="mb-6">
-            <h3 className="text-sm font-semibold text-gray-900 border-b border-gray-200 pb-1 mb-2">
-              {letter}. {sectionName}
-            </h3>
-            <dl className="space-y-1">
-              {fields.map(({ id, field }) => {
-                const label =
-                  field.question ?? FIELD_LABELS[id]?.label ?? id;
-                const displayValue = field.value_decoded ?? field.value;
-                return (
-                  <div
-                    key={id}
-                    className="flex justify-between py-1.5 text-sm border-b border-gray-50"
+      <div className="cd-fields__layout">
+        <aside className="cd-fields__gutter">
+          <div className="cd-fields__gutter-sticky">
+            <div className="meta" style={{ marginBottom: 12 }}>
+              § Index
+            </div>
+            {sections.map((sec) => (
+              <div
+                key={sec.letter}
+                style={{ marginBottom: 16 }}
+              >
+                <a
+                  href={`#sec-${sec.letter}`}
+                  className="cd-fields__gutter-section"
+                >
+                  <span className="cd-fields__gutter-letter">
+                    §{sec.letter}
+                  </span>
+                  <span>{sec.name}</span>
+                </a>
+                {sec.subsections.map((sub) => (
+                  <a
+                    key={sub.slug}
+                    href={`#sub-${sub.slug}`}
+                    className="cd-fields__gutter-sub"
                   >
-                    <dt className="text-gray-600 pr-4 min-w-0">
-                      {label}
-                    </dt>
-                    <dd className="font-medium text-gray-900 shrink-0 text-right max-w-[50%]">
-                      {displayValue}
-                    </dd>
-                  </div>
-                );
-              })}
-            </dl>
+                    {sub.code ? `${sub.code} · ` : ""}
+                    {sub.name}
+                  </a>
+                ))}
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        <div className="cd-fields__body">
+          {sections.map((sec) => (
+            <section
+              key={sec.letter}
+              id={`sec-${sec.letter}`}
+              style={{ marginBottom: 36, scrollMarginTop: 24 }}
+            >
+              <header
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 16,
+                  borderBottom: "1px solid var(--rule-strong)",
+                  paddingBottom: 8,
+                  marginBottom: 16,
+                }}
+              >
+                <h2
+                  className="serif"
+                  style={{
+                    fontWeight: 400,
+                    fontSize: 24,
+                    margin: 0,
+                    letterSpacing: "-0.01em",
+                  }}
+                >
+                  {sec.name}
+                </h2>
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--ink-3)",
+                    marginLeft: "auto",
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  {sec.subsections.length} TABLE
+                  {sec.subsections.length === 1 ? "" : "S"}
+                </span>
+              </header>
+              {sec.subsections.map((sub) => (
+                <SubsectionBlock key={sub.slug} sub={sub} />
+              ))}
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SubsectionBlock({ sub }: { sub: SubsectionGroup }) {
+  return (
+    <div
+      id={`sub-${sub.slug}`}
+      style={{ marginBottom: 24, scrollMarginTop: 24 }}
+    >
+      <div className="meta" style={{ marginBottom: 6 }}>
+        {sub.code ? `${sub.code} · ` : ""}
+        {sub.name}
+      </div>
+      <KVRows fields={sub.fields} />
+    </div>
+  );
+}
+
+function KVRows({ fields }: { fields: SubsectionGroup["fields"] }) {
+  return (
+    <div>
+      {fields.map(({ id, field }, i) => {
+        const labelMeta = FIELD_LABELS[id];
+        const label =
+          field.question?.trim() || labelMeta?.label?.trim() || id;
+        const valueType = field.value_type ?? labelMeta?.valueType;
+        const raw = field.value_decoded ?? field.value;
+        const display = formatFieldValue(raw, valueType);
+        const missing =
+          display === "" ||
+          display === "—" ||
+          display.toLowerCase().includes("not provided");
+        return (
+          <div
+            key={id}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0, 1.6fr) minmax(0, 1fr)",
+              gap: 16,
+              padding: "8px 10px",
+              borderBottom:
+                i === fields.length - 1
+                  ? "none"
+                  : "1px dashed var(--rule)",
+              fontSize: 13.5,
+              alignItems: "baseline",
+            }}
+          >
+            <span
+              style={{
+                color: "var(--ink-2)",
+                lineHeight: 1.45,
+                minWidth: 0,
+              }}
+            >
+              {label}
+            </span>
+            <span
+              className="nums"
+              style={{
+                color: missing ? "var(--ink-4)" : "var(--ink)",
+                fontWeight: missing ? 400 : 500,
+                textAlign: "right",
+                fontVariantNumeric: "tabular-nums",
+                overflowWrap: "anywhere",
+                minWidth: 0,
+                maxWidth: "100%",
+              }}
+            >
+              {display || "—"}
+            </span>
           </div>
         );
       })}
@@ -73,6 +187,42 @@ export function FieldsView({
   );
 }
 
-function sectionLetterToName(letter: string): string {
-  return SECTION_NAMES[letter] ?? `Section ${letter}`;
+function ProvenanceNote({
+  totalExtracted,
+  totalKnown,
+}: {
+  totalExtracted: number;
+  totalKnown?: number;
+}) {
+  return (
+    <div
+      className="cd-card"
+      style={{
+        padding: "12px 16px",
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        fontSize: 13,
+        flexWrap: "wrap",
+      }}
+    >
+      <span className="meta" style={{ color: "var(--forest)" }}>
+        § Extraction
+      </span>
+      <span className="serif stat-num" style={{ fontSize: 18 }}>
+        {totalExtracted.toLocaleString("en-US")}
+        {totalKnown != null && (
+          <>
+            {" "}
+            <span style={{ color: "var(--ink-3)" }}>
+              of ~{totalKnown.toLocaleString("en-US")}
+            </span>
+          </>
+        )}
+      </span>
+      <span style={{ color: "var(--ink-2)" }}>
+        field{totalExtracted === 1 ? "" : "s"} parsed from this CDS.
+      </span>
+    </div>
+  );
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -119,3 +119,55 @@ export function dataQualityLabel(flag: string | null): string | null {
 export function dataQualityColor(): string {
   return "bg-amber-100 text-amber-800";
 }
+
+// Display-time formatter for an extracted CDS field value. The DB stores
+// raw strings as the PDF surfaced them ("$45,612", "12000", "98.5"); we
+// reformat at render based on the schema's `value_type` so exports keep
+// the source representation. Falls back to the original string whenever
+// parsing fails so an unexpected value never disappears from the page.
+export function formatFieldValue(
+  raw: string,
+  valueType?: string | null,
+): string {
+  const value = raw.trim();
+  if (!value) return value;
+  if (value === "—" || value.toLowerCase().startsWith("not provided")) {
+    return value;
+  }
+
+  const numeric = parseFloat(value.replace(/[$,%\s]/g, ""));
+  if (Number.isNaN(numeric)) return value;
+
+  switch (valueType) {
+    case "Nearest $1":
+      return `$${Math.round(numeric).toLocaleString("en-US")}`;
+    case "Nearest 1%":
+      return `${Math.round(numeric)}%`;
+    case "Round to Nearest Hundredths":
+    case "Whole Number or Round to Nearest Hundredths":
+      return numeric.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+    case "Whole Number or Round to Nearest Tenth":
+      if (!Number.isInteger(numeric)) {
+        return numeric.toLocaleString("en-US", {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        });
+      }
+      return numeric.toLocaleString("en-US");
+    case "Number":
+    case "Numbers":
+      // Only re-format if the raw input was clearly numeric — preserves
+      // strings like "Required for some" that happen to begin with a digit.
+      if (/^[\d,.\s$]+$/.test(value)) {
+        return Number.isInteger(numeric)
+          ? numeric.toLocaleString("en-US")
+          : numeric.toLocaleString("en-US", { maximumFractionDigits: 2 });
+      }
+      return value;
+    default:
+      return value;
+  }
+}

--- a/web/src/lib/sections.ts
+++ b/web/src/lib/sections.ts
@@ -1,0 +1,112 @@
+import type { FieldValue } from "./types";
+import { FIELD_LABELS, SECTION_NAMES } from "./labels";
+
+export type ExtractedField = {
+  id: string;
+  field: FieldValue;
+};
+
+export type SubsectionGroup = {
+  // Slug used for anchor IDs — unique within a section.
+  slug: string;
+  // CDS table code derived from word_tag prefix (e.g. "B1", "C7", "H2A");
+  // null when no extracted field carries one.
+  code: string | null;
+  // Human name from the schema ("Institutional Enrollment").
+  name: string;
+  fields: ExtractedField[];
+};
+
+export type SectionGroup = {
+  letter: string;
+  name: string;
+  subsections: SubsectionGroup[];
+};
+
+// Build the section/subsection tree the textbook FieldsView consumes.
+// Ordering is by question_number so sections render in CDS reading order
+// (A → B → C → …) and subsections within a section follow the order their
+// fields appear, not alphabetical.
+export function groupBySection(
+  values: Record<string, FieldValue>,
+): SectionGroup[] {
+  const sectionMap = new Map<
+    string,
+    {
+      letter: string;
+      name: string;
+      // subsection name → group
+      subs: Map<string, SubsectionGroup>;
+      // tracks lowest field id per subsection so we can sort
+      subOrder: Map<string, string>;
+    }
+  >();
+
+  const entries = Object.entries(values).sort(([a], [b]) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+
+  for (const [id, field] of entries) {
+    const letter = id.split(".")[0];
+    const sectionName =
+      field.section ?? SECTION_NAMES[letter] ?? `Section ${letter}`;
+    const subsectionName =
+      field.subsection ?? FIELD_LABELS[id]?.subsection ?? "Other";
+
+    let sec = sectionMap.get(letter);
+    if (!sec) {
+      sec = {
+        letter,
+        name: sectionName,
+        subs: new Map(),
+        subOrder: new Map(),
+      };
+      sectionMap.set(letter, sec);
+    }
+
+    let sub = sec.subs.get(subsectionName);
+    if (!sub) {
+      sub = {
+        slug: slugify(`${letter}-${subsectionName}`),
+        code: null,
+        name: subsectionName,
+        fields: [],
+      };
+      sec.subs.set(subsectionName, sub);
+      sec.subOrder.set(subsectionName, id);
+    }
+    if (sub.code == null) {
+      sub.code = subsectionCodeFromWordTag(field.word_tag);
+    }
+    sub.fields.push({ id, field });
+  }
+
+  const sections: SectionGroup[] = [];
+  const orderedLetters = Array.from(sectionMap.keys()).sort();
+  for (const letter of orderedLetters) {
+    const sec = sectionMap.get(letter)!;
+    const subs = Array.from(sec.subs.values()).sort((a, b) => {
+      const aFirst = sec.subOrder.get(a.name) ?? "";
+      const bFirst = sec.subOrder.get(b.name) ?? "";
+      return aFirst.localeCompare(bFirst, undefined, { numeric: true });
+    });
+    sections.push({ letter, name: sec.name, subsections: subs });
+  }
+  return sections;
+}
+
+// word_tag like "b1_gr_ft_first_time_degseek_females" → "B1".
+// Returns null when the input is empty or malformed.
+function subsectionCodeFromWordTag(tag?: string | null): string | null {
+  if (!tag) return null;
+  const prefix = tag.split("_")[0];
+  if (!prefix || !/^[a-z]\d+[a-z]?$/i.test(prefix)) return null;
+  return prefix.toUpperCase();
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}


### PR DESCRIPTION
## Summary

Replaces the flat `<dl>` in `FieldsView` with the textbook-gutter layout from the Claude Design handoff — sticky section/subsection index on the left, grouped KV rows on the right. Phase 1 of the FieldsView redesign: gutter + per-subsection KV groups, no full table reconstruction yet.

## What changed

- **New `lib/sections.ts`** — groups extracted fields by `(section, subsection)`, derives the CDS table code from the schema's `word_tag` prefix (`b1_gr_ft_…` → `B1`), and orders sections by letter / subsections by first field id.
- **Provenance card** at the top: `§ Extraction · 425 of ~382 fields parsed from this CDS.`
- **Sticky gutter** lists every section + subsection with anchor jumps. The gutter cell stretches the full row height so the index stays pinned no matter how far you scroll. Collapses to a static index card under 800px.
- **Per-subsection KV groups** with the meta label (`B1 · Institutional Enrollment`), label/value pairs, dashed inter-row rules, tabular nums.
- **Long-value wrapping**: KV columns are `minmax(0, 1.6fr) minmax(0, 1fr)` with `overflow-wrap: anywhere` on the value, so URLs and emails wrap instead of forcing horizontal overflow.

## Display-time formatting

Adds `formatFieldValue(raw, valueType)` in `lib/format.ts` that reads the schema's `value_type` and renders:

- `Nearest $1` → `$X,XXX`
- `Nearest 1%` → `X%`
- `Round to Nearest Hundredths` / `Whole Number or Round to Nearest Hundredths` → 2-decimal
- `Whole Number or Round to Nearest Tenth` → 1-decimal when fractional, integer otherwise
- `Number` / `Numbers` → comma-separated when the raw input is purely numeric

Raw extracted values stay in the database — exports, CSV downloads, and the API still surface the source representation. The page reformats at render so corrections ship as a frontend deploy, not a re-extract.

## Out of scope

- Full reconstructed CDS tables (B1 pivoted Men/Women/Total, C7 importance matrix, H2A income brackets). The schema has the dimensions to do it — we just need to thread `category / cohort / gender / etc.` through `FieldValue`. That's a follow-up.
- "— not provided" for known-but-missing fields. Needs per-CDS-year schema awareness so we don't show fields-that-didn't-exist as missing on older years.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified `/schools/stanford/2024-25` at 1280×900 and 390×844 in Playwright; zero console errors
- [x] Confirmed sticky gutter stays pinned through section H (scrolled to bottom)
- [x] Confirmed currency formatting on H section dollar fields ($4,150, $56,823)
- [x] Confirmed mobile collapse: gutter becomes a static card; KV rows wrap long URLs/emails