### PR TITLE
PRD 015 M1: institution directory and slug crosswalk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: python -m unittest tools.browser_backend.project_browser_data_test
       - name: Run Tier 4 cleaner tests
         run: python -m unittest discover -s tools/extraction_worker -p "test_*.py"
+      - name: Run scorecard loader tests
+        run: python -m unittest tools.scorecard.test_load_directory
 
   migrations:
     # Structural sanity checks on supabase/migrations/. Verifies every

--- a/supabase/migrations/20260429113212_institution_directory.sql
+++ b/supabase/migrations/20260429113212_institution_directory.sql
@@ -1,0 +1,107 @@
+-- PRD 015 M1 — Institution directory and slug crosswalk.
+--
+-- The directory is one row per Title-IV institution from the College
+-- Scorecard institution file, including those without a CDS in our
+-- archive. The crosswalk records every (ipeds_id, school_id) mapping
+-- so search can resolve aliases and prior slugs to the canonical
+-- school_id.
+--
+-- This migration only creates the tables. The loader at
+-- tools/scorecard/load_directory.py populates them and is the only
+-- supported writer; web/edge-function clients read via RLS.
+
+CREATE TABLE IF NOT EXISTS public.institution_directory (
+  ipeds_id                  text PRIMARY KEY,
+  school_id                 text NOT NULL UNIQUE,
+  school_name               text NOT NULL,
+  aliases                   text[] NOT NULL DEFAULT '{}',
+  city                      text,
+  state                     text,
+  zip                       text,
+  website_url               text,
+  scorecard_data_year       text NOT NULL,
+  undergraduate_enrollment  integer,
+  control                   integer,
+  institution_level         integer,
+  predominant_degree        integer,
+  highest_degree            integer,
+  currently_operating       boolean,
+  main_campus               boolean,
+  branch_count              integer,
+  latitude                  numeric,
+  longitude                 numeric,
+  in_scope                  boolean NOT NULL,
+  exclusion_reason          text,
+  directory_source          text NOT NULL DEFAULT 'scorecard',
+  refreshed_at              timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT institution_directory_scope_reason_consistent
+    CHECK (
+      (in_scope = true  AND exclusion_reason IS NULL)
+      OR
+      (in_scope = false AND exclusion_reason IS NOT NULL)
+    )
+);
+
+COMMENT ON TABLE public.institution_directory IS
+  'Per-institution directory keyed by IPEDS UNITID. One row per Title-IV institution loaded from the College Scorecard institution file. in_scope=true means the row meets MVP public defaults (active, undergraduate-serving, four-year or two-year, degree-granting). exclusion_reason explains why an out-of-scope row is filtered from the public directory.';
+
+-- Common filter for search and coverage queries: in-scope rows ordered
+-- by school_name. Composite covers both the WHERE and the ORDER BY.
+CREATE INDEX IF NOT EXISTS institution_directory_in_scope_name_idx
+  ON public.institution_directory (in_scope, school_name);
+
+-- State filter on the coverage page.
+CREATE INDEX IF NOT EXISTS institution_directory_state_idx
+  ON public.institution_directory (state)
+  WHERE in_scope = true;
+
+-- Lookup by school_id is already covered by the UNIQUE constraint.
+
+CREATE TABLE IF NOT EXISTS public.institution_slug_crosswalk (
+  ipeds_id      text NOT NULL,
+  school_id     text NOT NULL,
+  alias         text NOT NULL,
+  source        text NOT NULL,
+  is_primary    boolean NOT NULL DEFAULT false,
+  reviewed_at   timestamptz,
+
+  PRIMARY KEY (ipeds_id, alias),
+
+  CONSTRAINT institution_slug_crosswalk_source_valid
+    CHECK (source IN ('schools_yaml', 'scorecard', 'manual', 'redirect'))
+);
+
+COMMENT ON TABLE public.institution_slug_crosswalk IS
+  'Maps every known alias for an institution to its canonical school_id. Sources: schools_yaml (preserved from existing site slugs), scorecard (auto-generated from INSTNM), manual (operator-curated), redirect (prior public slug that has been retired).';
+
+-- Reverse lookups: "what alias points at this school_id" used by
+-- redirect-resolution and admin tooling.
+CREATE INDEX IF NOT EXISTS institution_slug_crosswalk_school_id_idx
+  ON public.institution_slug_crosswalk (school_id);
+
+-- Primary-only lookups for fast canonical resolution.
+CREATE INDEX IF NOT EXISTS institution_slug_crosswalk_primary_idx
+  ON public.institution_slug_crosswalk (alias)
+  WHERE is_primary = true;
+
+-- RLS: the directory and crosswalk are public-safe. Anonymous and
+-- authenticated readers see everything. Writes go through the service
+-- role only (no public write policy).
+ALTER TABLE public.institution_directory ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.institution_slug_crosswalk ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY institution_directory_public_read
+  ON public.institution_directory
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY institution_slug_crosswalk_public_read
+  ON public.institution_slug_crosswalk
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+GRANT SELECT ON public.institution_directory      TO anon, authenticated;
+GRANT SELECT ON public.institution_slug_crosswalk TO anon, authenticated;

