### PR TITLE
Fix launch trust gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,11 @@ jobs:
       - name: Build web app
         working-directory: web
         run: npm run build
+      - name: Install Playwright browser
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+      - name: Run frontend smoke tests
+        working-directory: web
+        env:
+          PLAYWRIGHT_WEB_SERVER_COMMAND: "npm run start"
+        run: npm run test:smoke

--- a/README.md
+++ b/README.md
@@ -36,14 +36,22 @@ We also archive source files on discovery, because some schools do occasionally 
 
 **Query the API:**
 ```bash
+ANON_KEY="<copy the public anon key from https://www.collegedata.fyi/api>"
+
 # List all schools in the manifest
-curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?select=school_id,school_name,canonical_year&order=school_name'
+curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?select=school_id,school_name,canonical_year&order=school_name' \
+  -H "apikey: $ANON_KEY" \
+  -H "Authorization: Bearer $ANON_KEY"
 
 # Find a specific school's documents
-curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?school_id=eq.yale&order=canonical_year.desc'
+curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?school_id=eq.yale&order=canonical_year.desc' \
+  -H "apikey: $ANON_KEY" \
+  -H "Authorization: Bearer $ANON_KEY"
 
 # Get the structured extract for a document
-curl 'https://api.collegedata.fyi/rest/v1/cds_artifacts?document_id=eq.<uuid>&kind=eq.canonical'
+curl 'https://api.collegedata.fyi/rest/v1/cds_artifacts?document_id=eq.<uuid>&kind=eq.canonical' \
+  -H "apikey: $ANON_KEY" \
+  -H "Authorization: Bearer $ANON_KEY"
 ```
 
 ## How it works

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -10,62 +10,6 @@ Sections are ordered **Open → Resolved → Strategic context**. Every open ite
 
 ## Open
 
-### Coverage data quality (PRD 015 audit, 2026-04-29)
-
-A reconciliation between the homepage's `697 schools` (distinct `school_id`s
-in `cds_manifest`) and the `/coverage` page's `2,924 in-scope` (rows in
-`institution_cds_coverage` excluding `out_of_scope`) surfaced three
-data-quality items not blocking shipment but worth tracking:
-
-- **Slug fragmentation between schools.yaml and Scorecard slugs.** ~5–7
-  schools (UVA, U Washington Seattle Campus, Texas A&M College Station,
-  Rutgers New Brunswick, Georgia Tech, Tulane, Virginia Tech) appear in
-  `cds_documents` under long Scorecard-style `school_id` values
-  (`university-of-virginia-main-campus`) while `institution_directory`
-  uses the canonical short slugs from schools.yaml (`uva`). Same school,
-  two `school_id` values, no row-level reconciliation. The mirror
-  pipeline (College Transitions ingest) is the likely originator
-  because it slugifies Scorecard `INSTNM`. Effect: each affected school
-  shows up twice in the homepage's distinct-school count, and the
-  Scorecard-slug variant has zero coverage row at all so it disappears
-  from `/coverage`. **Fix shape:** either canonicalize at archive time
-  via the `institution_slug_crosswalk` (rewrite `cds_documents.school_id`
-  for any IPEDS that has a `schools_yaml`-source crosswalk row pointing
-  at a different canonical), or add the Scorecard slugs to the crosswalk
-  with `source='redirect'` so consumers can resolve through the
-  crosswalk. **Effort:** ~2 hours: a one-shot migration that walks
-  `cds_documents` + `institution_slug_crosswalk` joining on `ipeds_id`,
-  plus an archive-time guard so the mirror pipeline can't re-introduce
-  the divergence. **Affected schools (sample IPEDS):** UVA 234076,
-  U Washington Seattle 236948, Tulane 160755.
-
-- **Two schools missing from the Scorecard CSV entirely.** Bucknell
-  (IPEDS 211158) and Drexel (212160) are absent from both
-  `scorecard_summary` and `institution_directory`. We have CDS data for
-  both via `schools.yaml`, so they show up as `cds_manifest` rows but
-  have no coverage row. **Cause:** the March 2026 / 2022-23-vintage
-  Scorecard CSV from the federal data release doesn't include these
-  IPEDS. Could be a data-publication gap upstream or a federal-reporting
-  exemption granted to specific private universities for that cycle.
-  **Fix shape:** either (a) supplement `institution_directory` with a
-  manual `directory_source='operator_manual'` row keyed by IPEDS (the
-  loader already accepts this column), populated from IPEDS HD CSV
-  rather than Scorecard; or (b) flag upstream and wait for the next
-  Scorecard release to fix it. **Effort:** ~30 min for option (a) on a
-  per-IPEDS basis if more schools surface; ~0 for option (b).
-
-- **Stale system-office entries with CDS rows.** Four administrative
-  entities are in `cds_manifest` but should not have CDS docs:
-  `university-of-maine-system-central-office`,
-  `university-of-houston-system-administration`,
-  `university-of-hawaii-system-office`,
-  `the-university-of-texas-system-office`. The Maine entry already has
-  a partial backlog item below in "operational polish" — this groups
-  it with the others. **Fix:** flip `participation_status` to
-  `verified_absent` on each row (preserves history per the existing
-  takedown pattern in ADR 0008) and `extraction_status` to
-  `not_applicable`. **Effort:** ~10 minutes if done in a batch UPDATE.
-
 ### Near-term operational polish
 
 - **Ground-truth Tier 4 native-table candidates before LLM repair.** New
