### PR TITLE
M3 fix: compute search_text in refresh, not as generated column

### DIFF
--- a/supabase/migrations/20260429144126_institution_cds_coverage.sql
+++ b/supabase/migrations/20260429144126_institution_cds_coverage.sql
@@ -96,14 +96,12 @@ create table public.institution_cds_coverage (
 
   can_submit_source          boolean not null,
 
-  search_text                text generated always as (
-    lower(
-      school_name
-      || ' ' || coalesce(array_to_string(aliases, ' '), '')
-      || ' ' || coalesce(city, '')
-      || ' ' || coalesce(state, '')
-    )
-  ) stored,
+  -- search_text is populated at refresh time, not as a generated
+  -- column: array_to_string is STABLE (locale-dependent), not
+  -- IMMUTABLE, which Postgres rejects for STORED generation
+  -- expressions. Computing in the refresh function gives the same
+  -- result without that constraint.
+  search_text                text not null,
 
   updated_at                 timestamptz not null default now()
 );
@@ -434,6 +432,7 @@ begin
     latest_field_count,
     last_checked_at,
     can_submit_source,
+    search_text,
     updated_at
   )
   select
@@ -473,6 +472,16 @@ begin
       'source_not_automatically_accessible',
       'not_checked'
     )                                                              as can_submit_source,
+    -- Computed at refresh time rather than via a generated column
+    -- because array_to_string is STABLE (locale-dependent), not
+    -- IMMUTABLE, and Postgres rejects STABLE expressions in STORED
+    -- generation. Same result, no immutability constraint.
+    lower(
+      school_name
+      || ' ' || coalesce(array_to_string(aliases, ' '), '')
+      || ' ' || coalesce(city, '')
+      || ' ' || coalesce(state, '')
+    )                                                              as search_text,
     now()                                                          as updated_at
   from resolved;
 


### PR DESCRIPTION
## Summary

PR #24's migration failed on \`supabase db push\` against prod with:

\`\`\`
ERROR: generation expression is not immutable (SQLSTATE 42P17)
\`\`\`

Root cause: \`array_to_string()\` is **STABLE** (locale-dependent collation), not IMMUTABLE. STORED generation columns require an IMMUTABLE expression. This is unspecific to Supabase — every Postgres 13+ build has the same volatility classification.

Fix: declare \`search_text\` as a regular text column and populate it in \`refresh_institution_cds_coverage()\`'s INSERT alongside coverage_status / label / summary. Same end result, no immutability constraint.

## Why edit the original migration in-place

The migration never successfully applied anywhere — failed locally, failed on prod, rolled back atomically (verified: \`institution_cds_coverage\` table does not exist on prod). Nothing has consumed the broken file. Editing in-place is cleanest:
- An ALTER TABLE follow-up wouldn't work — you can't drop GENERATED via ALTER
- The broken file would still fail on any fresh \`supabase db reset\`

## Test plan

- [x] \`deno check\` clean (no edge function changes)
- [x] All 168 deno tests still pass
- [ ] Post-merge: \`supabase db push --linked\` runs the M3 self-test against prod data. The 7-scenario self-test exercises every status, plus invariants for can_submit_source and the source-URL exposure gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)