--- a/tools/scorecard/README.md
+++ b/tools/scorecard/README.md
@@ -21,6 +21,8 @@ is below.
 
 - [`backfill_ipeds_ids.py`](./backfill_ipeds_ids.py) — one-shot fill of `cds_documents.ipeds_id` for rows inserted before the migration shipped. New rows pick up `ipeds_id` automatically via the archive edge functions (`_shared/archive.ts` reads it off `SchoolInput`).
 - [`refresh_summary.py`](./refresh_summary.py) — annual upsert of `scorecard_summary` from the Scorecard Most-Recent Institution CSV. Schema-drift guard catches renamed columns; per-row dedup prevents `ON CONFLICT` failures; `--only-cds` scopes to schools we actually have CDS docs for.
+- [`load_directory.py`](./load_directory.py) — PRD 015 M1. Refreshes `institution_directory` and `institution_slug_crosswalk` from the same Scorecard CSV. Applies the MVP in-scope filter (active, undergraduate-serving, two-or-four-year, degree-granting) and records `exclusion_reason` on out-of-scope rows. Preserves `schools.yaml` slugs where IPEDS IDs match; generates deterministic slugs for Scorecard-only rows with collision resolution `state → city → ipeds_id`. Writes a refresh summary to `scratch/scorecard/directory-refresh-<year>.json`.
+- [`test_load_directory.py`](./test_load_directory.py) — unit tests for the loader's pure functions (slug determinism, collision tiers, schools.yaml preservation, in-scope filter, UNITID normalization, crosswalk construction).
 
 ## Migrations
 
@@ -32,6 +34,7 @@ Apply in order — the third depends on the first via `cds_manifest.ipeds_id`, a
 | `20260420170100_scorecard_summary.sql` | Creates `scorecard_summary` (43 columns, PK on `ipeds_id`, RLS-gated public read). |
 | `20260420170200_cds_scorecard_view.sql` | Creates the joined `cds_scorecard` view with `WITH (security_invoker = true)`. |
 | `20260420180000_scorecard_pell_remap.sql` | Drops `median_debt_non_pell` and `grad_rate_non_pell` (Scorecard removed the underlying CSV columns between the V2 plan and the March 2026 release). Recreates `cds_scorecard` without those fields. |
+| `20260429113212_institution_directory.sql` | PRD 015 M1. Adds `institution_directory` (one row per Title-IV institution, with `in_scope` flag) and `institution_slug_crosswalk` (every alias for an institution → its canonical `school_id`). RLS-gated public read. Populated by `load_directory.py`. |
 
 ## First-time setup
 