@@ -99,8 +43,6 @@ data-quality items not blocking shipment but worth tracking:
 - **Two schools pointing at the same archived file (U Maine System Central Office + U Southern Maine) — production DB cleanup pending.** schools.yaml side fixed 2026-04-15 in commit `59982f7` (flipped `university-of-maine-system-central-office` to `scrape_policy: verified_absent`). **Still pending: production DB cleanup.** The stale `cds_documents` row (id `6d0ef326-ce81-4f11-8214-125e29c1cd4f`, cds_year `2025-26`, status `extraction_pending`) and its `archive_queue` entry are still live. Operator action: either `UPDATE public.cds_documents SET participation_status = 'verified_absent', extraction_status = 'not_applicable' WHERE id = '6d0ef326-ce81-4f11-8214-125e29c1cd4f';` (preserves history) or `DELETE` outright; plus `DELETE FROM public.archive_queue WHERE school_id = 'university-of-maine-system-central-office';`. Broader class: `schools.yaml` entries populated via `last_method: brave` with `search_fallback_tried: true` should have their hint URLs cross-validated against the school's own domain before being accepted — a separate follow-up.
 
 ### Frontend polish
-
-- **Repo-native Playwright smoke tests.** Manual/local Playwright screenshot checks are being used for deploy smoke, but there is still no committed frontend smoke suite. Minimum: landing search works, `/browse` returns live rows + answerability metadata, school page source links resolve, and mobile filter layout does not overflow. **Effort:** ~45 minutes.
 
 - **Queryable browser CSV export pagination.** The `/browse` MVP exports the current browser result set through one Edge Function call capped at `page_size=500`. That is fine for current launch filters, but a broad export should page through all results or move export server-side before result sets grow. **Effort:** ~1 hour.
 
@@ -167,6 +109,35 @@ data-quality items not blocking shipment but worth tracking:
 ## Resolved
 
 Reverse chronological.
