### PR TITLE
PRD 015 M5: directory-only schools get Scorecard + submission CTA

### DIFF
--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -11,6 +11,7 @@ import { OutcomesSection } from "@/components/OutcomesSection";
 import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
 import { Sparkline } from "@/components/Sparkline";
 import { CoverageBadge } from "@/components/CoverageBadge";
+import { SubmissionForm } from "@/components/SubmissionForm";
 import { yearRange } from "@/lib/format";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
 
@@ -360,24 +361,26 @@ export default async function SchoolDetailPage({
   );
 }
 
-// PRD 015 M4 — minimal directory-only school page.
+// PRD 015 M5 — directory-only school page.
 //
 // Renders for in-scope institution_cds_coverage rows that have no
-// cds_documents row yet (most often: not_checked, no_public_cds_found,
+// cds_documents row yet (typically not_checked, no_public_cds_found,
 // source_not_automatically_accessible, verified_absent). The page
-// delivers on the search-promised result without faking CDS data we
-// don't have.
+// delivers on the search-promised result, gives federal Scorecard
+// baseline data so the school still feels first-class, and invites a
+// source submission when can_submit_source is true.
 //
-// PRD M5 will elaborate this with Scorecard baseline metrics + a
-// proper source-submission CTA. The v1 here is the smallest thing
-// that breaks the search-then-404 dead-end.
-function DirectoryOnlySchoolPage({
+// M4 originally shipped this as a search-dead-end stub. M5 layers on
+// the federal outcomes section + the Formspree-backed submission form.
+async function DirectoryOnlySchoolPage({
   coverage,
   school_id,
 }: {
   coverage: InstitutionCoverage;
   school_id: string;
 }) {
+  const scorecard = await fetchScorecardByIpedsId(coverage.ipeds_id);
+
   const { head, tail } = splitInstitutionalSuffix(coverage.school_name);
   const location = [coverage.city, coverage.state].filter(Boolean).join(", ");
   const lastChecked = coverage.last_checked_at
@@ -497,17 +500,49 @@ function DirectoryOnlySchoolPage({
         )}
       </section>
 
+      {coverage.can_submit_source && (
+        <SubmissionForm
+          school_id={school_id}
+          school_name={coverage.school_name}
+          coverage_status={coverage.coverage_status}
+        />
+      )}
+
+      {scorecard ? (
+        <div style={{ marginTop: 56 }}>
+          <OutcomesSection scorecard={scorecard} />
+        </div>
+      ) : (
+        <p
+          className="mono"
+          style={{
+            marginTop: 56,
+            fontSize: 12,
+            color: "var(--ink-3)",
+            letterSpacing: "0.05em",
+          }}
+        >
+          FEDERAL OUTCOMES DATA NOT AVAILABLE FOR THIS INSTITUTION.
+        </p>
+      )}
+
+      {scorecard && (
+        <div style={{ marginTop: 24 }}>
+          <ScorecardVintageNote scorecard={scorecard} />
+        </div>
+      )}
+
       <p
         style={{
-          marginTop: 32,
+          marginTop: 40,
           fontSize: 14,
           color: "var(--ink-3)",
           maxWidth: 640,
         }}
       >
-        We track every active, undergraduate-serving Title-IV institution.
-        When we archive a public Common Data Set for this school, full
-        outcomes will appear here. <Link href="/about">Read the method</Link>.
+        We track every active, undergraduate-serving Title-IV institution
+        and refresh CDS coverage every 15 minutes. Federal data above
+        comes from College Scorecard. <Link href="/about">Read the method</Link>.
       </p>
     </div>
   );

--- a/web/src/components/SubmissionForm.tsx
+++ b/web/src/components/SubmissionForm.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+// PRD 015 M5 — public source-submission form for directory-only and
+// no-public-CDS-found schools (anywhere can_submit_source is true).
+//
+// Posts to a Formspree endpoint when NEXT_PUBLIC_FORMSPREE_ENDPOINT is
+// configured; falls back to a mailto: link otherwise so the CTA is
+// never broken in environments missing the env var. The fallback uses
+// the same destination address Formspree forwards to so behavior is
+// consistent across paths.
+//
+// Form fields:
+//   school_id       hidden, identifies the submission
+//   school_name     hidden, gives the operator a readable subject
+//   coverage_status hidden, lets operator triage (verified_absent vs
+//                   no_public_cds_found vs not_checked submissions
+//                   warrant different reviews)
+//   url             required, the public CDS URL the user found
+//   note            optional, free-text context ("This is the IR page
+//                   for the Honors College, not the main CDS")
+//   submitter_email optional, lets us follow up if needed
+//
+// PRD M7 will swap the Formspree endpoint for a real backend once the
+// public-upload pipeline ships. The component shape stays the same.
+
+import { useState } from "react";
+import type { CoverageStatus } from "@/lib/types";
+
+const MAILTO_FALLBACK = "anthony+collegedata@bolewood.com";
+
+export function SubmissionForm({
+  school_id,
+  school_name,
+  coverage_status,
+}: {
+  school_id: string;
+  school_name: string;
+  coverage_status: CoverageStatus;
+}) {
+  const formspreeEndpoint = process.env.NEXT_PUBLIC_FORMSPREE_ENDPOINT;
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!formspreeEndpoint) return; // shouldn't happen — form is only rendered when set
+    setStatus("submitting");
+    setErrorMessage(null);
+    const formData = new FormData(e.currentTarget);
+    try {
+      const response = await fetch(formspreeEndpoint, {
+        method: "POST",
+        body: formData,
+        headers: { Accept: "application/json" },
+      });
+      if (response.ok) {
+        setStatus("success");
+      } else {
+        const body = await response.json().catch(() => ({}));
+        setErrorMessage(
+          (body as { error?: string })?.error ??
+            `Submission failed (HTTP ${response.status}). Try again or email ${MAILTO_FALLBACK}.`,
+        );
+        setStatus("error");
+      }
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${(err as Error).message}. Try again or email ${MAILTO_FALLBACK}.`,
+      );
+      setStatus("error");
+    }
+  }
+
+  // ── Mailto fallback when Formspree isn't configured ──────────────
+  // Encodes school context into the subject + body so the operator
+  // doesn't have to ask the submitter to identify the school.
+  if (!formspreeEndpoint) {
+    const subject = encodeURIComponent(`[CDS source] ${school_name}`);
+    const body = encodeURIComponent(
+      `School: ${school_name}\nschool_id: ${school_id}\ncoverage_status: ${coverage_status}\n\nWhere I found the CDS:\n\n\nNotes:\n`,
+    );
+    return (
+      <div
+        className="cd-card"
+        style={{ padding: "24px 28px", marginTop: 24 }}
+      >
+        <div className="meta" style={{ marginBottom: 10 }}>
+          § Help us find this one
+        </div>
+        <p style={{ margin: 0, fontSize: 15, lineHeight: 1.55 }}>
+          Know where {school_name} publishes its Common Data Set?{" "}
+          <a href={`mailto:${MAILTO_FALLBACK}?subject=${subject}&body=${body}`}>
+            Send us the link.
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  // ── Success state ─────────────────────────────────────────────────
+  if (status === "success") {
+    return (
+      <div
+        className="cd-card"
+        style={{ padding: "24px 28px", marginTop: 24 }}
+      >
+        <div className="meta" style={{ marginBottom: 10 }}>
+          § Submitted
+        </div>
+        <p style={{ margin: 0, fontSize: 15, lineHeight: 1.55 }}>
+          Thanks. We&rsquo;ll review the link for {school_name} and
+          archive it if it&rsquo;s a public CDS source. If we have
+          questions we&rsquo;ll reach out to the email you provided.
+        </p>
+      </div>
+    );
+  }
+
+  // ── Active form ──────────────────────────────────────────────────
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="cd-card"
+      style={{ padding: "24px 28px", marginTop: 24 }}
+    >
+      <div className="meta" style={{ marginBottom: 10 }}>
+        § Help us find this one
+      </div>
+      <p style={{ margin: "0 0 20px", fontSize: 15, lineHeight: 1.55 }}>
+        Know where {school_name} publishes its Common Data Set? Send us
+        the link and we&rsquo;ll archive it.
+      </p>
+
+      <input type="hidden" name="school_id" value={school_id} />
+      <input type="hidden" name="school_name" value={school_name} />
+      <input type="hidden" name="coverage_status" value={coverage_status} />
+      <input
+        type="hidden"
+        name="_subject"
+        value={`[CDS source] ${school_name}`}
+      />
+
+      <FormField label="CDS URL" required>
+        <input
+          name="url"
+          type="url"
+          required
+          placeholder="https://ir.example.edu/cds/2024-25.pdf"
+          style={inputStyle}
+        />
+      </FormField>
+
+      <FormField label="Where did you find it? (optional)">
+        <textarea
+          name="note"
+          rows={3}
+          placeholder="e.g., linked from the IR page, or sent to me by the registrar"
+          style={{ ...inputStyle, fontFamily: "var(--sans)", resize: "vertical" }}
+        />
+      </FormField>
+
+      <FormField label="Your email (optional, for follow-up)">
+        <input
+          name="submitter_email"
+          type="email"
+          placeholder="you@example.com"
+          style={inputStyle}
+        />
+      </FormField>
+
+      {status === "error" && errorMessage && (
+        <p
+          style={{
+            margin: "0 0 14px",
+            fontSize: 13,
+            color: "var(--brick)",
+          }}
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="cd-btn"
+        style={{ marginTop: 4 }}
+      >
+        {status === "submitting" ? "Sending…" : "Send the link"}
+      </button>
+    </form>
+  );
+}
+
+function FormField({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <label style={{ display: "block", marginBottom: 16 }}>
+      <span
+        className="meta"
+        style={{ display: "block", marginBottom: 6, color: "var(--ink-2)" }}
+      >
+        {label}
+        {required && <span style={{ color: "var(--ink-3)" }}> *</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "9px 12px",
+  border: "1px solid var(--rule-strong)",
+  background: "var(--paper)",
+  color: "var(--ink)",
+  fontFamily: "var(--sans)",
+  fontSize: 15,
+  borderRadius: 2,
+  outline: "none",
+};

--- a/web/src/components/SubmissionForm.tsx
+++ b/web/src/components/SubmissionForm.tsx
@@ -108,9 +108,7 @@ export function SubmissionForm({
           § Submitted
         </div>
         <p style={{ margin: 0, fontSize: 15, lineHeight: 1.55 }}>
-          Thanks. We&rsquo;ll review the link for {school_name} and
-          archive it if it&rsquo;s a public CDS source. If we have
-          questions we&rsquo;ll reach out to the email you provided.
+          {`Thanks. We’ll review the link for ${school_name} and archive it if it’s a public CDS source. If we have questions we’ll reach out to the email you provided.`}
         </p>
       </div>
     );
@@ -127,8 +125,7 @@ export function SubmissionForm({
         § Help us find this one
       </div>
       <p style={{ margin: "0 0 20px", fontSize: 15, lineHeight: 1.55 }}>
-        Know where {school_name} publishes its Common Data Set? Send us
-        the link and we&rsquo;ll archive it.
+        {`Know where ${school_name} publishes its Common Data Set? Send us the link and we’ll archive it.`}
       </p>
 
       <input type="hidden" name="school_id" value={school_id} />


### PR DESCRIPTION
## Summary

Layers federal outcomes data and a public source-submission form onto the M4 directory-only stub. After this lands, schools like Cincinnati and Tarrant County College — known to exist but with no public CDS — render a complete page: name, location, coverage badge, federal earnings + completion + retention metrics, method note, and an explicit "send us the link" CTA. The page stops feeling like a stub.

**What ships**

- \`DirectoryOnlySchoolPage\` now async; awaits \`fetchScorecardByIpedsId\` and renders \`OutcomesSection\` + \`ScorecardVintageNote\` alongside the existing coverage panel. Schools without Scorecard data show the same \`FEDERAL OUTCOMES NOT AVAILABLE\` caption the CDS-backed page uses, for symmetry.
- New \`SubmissionForm\` (client). Reads \`NEXT_PUBLIC_FORMSPREE_ENDPOINT\`; renders a Formspree-backed form when set, falls back to a mailto link to \`anthony+collegedata@bolewood.com\` when unset. Subject + body encode school context so submissions don't require operator follow-up to identify the school.
- Hidden fields carry \`school_id\`, \`school_name\`, \`coverage_status\` (lets operator triage \`verified_absent\` vs \`no_public_cds_found\` vs \`not_checked\` submissions differently). Visible fields: required URL, optional context note, optional submitter email. Success state replaces the form with a "thanks" message; error state surfaces Formspree's response with the mailto address as manual fallback.
- Form only renders when \`can_submit_source\` is true. \`cds_available_*\` rows skip it because the existing source URL is correct, not in need of a fresh submission.
- Method footer mentions the 15-minute coverage refresh and Scorecard provenance.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] Local dev: \`/schools/university-of-cincinnati-main-campus\` renders the full page (badge, summary, mailto submission section, Earnings + Completion bands, vintage note). No console errors.
- [x] Existing CDS-backed pages unchanged
- [ ] **After merge: set \`NEXT_PUBLIC_FORMSPREE_ENDPOINT\` in Vercel env** (and locally in \`web/.env.local\` if you want to test the form path). Without it, the mailto fallback is the active CTA — that's safe behavior, not a bug.

## Setup steps for the Formspree path (one-time)

1. Create a form at https://formspree.io targeting \`anthony+collegedata@bolewood.com\`
2. Copy the endpoint URL (\`https://formspree.io/f/<id>\`)
3. Add to Vercel env as \`NEXT_PUBLIC_FORMSPREE_ENDPOINT\` (Production + Preview)
4. Redeploy to pick up the env var

## Out of scope

- Submission moderation pipeline (PRD M7 still owns this — current setup just routes to email)
- Auto-archiving submitted URLs (also M7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)