--- a/tools/scorecard/load_directory.py
+++ b/tools/scorecard/load_directory.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Refresh institution_directory from the College Scorecard
+Most-Recent Institution-Level CSV.
+
+PRD 015 M1. The directory is keyed by IPEDS UNITID and includes one
+row per Title-IV institution in the loaded Scorecard vintage. The
+``in_scope`` flag captures whether the row meets the MVP public
+defaults (active, undergraduate-serving, four-year or two-year,
+degree-granting); out-of-scope rows are still loaded but flagged
+with an ``exclusion_reason``.
+
+The loader also writes the slug crosswalk: every (ipeds_id, alias) →
+school_id mapping needed to resolve search and prior-slug redirects.
+Existing ``tools/finder/schools.yaml`` slugs are preserved when the
+IPEDS ID matches; new Scorecard-only rows get a deterministic slug
+from INSTNM with collision resolution (``-state`` → ``-city`` →
+``-ipeds_id``).
+
+Usage:
+    # Dry run — parse, compute slugs, print summary, write nothing.
+    python tools/scorecard/load_directory.py \\
+      --csv ~/Downloads/Most-Recent-Cohorts-Institution.csv \\
+      --data-year 2022-23
+
+    # Apply — upsert directory + crosswalk, write a summary report.
+    python tools/scorecard/load_directory.py \\
+      --csv ~/Downloads/Most-Recent-Cohorts-Institution.csv \\
+      --data-year 2022-23 \\
+      --apply
+
+Requirements:
+  - pip install pandas pyyaml supabase python-dotenv
+  - .env file at repo root with SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHOOLS_YAML = REPO_ROOT / "tools" / "finder" / "schools.yaml"
+
+
+# Scorecard CSV column → directory field. Source-of-truth list comes
+# straight from PRD 015's directory data model. Keep this set distinct
+# from refresh_summary.py's COLUMN_MAP — those columns are curated
+# outcome metrics, not directory identity.
+DIRECTORY_COLUMN_MAP: dict[str, str] = {
+    "school_name":               "INSTNM",
+    "city":                      "CITY",
+    "state":                     "STABBR",
+    "zip":                       "ZIP",
+    "website_url":               "INSTURL",
+    "undergraduate_enrollment":  "UGDS",
+    "control":                   "CONTROL",
+    "institution_level":         "ICLEVEL",
+    "predominant_degree":        "PREDDEG",
+    "highest_degree":            "HIGHDEG",
+    "currently_operating":       "CURROPER",
+    "main_campus":               "MAIN",
+    "branch_count":              "NUMBRANCH",
+    "latitude":                  "LATITUDE",
+    "longitude":                 "LONGITUDE",
+}
+
+INT_COLS = {
+    "undergraduate_enrollment",
+    "control",
+    "institution_level",
+    "predominant_degree",
+    "highest_degree",
+    "branch_count",
+}
+
+NUMERIC_COLS = {"latitude", "longitude"}
+
+BOOL_COLS = {"currently_operating", "main_campus"}
+
+
+# In-scope filter, per PRD 015 "MVP Scope Decision". Fail conditions
+# return the exclusion_reason that ends up persisted on the row.
+def _scope_decision(row: dict[str, Any]) -> tuple[bool, Optional[str]]:
+    if row.get("currently_operating") is False:
+        return False, "closed"
+    enr = row.get("undergraduate_enrollment")
+    if enr is None or enr <= 0:
+        return False, "no_undergraduate_enrollment"
+    icl = row.get("institution_level")
+    if icl not in (1, 2):
+        return False, "not_two_or_four_year"
+    pred = row.get("predominant_degree")
+    if pred not in (2, 3, 4):
+        return False, "non_degree_predominant"
+    return True, None
+
+
+def _coerce(value: Any, col: str) -> Any:
+    """Mirror refresh_summary.py's _coerce semantics. Treat NULL,
+    'NULL', and 'PrivacySuppressed' as missing; cast int / float per
+    column's declared type."""
+    import pandas as pd
+
+    if pd.isna(value):
+        return None
+    if isinstance(value, str):
+        s = value.strip()
+        if s in {"", "NULL", "PrivacySuppressed"}:
+            return None
+        value = s
+    if col in INT_COLS:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+    if col in NUMERIC_COLS:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    if col in BOOL_COLS:
+        try:
+            return bool(int(float(value)))
+        except (TypeError, ValueError):
+            return None
+    return value
+
+
+def normalize_ipeds(unitid: Any) -> Optional[str]:
+    """Zero-pad to six digits when possible. Same convention as
+    refresh_summary.py — see that script for the rationale (silent
+    LEFT JOIN misses if formats diverge)."""
+    if unitid is None:
+        return None
+    if isinstance(unitid, float) and unitid != unitid:
+        return None
+    try:
+        n = int(float(unitid))
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return f"{n:06d}"
+
+
+# Slug generation. Deterministic and reversible enough that an operator
+# can predict a school's slug from its INSTNM and state without running
+# the loader.
+_SLUG_NONALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def base_slug(name: str) -> str:
+    """Lowercase, replace runs of non-alphanumerics with single
+    hyphens, strip leading/trailing hyphens. Empty result raises —
+    callers must skip rows whose INSTNM produces no slug at all."""
+    s = _SLUG_NONALNUM.sub("-", name.lower()).strip("-")
+    if not s:
+        raise ValueError(f"INSTNM produced an empty slug: {name!r}")
+    return s
+
+
+def state_suffix(state: Optional[str]) -> str:
+    return (state or "").lower().strip()
+
+
+def city_suffix(city: Optional[str]) -> str:
+    return _SLUG_NONALNUM.sub("-", (city or "").lower()).strip("-")
+
+
+def assign_slugs(
+    rows: list[dict[str, Any]],
+    schools_yaml_map: dict[str, str],
+) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    """Two-pass slug assignment.
+
+    Pass 1: claim all schools.yaml slugs (these are sacred). For
+    Scorecard rows whose IPEDS appears in schools.yaml, use that slug.
+
+    Pass 2: for remaining rows, compute base_slug. Any base_slug that
+    collides with another row OR a claimed slug escalates to
+    base-state, then base-state-city, then base-state-city-ipeds.
+
+    Returns:
+        (ipeds_id → school_id mapping for rows we slugged,
+         list of collision-report entries for the summary)
+    """
+    assigned: dict[str, str] = {}
+    claimed: set[str] = set()
+    collisions: list[dict[str, Any]] = []
+
+    # Pass 1: schools.yaml-preserved slugs. We claim these even when
+    # the matching scorecard row is out-of-scope, so a Scorecard-only
+    # row can never steal a slug that belongs to a curated school.
+    yaml_ipeds = {ipeds for ipeds in schools_yaml_map}
+    for row in rows:
+        ipeds = row["ipeds_id"]
+        if ipeds in yaml_ipeds:
+            slug = schools_yaml_map[ipeds]
+            assigned[ipeds] = slug
+            claimed.add(slug)
+            row["_slug_source"] = "schools_yaml"
+
+    # Pass 2: bucket remaining rows by base_slug, escalate collisions.
+    pending = [r for r in rows if r["ipeds_id"] not in assigned]
+    by_base: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in pending:
+        try:
+            row["_base_slug"] = base_slug(row["school_name"])
+        except ValueError as e:
+            row["_slug_error"] = str(e)
+            continue
+        by_base[row["_base_slug"]].append(row)
+
+    for slug, group in by_base.items():
+        # If only one row claims this base, and the slug is not already
+        # claimed by schools.yaml, take it as-is.
+        if len(group) == 1 and slug not in claimed:
+            row = group[0]
+            assigned[row["ipeds_id"]] = slug
+            claimed.add(slug)
+            row["_slug_source"] = "scorecard"
+            continue
+
+        # Collision (either group size > 1, or schools.yaml already
+        # owns this slug). Escalate. First try base-state.
+        unresolved = list(group)
+        for tier_fn, tier_name in (
+            (lambda r: f"{slug}-{state_suffix(r['state'])}".rstrip("-"), "state"),
+            (
+                lambda r: f"{slug}-{state_suffix(r['state'])}-{city_suffix(r['city'])}".rstrip("-"),
+                "city",
+            ),
+            (
+                lambda r: f"{slug}-{state_suffix(r['state'])}-{city_suffix(r['city'])}-{r['ipeds_id']}".rstrip("-"),
+                "ipeds",
+            ),
+        ):
+            still_colliding: list[dict[str, Any]] = []
+            tier_buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+            for row in unresolved:
+                tier_buckets[tier_fn(row)].append(row)
+            for candidate, bucket in tier_buckets.items():
+                if len(bucket) == 1 and candidate not in claimed:
+                    row = bucket[0]
+                    assigned[row["ipeds_id"]] = candidate
+                    claimed.add(candidate)
+                    row["_slug_source"] = "scorecard"
+                    collisions.append(
+                        {
+                            "ipeds_id": row["ipeds_id"],
+                            "school_name": row["school_name"],
+                            "base_slug": slug,
+                            "resolved_slug": candidate,
+                            "tier": tier_name,
+                        }
+                    )
+                else:
+                    still_colliding.extend(bucket)
+            unresolved = still_colliding
+            if not unresolved:
+                break
+
+        # If anything is still colliding after the ipeds tier, the
+        # caller has duplicate (ipeds_id, INSTNM, state, city) tuples,
+        # which means the input CSV is corrupt. Fail loudly.
+        if unresolved:
+            raise RuntimeError(
+                "slug assignment failed after all collision tiers; "
+                f"unresolved rows: {[r['ipeds_id'] for r in unresolved]}"
+            )
+
+    return assigned, collisions
+
+
+def load_schools_yaml(path: Path) -> dict[str, str]:
+    """Return ipeds_id → school_id from schools.yaml. Skips entries
+    without an ipeds_id (none currently, but the loader shouldn't
+    crash if one shows up)."""
+    try:
+        import yaml
+    except ImportError:
+        print("pyyaml not installed. pip install pyyaml", file=sys.stderr)
+        sys.exit(1)
+    data = yaml.safe_load(path.read_text())
+    out: dict[str, str] = {}
+    for entry in data.get("schools", []):
+        ipeds = entry.get("ipeds_id")
+        slug = entry.get("id")
+        if ipeds and slug:
+            # schools.yaml carries ipeds as a string already (quoted in
+            # the YAML to preserve leading zeros). Re-normalize defensively.
+            normalized = normalize_ipeds(ipeds)
+            if normalized:
+                out[normalized] = slug
+    return out
+
+
+def build_directory_row(
+    raw: dict[str, Any],
+    data_year: str,
+) -> Optional[dict[str, Any]]:
+    """Transform one Scorecard CSV row into a directory row, or None
+    when UNITID is missing/invalid."""
+    ipeds = normalize_ipeds(raw.get("UNITID"))
+    if ipeds is None:
+        return None
+    out: dict[str, Any] = {
+        "ipeds_id": ipeds,
+        "scorecard_data_year": data_year,
+        "directory_source": "scorecard",
+    }
+    for target, source in DIRECTORY_COLUMN_MAP.items():
+        out[target] = _coerce(raw.get(source), target)
+    if not out.get("school_name"):
+        return None
+    in_scope, reason = _scope_decision(out)
+    out["in_scope"] = in_scope
+    out["exclusion_reason"] = reason
+    return out
+
+
+def build_crosswalk_rows(
+    directory_rows: list[dict[str, Any]],
+    schools_yaml_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    """One row per known alias. Each ipeds_id always has at least one
+    primary row (its school_id). When a schools.yaml ID and the
+    Scorecard auto-slug differ, both end up in the table — schools.yaml
+    as primary, the auto-generated as a non-primary alias for redirect
+    resolution."""
+    out: list[dict[str, Any]] = []
+    for row in directory_rows:
+        ipeds = row["ipeds_id"]
+        primary = row["school_id"]
+        source = "schools_yaml" if ipeds in schools_yaml_map else "scorecard"
+        out.append(
+            {
+                "ipeds_id": ipeds,
+                "school_id": primary,
+                "alias": primary,
+                "source": source,
+                "is_primary": True,
+            }
+        )
+        # Auto-generated slug as a non-primary alias when the curated
+        # schools.yaml slug differs from what the loader would compute
+        # — useful when an operator searches by INSTNM tokens.
+        if ipeds in schools_yaml_map:
+            try:
+                auto = base_slug(row["school_name"])
+            except ValueError:
+                auto = None
+            if auto and auto != primary:
+                out.append(
+                    {
+                        "ipeds_id": ipeds,
+                        "school_id": primary,
+                        "alias": auto,
+                        "source": "scorecard",
+                        "is_primary": False,
+                    }
+                )
+    return out
+
+
+def required_scorecard_columns() -> set[str]:
+    return {"UNITID"} | set(DIRECTORY_COLUMN_MAP.values())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, help="Path to Most-Recent-Cohorts-Institution.csv")
+    parser.add_argument("--data-year", required=True, help="Scorecard vintage, e.g. 2022-23")
+    parser.add_argument("--schools-yaml", default=str(DEFAULT_SCHOOLS_YAML),
+                        help="Path to schools.yaml for slug preservation (default: tools/finder/schools.yaml)")
+    parser.add_argument("--apply", action="store_true",
+                        help="Write to Supabase. Without this flag the loader is a dry run that prints the summary only.")
+    parser.add_argument("--summary-out", default=None,
+                        help="Optional path to write the refresh summary as JSON. Defaults to scratch/scorecard/directory-refresh-<data_year>.json")
+    parser.add_argument("--env", default=str(REPO_ROOT / ".env"), help=".env path")
+    parser.add_argument("--batch-size", type=int, default=500, help="Upsert batch size")
+    args = parser.parse_args()
+
+    try:
+        import pandas as pd
+    except ImportError:
+        print("pandas not installed. pip install pandas", file=sys.stderr)
+        return 1
+
+    csv_path = Path(args.csv).expanduser()
+    if not csv_path.exists():
+        print(f"CSV not found: {csv_path}", file=sys.stderr)
+        return 1
+
+    yaml_path = Path(args.schools_yaml).expanduser()
+    schools_yaml_map = load_schools_yaml(yaml_path) if yaml_path.exists() else {}
+    print(f"Loaded {len(schools_yaml_map)} schools.yaml slug claims", file=sys.stderr)
+
+    print(f"Reading {csv_path} ...", file=sys.stderr)
+    df = pd.read_csv(csv_path, dtype=str, low_memory=False)
+    print(f"  {len(df):,} rows x {len(df.columns):,} cols", file=sys.stderr)
+
+    # Schema-drift guard. Fail loud if Scorecard renamed a directory
+    # column between releases.
+    required = required_scorecard_columns()
+    missing = required - set(df.columns)
+    if missing:
+        print(
+            f"Scorecard CSV is missing required columns: {sorted(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Build directory rows. Skip rows missing UNITID or INSTNM.
+    rows: list[dict[str, Any]] = []
+    skipped_no_ipeds = 0
+    skipped_no_name = 0
+    for raw in df.to_dict(orient="records"):
+        ipeds = normalize_ipeds(raw.get("UNITID"))
+        if ipeds is None:
+            skipped_no_ipeds += 1
+            continue
+        row = build_directory_row(raw, args.data_year)
+        if row is None:
+            skipped_no_name += 1
+            continue
+        rows.append(row)
+
+    # Slug assignment. We slug every row, in-scope or not, so the
+    # crosswalk includes inactive/closed institutions too (they may
+    # still need search redirects).
+    assigned, collisions = assign_slugs(rows, schools_yaml_map)
+    for row in rows:
+        row["school_id"] = assigned.get(row["ipeds_id"])
+
+    # Drop rows we couldn't slug. Per PRD 015 "Do not publish directory
+    # rows that fail slug assignment" — these are typically rows whose
+    # INSTNM normalized to an empty string.
+    no_slug = [r for r in rows if not r.get("school_id")]
+    rows = [r for r in rows if r.get("school_id")]
+
+    # Strip transient slug-assignment fields before persistence.
+    for row in rows:
+        row.pop("_slug_source", None)
+        row.pop("_base_slug", None)
+        row.pop("_slug_error", None)
+
+    crosswalk_rows = build_crosswalk_rows(rows, schools_yaml_map)
+
+    in_scope_rows = [r for r in rows if r["in_scope"]]
+    excluded_rows = [r for r in rows if not r["in_scope"]]
+    no_url_rows = [r for r in in_scope_rows if not (r.get("website_url") or "").strip()]
+    exclusion_breakdown = Counter(r["exclusion_reason"] for r in excluded_rows)
+
+    summary: dict[str, Any] = {
+        "data_year": args.data_year,
+        "csv_path": str(csv_path),
+        "total_csv_rows": int(len(df)),
+        "skipped_no_ipeds": skipped_no_ipeds,
+        "skipped_no_name": skipped_no_name,
+        "skipped_no_slug": len(no_slug),
+        "directory_rows": len(rows),
+        "in_scope_rows": len(in_scope_rows),
+        "excluded_rows": len(excluded_rows),
+        "exclusion_breakdown": dict(exclusion_breakdown),
+        "in_scope_without_website_url": len(no_url_rows),
+        "slug_collisions_resolved": len(collisions),
+        "slug_collisions_by_tier": dict(Counter(c["tier"] for c in collisions)),
+        "schools_yaml_preserved": sum(1 for r in rows if r["ipeds_id"] in schools_yaml_map),
+        "crosswalk_rows": len(crosswalk_rows),
+    }
+
+    print("\n=== Refresh summary ===", file=sys.stderr)
+    print(json.dumps(summary, indent=2), file=sys.stderr)
+
+    if collisions:
+        print("\n=== Sample slug collisions (first 10) ===", file=sys.stderr)
+        for c in collisions[:10]:
+            print(
+                f"  {c['ipeds_id']} {c['school_name']!r}: "
+                f"{c['base_slug']} -> {c['resolved_slug']} (tier={c['tier']})",
+                file=sys.stderr,
+            )
+
+    summary_path = Path(args.summary_out) if args.summary_out else (
+        REPO_ROOT / "scratch" / "scorecard" / f"directory-refresh-{args.data_year}.json"
+    )
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(
+        json.dumps({"summary": summary, "collisions": collisions}, indent=2) + "\n"
+    )
+    print(f"\nWrote summary to {summary_path}", file=sys.stderr)
+
+    if not args.apply:
+        print("\nDry run — no writes. Pass --apply to upsert.", file=sys.stderr)
+        return 0
+
+    # Apply path. Service-role client; same pattern as refresh_summary.py.
+    from supabase import create_client  # type: ignore
+
+    env_path = Path(args.env).expanduser()
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+    if not os.environ.get("SUPABASE_URL") or not os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
+        print("SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set", file=sys.stderr)
+        return 1
+
+    client = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_ROLE_KEY"])
+
+    print(f"\nUpserting {len(rows)} institution_directory rows in batches of {args.batch_size}...", file=sys.stderr)
+    for i in range(0, len(rows), args.batch_size):
+        batch = rows[i : i + args.batch_size]
+        client.table("institution_directory").upsert(batch, on_conflict="ipeds_id").execute()
+        print(f"  {i + len(batch):,}/{len(rows):,}", file=sys.stderr)
+
+    print(f"\nUpserting {len(crosswalk_rows)} institution_slug_crosswalk rows...", file=sys.stderr)
+    for i in range(0, len(crosswalk_rows), args.batch_size):
+        batch = crosswalk_rows[i : i + args.batch_size]
+        client.table("institution_slug_crosswalk").upsert(
+            batch, on_conflict="ipeds_id,alias"
+        ).execute()
+        print(f"  {i + len(batch):,}/{len(crosswalk_rows):,}", file=sys.stderr)
+
+    print("\nDone.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scorecard/test_load_directory.py
+++ b/tools/scorecard/test_load_directory.py
@@ -1,0 +1,251 @@
+"""Unit tests for PRD 015 M1's institution-directory loader. Covers
+the deterministic pure functions: UNITID normalization, in-scope
+filter, base slug generation, collision resolution, schools.yaml
+preservation, and crosswalk row construction.
+
+Run from repo root:
+    python -m unittest tools.scorecard.test_load_directory
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.scorecard.load_directory import (  # noqa: E402
+    _scope_decision,
+    assign_slugs,
+    base_slug,
+    build_crosswalk_rows,
+    normalize_ipeds,
+)
+
+
+class NormalizeIpedsTests(unittest.TestCase):
+    def test_zero_pads_to_six(self):
+        self.assertEqual(normalize_ipeds("1234"), "001234")
+        self.assertEqual(normalize_ipeds("211440"), "211440")
+
+    def test_handles_float_string(self):
+        self.assertEqual(normalize_ipeds("211440.0"), "211440")
+
+    def test_passes_through_seven_digit(self):
+        # Some branch campuses exceed 6 digits; do not truncate.
+        self.assertEqual(normalize_ipeds("1234567"), "1234567")
+
+    def test_returns_none_for_invalid(self):
+        self.assertIsNone(normalize_ipeds(None))
+        self.assertIsNone(normalize_ipeds(""))
+        self.assertIsNone(normalize_ipeds("abc"))
+        self.assertIsNone(normalize_ipeds("0"))
+        self.assertIsNone(normalize_ipeds("-5"))
+
+
+class ScopeDecisionTests(unittest.TestCase):
+    def _row(self, **overrides):
+        base = dict(
+            currently_operating=True,
+            undergraduate_enrollment=5000,
+            institution_level=1,
+            predominant_degree=3,
+        )
+        base.update(overrides)
+        return base
+
+    def test_default_in_scope(self):
+        in_scope, reason = _scope_decision(self._row())
+        self.assertTrue(in_scope)
+        self.assertIsNone(reason)
+
+    def test_closed_institution_excluded(self):
+        in_scope, reason = _scope_decision(self._row(currently_operating=False))
+        self.assertFalse(in_scope)
+        self.assertEqual(reason, "closed")
+
+    def test_zero_undergrad_excluded(self):
+        in_scope, reason = _scope_decision(self._row(undergraduate_enrollment=0))
+        self.assertFalse(in_scope)
+        self.assertEqual(reason, "no_undergraduate_enrollment")
+
+    def test_null_undergrad_excluded(self):
+        in_scope, reason = _scope_decision(self._row(undergraduate_enrollment=None))
+        self.assertFalse(in_scope)
+        self.assertEqual(reason, "no_undergraduate_enrollment")
+
+    def test_iclevel_3_excluded(self):
+        # ICLEVEL=3 is "less than two-year" — excluded from MVP.
+        in_scope, reason = _scope_decision(self._row(institution_level=3))
+        self.assertFalse(in_scope)
+        self.assertEqual(reason, "not_two_or_four_year")
+
+    def test_certificate_only_excluded(self):
+        # PREDDEG=1 = certificate-only — excluded.
+        in_scope, reason = _scope_decision(self._row(predominant_degree=1))
+        self.assertFalse(in_scope)
+        self.assertEqual(reason, "non_degree_predominant")
+
+    def test_graduate_predominant_with_undergrad_in_scope(self):
+        # PREDDEG=4 (graduate) is allowed when UGDS > 0 (per PRD).
+        in_scope, _ = _scope_decision(
+            self._row(predominant_degree=4, undergraduate_enrollment=100)
+        )
+        self.assertTrue(in_scope)
+
+
+class BaseSlugTests(unittest.TestCase):
+    def test_lowercases_and_hyphenates(self):
+        self.assertEqual(base_slug("Harvard University"), "harvard-university")
+
+    def test_collapses_runs_of_punctuation(self):
+        self.assertEqual(base_slug("St. Olaf College"), "st-olaf-college")
+        self.assertEqual(
+            base_slug("Texas A&M University-Kingsville"),
+            "texas-a-m-university-kingsville",
+        )
+
+    def test_strips_leading_trailing_hyphens(self):
+        self.assertEqual(base_slug("---Quirky Name---"), "quirky-name")
+
+    def test_empty_input_raises(self):
+        with self.assertRaises(ValueError):
+            base_slug("...")
+        with self.assertRaises(ValueError):
+            base_slug("")
+
+    def test_deterministic(self):
+        # Same INSTNM → same slug, always.
+        self.assertEqual(base_slug("Yale University"), base_slug("Yale University"))
+
+
+class AssignSlugsTests(unittest.TestCase):
+    def _row(self, ipeds, name, state="NY", city="New York"):
+        return {
+            "ipeds_id": ipeds,
+            "school_name": name,
+            "state": state,
+            "city": city,
+            "in_scope": True,
+        }
+
+    def test_no_collisions_uses_base_slug(self):
+        rows = [
+            self._row("000001", "Harvard University"),
+            self._row("000002", "Yale University"),
+        ]
+        assigned, collisions = assign_slugs(rows, {})
+        self.assertEqual(assigned["000001"], "harvard-university")
+        self.assertEqual(assigned["000002"], "yale-university")
+        self.assertEqual(collisions, [])
+
+    def test_state_tier_resolves_same_name_different_state(self):
+        rows = [
+            self._row("000001", "Lincoln College", state="IL", city="Lincoln"),
+            self._row("000002", "Lincoln College", state="CA", city="Oakland"),
+        ]
+        assigned, collisions = assign_slugs(rows, {})
+        self.assertEqual(assigned["000001"], "lincoln-college-il")
+        self.assertEqual(assigned["000002"], "lincoln-college-ca")
+        self.assertEqual({c["tier"] for c in collisions}, {"state"})
+
+    def test_city_tier_resolves_same_name_state_different_city(self):
+        rows = [
+            self._row("000001", "Community College", state="CA", city="San Diego"),
+            self._row("000002", "Community College", state="CA", city="Los Angeles"),
+        ]
+        assigned, _ = assign_slugs(rows, {})
+        self.assertEqual(assigned["000001"], "community-college-ca-san-diego")
+        self.assertEqual(assigned["000002"], "community-college-ca-los-angeles")
+
+    def test_ipeds_tier_resolves_identical_name_state_city(self):
+        # Pathological — two rows with literally the same INSTNM, state,
+        # city. Should still resolve uniquely.
+        rows = [
+            self._row("000001", "Same Same", state="NY", city="Albany"),
+            self._row("000002", "Same Same", state="NY", city="Albany"),
+        ]
+        assigned, _ = assign_slugs(rows, {})
+        self.assertEqual(assigned["000001"], "same-same-ny-albany-000001")
+        self.assertEqual(assigned["000002"], "same-same-ny-albany-000002")
+
+    def test_schools_yaml_slug_preserved(self):
+        # The Scorecard row's INSTNM would generate "harvard-university"
+        # but schools.yaml has it pinned to "harvard". Preserve.
+        rows = [self._row("000001", "Harvard University")]
+        assigned, _ = assign_slugs(rows, {"000001": "harvard"})
+        self.assertEqual(assigned["000001"], "harvard")
+
+    def test_schools_yaml_blocks_unrelated_scorecard_collision(self):
+        # schools.yaml claims "harvard-university" via a curated slug.
+        # A separate Scorecard row whose INSTNM also normalizes to
+        # "harvard-university" must NOT steal that slug — it escalates
+        # to the state tier instead.
+        rows = [
+            self._row("000001", "Harvard University", state="MA"),
+            self._row("000002", "Harvard University", state="WA"),
+        ]
+        assigned, _ = assign_slugs(rows, {"000001": "harvard-university"})
+        self.assertEqual(assigned["000001"], "harvard-university")
+        # The non-yaml row must escalate; without yaml, it would have
+        # tied with row 1 and gone to -wa anyway, so this confirms the
+        # claim was respected.
+        self.assertNotEqual(assigned["000002"], "harvard-university")
+        self.assertEqual(assigned["000002"], "harvard-university-wa")
+
+
+class BuildCrosswalkRowsTests(unittest.TestCase):
+    def test_one_primary_per_directory_row(self):
+        rows = [
+            {"ipeds_id": "000001", "school_id": "harvard", "school_name": "Harvard University"},
+            {"ipeds_id": "000002", "school_id": "yale-university", "school_name": "Yale University"},
+        ]
+        cw = build_crosswalk_rows(rows, {"000001": "harvard"})
+        primaries = [r for r in cw if r["is_primary"]]
+        self.assertEqual(len(primaries), 2)
+        self.assertEqual({r["alias"] for r in primaries}, {"harvard", "yale-university"})
+
+    def test_yaml_slug_emits_auto_alias_when_different(self):
+        # schools.yaml uses "harvard"; auto would compute "harvard-university".
+        # Both should appear in the crosswalk so search by INSTNM tokens
+        # finds the row.
+        rows = [
+            {"ipeds_id": "000001", "school_id": "harvard", "school_name": "Harvard University"},
+        ]
+        cw = build_crosswalk_rows(rows, {"000001": "harvard"})
+        aliases = sorted({(r["alias"], r["is_primary"], r["source"]) for r in cw})
+        self.assertEqual(
+            aliases,
+            [
+                ("harvard", True, "schools_yaml"),
+                ("harvard-university", False, "scorecard"),
+            ],
+        )
+
+    def test_yaml_slug_matching_auto_emits_only_one_alias(self):
+        # When the yaml slug equals what the loader would auto-generate,
+        # don't double-write the same alias row.
+        rows = [
+            {"ipeds_id": "000001", "school_id": "yale-university",
+             "school_name": "Yale University"},
+        ]
+        cw = build_crosswalk_rows(rows, {"000001": "yale-university"})
+        self.assertEqual(len(cw), 1)
+        self.assertTrue(cw[0]["is_primary"])
+
+    def test_scorecard_only_row_emits_single_primary(self):
+        # No schools.yaml entry → just the primary, no alias.
+        rows = [
+            {"ipeds_id": "000003", "school_id": "tiny-college",
+             "school_name": "Tiny College"},
+        ]
+        cw = build_crosswalk_rows(rows, {})
+        self.assertEqual(len(cw), 1)
+        self.assertEqual(cw[0]["alias"], "tiny-college")
+        self.assertTrue(cw[0]["is_primary"])
+        self.assertEqual(cw[0]["source"], "scorecard")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PRD 015 M1: ships the directory substrate that every subsequent milestone (search over all in-scope institutions, public-safe coverage table, directory-only school pages, coverage page, etc.) depends on. No user-visible change in this PR.

## What ships

- **Migration** ``supabase/migrations/20260429113212_institution_directory.sql``
  - ``institution_directory`` — one row per IPEDS UNITID from the College Scorecard institution file. Carries identity columns (school_id, school_name, aliases, location, website), Scorecard reference fields (UGDS, CONTROL, ICLEVEL, PREDDEG, HIGHDEG, CURROPER, MAIN, NUMBRANCH, lat/lng), and the public-defaults filter result (``in_scope`` boolean + ``exclusion_reason``).
  - ``institution_slug_crosswalk`` — every (ipeds_id, alias) → school_id row. Sources: ``schools_yaml`` (preserved curated slugs), ``scorecard`` (auto-generated), ``manual``, ``redirect``.
  - RLS public-read on both tables; no public write policy.
  - Indexes on the common search/coverage filters.

- **Loader** ``tools/scorecard/load_directory.py``
  - Reads the same Scorecard CSV ``refresh_summary.py`` consumes; reuses its UNITID six-digit zero-pad convention.
  - Applies MVP in-scope filter per PRD: ``CURROPER=1``, ``UGDS>0``, ``ICLEVEL ∈ {1, 2}``, ``PREDDEG ∈ {2, 3, 4}``. Records ``exclusion_reason`` on out-of-scope rows.
  - Preserves ``schools.yaml`` slugs when IPEDS IDs match — ensures existing public URLs stay stable.
  - For Scorecard-only rows, generates deterministic slugs from ``INSTNM`` with collision resolution: ``state → city → ipeds_id``. The escalator respects schools.yaml claims so a curated slug can never be stolen by a similarly-named Scorecard row.
  - Schema-drift guard aborts with the missing-column list, matching ``refresh_summary.py``'s loud-fail pattern.
  - Refresh summary written to ``scratch/scorecard/directory-refresh-<year>.json`` (gitignored per recent hygiene PR).

- **Tests** ``tools/scorecard/test_load_directory.py`` — 26 cases covering:
  - UNITID normalization (zero-pad, float strings, 7-digit branches, invalid input)
  - In-scope filter (each exclusion path tested independently, plus the graduate-predominant-with-undergrad allow rule)
  - Slug base function (lowercase + hyphenate, punctuation collapse, trim, empty-input raise, determinism)
  - Slug assignment with no collisions, state-tier escalation, city-tier escalation, ipeds-tier fallback for pathological duplicates
  - schools.yaml preservation, including the case where a Scorecard collision must escalate around a yaml-claimed slug
  - Crosswalk emission: one primary per row, auto-alias when yaml differs from auto-generated, no double-write when they match, single-primary for Scorecard-only

- **CI:** ``.github/workflows/ci.yml`` runs ``test_load_directory`` on every PR. No new dependencies required (tests exercise pure functions; pandas/yaml/supabase are lazy-imported in the loader's apply path only).

- **Docs:** ``tools/scorecard/README.md`` updated to describe the new loader and its place in the pipeline.

## What does NOT ship

- No data is written by this PR. The loader is run manually by an operator with ``--apply`` against the production Supabase to populate the directory. That is an operational step after merge.
- M2 (Scorecard-only discovery enrollment) and M3 (public-safe coverage table) build on top of this substrate but are separate milestones.
- Search behavior (M4), school-page rendering (M5), the ``/coverage`` page (M6), and the submission form (M7) are all downstream of M1.

## Test plan

- [x] All 26 ``test_load_directory`` unit tests pass locally
- [x] Migration filename passes the local hygiene check (timestamp prefix unique, sort order correct)
- [x] No new CI dependencies introduced (test exercises pure functions only)
- [ ] CI green on this PR (Python tests, migrations hygiene, Next.js build, Supabase function tests)
- [ ] Operator dry-run of ``load_directory.py`` against a Scorecard CSV before ``--apply``

🤖 Generated with [Claude Code](https://claude.com/claude-code)