+
+### 2026-04-29
+
+- **[RESOLVED 2026-04-29] ~~Coverage data-quality launch cleanup.~~**
+  The PRD 015 audit found three launch-trust issues in the coverage layer:
+  slug fragmentation between schools.yaml canonical slugs and Scorecard-style
+  mirror slugs, Bucknell/Drexel missing from `/coverage`, and stale
+  administrative system-office rows with CDS documents. Shipped
+  `20260429190000_launch_coverage_data_quality.sql`: corrects Bucknell and
+  Drexel IPEDS IDs in existing rows, repairs their `institution_directory`
+  / `institution_slug_crosswalk` canonical slugs, canonicalizes
+  non-conflicting `cds_documents` rows through the primary schools.yaml
+  crosswalk, preserves remaining old aliases as redirects, marks the four
+  system offices `verified_absent` / `not_applicable`, deletes their
+  queue entries, and refreshes `institution_cds_coverage`. Also corrected
+  `tools/finder/schools.yaml` so future loads preserve `bucknell` and
+  `drexel`, with a regression test pinning their NCES UNITIDs.
+
+- **[RESOLVED 2026-04-29] ~~Repo-native Playwright smoke tests.~~**
+  Added `web/tests/smoke.spec.ts` and `web/playwright.config.ts` with
+  smoke coverage for homepage institution search, `/coverage`, `/browse`
+  live rows + source-link HTTP resolution, `/api/facts/mit` JSON, and
+  mobile body-overflow checks. The web CI job now installs Chromium and
+  runs `npm run test:smoke` against the production Next build.
+
+- **[RESOLVED 2026-04-29] ~~API launch copy drift.~~** README curl examples
+  now include the required public Supabase anon key headers, the Show HN
+  draft no longer claims raw PostgREST is headerless, and the facts endpoint
+  no longer links to a nonexistent `/api/facts/{school_id}/full` route.
 
 ### 2026-04-28
 

--- a/docs/blog/show-hn-draft.md
+++ b/docs/blog/show-hn-draft.md
@@ -28,7 +28,7 @@ I fixed that.
 
 - 697 schools indexed, 3,924 archived CDS documents, 98% extracted to a canonical 1,105-field schema
 - Five of six extraction tiers running: filled XLSX (template cell-position map), fillable PDF (AcroForm direct read), flat PDF (Docling + schema-targeting cleaner), image-only scan (force-OCR), and structured HTML (normalizer that reuses the flat-PDF cleaner). DOCX is the only tier still pending
-- Public read-only REST API at `api.collegedata.fyi` — query the whole corpus without a login
+- Public read-only REST API at `api.collegedata.fyi` — query the whole corpus with a public anon key, no account required
 - Public LLM-citable endpoint at `/api/facts/{school_id}` with the most-asked fields in a flat JSON shape
 - 94% accuracy on hand-audited schools (Harvard, Yale, Dartmouth, Harvey Mudd)
 - Source files archived on first discovery. If a school removes their CDS, the archive retains the original
@@ -41,7 +41,7 @@ I fixed that.
 
 - Browse: https://collegedata.fyi
 - A big-name example: https://www.collegedata.fyi/schools/mit (four years of CDS, all HTML-sourced)
-- The API, no auth: `curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?school_id=eq.yale&order=canonical_year.desc'`
+- API docs and key: https://www.collegedata.fyi/api
 - LLM-friendly facts: `curl 'https://www.collegedata.fyi/api/facts/mit'`
 - Code: https://github.com/bolewood/collegedata-fyi (MIT license)
 

