### PR TITLE
PRD 015 M4: server-backed search + directory-only school stub

### DIFF
--- a/supabase/migrations/20260429152654_search_institutions_rpc.sql
+++ b/supabase/migrations/20260429152654_search_institutions_rpc.sql
@@ -1,0 +1,146 @@
+-- PRD 015 M4 — search_institutions() RPC.
+--
+-- Server-backed autocomplete for the homepage search box. Replaces the
+-- hardcoded in-memory ILIKE that only knew about CDS-backed schools.
+-- Returns rows from institution_cds_coverage so search results include
+-- directory-only schools with honest coverage badges, instead of empty
+-- silence for known schools we just haven't archived a CDS for.
+--
+-- Match strategy: substring ILIKE on the materialized search_text
+-- column (school name + aliases + city + state, lowercased). On 2,924
+-- in-scope rows a sequential scan completes in microseconds, so no
+-- pg_trgm index is needed for v1. If we ever want fuzzy matching, swap
+-- this to use pg_trgm + similarity().
+--
+-- Rank order:
+--   0  exact name match           "harvard university"  →  Harvard
+--   1  name prefix                "harv"                →  Harvard, Harvey Mudd
+--   2  name substring             "art"                 →  Hartford, Art Inst
+--   3  match anywhere in search   "cambridge"           →  MIT (city match)
+-- Within a tier, ties broken by undergraduate_enrollment DESC NULLS LAST
+-- and then school_name. The two-level sort surfaces the highest-interest
+-- match first when many schools share a token (e.g. typing "state").
+--
+-- Authorization: anon and authenticated. The function is SECURITY
+-- INVOKER, so the underlying RLS policy on institution_cds_coverage
+-- (which already hides out_of_scope rows from anon/authenticated)
+-- applies. The explicit `<> 'out_of_scope'` filter is redundant
+-- defense-in-depth but kept for readability.
+--
+-- The search_text column is populated by refresh_institution_cds_coverage()
+-- at refresh time (see migration 20260429144126_institution_cds_coverage.sql);
+-- this function only reads it.
+
+create or replace function public.search_institutions(
+  p_query text,
+  p_limit int default 10
+)
+returns table (
+  school_id                  text,
+  school_name                text,
+  city                       text,
+  state                      text,
+  coverage_status            public.coverage_status_t,
+  coverage_label             text,
+  latest_available_cds_year  text
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with q as (
+    select lower(trim(coalesce(p_query, ''))) as qstr
+  )
+  select
+    c.school_id,
+    c.school_name,
+    c.city,
+    c.state,
+    c.coverage_status,
+    c.coverage_label,
+    c.latest_available_cds_year
+  from public.institution_cds_coverage c, q
+  where c.coverage_status <> 'out_of_scope'
+    and length(q.qstr) > 0
+    and c.search_text like '%' || q.qstr || '%'
+  order by
+    case
+      when lower(c.school_name) = q.qstr                       then 0
+      when lower(c.school_name) like q.qstr || '%'             then 1
+      when lower(c.school_name) like '%' || q.qstr || '%'      then 2
+      else 3
+    end,
+    c.undergraduate_enrollment desc nulls last,
+    c.school_name
+  limit greatest(p_limit, 1);
+$$;
+
+comment on function public.search_institutions(text, int) is
+  'Public autocomplete search over institution_cds_coverage. Returns up to p_limit rows ranked by name-exact > name-prefix > name-substring > other-substring, with enrollment as tie-breaker. SECURITY INVOKER so RLS on the coverage table applies — out_of_scope rows are hidden from anon/authenticated regardless of the explicit filter in this function.';
+
+grant execute on function public.search_institutions(text, int) to anon, authenticated;
+
+-- Self-test. Inserts a sentinel directory + coverage row, refreshes the
+-- coverage table, exercises the RPC, asserts shape and ordering, then
+-- cleans up. Aborts the migration if any assertion fails.
+do $$
+declare
+  ipeds_a constant text := '9999101';
+  ipeds_b constant text := '9999102';
+  ipeds_c constant text := '9999103';
+  found_count int;
+  first_school text;
+begin
+  insert into public.institution_directory (
+    ipeds_id, school_id, school_name, scorecard_data_year, in_scope, exclusion_reason, undergraduate_enrollment
+  ) values
+    (ipeds_a, '__test_search_alpha__', 'Alpha University',          '2024', true, null, 5000),
+    (ipeds_b, '__test_search_beta__',  'Beta College',              '2024', true, null, 1000),
+    (ipeds_c, '__test_search_gamma__', 'Gamma School of the Arts',  '2024', true, null, 500);
+
+  perform public.refresh_institution_cds_coverage();
+
+  -- Exact name match returns the right row.
+  select count(*) into found_count
+    from public.search_institutions('Alpha University', 5)
+   where school_id = '__test_search_alpha__';
+  if found_count <> 1 then
+    raise exception 'M4 search self-test FAIL: exact match for "Alpha University" returned % rows', found_count;
+  end if;
+
+  -- Prefix match returns Beta first (only one Beta).
+  select school_id into first_school
+    from public.search_institutions('beta', 5)
+   where school_id like '__test_search_%'
+   order by 1 limit 1;
+  if first_school is distinct from '__test_search_beta__' then
+    raise exception 'M4 search self-test FAIL: prefix "beta" did not return beta first, got %', first_school;
+  end if;
+
+  -- Substring match catches name-internal tokens.
+  select count(*) into found_count
+    from public.search_institutions('arts', 5)
+   where school_id = '__test_search_gamma__';
+  if found_count <> 1 then
+    raise exception 'M4 search self-test FAIL: substring "arts" did not return Gamma School of the Arts';
+  end if;
+
+  -- Empty query returns zero rows (length filter).
+  select count(*) into found_count
+    from public.search_institutions('   ', 5);
+  if found_count <> 0 then
+    raise exception 'M4 search self-test FAIL: blank query returned % rows, expected 0', found_count;
+  end if;
+
+  -- Cleanup. The fixture rows live in institution_directory only;
+  -- deleting them and re-running refresh removes them from the
+  -- coverage table without touching real data.
+  delete from public.institution_directory where school_id like '__test_search_%';
+  perform public.refresh_institution_cds_coverage();
+
+  if exists (select 1 from public.search_institutions('Alpha University', 5)
+              where school_id like '__test_search_%') then
+    raise exception 'M4 search self-test FAIL: test fixtures leaked after cleanup';
+  end if;
+end$$;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { fetchManifest, aggregateSchools, fetchSiteStats } from "@/lib/queries";
+import { fetchManifest, fetchSiteStats } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
 import type { ManifestRow } from "@/lib/types";
 import { SchoolSearch } from "@/components/SchoolSearch";
@@ -65,7 +65,6 @@ function latestDrain(rows: ManifestRow[]): DrainEntry[] {
 
 export default async function HomePage() {
   const [manifest, stats] = await Promise.all([fetchManifest(), fetchSiteStats()]);
-  const schools = aggregateSchools(manifest);
   const drain = latestDrain(manifest);
 
   const schoolsValue = stats.total_schools.toLocaleString();
@@ -127,7 +126,7 @@ export default async function HomePage() {
           </p>
 
           <div style={{ marginTop: 36, maxWidth: 560, marginInline: "auto" }}>
-            <SchoolSearch schools={schools} />
+            <SchoolSearch />
           </div>
 
           <div style={{ display: "flex", gap: 12, justifyContent: "center", marginTop: 24, flexWrap: "wrap" }}>

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -4,13 +4,15 @@ import Link from "next/link";
 import {
   fetchSchoolDocuments,
   fetchScorecardByIpedsId,
+  fetchInstitutionCoverage,
 } from "@/lib/queries";
 import { DocumentCard } from "@/components/DocumentCard";
 import { OutcomesSection } from "@/components/OutcomesSection";
 import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
 import { Sparkline } from "@/components/Sparkline";
+import { CoverageBadge } from "@/components/CoverageBadge";
 import { yearRange } from "@/lib/format";
-import type { ManifestRow } from "@/lib/types";
+import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
 
 export const revalidate = 3600;
 
@@ -21,7 +23,26 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { school_id } = await params;
   const docs = await fetchSchoolDocuments(school_id);
-  if (docs.length === 0) return { title: "School Not Found" };
+  if (docs.length === 0) {
+    // PRD 015 M4 — directory-only schools render a coverage stub.
+    // Title reflects the school name (not "Not Found") so the browser
+    // tab and OG share match what the user sees.
+    const coverage = await fetchInstitutionCoverage(school_id);
+    if (coverage) {
+      const path = `/schools/${school_id}`;
+      return {
+        title: `${coverage.school_name} - ${coverage.coverage_label}`,
+        description: coverage.coverage_summary,
+        alternates: { canonical: path },
+        openGraph: {
+          url: path,
+          title: coverage.school_name,
+          description: coverage.coverage_summary,
+        },
+      };
+    }
+    return { title: "School Not Found" };
+  }
 
   const name = docs[0].school_name;
   const years = docs
@@ -89,6 +110,15 @@ export default async function SchoolDetailPage({
   const docs = await fetchSchoolDocuments(school_id);
 
   if (docs.length === 0) {
+    // PRD 015 M4 — directory-only stub. Search now returns Title-IV
+    // schools that have no archived CDS yet; clicking those slugs
+    // would otherwise hit a 404, contradicting the search promise.
+    // If we have a coverage row, render the minimal panel; otherwise
+    // genuine 404.
+    const coverage = await fetchInstitutionCoverage(school_id);
+    if (coverage && coverage.coverage_status !== "out_of_scope") {
+      return <DirectoryOnlySchoolPage coverage={coverage} school_id={school_id} />;
+    }
     notFound();
   }
 
@@ -326,6 +356,159 @@ export default async function SchoolDetailPage({
           <ScorecardVintageNote scorecard={scorecard} />
         </div>
       )}
+    </div>
+  );
+}
+
+// PRD 015 M4 — minimal directory-only school page.
+//
+// Renders for in-scope institution_cds_coverage rows that have no
+// cds_documents row yet (most often: not_checked, no_public_cds_found,
+// source_not_automatically_accessible, verified_absent). The page
+// delivers on the search-promised result without faking CDS data we
+// don't have.
+//
+// PRD M5 will elaborate this with Scorecard baseline metrics + a
+// proper source-submission CTA. The v1 here is the smallest thing
+// that breaks the search-then-404 dead-end.
+function DirectoryOnlySchoolPage({
+  coverage,
+  school_id,
+}: {
+  coverage: InstitutionCoverage;
+  school_id: string;
+}) {
+  const { head, tail } = splitInstitutionalSuffix(coverage.school_name);
+  const location = [coverage.city, coverage.state].filter(Boolean).join(", ");
+  const lastChecked = coverage.last_checked_at
+    ? new Date(coverage.last_checked_at).toLocaleDateString("en-US", {
+        month: "long",
+        year: "numeric",
+      })
+    : null;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollegeOrUniversity",
+    name: coverage.school_name,
+    url: `https://www.collegedata.fyi/schools/${school_id}`,
+    description: coverage.coverage_summary,
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
+
+      <header style={{ paddingTop: 48, paddingBottom: 32 }}>
+        <div className="meta" style={{ marginBottom: 16 }}>
+          § Institution directory
+        </div>
+        <h1
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: "clamp(36px, 5.5vw, 56px)",
+            lineHeight: 1.05,
+            margin: 0,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          {head}
+          {tail && (
+            <>
+              {" "}
+              <span style={{ fontStyle: "italic", color: "var(--ink-2)" }}>{tail}</span>
+            </>
+          )}
+        </h1>
+        {location && (
+          <div
+            className="mono"
+            style={{ marginTop: 12, fontSize: 13, color: "var(--ink-3)" }}
+          >
+            {location}
+            {coverage.undergraduate_enrollment != null && (
+              <span style={{ marginLeft: 16 }}>
+                {coverage.undergraduate_enrollment.toLocaleString()} undergraduates
+              </span>
+            )}
+          </div>
+        )}
+      </header>
+
+      <section
+        className="cd-card"
+        style={{ padding: "28px 32px", marginTop: 8 }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+            marginBottom: 16,
+          }}
+        >
+          <CoverageBadge
+            status={coverage.coverage_status}
+            label={coverage.coverage_label}
+          />
+          {lastChecked && (
+            <span
+              className="mono"
+              style={{ fontSize: 11, color: "var(--ink-3)", letterSpacing: "0.05em" }}
+            >
+              LAST CHECKED {lastChecked.toUpperCase()}
+            </span>
+          )}
+        </div>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 16,
+            lineHeight: 1.55,
+            color: "var(--ink)",
+            maxWidth: 640,
+          }}
+        >
+          {coverage.coverage_summary}
+        </p>
+        {coverage.website_url && (
+          <p
+            className="mono"
+            style={{ marginTop: 20, fontSize: 12, color: "var(--ink-3)" }}
+          >
+            School website:{" "}
+            <a
+              href={coverage.website_url.startsWith("http")
+                ? coverage.website_url
+                : `https://${coverage.website_url}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {coverage.website_url.replace(/^https?:\/\//, "")}
+            </a>
+          </p>
+        )}
+      </section>
+
+      <p
+        style={{
+          marginTop: 32,
+          fontSize: 14,
+          color: "var(--ink-3)",
+          maxWidth: 640,
+        }}
+      >
+        We track every active, undergraduate-serving Title-IV institution.
+        When we archive a public Common Data Set for this school, full
+        outcomes will appear here. <Link href="/about">Read the method</Link>.
+      </p>
     </div>
   );
 }

--- a/web/src/components/CoverageBadge.tsx
+++ b/web/src/components/CoverageBadge.tsx
@@ -1,0 +1,36 @@
+// Coverage status pill for institution_cds_coverage rows. Maps the
+// coverage_status_t enum to one of the four .cd-chip variants in
+// tokens.css (default outline / forest-filled / ochre / brick), with
+// the user-facing copy coming from coverage_status_label() server-side.
+//
+// Design system (DESIGN_SYSTEM.md):
+//   - .cd-chip          outline, neutral — most factual states
+//   - .cd-chip--forest  positive — only for cds_available_current
+//   - .cd-chip--ochre   rare emphasis — extraction needing review
+//   - .cd-chip--brick   alarm/destructive — never used here, since
+//                       PRD line 138 warns against accusatory tone
+
+import type { CoverageStatus } from "@/lib/types";
+
+const VARIANT: Record<CoverageStatus, string> = {
+  cds_available_current: "cd-chip cd-chip--forest",
+  cds_available_stale: "cd-chip",
+  cds_found_processing: "cd-chip",
+  latest_found_extract_failed_with_prior_available: "cd-chip",
+  extract_failed: "cd-chip cd-chip--ochre",
+  source_not_automatically_accessible: "cd-chip",
+  no_public_cds_found: "cd-chip",
+  verified_absent: "cd-chip",
+  not_checked: "cd-chip",
+  out_of_scope: "cd-chip",
+};
+
+export function CoverageBadge({
+  status,
+  label,
+}: {
+  status: CoverageStatus;
+  label: string;
+}) {
+  return <span className={VARIANT[status] ?? "cd-chip"}>{label}</span>;
+}

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -2,47 +2,97 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import type { SchoolSummary } from "@/lib/types";
+import { supabase } from "@/lib/supabase";
+import type { InstitutionSearchResult } from "@/lib/types";
+import { CoverageBadge } from "./CoverageBadge";
 
-export function SchoolSearch({ schools }: { schools: SchoolSummary[] }) {
+// PRD 015 M4 — server-backed autocomplete over institution_cds_coverage.
+// Calls the search_institutions RPC with a debounced query so missing-
+// CDS and not-yet-checked schools surface as first-class results. The
+// RPC ranks name-exact > prefix > substring; we just render the order
+// it returns.
+//
+// Replaces the prior in-memory ILIKE that only knew about CDS-backed
+// schools (see git blame for the swap).
+
+const DEBOUNCE_MS = 220;
+
+export function SchoolSearch() {
   const [query, setQuery] = useState("");
+  const [results, setResults] = useState<InstitutionSearchResult[]>([]);
   const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
-
-  const filtered = query.length > 0
-    ? schools.filter((s) =>
-        s.school_name.toLowerCase().includes(query.toLowerCase())
-      ).slice(0, 10)
-    : [];
+  // Generation counter so a slow network response can never overwrite
+  // a fresher one. Each new query increments; only the latest gen
+  // commits to state.
+  const genRef = useRef(0);
 
   useEffect(() => {
-    setSelectedIndex(0);
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+    const gen = ++genRef.current;
+    setIsLoading(true);
+    const timer = setTimeout(async () => {
+      // database.types.ts lags new RPCs until regenerated; cast to a
+      // permissive shape so the call typechecks. Same pattern queries.ts
+      // uses for tables that aren't in the generated type yet.
+      const rpcClient = supabase as unknown as {
+        rpc: (
+          fn: string,
+          args: Record<string, unknown>,
+        ) => Promise<{
+          data: InstitutionSearchResult[] | null;
+          error: { message: string } | null;
+        }>;
+      };
+      const { data, error } = await rpcClient.rpc("search_institutions", {
+        p_query: trimmed,
+        p_limit: 10,
+      });
+      if (gen !== genRef.current) return; // a newer query has fired
+      setIsLoading(false);
+      if (error) {
+        setResults([]);
+        return;
+      }
+      setResults(data ?? []);
+      setSelectedIndex(0);
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
   }, [query]);
 
   function handleSelect(schoolId: string) {
     setIsOpen(false);
     setQuery("");
+    setResults([]);
     router.push(`/schools/${schoolId}`);
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (!isOpen || filtered.length === 0) return;
+    if (!isOpen || results.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      handleSelect(filtered[selectedIndex].school_id);
+      handleSelect(results[selectedIndex].school_id);
     } else if (e.key === "Escape") {
       setIsOpen(false);
     }
   }
+
+  const showDropdown = isOpen && (results.length > 0 || (isLoading && query.trim().length > 0));
 
   return (
     <div className="relative w-full max-w-lg mx-auto">
@@ -57,28 +107,88 @@ export function SchoolSearch({ schools }: { schools: SchoolSummary[] }) {
         onFocus={() => setIsOpen(true)}
         onBlur={() => setTimeout(() => setIsOpen(false), 200)}
         onKeyDown={handleKeyDown}
-        placeholder={`Search ${schools.length} schools...`}
-        className="w-full rounded-lg border border-gray-300 px-4 py-3 text-lg shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
+        placeholder="Search schools by name, alias, or city..."
+        className="w-full px-4 py-3"
+        style={{
+          border: "1px solid var(--rule-strong)",
+          background: "#faf6ec",
+          color: "var(--ink)",
+          fontFamily: "var(--sans)",
+          fontSize: 16,
+          borderRadius: 2,
+          outline: "none",
+        }}
+        onFocusCapture={(e) => {
+          e.currentTarget.style.borderColor = "var(--forest)";
+        }}
+        onBlurCapture={(e) => {
+          e.currentTarget.style.borderColor = "var(--rule-strong)";
+        }}
       />
-      {isOpen && filtered.length > 0 && (
+      {showDropdown && (
         <ul
           ref={listRef}
-          className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg max-h-80 overflow-auto"
+          className="absolute z-10 mt-1 w-full overflow-auto"
+          style={{
+            background: "#faf6ec",
+            border: "1px solid var(--rule-strong)",
+            borderRadius: 2,
+            maxHeight: 360,
+          }}
         >
-          {filtered.map((school, i) => (
+          {results.length === 0 && isLoading && (
             <li
-              key={school.school_id}
-              onMouseDown={() => handleSelect(school.school_id)}
-              className={`px-4 py-2.5 cursor-pointer text-sm ${
-                i === selectedIndex
-                  ? "bg-blue-50 text-blue-900"
-                  : "text-gray-700 hover:bg-gray-50"
-              }`}
+              className="px-4 py-3 mono"
+              style={{ color: "var(--ink-3)", fontSize: 12 }}
             >
-              <span className="font-medium">{school.school_name}</span>
-              <span className="ml-2 text-gray-400">
-                {school.doc_count} doc{school.doc_count !== 1 ? "s" : ""}
-              </span>
+              Searching…
+            </li>
+          )}
+          {results.map((r, i) => (
+            <li
+              key={r.school_id}
+              onMouseDown={() => handleSelect(r.school_id)}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr auto",
+                gap: 12,
+                alignItems: "baseline",
+                padding: "10px 14px",
+                cursor: "pointer",
+                background: i === selectedIndex ? "var(--paper-2)" : "transparent",
+                borderTop: i === 0 ? "none" : "1px solid var(--rule)",
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div
+                  style={{
+                    fontFamily: "var(--serif)",
+                    fontSize: 17,
+                    color: "var(--ink)",
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {r.school_name}
+                </div>
+                {(r.city || r.state) && (
+                  <div
+                    className="mono"
+                    style={{
+                      fontSize: 11,
+                      color: "var(--ink-3)",
+                      marginTop: 2,
+                    }}
+                  >
+                    {[r.city, r.state].filter(Boolean).join(", ")}
+                    {r.latest_available_cds_year && (
+                      <span style={{ marginLeft: 12 }}>
+                        CDS {r.latest_available_cds_year}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+              <CoverageBadge status={r.coverage_status} label={r.coverage_label} />
             </li>
           ))}
         </ul>

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -10,6 +10,7 @@ import type {
   CorpusStats,
   ScorecardSummary,
   SiteStats,
+  InstitutionCoverage,
 } from "./types";
 
 // Documents with these participation_status values are excluded from every
@@ -235,6 +236,41 @@ export const fetchSiteStats = cache(async function fetchSiteStats(): Promise<Sit
     scorecard_refreshed_at: scorecardLatest.error ? null : scorecardLatest.data?.refreshed_at ?? null,
   };
 });
+
+// PRD 015 M4 — institution_cds_coverage row by school_id.
+//
+// Used by the school detail page when fetchSchoolDocuments returns
+// empty: if a coverage row exists, render the directory-only stub
+// (name, location, badge, summary). Returns null when the slug isn't
+// in the materialized table at all (or the table itself is missing
+// in a pre-migration environment), in which case the page genuinely
+// 404s.
+//
+// Tolerant of all errors: this is a defensive stub fetch whose only
+// failure mode should be "render a 404." Throwing would surface a
+// 500 to the user for a slug that simply has no coverage row, which
+// is strictly worse UX than showing the not-found page. RLS already
+// hides out_of_scope rows from anon.
+export const fetchInstitutionCoverage = cache(
+  async function fetchInstitutionCoverage(
+    schoolId: string,
+  ): Promise<InstitutionCoverage | null> {
+    try {
+      const { data, error } = await (supabase as unknown as UntypedSupabase)
+        .from("institution_cds_coverage")
+        .select(
+          "ipeds_id, school_id, school_name, city, state, website_url, undergraduate_enrollment, coverage_status, coverage_label, coverage_summary, latest_available_cds_year, last_checked_at, can_submit_source",
+        )
+        .eq("school_id", schoolId)
+        .maybeSingle();
+
+      if (error) return null;
+      return (data as InstitutionCoverage | null) ?? null;
+    } catch {
+      return null;
+    }
+  },
+);
 
 export const fetchSchoolDocuments = cache(async function fetchSchoolDocuments(
   schoolId: string

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -63,6 +63,53 @@ export interface SchoolSummary {
   has_extracted: boolean;
 }
 
+// PRD 015 M3 — coverage_status_t enum from
+// supabase/migrations/20260429144126_institution_cds_coverage.sql.
+// Out_of_scope is hidden by RLS for anon/authenticated, so it should
+// never appear in any payload reaching the frontend, but it's listed
+// here so the union type stays exhaustive against the DB enum.
+export type CoverageStatus =
+  | "cds_available_current"
+  | "cds_available_stale"
+  | "cds_found_processing"
+  | "latest_found_extract_failed_with_prior_available"
+  | "extract_failed"
+  | "source_not_automatically_accessible"
+  | "no_public_cds_found"
+  | "verified_absent"
+  | "not_checked"
+  | "out_of_scope";
+
+// search_institutions() RPC return shape (PRD 015 M4).
+export interface InstitutionSearchResult {
+  school_id: string;
+  school_name: string;
+  city: string | null;
+  state: string | null;
+  coverage_status: CoverageStatus;
+  coverage_label: string;
+  latest_available_cds_year: string | null;
+}
+
+// fetchInstitutionCoverage() return shape — a single row from
+// institution_cds_coverage for the school detail page directory-only
+// stub (PRD 015 M4 stub for M5).
+export interface InstitutionCoverage {
+  ipeds_id: string;
+  school_id: string;
+  school_name: string;
+  city: string | null;
+  state: string | null;
+  website_url: string | null;
+  undergraduate_enrollment: number | null;
+  coverage_status: CoverageStatus;
+  coverage_label: string;
+  coverage_summary: string;
+  latest_available_cds_year: string | null;
+  last_checked_at: string | null;
+  can_submit_source: boolean;
+}
+
 export interface CorpusStats {
   total_schools: number;
   total_documents: number;


### PR DESCRIPTION
## Summary

Replaces the homepage autocomplete's hardcoded in-memory ILIKE — which only knew about CDS-backed schools — with a server-backed search over the new \`institution_cds_coverage\` table. After this lands, typing **Rice** into the search box returns Rice University with a \`Not checked yet\` badge instead of silence. PRD lines 39–51 frame this as a trust-signal issue: silent absence reads as "we don't know this school exists," and that's the wrong product stance.

Plus a minimal \`/schools/[slug]\` stub for directory-only schools so clicking a search result doesn't dead-end at a 404.

**Backend**
- \`search_institutions(p_query text, p_limit int)\` RPC. Substring match on \`search_text\` (name + aliases + city + state, lowercased). Ranks name-exact > prefix > substring, with enrollment as tie-breaker. \`SECURITY INVOKER\` so the existing RLS policy hides \`out_of_scope\` rows. Inline self-test covers exact / prefix / substring / blank-query cases.

**Frontend (web/)**
- \`CoverageBadge\` maps \`coverage_status_t\` to \`cd-chip\` variants from \`tokens.css\`. \`cds_available_current\` → forest fill, \`extract_failed\` → ochre, everything else → default outline (factual, never alarmist — PRD line 138).
- \`SchoolSearch\` refactored from prop-driven hardcoded list to debounced (220ms) RPC call. Generation counter prevents stale responses from overwriting fresher queries. Replaces blue Tailwind focus styles with forest border + paper-2 hover row.
- \`/schools/[slug]\` falls through to \`fetchInstitutionCoverage\` when \`fetchSchoolDocuments\` is empty. If a coverage row exists, renders \`DirectoryOnlySchoolPage\` (serif name, location + enrollment caption, \`.cd-card\` panel with badge + summary + last-checked date + linked website). Genuine 404 when neither query finds the slug.
- \`fetchInstitutionCoverage\` is **error-tolerant** — returns null for any failure rather than throwing 500. Defensive because pre-merge environments don't have the table at all.

## Architecture decision: homepage search only, not /browse

PRD's "search" framing throughout is about the **find-a-school entry point**, not the analytical \`/browse\` page. \`/browse\` is for filtering by acceptance rate, enrollment, etc. — schools without CDS have nothing to filter on, so adding them would clutter rather than clarify. \`/browse\` belongs with PRD M6 (coverage page) if anything.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean (with prod env vars set)
- [x] Local dev server: homepage renders, search input has correct design-system styles
- [x] Typing fires RPC; pre-deploy 404s gracefully (empty dropdown, no crash)
- [x] \`/schools/harvard\` regression check: CDS-backed flow unchanged
- [x] \`/schools/this-school-does-not-exist\`: returns 404 correctly via the new fallback
- [ ] Post-merge: \`supabase db push --linked\` runs the search-RPC self-test against prod data
- [ ] Post-merge: refresh-coverage cron runs (or manual curl), populating \`institution_cds_coverage\`. Then live test: typing "rice" should return Rice University with a coverage badge

## Out of scope (deferred to M5)

- Full Scorecard baseline metrics on the directory-only page
- Source-submission CTA (\`can_submit_source\` is fetched but not yet rendered as a form)
- \`/browse\` page integration — analytical filters require CDS data, so \`/browse\` stays CDS-only by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)