--- a/supabase/migrations/20260429190000_launch_coverage_data_quality.sql
+++ b/supabase/migrations/20260429190000_launch_coverage_data_quality.sql
@@ -1,0 +1,171 @@
+-- Launch coverage data-quality cleanup.
+--
+-- Addresses the PRD 015 audit findings that directly affect public
+-- coverage/search trust before launch:
+--   1. Correct stale Bucknell/Drexel IPEDS IDs that prevented their
+--      CDS-backed rows from joining to Scorecard directory rows.
+--   2. Canonicalize non-conflicting cds_documents rows whose IPEDS ID
+--      points at a primary schools.yaml slug but whose school_id is a
+--      Scorecard-style alias.
+--   3. Preserve remaining alias routes in institution_slug_crosswalk as
+--      redirects so consumers can resolve old/Scorecard-style slugs.
+--   4. Mark stale system-office CDS rows as verified_absent and remove
+--      their archive queue work.
+
+begin;
+
+-- Bucknell and Drexel had stale IPEDS IDs in schools.yaml, so production
+-- rows inserted before this migration can carry the wrong ID. The NCES
+-- institution profiles identify Bucknell as 211291 and Drexel as 212054.
+update public.cds_documents
+set ipeds_id = case school_id
+  when 'bucknell' then '211291'
+  when 'drexel' then '212054'
+  else ipeds_id
+end
+where school_id in ('bucknell', 'drexel');
+
+-- If institution_directory was loaded while schools.yaml had the stale
+-- IDs, Scorecard rows for these institutions got auto-slugs instead of
+-- preserving the public canonical slugs. Repair that serving substrate.
+update public.institution_directory
+set school_id = 'bucknell',
+    directory_source = 'scorecard',
+    refreshed_at = now()
+where ipeds_id = '211291'
+  and school_id <> 'bucknell'
+  and not exists (
+    select 1
+    from public.institution_directory existing
+    where existing.school_id = 'bucknell'
+      and existing.ipeds_id <> '211291'
+  );
+
+update public.institution_directory
+set school_id = 'drexel',
+    directory_source = 'scorecard',
+    refreshed_at = now()
+where ipeds_id = '212054'
+  and school_id <> 'drexel'
+  and not exists (
+    select 1
+    from public.institution_directory existing
+    where existing.school_id = 'drexel'
+      and existing.ipeds_id <> '212054'
+  );
+
+-- Keep the crosswalk coherent after the directory slug repair. The
+-- Scorecard-style slugs remain aliases; the short schools.yaml slugs
+-- become primary.
+insert into public.institution_slug_crosswalk
+  (ipeds_id, school_id, alias, source, is_primary, reviewed_at)
+values
+  ('211291', 'bucknell', 'bucknell', 'schools_yaml', true, now()),
+  ('211291', 'bucknell', 'bucknell-university', 'scorecard', false, now()),
+  ('212054', 'drexel', 'drexel', 'schools_yaml', true, now()),
+  ('212054', 'drexel', 'drexel-university', 'scorecard', false, now())
+on conflict (ipeds_id, alias) do update
+set school_id = excluded.school_id,
+    source = excluded.source,
+    is_primary = excluded.is_primary,
+    reviewed_at = excluded.reviewed_at;
+
+-- Ensure no stale primary aliases remain for the repaired institutions.
+update public.institution_slug_crosswalk
+set school_id = case ipeds_id
+      when '211291' then 'bucknell'
+      when '212054' then 'drexel'
+      else school_id
+    end,
+    is_primary = (alias = case ipeds_id
+      when '211291' then 'bucknell'
+      when '212054' then 'drexel'
+      else alias
+    end),
+    source = case
+      when ipeds_id = '211291' and alias = 'bucknell' then 'schools_yaml'
+      when ipeds_id = '212054' and alias = 'drexel' then 'schools_yaml'
+      else source
+    end
+where ipeds_id in ('211291', '212054');
+
+-- General slug-fragmentation repair: if a document carries an IPEDS ID
+-- whose primary crosswalk row is a schools.yaml canonical slug, move it
+-- to that canonical slug when doing so cannot violate the existing
+-- (school_id, sub_institutional, cds_year) uniqueness contract.
+with primary_slug as (
+  select ipeds_id, school_id as canonical_school_id
+  from public.institution_slug_crosswalk
+  where is_primary = true
+    and source = 'schools_yaml'
+),
+candidates as (
+  select d.id, d.school_id as old_school_id, p.canonical_school_id
+  from public.cds_documents d
+  join primary_slug p on p.ipeds_id = d.ipeds_id
+  where d.school_id <> p.canonical_school_id
+),
+to_update as (
+  select c.id, c.old_school_id, c.canonical_school_id
+  from (
+    select
+      c.*,
+      count(*) over (
+        partition by c.canonical_school_id, d.sub_institutional, d.cds_year
+      ) as candidate_count
+    from candidates c
+    join public.cds_documents d on d.id = c.id
+  ) c
+  join public.cds_documents d on d.id = c.id
+  where c.candidate_count = 1
+    and not exists (
+      select 1
+      from public.cds_documents existing
+      where existing.school_id = c.canonical_school_id
+        and existing.sub_institutional is not distinct from d.sub_institutional
+        and existing.cds_year = d.cds_year
+    )
+),
+redirects as (
+  insert into public.institution_slug_crosswalk
+    (ipeds_id, school_id, alias, source, is_primary, reviewed_at)
+  select distinct d.ipeds_id, p.canonical_school_id, d.school_id, 'redirect', false, now()
+  from public.cds_documents d
+  join primary_slug p on p.ipeds_id = d.ipeds_id
+  where d.school_id <> p.canonical_school_id
+  on conflict (ipeds_id, alias) do update
+  set school_id = excluded.school_id,
+      source = 'redirect',
+      is_primary = false,
+      reviewed_at = excluded.reviewed_at
+  returning 1
+)
+update public.cds_documents d
+set school_id = u.canonical_school_id
+from to_update u
+where d.id = u.id;
+
+-- System offices are administrative entities, not CDS publishers. Keep
+-- row history but remove them from public extraction/search surfaces.
+update public.cds_documents
+set participation_status = 'verified_absent',
+    extraction_status = 'not_applicable'
+where school_id in (
+  'university-of-maine-system-central-office',
+  'university-of-houston-system-administration',
+  'university-of-hawaii-system-office',
+  'the-university-of-texas-system-office'
+);
+
+delete from public.archive_queue
+where school_id in (
+  'university-of-maine-system-central-office',
+  'university-of-houston-system-administration',
+  'university-of-hawaii-system-office',
+  'the-university-of-texas-system-office'
+);
+
+-- Refresh the serving table immediately when this migration is applied.
+select * from public.refresh_institution_cds_coverage();
+
+commit;

--- a/tools/ci-requirements.txt
+++ b/tools/ci-requirements.txt
@@ -3,3 +3,4 @@ supabase>=2.9
 openpyxl>=3.1
 beautifulsoup4>=4.12
 lxml>=5.0
+pyyaml>=6.0

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -155,7 +155,7 @@ schools:
 - id: bucknell
   name: Bucknell University
   domain: bucknell.edu
-  ipeds_id: '211158'
+  ipeds_id: '211291'
   scrape_policy: active
   discovery_seed_url: https://www.bucknell.edu/commondataset/
   probe_state:
@@ -228,7 +228,7 @@ schools:
 - id: drexel
   name: Drexel University
   domain: drexel.edu
-  ipeds_id: '212160'
+  ipeds_id: '212054'
   scrape_policy: active
   discovery_seed_url: https://drexel.edu/institutionalresearch/~/media/Drexel/Provost-Group/InstitutionalResearch/Documents/Factbook/CDS_2020-2021.pdf
   probe_state:

--- a/tools/scorecard/test_load_directory.py
+++ b/tools/scorecard/test_load_directory.py
@@ -16,10 +16,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from tools.scorecard.load_directory import (  # noqa: E402
+    DEFAULT_SCHOOLS_YAML,
     _scope_decision,
     assign_slugs,
     base_slug,
     build_crosswalk_rows,
+    load_schools_yaml,
     normalize_ipeds,
 )
 
@@ -276,6 +278,17 @@ class BuildCrosswalkRowsTests(unittest.TestCase):
         self.assertEqual(cw[0]["alias"], "tiny-college")
         self.assertTrue(cw[0]["is_primary"])
         self.assertEqual(cw[0]["source"], "scorecard")
+
+
+class SchoolsYamlRegressionTests(unittest.TestCase):
+    def test_launch_critical_ipeds_ids_match_nces(self):
+        # These two IDs were stale in schools.yaml and caused CDS-backed
+        # rows to miss the Scorecard directory join before launch.
+        claims = load_schools_yaml(DEFAULT_SCHOOLS_YAML)
+        self.assertEqual(claims["211291"], "bucknell")
+        self.assertEqual(claims["212054"], "drexel")
+        self.assertNotIn("211158", claims)
+        self.assertNotIn("212160", claims)
 
 
 if __name__ == "__main__":

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -697,6 +698,23 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -1449,6 +1467,21 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -2848,6 +2881,38 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "start": "next start"
+    "start": "next start",
+    "test:smoke": "playwright test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.103.3",
@@ -19,6 +20,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PORT ?? 3000);
+const suppliedBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
+const baseURL = suppliedBaseUrl ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+  },
+  webServer: suppliedBaseUrl
+    ? undefined
+    : {
+        command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND ?? "npm run dev",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+          PORT: String(port),
+        },
+      },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+});

--- a/web/src/app/api/facts/[school_id]/route.ts
+++ b/web/src/app/api/facts/[school_id]/route.ts
@@ -107,7 +107,7 @@ export async function GET(
       B_126_ft_women_enrolled: readValue(mergedValues, "B.126"),
     },
     note:
-      "Values extracted from the school's own Common Data Set document. Pipeline source: https://github.com/bolewood/collegedata-fyi. For the full 1,105-field extract, see /api/facts/{school_id}/full or query /rest/v1/cds_artifacts directly.",
+      "Values extracted from the school's own Common Data Set document. Pipeline source: https://github.com/bolewood/collegedata-fyi. For the full extract, query /rest/v1/cds_artifacts directly using the public anon-key instructions at /api.",
   };
 
   return NextResponse.json(body, {

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function expectNoBodyOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const body = document.body;
+    const html = document.documentElement;
+    return Math.max(body.scrollWidth, html.scrollWidth) - window.innerWidth;
+  });
+  expect(overflow).toBeLessThanOrEqual(2);
+}
+
+test("homepage search opens an institution page", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: /college data/i }),
+  ).toBeVisible();
+
+  await page
+    .getByPlaceholder("Search schools by name, alias, or city...")
+    .fill("Rice");
+  const result = page.getByText("Rice University").first();
+  await expect(result).toBeVisible();
+  await result.click();
+
+  await expect(page).toHaveURL(/\/schools\/rice/);
+  await expect(
+    page.getByRole("heading", { name: /Rice University/i }),
+  ).toBeVisible();
+});
+
+test("coverage page renders filterable accountability data", async ({ page }) => {
+  await page.goto("/coverage");
+  await expect(
+    page.getByRole("heading", { name: /What we have/i }),
+  ).toBeVisible();
+  await expect(page.getByText("No public CDS found").first()).toBeVisible();
+  await expect(page.getByText("Methodology")).toBeVisible();
+});
+
+test("browser loads live rows and source links resolve", async ({ page, request }) => {
+  await page.goto("/browse");
+  await expect(
+    page.getByRole("heading", { name: /Queryable school browser/i }),
+  ).toBeVisible();
+  await expect(page.getByText("Browser query failed")).toHaveCount(0);
+  await expect(page.getByText(/Showing 1-/)).toBeVisible();
+
+  const source = page.locator("tbody a.cd-chip").first();
+  await expect(source).toBeVisible();
+  const href = await source.getAttribute("href");
+  expect(href).toBeTruthy();
+  const response = await request.get(href!);
+  expect(response.status()).toBeLessThan(400);
+});
+
+test("facts endpoint returns flat JSON", async ({ request }) => {
+  const response = await request.get("/api/facts/mit");
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json();
+  expect(body.school_id).toBe("mit");
+  expect(body.school_name).toContain("Massachusetts Institute of Technology");
+  expect(typeof body.raw).toBe("object");
+});
+
+test("mobile launch surfaces do not overflow", async ({ page, isMobile }) => {
+  test.skip(!isMobile, "mobile project only");
+
+  for (const path of ["/", "/coverage", "/browse"]) {
+    await page.goto(path);
+    await expectNoBodyOverflow(page);
+  }
+});


### PR DESCRIPTION
## Summary
- fix public API examples and Show HN copy so PostgREST usage includes the public anon key
- add repo-native Playwright smoke tests and wire them into CI
- repair coverage data-quality issues for Bucknell/Drexel IPEDS, slug fragmentation, and stale system-office rows

## Verification
- python3 -m unittest tools.browser_backend.project_browser_data_test tools.scorecard.test_load_directory
- python3 -m unittest discover -s tools/extraction_worker -p "test_*.py"
- deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts
- npm run typecheck
- npm run build
- npm run test:smoke

## Deploy notes
- includes Supabase migration 20260429190000_launch_coverage_data_quality.sql
- Vercel preview should deploy from this PR; production deploy needs merge to main