### PR TITLE
Add controlled directory drain ops tooling

### DIFF
--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -423,6 +423,19 @@ It also records every baseline, dry-run, enqueue, poll, drain, and
 refresh event as JSONL in `scratch/directory-enqueue-runs/`. That
 directory is intentionally uncommitted operator evidence.
 
+After each applied batch, both `directory_enqueue_batches.py` and
+`directory_enqueue_autopilot.py` run an extraction backlog audit unless
+`--skip-extraction-backlog-audit` is passed. The audit reads
+`cds_documents WHERE extraction_status='extraction_pending'`, prints the
+pending count, oldest pending age, source-format buckets, oldest rows, and
+high-enrollment pending rows, then writes the result into the JSONL run log.
+By default it stops the wrapper if any pending row is older than 24 hours.
+Use `--extraction-max-pending-age-hours N` to change that gate and
+`--extraction-max-pending-count N` to add a hard backlog-size gate. During
+launch drains, pass `--extraction-audit-github` to also require a recent
+successful `.github/workflows/ops-extraction-worker.yml` run; the default
+GitHub success freshness gate is 30 hours.
+
 For unattended launch drains, `directory_enqueue_autopilot.py` wraps the
 same batch workflow and then audits only the just-drained
 `last_outcome='no_pdfs_found'` rows above the configured enrollment
@@ -447,7 +460,11 @@ Batch gate:
 3. Wait for each `run_id` to drain before starting the next batch.
 4. Run `refresh-coverage` immediately after each drained batch; the
    wrapper does this automatically in `--apply` mode.
-5. Do not use `--force-recheck` for the first top-500 pass. The first
+5. Review the extraction backlog audit after each drained batch. Stop and
+   run the extraction worker if the oldest pending row is older than 24
+   hours, if high-enrollment rows are piling up, or if the GitHub ops
+   worker has not succeeded recently.
+6. Do not use `--force-recheck` for the first top-500 pass. The first
    pass should respect cooldowns, existing-CDS rows, in-flight rows, and
    curated schools.yaml exclusions.
 
@@ -585,11 +602,21 @@ Capped at 10 schools per request to keep memory bounded.
 **Run extraction over archived pending rows:**
 
 ```bash
+python tools/ops/extraction_backlog_audit.py
+python tools/ops/extraction_backlog_audit.py --skip-github
 python tools/extraction_worker/worker.py
 python tools/extraction_worker/worker.py --limit 25
 python tools/extraction_worker/worker.py --school yale
 python tools/extraction_worker/worker.py --dry-run
 ```
+
+`tools/ops/extraction_backlog_audit.py` is the pre-flight/status check for
+the worker. It writes JSON reports to `scratch/extraction-backlog-audits/`
+and exits non-zero when the configured gates fail. The default gate is:
+oldest pending extraction row must be no older than 24 hours. The optional
+GitHub gate checks the bounded ops workflow's last success so missing
+secrets or a broken scheduled drain do not stay hidden behind healthy
+archive/coverage numbers.
 
 The worker detects or backfills `source_format`, writes one canonical
 `cds_artifacts` row per successful extraction, and flips

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -350,7 +350,72 @@ touching the database or Storage.
 **Enqueue Scorecard-only directory schools for discovery** (PRD 015 M2 —
 the path that turns `not_checked` rows into real archive attempts so
 coverage status precedence has actual data to read). Operator-triggered;
-no cron. `limit` is required so every batch is sized intentionally:
+no cron. `limit` is required so every batch is sized intentionally.
+
+For the production launch backlog, use the controlled batch wrapper
+instead of one-off curls. The launch state still had ~2.1K
+`not_checked` rows; the first reduction pass targets the top 500
+highest-enrollment remaining institutions in staged batches:
+`25 -> 75 -> 150 -> 250`. This keeps PRD 015's scope intact: no CI
+drain, no pg_cron drain, and no automatic full-universe discovery.
+
+```bash
+cd /Users/santhonys/Projects/Owen/colleges/collegedata-fyi
+
+# Inspect baseline counts, current in-flight rows, and the next 25 picks.
+# This is dry-run-only; it never enqueues archive_queue rows.
+python3 tools/ops/directory_enqueue_batches.py --limit 25
+
+# First canary: dry-run, enqueue 25, wait for the run_id to drain,
+# refresh coverage, print deltas, and write JSONL under scratch/.
+python3 tools/ops/directory_enqueue_batches.py --apply --limit 25
+
+# Continue only after the canary looks sane.
+python3 tools/ops/directory_enqueue_batches.py --apply --batches 75,150,250
+```
+
+The wrapper reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from
+`.env`, calls `directory-enqueue?dry_run=true` before every real enqueue,
+polls `archive_queue` for that run's `ready`/`processing` rows, calls
+`refresh-coverage` after the run drains, then prints before/after
+coverage histograms and watched status deltas for:
+
+- `not_checked`
+- `no_public_cds_found`
+- `source_not_automatically_accessible`
+- `cds_available_current`
+- `extract_failed`
+
+It also records every baseline, dry-run, enqueue, poll, drain, and
+refresh event as JSONL in `scratch/directory-enqueue-runs/`. That
+directory is intentionally uncommitted operator evidence.
+
+Batch gate:
+
+1. Capture the baseline that the wrapper prints: coverage histogram,
+   top `not_checked` schools by enrollment, and current in-flight
+   `archive_queue` rows with `source='institution_directory'`.
+2. Dry-run every batch. Continue to the real enqueue only if the sample
+   schools and skipped buckets look sane.
+3. Wait for each `run_id` to drain before starting the next batch.
+4. Run `refresh-coverage` immediately after each drained batch; the
+   wrapper does this automatically in `--apply` mode.
+5. Do not use `--force-recheck` for the first top-500 pass. The first
+   pass should respect cooldowns, existing-CDS rows, in-flight rows, and
+   schools.yaml exclusions.
+
+Stop the rollout if any of these happen:
+
+- More than 10% of a batch ends with unexpected `last_outcome` values
+  `transient` or `permanent_other`.
+- The queue stalls for more than 20 minutes with no additional terminal
+  rows.
+- `directory-enqueue` or `refresh-coverage` returns an auth, load, or
+  enqueue error.
+- The coverage histogram is wildly implausible, for example the total
+  row count shifts unexpectedly or a known-good bucket disappears.
+
+Raw curl remains useful for debugging the Edge Function directly:
 
 ```bash
 cd /Users/santhonys/Projects/Owen/colleges/collegedata-fyi

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -376,6 +376,17 @@ python3 tools/ops/directory_enqueue_batches.py --apply --batches 75,150,250
 # If local polling is interrupted after enqueue, resume the same run_id
 # without enqueueing another batch.
 python3 tools/ops/directory_enqueue_batches.py --resume-run-id <run_id>
+
+# Overnight mode from an operator Mac: keep the machine awake, stream logs,
+# drain repeated 25-row batches, stop on permanent_other spikes, and warn
+# on transient-heavy batches without stopping.
+caffeinate -dimsu python3 -u tools/ops/directory_enqueue_batches.py \
+  --apply \
+  --batches 25,25,25,25,25,25,25,25,25,25 \
+  --poll-interval-seconds 30 \
+  --stall-timeout-minutes 20 \
+  --max-transient-rate 0.25 \
+  --max-permanent-other-rate 0.05
 ```
 
 The wrapper reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from
@@ -410,8 +421,13 @@ Batch gate:
 
 Stop the rollout if any of these happen:
 
-- More than 10% of a batch ends with unexpected `last_outcome` values
-  `transient` or `permanent_other`.
+- More than 5% of a batch ends with unexpected `permanent_other`
+  outcomes.
+- `transient` outcomes exceed the configured warning gate and the run
+  was started with `--stop-on-transient-gate`. For overnight drains,
+  transient-heavy batches are logged and reviewed in the morning because
+  they usually mean flaky school infrastructure rather than product
+  corruption.
 - The queue stalls for more than 20 minutes with no additional terminal
   rows.
 - `directory-enqueue` or `refresh-coverage` returns an auth, load, or

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -372,6 +372,10 @@ python3 tools/ops/directory_enqueue_batches.py --apply --limit 25
 
 # Continue only after the canary looks sane.
 python3 tools/ops/directory_enqueue_batches.py --apply --batches 75,150,250
+
+# If local polling is interrupted after enqueue, resume the same run_id
+# without enqueueing another batch.
+python3 tools/ops/directory_enqueue_batches.py --resume-run-id <run_id>
 ```
 
 The wrapper reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -387,6 +387,24 @@ caffeinate -dimsu python3 -u tools/ops/directory_enqueue_batches.py \
   --stall-timeout-minutes 20 \
   --max-transient-rate 0.25 \
   --max-permanent-other-rate 0.05
+
+# Unattended mode with high-signal repair after each drained batch.
+# This remains operator-controlled: no cron, no CI drain, and explicit
+# batch limits. Repairs are conservative: only high-enrollment failed
+# rows are probed, only official-domain documents are force-archived,
+# and third-party/cached search hits are skipped.
+caffeinate -dimsu python3 -u tools/ops/directory_enqueue_autopilot.py \
+  --apply \
+  --batch-size 25 \
+  --max-batches 8 \
+  --uniform-cooldown-days 1 \
+  --poll-interval-seconds 30 \
+  --stall-timeout-minutes 20 \
+  --max-transient-rate 0.25 \
+  --max-permanent-other-rate 0.05 \
+  --repair-min-enrollment 10000 \
+  --repair-max-per-batch 5 \
+  --repair-bing-fallback
 ```
 
 The wrapper reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from
@@ -404,6 +422,20 @@ coverage histograms and watched status deltas for:
 It also records every baseline, dry-run, enqueue, poll, drain, and
 refresh event as JSONL in `scratch/directory-enqueue-runs/`. That
 directory is intentionally uncommitted operator evidence.
+
+For unattended launch drains, `directory_enqueue_autopilot.py` wraps the
+same batch workflow and then audits only the just-drained
+`last_outcome='no_pdfs_found'` rows above the configured enrollment
+threshold. Its repair ladder is intentionally narrow:
+
+1. Try the free official-domain pattern ladder from `tools/finder/probe_urls.py`.
+2. Optionally try Bing HTML search with `site:<school-domain> "Common Data Set"`.
+3. Accept only URLs on the school's own root domain/subdomains.
+4. If the hit is a landing page, archive only direct PDF/XLSX/DOCX links
+   whose text or URL says CDS/Common Data Set.
+5. Refresh coverage after any successful repair. Extraction can be run
+   inline with `--extract-repaired` when the local worker environment has
+   the dependencies installed.
 
 Batch gate:
 

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -417,7 +417,16 @@ Batch gate:
    wrapper does this automatically in `--apply` mode.
 5. Do not use `--force-recheck` for the first top-500 pass. The first
    pass should respect cooldowns, existing-CDS rows, in-flight rows, and
-   schools.yaml exclusions.
+   curated schools.yaml exclusions.
+
+`schools_yaml_covered` means "protected from the directory fallback,"
+not "present anywhere in schools.yaml." Active schools with explicit
+seed URLs remain owned by `archive-enqueue`, and `verified_absent` rows
+remain manual/override-owned. YAML rows with `scrape_policy: unknown`
+or `active` without a seed URL can be probed by `directory-enqueue`
+using the Scorecard website URL, which closes the old dead zone where
+those rows were neither archivable by `archive-enqueue` nor eligible for
+directory batches.
 
 Stop the rollout if any of these happen:
 

--- a/supabase/functions/_shared/schools.test.ts
+++ b/supabase/functions/_shared/schools.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert";
 import {
+  directoryProtectedIpeds,
   filterArchivable,
   normalizeSchoolToken,
   resolveSchoolName,
@@ -98,6 +99,38 @@ Deno.test("filterArchivable threads ipeds_id through when present", () => {
   // ipeds_id is conditionally spread — absent in the output when the
   // schools.yaml entry has none. This guards the optional contract.
   assertEquals("ipeds_id" in mit, false);
+});
+
+Deno.test("directoryProtectedIpeds protects only curated YAML-owned rows", () => {
+  const fixtures: SchoolEntry[] = [
+    {
+      id: "active-seed",
+      name: "Active With Seed",
+      ipeds_id: "111111",
+      scrape_policy: "active",
+      discovery_seed_url: "https://example.edu/cds/",
+    },
+    {
+      id: "active-no-seed",
+      name: "Active Missing Seed",
+      ipeds_id: "222222",
+      scrape_policy: "active",
+    },
+    {
+      id: "unknown",
+      name: "Unknown Discovery Tail",
+      ipeds_id: "333333",
+      scrape_policy: "unknown",
+    },
+    {
+      id: "verified-absent",
+      name: "Verified Absent",
+      ipeds_id: "444444",
+      scrape_policy: "verified_absent",
+    },
+  ];
+
+  assertEquals(directoryProtectedIpeds(fixtures), new Set(["111111", "444444"]));
 });
 
 // resolveSchoolName's fail-closed behavior when the id is unknown cannot be

--- a/supabase/functions/_shared/schools.ts
+++ b/supabase/functions/_shared/schools.ts
@@ -452,3 +452,28 @@ export function filterArchivable(schools: SchoolEntry[]): ArchivableSchool[] {
   }
   return out;
 }
+
+// IPEDS rows that directory-enqueue must not probe from the Scorecard
+// website fallback. This is intentionally narrower than "every row in
+// schools.yaml": unknown/no-seed YAML rows are the discovery tail and can
+// safely flow through the operator-controlled directory path. Curated
+// active-seed rows stay owned by archive-enqueue, and verified_absent rows
+// stay owned by manual coverage overrides.
+export function directoryProtectedIpeds(schools: SchoolEntry[]): Set<string> {
+  const out = new Set<string>();
+  for (const s of schools) {
+    const ipeds = s.ipeds_id?.trim();
+    if (!ipeds) continue;
+
+    if (s.scrape_policy === "verified_absent") {
+      out.add(ipeds);
+      continue;
+    }
+
+    const seed = (s.discovery_seed_url ?? s.cds_url_hint)?.trim();
+    if (s.scrape_policy === "active" && seed) {
+      out.add(ipeds);
+    }
+  }
+  return out;
+}

--- a/supabase/functions/directory-enqueue/index.ts
+++ b/supabase/functions/directory-enqueue/index.ts
@@ -4,9 +4,9 @@
 // Companion to archive-enqueue. Both write to archive_queue, but they
 // pull from different universes:
 //
-//   archive-enqueue     reads tools/finder/schools.yaml. Daily cron.
-//                       Source of truth for hand-curated, actively
-//                       scraped schools. Source = 'schools_yaml'.
+//   archive-enqueue     reads tools/finder/schools.yaml. Source of truth
+//                       for hand-curated, actively scraped schools.
+//                       Source = 'schools_yaml'.
 //
 //   directory-enqueue   (this function) reads institution_directory.
 //                       Operator-triggered, no cron. Targets the Scorecard
@@ -38,9 +38,10 @@
 //      coverage status flips off `not_checked`, and are the schools
 //      where missing-CDS visibility matters most.
 //
-//   4. Schools already covered by schools.yaml are skipped. archive-enqueue
-//      owns those; double-enqueueing would race the cooldown logic.
-//      Excluded by joining institution_slug_crosswalk.
+//   4. Curated schools.yaml rows are skipped. archive-enqueue owns active
+//      rows with explicit seed URLs, and manual overrides own
+//      verified_absent rows. Unknown/no-seed YAML rows can still flow
+//      through this operator-controlled directory path.
 //
 //   5. cooldown / in-flight / has-cds checks all use the existing
 //      archive_queue + cds_documents tables. directory-sourced rows
@@ -61,6 +62,10 @@ import {
   selectCandidates,
 } from "./select.ts";
 import { ProbeOutcome } from "../_shared/probe_outcome.ts";
+import {
+  directoryProtectedIpeds,
+  fetchSchoolsYaml,
+} from "../_shared/schools.ts";
 
 Deno.serve(async (req: Request) => {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -106,7 +111,7 @@ Deno.serve(async (req: Request) => {
     terminalResult,
   ] = await Promise.all([
     loadDirectoryRows(supabase, params),
-    loadSchoolsYamlIpeds(supabase),
+    loadSchoolsYamlIpeds(),
     loadSchoolsWithCds(supabase),
     loadInFlightSchools(supabase),
     loadLatestTerminals(supabase),
@@ -371,19 +376,13 @@ async function loadDirectoryRows(
   });
 }
 
-async function loadSchoolsYamlIpeds(
-  supabase: SupabaseClient,
-): Promise<{ ipeds: Set<string> } | { error: string }> {
-  const result = await fetchPaged<{ ipeds_id: string }>((start, end) =>
-    supabase
-      .from("institution_slug_crosswalk")
-      .select("ipeds_id")
-      .eq("source", "schools_yaml")
-      .order("ipeds_id", { ascending: true })
-      .range(start, end)
-  );
-  if ("error" in result) return result;
-  return { ipeds: new Set(result.rows.map((r) => r.ipeds_id)) };
+async function loadSchoolsYamlIpeds(): Promise<{ ipeds: Set<string> } | { error: string }> {
+  try {
+    const result = await fetchSchoolsYaml();
+    return { ipeds: directoryProtectedIpeds(result.entries) };
+  } catch (e) {
+    return { error: `schools.yaml fetch failed: ${(e as Error).message}` };
+  }
 }
 
 async function loadSchoolsWithCds(

--- a/supabase/functions/directory-enqueue/select.ts
+++ b/supabase/functions/directory-enqueue/select.ts
@@ -30,11 +30,10 @@ export interface LatestTerminal {
 
 export interface SelectionInputs {
   rows: DirectoryRow[];
-  // IPEDS UNITIDs already covered by the schools.yaml universe.
-  // Loaded from institution_slug_crosswalk WHERE source = 'schools_yaml'.
-  // archive-enqueue is the canonical writer for these — directory-enqueue
-  // must skip them so the same school doesn't end up enqueued twice on
-  // overlapping cron + manual runs.
+  // IPEDS UNITIDs still protected by the schools.yaml path. This is not
+  // every schools.yaml row: unknown/no-seed YAML rows can flow through
+  // directory-enqueue, while active-seed and verified_absent rows stay
+  // under the curated/manual paths.
   schoolsYamlIpeds: Set<string>;
   // school_ids that already have any cds_documents row. Per PRD: "Enqueue
   // in-scope institutions that have no cds_documents row and no recent

--- a/supabase/migrations/20260429193000_marked_removed_coverage_status.sql
+++ b/supabase/migrations/20260429193000_marked_removed_coverage_status.sql
@@ -1,0 +1,123 @@
+-- PRD 015 M3 hotfix - `marked_removed` is a real terminal probe.
+--
+-- Directory-enqueue can produce archive_queue rows whose successful
+-- archive action is `marked_removed` when the resolver reaches a stale
+-- source URL and confirms the upstream file is gone. That is not the
+-- same as "never checked"; public coverage should reflect a completed
+-- scan. Treat it with the same precedence as no_pdfs_found/dead_url:
+-- known usable archive remains stale, known failed/pending source keeps
+-- its source state, and no source on file becomes no_public_cds_found.
+
+create or replace function public.derive_coverage_status(
+  p_in_scope boolean,
+  p_latest_extracted_year text,
+  p_latest_found_year text,
+  p_latest_found_extraction_status text,
+  p_last_outcome text
+)
+returns public.coverage_status_t
+language sql
+immutable
+set search_path = public
+as $$
+  select case
+    when p_in_scope = false then 'out_of_scope'::public.coverage_status_t
+
+    -- Latest discovery FOUND a source (or re-confirmed one).
+    when p_last_outcome in ('inserted', 'refreshed', 'unchanged_verified', 'unchanged_repaired') then
+      case
+        when p_latest_extracted_year is not null
+             and (p_latest_found_year is null
+                  or p_latest_extracted_year >= p_latest_found_year)
+          then 'cds_available_current'::public.coverage_status_t
+        when p_latest_found_extraction_status = 'failed'
+             and p_latest_extracted_year is not null
+             and p_latest_found_year > p_latest_extracted_year
+          then 'latest_found_extract_failed_with_prior_available'::public.coverage_status_t
+        when p_latest_found_extraction_status = 'failed'
+          then 'extract_failed'::public.coverage_status_t
+        when p_latest_found_extraction_status in ('discovered', 'extraction_pending')
+          then 'cds_found_processing'::public.coverage_status_t
+        else 'cds_available_current'::public.coverage_status_t
+      end
+
+    -- Latest discovery FOUND NOTHING / SOURCE GONE.
+    -- Three-way: usable extraction -> stale; known source but extraction
+    -- failed/pending keeps that state; pure no-source -> no_public_cds_found.
+    when p_last_outcome in ('marked_removed', 'no_pdfs_found', 'dead_url',
+                            'wrong_content_type', 'transient',
+                            'permanent_other', 'blocked_url',
+                            'file_too_large') then
+      case
+        when p_latest_extracted_year is not null
+          then 'cds_available_stale'::public.coverage_status_t
+        when p_latest_found_year is not null
+             and p_latest_found_extraction_status = 'failed'
+          then 'extract_failed'::public.coverage_status_t
+        when p_latest_found_year is not null
+             and p_latest_found_extraction_status in ('discovered', 'extraction_pending')
+          then 'cds_found_processing'::public.coverage_status_t
+        else 'no_public_cds_found'::public.coverage_status_t
+      end
+
+    -- Latest discovery BLOCKED by auth wall.
+    when p_last_outcome in ('auth_walled_microsoft', 'auth_walled_okta', 'auth_walled_google') then
+      case
+        when p_latest_extracted_year is not null
+          then 'cds_available_stale'::public.coverage_status_t
+        when p_latest_found_year is not null
+             and p_latest_found_extraction_status = 'failed'
+          then 'extract_failed'::public.coverage_status_t
+        when p_latest_found_year is not null
+             and p_latest_found_extraction_status in ('discovered', 'extraction_pending')
+          then 'cds_found_processing'::public.coverage_status_t
+        else 'source_not_automatically_accessible'::public.coverage_status_t
+      end
+
+    -- No queue history (legacy data, manual uploads, etc.).
+    when p_latest_extracted_year is not null
+         and (p_latest_found_year is null
+              or p_latest_extracted_year >= p_latest_found_year)
+      then 'cds_available_current'::public.coverage_status_t
+    when p_latest_found_extraction_status in ('discovered', 'extraction_pending')
+         and p_latest_extracted_year is null
+      then 'cds_found_processing'::public.coverage_status_t
+    when p_latest_found_extraction_status = 'failed'
+         and p_latest_extracted_year is not null
+         and p_latest_found_year > p_latest_extracted_year
+      then 'latest_found_extract_failed_with_prior_available'::public.coverage_status_t
+    when p_latest_found_extraction_status = 'failed'
+      then 'extract_failed'::public.coverage_status_t
+
+    else 'not_checked'::public.coverage_status_t
+  end;
+$$;
+
+do $$
+declare
+  s public.coverage_status_t;
+begin
+  -- Directory-only, terminal marked_removed means we checked and found no
+  -- public source; it must not remain not_checked.
+  select public.derive_coverage_status(true, null, null, null, 'marked_removed')
+    into s;
+  if s is distinct from 'no_public_cds_found' then
+    raise exception 'marked_removed coverage hotfix FAIL: no-doc shape returned %, expected no_public_cds_found', s;
+  end if;
+
+  -- Existing usable archive stays stale when the latest probe says the
+  -- upstream source is gone.
+  select public.derive_coverage_status(true, '2023-24', null, null, 'marked_removed')
+    into s;
+  if s is distinct from 'cds_available_stale' then
+    raise exception 'marked_removed coverage hotfix FAIL: existing archive shape returned %, expected cds_available_stale', s;
+  end if;
+
+  -- Known source states should not be hidden by a later marked_removed
+  -- queue terminal.
+  select public.derive_coverage_status(true, null, '2024-25', 'failed', 'marked_removed')
+    into s;
+  if s is distinct from 'extract_failed' then
+    raise exception 'marked_removed coverage hotfix FAIL: failed source shape returned %, expected extract_failed', s;
+  end if;
+end $$;

--- a/tools/ops/directory_enqueue_autopilot.py
+++ b/tools/ops/directory_enqueue_autopilot.py
@@ -118,20 +118,37 @@ def is_official_host(url: str, root_domain: str) -> bool:
 
 
 def is_high_signal(row: dict[str, Any], min_enrollment: int) -> bool:
+    return high_signal_score(row, min_enrollment) > 0
+
+
+def high_signal_score(row: dict[str, Any], min_enrollment: int) -> int:
     enrollment = row.get("undergraduate_enrollment")
     try:
         enrollment_int = int(enrollment)
     except (TypeError, ValueError):
         enrollment_int = 0
+    score = 0
     if enrollment_int >= min_enrollment:
-        return True
+        score += 100 + min(enrollment_int // 1000, 50)
     name = str(row.get("school_name") or "").lower()
     state = str(row.get("state") or "")
-    return (
-        enrollment_int >= min_enrollment // 2
-        and state
-        and (" university" in name or "state university" in name)
+    recognizable_patterns = (
+        "state university",
+        "university of ",
+        "california state university",
+        "pennsylvania state university",
+        "suny ",
+        "cuny ",
+        "texas a&m",
+        "university-",
     )
+    if state and any(pattern in name for pattern in recognizable_patterns):
+        score += 80
+    elif state and " university" in name and enrollment_int >= min_enrollment // 2:
+        score += 45
+    elif state and " college" in name and enrollment_int >= min_enrollment:
+        score += 20
+    return score
 
 
 def infer_year(text: str) -> str | None:
@@ -363,10 +380,18 @@ def repair_high_signal_failures(
         if row.get("last_outcome") == "no_pdfs_found" and row.get("school_id")
     ]
     metadata = fetch_directory_rows_by_school_id(client, [str(row["school_id"]) for row in failed])
-    high_signal = [
-        metadata[str(row["school_id"])]
+    scored_high_signal = [
+        (
+            high_signal_score(metadata[str(row["school_id"])], options.min_enrollment),
+            metadata[str(row["school_id"])],
+        )
         for row in failed
-        if str(row["school_id"]) in metadata and is_high_signal(metadata[str(row["school_id"])], options.min_enrollment)
+        if str(row["school_id"]) in metadata
+    ]
+    high_signal = [
+        row
+        for score, row in sorted(scored_high_signal, key=lambda item: item[0], reverse=True)
+        if score > 0
     ][: options.max_per_batch]
 
     brave_api_key = os.environ.get("BRAVE_API_KEY")

--- a/tools/ops/directory_enqueue_autopilot.py
+++ b/tools/ops/directory_enqueue_autopilot.py
@@ -31,6 +31,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from tools.finder import probe_urls
 from tools.ops import directory_enqueue_batches as batches
+from tools.ops import extraction_backlog_audit
 
 
 DOC_EXTENSIONS = (".pdf", ".xlsx", ".docx")
@@ -484,6 +485,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--extract-repaired", action="store_true")
     parser.add_argument("--extraction-python", default=".context/extraction-venv/bin/python")
     parser.add_argument("--extraction-limit", type=int, default=3)
+    parser.add_argument("--skip-extraction-backlog-audit", action="store_true")
+    parser.add_argument("--extraction-max-pending-age-hours", type=float, default=24.0)
+    parser.add_argument("--extraction-max-pending-count", type=int)
+    parser.add_argument("--extraction-audit-sample-limit", type=int, default=15)
+    parser.add_argument("--extraction-audit-github", action="store_true")
+    parser.add_argument("--extraction-audit-github-repo", default=extraction_backlog_audit.DEFAULT_GITHUB_REPO)
+    parser.add_argument("--extraction-audit-github-workflow", default=extraction_backlog_audit.DEFAULT_GITHUB_WORKFLOW)
+    parser.add_argument("--extraction-max-github-success-age-hours", type=float, default=30.0)
+    parser.add_argument("--fail-on-extraction-pending-growth", action="store_true")
     return parser
 
 
@@ -511,6 +521,7 @@ def main(argv: list[str] | None = None) -> int:
 
         print(f"Writing JSONL log to {logger.path}")
         reports: list[dict[str, Any]] = []
+        previous_pending_count: int | None = None
         for batch_number in range(1, args.max_batches + 1):
             print(f"\n## Autopilot batch {batch_number}/{args.max_batches}")
             report = batches.run_batch(
@@ -541,7 +552,46 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 batches.print_json("High-signal repair", repair_report)
 
-            reports.append({"batch": report, "repair": repair_report})
+            extraction_audit_report = None
+            if args.apply and not args.skip_extraction_backlog_audit:
+                extraction_audit_report = extraction_backlog_audit.build_audit(
+                    client,
+                    sample_limit=args.extraction_audit_sample_limit,
+                    include_github=args.extraction_audit_github,
+                    github_repo=args.extraction_audit_github_repo,
+                    github_workflow=args.extraction_audit_github_workflow,
+                    github_limit=20,
+                )
+                gate_failures = extraction_backlog_audit.evaluate_gates(
+                    extraction_audit_report,
+                    extraction_backlog_audit.AuditThresholds(
+                        max_pending_age_hours=args.extraction_max_pending_age_hours,
+                        max_pending_count=args.extraction_max_pending_count,
+                        max_github_success_age_hours=(
+                            args.extraction_max_github_success_age_hours
+                            if args.extraction_audit_github
+                            else None
+                        ),
+                        fail_on_pending_growth=args.fail_on_extraction_pending_growth,
+                    ),
+                    previous_pending_count=previous_pending_count,
+                )
+                previous_pending_count = int(extraction_audit_report.get("pending_count") or 0)
+                logger.write(
+                    "extraction_backlog_audit",
+                    batch_number=batch_number,
+                    audit=extraction_audit_report,
+                    gate_failures=gate_failures,
+                )
+                extraction_backlog_audit.print_audit(extraction_audit_report, gate_failures)
+                if gate_failures:
+                    raise batches.OpsError("extraction backlog gate failed: " + "; ".join(gate_failures))
+
+            reports.append({
+                "batch": report,
+                "repair": repair_report,
+                "extraction_backlog_audit": extraction_audit_report,
+            })
             if not report.get("applied"):
                 break
 

--- a/tools/ops/directory_enqueue_autopilot.py
+++ b/tools/ops/directory_enqueue_autopilot.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Unattended directory drain with conservative high-signal repair.
+
+This is still an operator workflow, not CI/cron. It runs a sequence of small
+directory-enqueue batches, waits for each batch to drain, audits only that
+batch's high-value `no_pdfs_found` rows, and force-archives official CDS
+documents when discovery is unambiguous.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html.parser
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.finder import probe_urls
+from tools.ops import directory_enqueue_batches as batches
+
+
+DOC_EXTENSIONS = (".pdf", ".xlsx", ".docx")
+BAD_DOC_KEYWORDS = (
+    "definition",
+    "definitions",
+    "template",
+    "instruction",
+    "instructions",
+    "blank",
+    "glossary",
+)
+CURRENT_YEAR_RE = re.compile(r"20(24|25)[-_ /]?(20)?(25|26)|2024-25|2025-26", re.I)
+ANY_YEAR_RE = re.compile(r"(20\d{2})[-_/ ]?(?:20)?(\d{2})")
+
+
+@dataclass(frozen=True)
+class RepairOptions:
+    min_enrollment: int
+    max_per_batch: int
+    rps: float
+    school_budget_seconds: float
+    bing_fallback: bool
+    brave_fallback: bool
+    extract_repaired: bool
+    extraction_python: str
+    extraction_limit: int
+
+
+@dataclass(frozen=True)
+class RepairCandidate:
+    url: str
+    year: str | None
+    evidence: str
+
+
+class LinkParser(html.parser.HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[dict[str, str]] = []
+        self._current: dict[str, str] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() == "a":
+            self._current = {k: v or "" for k, v in attrs}
+            self._current["text"] = ""
+
+    def handle_data(self, data: str) -> None:
+        if self._current is not None:
+            self._current["text"] = self._current.get("text", "") + data
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "a" and self._current is not None:
+            self.links.append(self._current)
+            self._current = None
+
+
+def root_domain_from_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    raw = url.strip()
+    if not raw:
+        return None
+    if "://" not in raw:
+        raw = f"https://{raw}"
+    try:
+        host = urllib.parse.urlparse(raw).netloc.lower()
+    except ValueError:
+        return None
+    if host.startswith("www."):
+        host = host[4:]
+    parts = host.split(".")
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return host or None
+
+
+def url_host(url: str) -> str:
+    return urllib.parse.urlparse(url).netloc.lower()
+
+
+def is_official_host(url: str, root_domain: str) -> bool:
+    host = url_host(url)
+    return host == root_domain or host.endswith(f".{root_domain}")
+
+
+def is_high_signal(row: dict[str, Any], min_enrollment: int) -> bool:
+    enrollment = row.get("undergraduate_enrollment")
+    try:
+        enrollment_int = int(enrollment)
+    except (TypeError, ValueError):
+        enrollment_int = 0
+    if enrollment_int >= min_enrollment:
+        return True
+    name = str(row.get("school_name") or "").lower()
+    state = str(row.get("state") or "")
+    return (
+        enrollment_int >= min_enrollment // 2
+        and state
+        and (" university" in name or "state university" in name)
+    )
+
+
+def infer_year(text: str) -> str | None:
+    match = ANY_YEAR_RE.search(text)
+    if not match:
+        return None
+    start = int(match.group(1))
+    end = int(match.group(2))
+    if 2000 <= start <= 2030 and 0 <= end <= 99:
+        return f"{start}-{end:02d}"
+    return None
+
+
+def looks_like_bad_doc(url: str) -> bool:
+    lower = url.lower()
+    return any(keyword in lower for keyword in BAD_DOC_KEYWORDS)
+
+
+def looks_like_doc_url(url: str) -> bool:
+    path = urllib.parse.urlparse(url).path.lower()
+    return path.endswith(DOC_EXTENSIONS)
+
+
+def fetch_bytes(url: str, *, read_bytes: int = 0, timeout: int = 20) -> tuple[int, dict[str, str], bytes]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "collegedata-fyi-ops/0.1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout, context=probe_urls._SSL_CTX) as response:
+            headers = {k.lower(): v for k, v in response.getheaders()}
+            body = response.read(read_bytes) if read_bytes else response.read()
+            return response.status, headers, body
+    except (urllib.error.URLError, OSError, ValueError):
+        return -1, {}, b""
+
+
+def classify_url(url: str) -> str:
+    status, headers, body = fetch_bytes(url, read_bytes=4096)
+    if status != 200:
+        return "unreachable"
+    content_type = headers.get("content-type", "").lower()
+    if any(kind in content_type for kind in ("pdf", "spreadsheet", "excel", "wordprocessingml")):
+        return "document"
+    if looks_like_doc_url(url):
+        return "document"
+    if "html" in content_type and b"common data set" in body.lower():
+        return "landing"
+    return "other"
+
+
+def extract_document_candidates(landing_url: str, root_domain: str, *, max_docs: int = 1) -> list[RepairCandidate]:
+    status, headers, body = fetch_bytes(landing_url)
+    if status != 200:
+        return []
+    content_type = headers.get("content-type", "").lower()
+    if "html" not in content_type:
+        return []
+
+    parser = LinkParser()
+    parser.feed(body.decode("utf-8", errors="replace"))
+    scored: list[tuple[int, RepairCandidate]] = []
+    for link in parser.links:
+        href = link.get("href") or ""
+        if not href:
+            continue
+        url = urllib.parse.urljoin(landing_url, href.split("#", 1)[0])
+        if not is_official_host(url, root_domain):
+            continue
+        if looks_like_bad_doc(url):
+            continue
+        if not looks_like_doc_url(url):
+            continue
+
+        text = " ".join((link.get("text") or "").split())
+        evidence = f"{text} {url}"
+        lower_evidence = evidence.lower()
+        if "common data set" not in lower_evidence and "cds" not in lower_evidence:
+            continue
+
+        score = 0
+        if CURRENT_YEAR_RE.search(evidence):
+            score += 100
+        if url.lower().endswith(".pdf"):
+            score += 20
+        if "common data set" in lower_evidence:
+            score += 10
+        scored.append((score, RepairCandidate(url=url, year=infer_year(evidence), evidence=text or url)))
+
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [candidate for _, candidate in scored[:max_docs]]
+
+
+def discover_repair_candidate(
+    *,
+    school_name: str,
+    website_url: str,
+    options: RepairOptions,
+    brave_api_key: str | None,
+) -> tuple[RepairCandidate | None, dict[str, Any]]:
+    root_domain = root_domain_from_url(website_url)
+    if not root_domain:
+        return None, {"reason": "missing_domain"}
+
+    attempts: list[dict[str, Any]] = []
+    urls: list[tuple[str, str]] = []
+    pattern_url, patterns_tried = probe_urls.probe_school(
+        root_domain,
+        options.rps,
+        options.school_budget_seconds,
+    )
+    attempts.append({"method": "pattern", "url": pattern_url, "patterns_tried": patterns_tried})
+    if pattern_url:
+        urls.append(("pattern", pattern_url))
+
+    if not urls and options.bing_fallback:
+        found = probe_urls.bing_html_search(root_domain)
+        attempts.append({"method": "bing_html", "url": found})
+        if found:
+            urls.append(("bing_html", found))
+
+    if not urls and options.brave_fallback and brave_api_key:
+        found = probe_urls.brave_search(root_domain, brave_api_key)
+        attempts.append({"method": "brave", "url": found})
+        if found:
+            urls.append(("brave", found))
+
+    for method, found_url in urls:
+        if not is_official_host(found_url, root_domain):
+            attempts.append({"method": method, "url": found_url, "rejected": "non_official_host"})
+            continue
+        kind = classify_url(found_url)
+        attempts.append({"method": method, "url": found_url, "kind": kind})
+        if kind == "document" and not looks_like_bad_doc(found_url):
+            return RepairCandidate(found_url, infer_year(found_url), f"{method}: direct document"), {
+                "domain": root_domain,
+                "attempts": attempts,
+            }
+        if kind == "landing":
+            docs = extract_document_candidates(found_url, root_domain)
+            if docs:
+                return docs[0], {"domain": root_domain, "attempts": attempts, "landing_url": found_url}
+
+    return None, {
+        "domain": root_domain,
+        "school_name": school_name,
+        "attempts": attempts,
+        "reason": "no_unambiguous_document",
+    }
+
+
+def fetch_directory_rows_by_school_id(client: Any, school_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not school_ids:
+        return {}
+    rows = client.rest_get(
+        "institution_directory",
+        {
+            "select": "school_id,school_name,state,website_url,undergraduate_enrollment",
+            "school_id": f"in.({','.join(school_ids)})",
+            "order": "school_id.asc",
+        },
+    )
+    return {str(row.get("school_id")): row for row in rows}
+
+
+def post_force_urls(client: Any, school: dict[str, Any], candidate: RepairCandidate) -> dict[str, Any]:
+    item: dict[str, str] = {"url": candidate.url}
+    if candidate.year:
+        item["year"] = candidate.year
+    payload = {
+        "school_id": school["school_id"],
+        "school_name": school["school_name"],
+        "urls": [item],
+    }
+    return client.post_function_json("archive-process", payload)
+
+
+def run_extraction_for_school(
+    *,
+    supabase_url: str,
+    service_key: str,
+    school_id: str,
+    python_bin: str,
+    limit: int,
+) -> dict[str, Any]:
+    if not Path(python_bin).exists() and "/" in python_bin:
+        return {"school_id": school_id, "skipped": True, "reason": f"{python_bin} does not exist"}
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
+        fh.write(f"SUPABASE_URL={supabase_url}\n")
+        fh.write(f"SUPABASE_SERVICE_ROLE_KEY={service_key}\n")
+        env_path = fh.name
+    try:
+        command = [
+            python_bin,
+            "tools/extraction_worker/worker.py",
+            "--env",
+            env_path,
+            "--school",
+            school_id,
+            "--limit",
+            str(limit),
+            "--include-failed",
+        ]
+        completed = subprocess.run(command, text=True, capture_output=True, timeout=900)
+        return {
+            "school_id": school_id,
+            "returncode": completed.returncode,
+            "stdout_tail": completed.stdout[-4000:],
+            "stderr_tail": completed.stderr[-2000:],
+        }
+    finally:
+        try:
+            os.unlink(env_path)
+        except OSError:
+            pass
+
+
+def repair_high_signal_failures(
+    *,
+    client: Any,
+    supabase_url: str,
+    service_key: str,
+    queue_rows: list[dict[str, Any]],
+    options: RepairOptions,
+    logger: batches.JsonlLogger,
+) -> dict[str, Any]:
+    failed = [
+        row for row in queue_rows
+        if row.get("last_outcome") == "no_pdfs_found" and row.get("school_id")
+    ]
+    metadata = fetch_directory_rows_by_school_id(client, [str(row["school_id"]) for row in failed])
+    high_signal = [
+        metadata[str(row["school_id"])]
+        for row in failed
+        if str(row["school_id"]) in metadata and is_high_signal(metadata[str(row["school_id"])], options.min_enrollment)
+    ][: options.max_per_batch]
+
+    brave_api_key = os.environ.get("BRAVE_API_KEY")
+    repaired: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    extraction: list[dict[str, Any]] = []
+
+    for school in high_signal:
+        candidate, evidence = discover_repair_candidate(
+            school_name=str(school.get("school_name") or school["school_id"]),
+            website_url=str(school.get("website_url") or ""),
+            options=options,
+            brave_api_key=brave_api_key,
+        )
+        if not candidate:
+            record = {"school_id": school["school_id"], "school_name": school.get("school_name"), **evidence}
+            skipped.append(record)
+            logger.write("repair_skipped", **record)
+            continue
+
+        try:
+            outcome = post_force_urls(client, school, candidate)
+            record = {
+                "school_id": school["school_id"],
+                "school_name": school.get("school_name"),
+                "url": candidate.url,
+                "year": candidate.year,
+                "evidence": candidate.evidence,
+                "outcome": outcome,
+            }
+            repaired.append(record)
+            logger.write("repair_force_urls", **record)
+            if options.extract_repaired:
+                extract_report = run_extraction_for_school(
+                    supabase_url=supabase_url,
+                    service_key=service_key,
+                    school_id=str(school["school_id"]),
+                    python_bin=options.extraction_python,
+                    limit=options.extraction_limit,
+                )
+                extraction.append(extract_report)
+                logger.write("repair_extraction", **extract_report)
+        except Exception as exc:
+            record = {
+                "school_id": school["school_id"],
+                "school_name": school.get("school_name"),
+                "url": candidate.url,
+                "error": str(exc),
+            }
+            skipped.append(record)
+            logger.write("repair_failed", **record)
+
+    if repaired or skipped:
+        refresh = batches.refresh_coverage(client)
+        logger.write("repair_refresh", refresh=refresh)
+    else:
+        refresh = None
+
+    return {
+        "considered_failed": len(failed),
+        "high_signal": len(high_signal),
+        "repaired": repaired,
+        "skipped": skipped,
+        "extraction": extraction,
+        "refresh": refresh,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", default=".env")
+    parser.add_argument("--out-dir", default="scratch/directory-enqueue-runs")
+    parser.add_argument("--batch-size", type=int, default=25)
+    parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--uniform-cooldown-days", type=int, default=1)
+    parser.add_argument("--poll-interval-seconds", type=int, default=30)
+    parser.add_argument("--timeout-minutes", type=int, default=360)
+    parser.add_argument("--stall-timeout-minutes", type=int, default=20)
+    parser.add_argument("--max-transient-rate", type=float, default=0.25)
+    parser.add_argument("--max-permanent-other-rate", type=float, default=0.05)
+    parser.add_argument("--stop-on-transient-gate", action="store_true")
+    parser.add_argument("--repair-min-enrollment", type=int, default=10_000)
+    parser.add_argument("--repair-max-per-batch", type=int, default=5)
+    parser.add_argument("--repair-school-budget-seconds", type=float, default=45.0)
+    parser.add_argument("--repair-rps", type=float, default=2.0)
+    parser.add_argument("--repair-bing-fallback", action="store_true")
+    parser.add_argument("--repair-brave-fallback", action="store_true")
+    parser.add_argument("--no-repair", action="store_true")
+    parser.add_argument("--extract-repaired", action="store_true")
+    parser.add_argument("--extraction-python", default=".context/extraction-venv/bin/python")
+    parser.add_argument("--extraction-limit", type=int, default=3)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    batches.configure_output_buffering()
+    args = build_parser().parse_args(argv)
+    try:
+        supabase_url, service_key = batches.require_supabase_credentials(Path(args.env))
+        client = batches.SupabaseClient(supabase_url, service_key)
+        logger = batches.JsonlLogger(Path(args.out_dir))
+        enqueue_options = batches.DirectoryEnqueueOptions(
+            uniform_cooldown_days=args.uniform_cooldown_days,
+        )
+        repair_options = RepairOptions(
+            min_enrollment=args.repair_min_enrollment,
+            max_per_batch=args.repair_max_per_batch,
+            rps=args.repair_rps,
+            school_budget_seconds=args.repair_school_budget_seconds,
+            bing_fallback=args.repair_bing_fallback,
+            brave_fallback=args.repair_brave_fallback,
+            extract_repaired=args.extract_repaired,
+            extraction_python=args.extraction_python,
+            extraction_limit=args.extraction_limit,
+        )
+
+        print(f"Writing JSONL log to {logger.path}")
+        reports: list[dict[str, Any]] = []
+        for batch_number in range(1, args.max_batches + 1):
+            print(f"\n## Autopilot batch {batch_number}/{args.max_batches}")
+            report = batches.run_batch(
+                client,
+                limit=args.batch_size,
+                apply=args.apply,
+                options=enqueue_options,
+                logger=logger,
+                timeout_seconds=args.timeout_minutes * 60,
+                poll_interval_seconds=args.poll_interval_seconds,
+                stall_timeout_seconds=args.stall_timeout_minutes * 60,
+                max_transient_rate=args.max_transient_rate,
+                max_permanent_other_rate=args.max_permanent_other_rate,
+                stop_on_transient_gate=args.stop_on_transient_gate,
+            )
+
+            repair_report = None
+            if args.apply and not args.no_repair and report.get("applied"):
+                run_id = str(report.get("enqueue", {}).get("run_id") or "")
+                queue_rows = batches.fetch_queue_rows(client, run_id)
+                repair_report = repair_high_signal_failures(
+                    client=client,
+                    supabase_url=supabase_url,
+                    service_key=service_key,
+                    queue_rows=queue_rows,
+                    options=repair_options,
+                    logger=logger,
+                )
+                batches.print_json("High-signal repair", repair_report)
+
+            reports.append({"batch": report, "repair": repair_report})
+            if not report.get("applied"):
+                break
+
+        logger.write("autopilot_completed", reports=reports)
+        print(f"\nCompleted. JSONL log: {logger.path}")
+        return 0
+    except (batches.OpsError, TimeoutError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -160,7 +160,7 @@ def directory_enqueue_params(limit: int, options: DirectoryEnqueueOptions, *, dr
     if options.force_recheck:
         params["force_recheck"] = "true"
     if options.uniform_cooldown_days is not None:
-        params["uniform_cooldown_days"] = str(options.uniform_cooldown_days)
+        params["cooldown_days"] = str(options.uniform_cooldown_days)
     return params
 
 

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -24,7 +24,8 @@ from typing import Any, Callable, Iterable
 
 
 ACTIVE_QUEUE_STATUSES = {"ready", "processing"}
-UNEXPECTED_OUTCOMES = {"transient", "permanent_other"}
+TRANSIENT_OUTCOME = "transient"
+PERMANENT_OTHER_OUTCOME = "permanent_other"
 WATCH_STATUSES = [
     "not_checked",
     "no_public_cds_found",
@@ -37,6 +38,12 @@ DEFAULT_BATCHES = [25, 75, 150, 250]
 
 class OpsError(RuntimeError):
     """Raised for operator-visible failures that should stop the rollout."""
+
+
+def configure_output_buffering() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(line_buffering=True)
 
 
 @dataclass(frozen=True)
@@ -253,15 +260,20 @@ def summarize_queue_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
     outcomes = Counter(row.get("last_outcome") for row in rows if row.get("last_outcome"))
     active = sum(statuses.get(status, 0) for status in ACTIVE_QUEUE_STATUSES)
     terminal = len(rows) - active
-    unexpected = sum(outcomes.get(outcome, 0) for outcome in UNEXPECTED_OUTCOMES)
+    transient = outcomes.get(TRANSIENT_OUTCOME, 0)
+    permanent_other = outcomes.get(PERMANENT_OTHER_OUTCOME, 0)
     return {
         "total": len(rows),
         "active": active,
         "terminal": terminal,
         "statuses": dict(statuses),
         "last_outcomes": dict(outcomes),
-        "unexpected_outcomes": unexpected,
-        "unexpected_outcome_rate": unexpected / len(rows) if rows else 0.0,
+        "transient_outcomes": transient,
+        "transient_outcome_rate": transient / len(rows) if rows else 0.0,
+        "permanent_other_outcomes": permanent_other,
+        "permanent_other_outcome_rate": permanent_other / len(rows) if rows else 0.0,
+        "unexpected_outcomes": transient + permanent_other,
+        "unexpected_outcome_rate": (transient + permanent_other) / len(rows) if rows else 0.0,
     }
 
 
@@ -340,14 +352,34 @@ def assert_histogram_plausible(before: dict[str, int], after: dict[str, int]) ->
         raise OpsError("Coverage histogram lost all not_checked rows")
 
 
-def enforce_unexpected_outcome_gate(summary: dict[str, Any], max_rate: float) -> None:
-    rate = float(summary.get("unexpected_outcome_rate", 0.0))
+def enforce_outcome_gates(
+    summary: dict[str, Any],
+    *,
+    max_transient_rate: float,
+    max_permanent_other_rate: float,
+    stop_on_transient_gate: bool,
+) -> None:
     total = int(summary.get("total", 0))
-    if total and rate > max_rate:
+    if not total:
+        return
+
+    permanent_other_rate = float(summary.get("permanent_other_outcome_rate", 0.0))
+    if permanent_other_rate > max_permanent_other_rate:
         raise OpsError(
-            f"Unexpected archive outcomes exceeded gate: {rate:.1%} > {max_rate:.1%} "
-            f"({summary.get('unexpected_outcomes', 0)} of {total})"
+            f"permanent_other outcomes exceeded gate: {permanent_other_rate:.1%} > "
+            f"{max_permanent_other_rate:.1%} "
+            f"({summary.get('permanent_other_outcomes', 0)} of {total})"
         )
+
+    transient_rate = float(summary.get("transient_outcome_rate", 0.0))
+    if transient_rate > max_transient_rate:
+        message = (
+            f"transient outcomes exceeded warning gate: {transient_rate:.1%} > "
+            f"{max_transient_rate:.1%} ({summary.get('transient_outcomes', 0)} of {total})"
+        )
+        if stop_on_transient_gate:
+            raise OpsError(message)
+        print(f"WARNING: {message}")
 
 
 def run_batch(
@@ -360,7 +392,9 @@ def run_batch(
     timeout_seconds: int,
     poll_interval_seconds: int,
     stall_timeout_seconds: int,
-    unexpected_outcome_rate: float,
+    max_transient_rate: float,
+    max_permanent_other_rate: float,
+    stop_on_transient_gate: bool,
 ) -> dict[str, Any]:
     print(f"\n== Batch limit={limit} ==")
     before = fetch_coverage_histogram(client)
@@ -439,7 +473,12 @@ def run_batch(
     logger.write("refresh", **refresh_report)
     print_histogram("Coverage after", after)
     print_json("Watched status delta", delta)
-    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
+    enforce_outcome_gates(
+        queue_summary,
+        max_transient_rate=max_transient_rate,
+        max_permanent_other_rate=max_permanent_other_rate,
+        stop_on_transient_gate=stop_on_transient_gate,
+    )
 
     return {
         "dry_run": dry_run_report,
@@ -458,7 +497,9 @@ def resume_run(
     timeout_seconds: int,
     poll_interval_seconds: int,
     stall_timeout_seconds: int,
-    unexpected_outcome_rate: float,
+    max_transient_rate: float,
+    max_permanent_other_rate: float,
+    stop_on_transient_gate: bool,
 ) -> dict[str, Any]:
     print(f"\n== Resume run_id={run_id} ==")
     before = fetch_coverage_histogram(client)
@@ -492,7 +533,12 @@ def resume_run(
     logger.write("resume_refresh", **refresh_report)
     print_histogram("Coverage after", after)
     print_json("Watched status delta", delta)
-    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
+    enforce_outcome_gates(
+        queue_summary,
+        max_transient_rate=max_transient_rate,
+        max_permanent_other_rate=max_permanent_other_rate,
+        stop_on_transient_gate=stop_on_transient_gate,
+    )
 
     return {"run_id": run_id, "queue": queue_summary, "refresh": refresh_report}
 
@@ -544,12 +590,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--poll-interval-seconds", type=int, default=30)
     parser.add_argument("--timeout-minutes", type=int, default=360)
     parser.add_argument("--stall-timeout-minutes", type=int, default=20)
-    parser.add_argument("--unexpected-outcome-rate", type=float, default=0.10)
+    parser.add_argument("--max-transient-rate", type=float, default=0.25, help="Warn when terminal transient outcomes exceed this rate")
+    parser.add_argument("--max-permanent-other-rate", type=float, default=0.05, help="Stop when terminal permanent_other outcomes exceed this rate")
+    parser.add_argument("--stop-on-transient-gate", action="store_true", help="Treat --max-transient-rate as a stop gate instead of a warning")
     parser.add_argument("--baseline-sample-size", type=int, default=10)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    configure_output_buffering()
     parser = build_parser()
     args = parser.parse_args(argv)
 
@@ -576,7 +625,9 @@ def main(argv: list[str] | None = None) -> int:
                 timeout_seconds=args.timeout_minutes * 60,
                 poll_interval_seconds=args.poll_interval_seconds,
                 stall_timeout_seconds=args.stall_timeout_minutes * 60,
-                unexpected_outcome_rate=args.unexpected_outcome_rate,
+                max_transient_rate=args.max_transient_rate,
+                max_permanent_other_rate=args.max_permanent_other_rate,
+                stop_on_transient_gate=args.stop_on_transient_gate,
             )
             logger.write("completed", reports=[report])
             print(f"\nCompleted. JSONL log: {logger.path}")
@@ -613,7 +664,9 @@ def main(argv: list[str] | None = None) -> int:
                     timeout_seconds=args.timeout_minutes * 60,
                     poll_interval_seconds=args.poll_interval_seconds,
                     stall_timeout_seconds=args.stall_timeout_minutes * 60,
-                    unexpected_outcome_rate=args.unexpected_outcome_rate,
+                    max_transient_rate=args.max_transient_rate,
+                    max_permanent_other_rate=args.max_permanent_other_rate,
+                    stop_on_transient_gate=args.stop_on_transient_gate,
                 )
             )
 

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Operator workflow for controlled directory-enqueue batches.
+
+The script intentionally wraps existing Edge Functions instead of adding any
+new automatic discovery path. By default it only performs dry-runs; pass
+--apply to enqueue and drain staged batches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+ACTIVE_QUEUE_STATUSES = {"ready", "processing"}
+UNEXPECTED_OUTCOMES = {"transient", "permanent_other"}
+WATCH_STATUSES = [
+    "not_checked",
+    "no_public_cds_found",
+    "source_not_automatically_accessible",
+    "cds_available_current",
+    "extract_failed",
+]
+DEFAULT_BATCHES = [25, 75, 150, 250]
+
+
+class OpsError(RuntimeError):
+    """Raised for operator-visible failures that should stop the rollout."""
+
+
+@dataclass(frozen=True)
+class DirectoryEnqueueOptions:
+    min_enrollment: int | None = None
+    state: str | None = None
+    force_recheck: bool = False
+    uniform_cooldown_days: int | None = None
+
+
+class SupabaseClient:
+    def __init__(self, supabase_url: str, service_role_key: str) -> None:
+        self.supabase_url = supabase_url.rstrip("/")
+        self.service_role_key = service_role_key
+
+    def rest_get(self, table: str, params: dict[str, str], *, page: tuple[int, int] | None = None) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode(params)
+        url = f"{self.supabase_url}/rest/v1/{table}?{query}"
+        headers = self._headers()
+        if page is not None:
+            headers["Range"] = f"{page[0]}-{page[1]}"
+            headers["Prefer"] = "count=exact"
+        return self._request_json("GET", url, headers=headers)
+
+    def post_function(self, name: str, params: dict[str, str]) -> dict[str, Any]:
+        query = urllib.parse.urlencode(params)
+        url = f"{self.supabase_url}/functions/v1/{name}"
+        if query:
+            url = f"{url}?{query}"
+        return self._request_json("POST", url, headers=self._headers())
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.service_role_key}",
+            "apikey": self.service_role_key,
+            "Content-Type": "application/json",
+        }
+
+    def _request_json(self, method: str, url: str, *, headers: dict[str, str]) -> Any:
+        request = urllib.request.Request(url, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise OpsError(f"{method} {url} failed with HTTP {exc.code}: {body}") from exc
+        except urllib.error.URLError as exc:
+            raise OpsError(f"{method} {url} failed: {exc.reason}") from exc
+        if not body:
+            return {}
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise OpsError(f"{method} {url} returned non-JSON response: {body[:500]}") from exc
+
+
+class JsonlLogger:
+    def __init__(self, out_dir: Path, started_at: datetime | None = None) -> None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = (started_at or utc_now()).strftime("%Y%m%dT%H%M%SZ")
+        self.path = out_dir / f"directory-enqueue-{stamp}.jsonl"
+
+    def write(self, event: str, **payload: Any) -> None:
+        record = {
+            "ts": utc_now().isoformat().replace("+00:00", "Z"),
+            "event": event,
+            **payload,
+        }
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def require_supabase_credentials(env_path: Path) -> tuple[str, str]:
+    file_env = load_env_file(env_path)
+    supabase_url = file_env.get("SUPABASE_URL") or os.environ.get("SUPABASE_URL")
+    service_key = file_env.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not supabase_url or not service_key:
+        raise OpsError(
+            f"Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Add them to {env_path} or export them."
+        )
+    return supabase_url, service_key
+
+
+def directory_enqueue_params(limit: int, options: DirectoryEnqueueOptions, *, dry_run: bool) -> dict[str, str]:
+    params = {"limit": str(limit)}
+    if dry_run:
+        params["dry_run"] = "true"
+    if options.min_enrollment is not None:
+        params["min_enrollment"] = str(options.min_enrollment)
+    if options.state:
+        params["state"] = options.state
+    if options.force_recheck:
+        params["force_recheck"] = "true"
+    if options.uniform_cooldown_days is not None:
+        params["uniform_cooldown_days"] = str(options.uniform_cooldown_days)
+    return params
+
+
+def call_directory_enqueue(
+    client: Any,
+    limit: int,
+    options: DirectoryEnqueueOptions,
+    *,
+    dry_run: bool,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    params = directory_enqueue_params(limit, options, dry_run=dry_run)
+    if run_id:
+        params["run_id"] = run_id
+    return client.post_function("directory-enqueue", params)
+
+
+def refresh_coverage(client: Any) -> dict[str, Any]:
+    return client.post_function("refresh-coverage", {})
+
+
+def fetch_coverage_histogram(client: Any) -> dict[str, int]:
+    rows = paged_rest_get(
+        client,
+        "institution_cds_coverage",
+        {
+            "select": "coverage_status",
+            "order": "ipeds_id.asc",
+        },
+    )
+    return dict(Counter(row.get("coverage_status") for row in rows if row.get("coverage_status")))
+
+
+def fetch_top_not_checked(client: Any, limit: int) -> list[dict[str, Any]]:
+    return client.rest_get(
+        "institution_cds_coverage",
+        {
+            "select": "ipeds_id,school_id,school_name,state,undergraduate_enrollment",
+            "coverage_status": "eq.not_checked",
+            "order": "undergraduate_enrollment.desc.nullslast,school_name.asc",
+            "limit": str(limit),
+        },
+    )
+
+
+def fetch_in_flight_directory_rows(client: Any) -> list[dict[str, Any]]:
+    return client.rest_get(
+        "archive_queue",
+        {
+            "select": "school_id,school_name,status,enqueued_run_id,enqueued_at,claimed_at",
+            "source": "eq.institution_directory",
+            "status": "in.(ready,processing)",
+            "order": "enqueued_at.asc",
+        },
+    )
+
+
+def fetch_queue_rows(client: Any, run_id: str) -> list[dict[str, Any]]:
+    return paged_rest_get(
+        client,
+        "archive_queue",
+        {
+            "select": "school_id,school_name,status,last_outcome,processed_at,attempts,last_error",
+            "source": "eq.institution_directory",
+            "enqueued_run_id": f"eq.{run_id}",
+            "order": "school_name.asc",
+        },
+    )
+
+
+def fetch_sample_schools(client: Any, school_ids: Iterable[str]) -> list[dict[str, Any]]:
+    ids = [school_id for school_id in school_ids if school_id]
+    if not ids:
+        return []
+    return client.rest_get(
+        "institution_directory",
+        {
+            "select": "school_id,school_name,state,undergraduate_enrollment",
+            "school_id": f"in.({','.join(ids)})",
+            "order": "undergraduate_enrollment.desc.nullslast,school_name.asc",
+        },
+    )
+
+
+def paged_rest_get(client: Any, table: str, params: dict[str, str], *, page_size: int = 1000) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for start in range(0, 50_000, page_size):
+        page = client.rest_get(table, params, page=(start, start + page_size - 1))
+        rows.extend(page)
+        if len(page) < page_size:
+            return rows
+    raise OpsError(f"Refusing to read more than 50,000 rows from {table}")
+
+
+def summarize_queue_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    statuses = Counter(row.get("status") for row in rows if row.get("status"))
+    outcomes = Counter(row.get("last_outcome") for row in rows if row.get("last_outcome"))
+    active = sum(statuses.get(status, 0) for status in ACTIVE_QUEUE_STATUSES)
+    terminal = len(rows) - active
+    unexpected = sum(outcomes.get(outcome, 0) for outcome in UNEXPECTED_OUTCOMES)
+    return {
+        "total": len(rows),
+        "active": active,
+        "terminal": terminal,
+        "statuses": dict(statuses),
+        "last_outcomes": dict(outcomes),
+        "unexpected_outcomes": unexpected,
+        "unexpected_outcome_rate": unexpected / len(rows) if rows else 0.0,
+    }
+
+
+def poll_until_drained(
+    client: Any,
+    run_id: str,
+    *,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    stall_timeout_seconds: int,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    logger: JsonlLogger | None = None,
+) -> dict[str, Any]:
+    started = now()
+    last_progress_at = started
+    last_terminal = -1
+
+    while True:
+        rows = fetch_queue_rows(client, run_id)
+        summary = summarize_queue_rows(rows)
+        if logger:
+            logger.write("poll", run_id=run_id, queue=summary)
+
+        if summary["active"] == 0:
+            return {"rows": rows, "summary": summary}
+
+        terminal = int(summary["terminal"])
+        if terminal > last_terminal:
+            last_terminal = terminal
+            last_progress_at = now()
+
+        elapsed = now() - started
+        stalled = now() - last_progress_at
+        if elapsed >= timeout_seconds:
+            raise TimeoutError(f"Timed out waiting for run_id={run_id} after {int(elapsed)} seconds")
+        if stalled >= stall_timeout_seconds:
+            raise TimeoutError(f"Queue stalled for run_id={run_id} after {int(stalled)} seconds without progress")
+
+        print_queue_progress(run_id, summary)
+        sleep(poll_interval_seconds)
+
+
+def histogram_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    statuses = sorted(set(before) | set(after))
+    return {status: after.get(status, 0) - before.get(status, 0) for status in statuses}
+
+
+def watched_histogram_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    delta = histogram_delta(before, after)
+    return {status: delta.get(status, 0) for status in WATCH_STATUSES}
+
+
+def assert_histogram_plausible(before: dict[str, int], after: dict[str, int]) -> None:
+    before_total = sum(before.values())
+    after_total = sum(after.values())
+    if before_total and after_total and abs(after_total - before_total) > 5:
+        raise OpsError(f"Coverage row count changed implausibly: before={before_total}, after={after_total}")
+    if before.get("cds_available_current", 0) > 0 and after.get("cds_available_current", 0) == 0:
+        raise OpsError("Coverage histogram lost all cds_available_current rows")
+    if before.get("not_checked", 0) > 0 and after.get("not_checked", 0) == 0:
+        raise OpsError("Coverage histogram lost all not_checked rows")
+
+
+def enforce_unexpected_outcome_gate(summary: dict[str, Any], max_rate: float) -> None:
+    rate = float(summary.get("unexpected_outcome_rate", 0.0))
+    total = int(summary.get("total", 0))
+    if total and rate > max_rate:
+        raise OpsError(
+            f"Unexpected archive outcomes exceeded gate: {rate:.1%} > {max_rate:.1%} "
+            f"({summary.get('unexpected_outcomes', 0)} of {total})"
+        )
+
+
+def run_batch(
+    client: Any,
+    *,
+    limit: int,
+    apply: bool,
+    options: DirectoryEnqueueOptions,
+    logger: JsonlLogger,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    stall_timeout_seconds: int,
+    unexpected_outcome_rate: float,
+) -> dict[str, Any]:
+    print(f"\n== Batch limit={limit} ==")
+    before = fetch_coverage_histogram(client)
+    logger.write("coverage_before", limit=limit, histogram=before)
+    print_histogram("Coverage before", before)
+
+    dry_run = call_directory_enqueue(client, limit, options, dry_run=True)
+    sample_ids = dry_run.get("sample_school_ids") or []
+    sample = fetch_sample_schools(client, sample_ids[:10])
+    dry_run_report = {
+        "limit": limit,
+        "mode": dry_run.get("mode"),
+        "run_id": dry_run.get("run_id"),
+        "would_enqueue": dry_run.get("would_enqueue", 0),
+        "considered": dry_run.get("considered"),
+        "skipped": dry_run.get("skipped", {}),
+        "sample_schools": sample,
+    }
+    logger.write("dry_run", **dry_run_report)
+    print_json("Dry-run", dry_run_report)
+
+    if not apply:
+        print("Dry-run only. Pass --apply to enqueue and drain this batch.")
+        return {"dry_run": dry_run_report, "applied": False}
+
+    if int(dry_run.get("would_enqueue") or 0) == 0:
+        print("No selected schools passed the dry-run filters; skipping real enqueue.")
+        return {"dry_run": dry_run_report, "applied": False, "reason": "empty_dry_run"}
+
+    enqueue = call_directory_enqueue(
+        client,
+        limit,
+        options,
+        dry_run=False,
+        run_id=str(dry_run.get("run_id") or ""),
+    )
+    run_id = str(enqueue.get("run_id") or "")
+    if not run_id:
+        raise OpsError(f"directory-enqueue did not return run_id: {enqueue}")
+
+    enqueue_report = {
+        "limit": limit,
+        "run_id": run_id,
+        "enqueued": enqueue.get("enqueued", 0),
+        "considered": enqueue.get("considered"),
+        "skipped_existing": enqueue.get("skipped_existing", 0),
+        "skipped": enqueue.get("skipped", {}),
+    }
+    logger.write("enqueue", **enqueue_report)
+    print_json("Enqueue", enqueue_report)
+
+    drained = poll_until_drained(
+        client,
+        run_id,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+        logger=logger,
+    )
+    queue_summary = drained["summary"]
+    logger.write("drained", run_id=run_id, queue=queue_summary)
+    print_json("Queue drained", queue_summary)
+    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
+
+    refresh = refresh_coverage(client)
+    after = refresh.get("coverage_status_histogram") or fetch_coverage_histogram(client)
+    assert_histogram_plausible(before, after)
+    delta = watched_histogram_delta(before, after)
+    refresh_report = {
+        "run_id": run_id,
+        "rows_written": refresh.get("rows_written"),
+        "refresh_duration_ms": refresh.get("refresh_duration_ms"),
+        "total_duration_ms": refresh.get("total_duration_ms"),
+        "coverage_after": after,
+        "watched_delta": delta,
+    }
+    logger.write("refresh", **refresh_report)
+    print_histogram("Coverage after", after)
+    print_json("Watched status delta", delta)
+
+    return {
+        "dry_run": dry_run_report,
+        "enqueue": enqueue_report,
+        "queue": queue_summary,
+        "refresh": refresh_report,
+        "applied": True,
+    }
+
+
+def print_queue_progress(run_id: str, summary: dict[str, Any]) -> None:
+    statuses = summary.get("statuses", {})
+    print(
+        f"Waiting for run_id={run_id}: "
+        f"active={summary.get('active', 0)} terminal={summary.get('terminal', 0)} statuses={statuses}"
+    )
+
+
+def print_histogram(label: str, histogram: dict[str, int]) -> None:
+    print(f"\n{label}")
+    for status, count in sorted(histogram.items()):
+        print(f"  {status}: {count}")
+
+
+def print_json(label: str, payload: Any) -> None:
+    print(f"\n{label}")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def parse_batches(raw: str | None, single_limit: int | None) -> list[int]:
+    if single_limit is not None:
+        if single_limit < 0:
+            raise ValueError("limit must be a non-negative integer")
+        return [single_limit]
+    if not raw:
+        return DEFAULT_BATCHES
+    batches = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not batches or any(limit < 0 for limit in batches):
+        raise ValueError("batches must be comma-separated non-negative integers")
+    return batches
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", default=".env", help="Path to .env containing Supabase credentials")
+    parser.add_argument("--out-dir", default="scratch/directory-enqueue-runs", help="Directory for JSONL run logs")
+    parser.add_argument("--limit", type=int, help="Run one batch with this explicit limit")
+    parser.add_argument("--batches", help="Comma-separated staged limits; default: 25,75,150,250")
+    parser.add_argument("--apply", action="store_true", help="Actually enqueue, poll, refresh, and gate each batch")
+    parser.add_argument("--min-enrollment", type=int, help="Pass min_enrollment through to directory-enqueue")
+    parser.add_argument("--state", help="Pass a two-letter state filter through to directory-enqueue")
+    parser.add_argument("--force-recheck", action="store_true", help="Pass force_recheck=true; do not use for first top-500 pass")
+    parser.add_argument("--uniform-cooldown-days", type=int, help="Override outcome cooldowns")
+    parser.add_argument("--poll-interval-seconds", type=int, default=30)
+    parser.add_argument("--timeout-minutes", type=int, default=360)
+    parser.add_argument("--stall-timeout-minutes", type=int, default=20)
+    parser.add_argument("--unexpected-outcome-rate", type=float, default=0.10)
+    parser.add_argument("--baseline-sample-size", type=int, default=10)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.force_recheck:
+            print("WARNING: --force-recheck bypasses cooldowns and is not for the first top-500 pass.", file=sys.stderr)
+
+        batches = parse_batches(args.batches, args.limit)
+        supabase_url, service_key = require_supabase_credentials(Path(args.env))
+        client = SupabaseClient(supabase_url, service_key)
+        logger = JsonlLogger(Path(args.out_dir))
+        options = DirectoryEnqueueOptions(
+            min_enrollment=args.min_enrollment,
+            state=args.state,
+            force_recheck=args.force_recheck,
+            uniform_cooldown_days=args.uniform_cooldown_days,
+        )
+
+        baseline = {
+            "coverage": fetch_coverage_histogram(client),
+            "top_not_checked": fetch_top_not_checked(client, args.baseline_sample_size),
+            "in_flight_directory_rows": fetch_in_flight_directory_rows(client),
+            "batches": batches,
+            "apply": args.apply,
+            "options": {
+                "min_enrollment": options.min_enrollment,
+                "state": options.state,
+                "force_recheck": options.force_recheck,
+                "uniform_cooldown_days": options.uniform_cooldown_days,
+            },
+        }
+        logger.write("baseline", **baseline)
+        print(f"Writing JSONL log to {logger.path}")
+        print_histogram("Baseline coverage", baseline["coverage"])
+        print_json("Top not_checked sample", baseline["top_not_checked"])
+        print_json("Current in-flight directory rows", baseline["in_flight_directory_rows"])
+
+        reports = []
+        for limit in batches:
+            reports.append(
+                run_batch(
+                    client,
+                    limit=limit,
+                    apply=args.apply,
+                    options=options,
+                    logger=logger,
+                    timeout_seconds=args.timeout_minutes * 60,
+                    poll_interval_seconds=args.poll_interval_seconds,
+                    stall_timeout_seconds=args.stall_timeout_minutes * 60,
+                    unexpected_outcome_rate=args.unexpected_outcome_rate,
+                )
+            )
+
+        logger.write("completed", reports=reports)
+        print(f"\nCompleted. JSONL log: {logger.path}")
+        return 0
+    except (OpsError, TimeoutError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -601,6 +601,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-permanent-other-rate", type=float, default=0.05, help="Stop when terminal permanent_other outcomes exceed this rate")
     parser.add_argument("--stop-on-transient-gate", action="store_true", help="Treat --max-transient-rate as a stop gate instead of a warning")
     parser.add_argument("--baseline-sample-size", type=int, default=10)
+    parser.add_argument("--skip-extraction-backlog-audit", action="store_true")
+    parser.add_argument("--extraction-max-pending-age-hours", type=float, default=24.0)
+    parser.add_argument("--extraction-max-pending-count", type=int)
+    parser.add_argument("--extraction-audit-sample-limit", type=int, default=15)
+    parser.add_argument("--extraction-audit-github", action="store_true")
+    parser.add_argument("--extraction-audit-github-repo", default="bolewood/collegedata-fyi")
+    parser.add_argument("--extraction-audit-github-workflow", default="Ops extraction worker")
+    parser.add_argument("--extraction-max-github-success-age-hours", type=float, default=30.0)
+    parser.add_argument("--fail-on-extraction-pending-growth", action="store_true")
     return parser
 
 
@@ -624,6 +633,37 @@ def main(argv: list[str] | None = None) -> int:
             uniform_cooldown_days=args.uniform_cooldown_days,
         )
 
+        def audit_extraction_backlog(previous_pending_count: int | None) -> tuple[dict[str, Any], int]:
+            from tools.ops import extraction_backlog_audit
+
+            audit = extraction_backlog_audit.build_audit(
+                client,
+                sample_limit=args.extraction_audit_sample_limit,
+                include_github=args.extraction_audit_github,
+                github_repo=args.extraction_audit_github_repo,
+                github_workflow=args.extraction_audit_github_workflow,
+                github_limit=20,
+            )
+            gate_failures = extraction_backlog_audit.evaluate_gates(
+                audit,
+                extraction_backlog_audit.AuditThresholds(
+                    max_pending_age_hours=args.extraction_max_pending_age_hours,
+                    max_pending_count=args.extraction_max_pending_count,
+                    max_github_success_age_hours=(
+                        args.extraction_max_github_success_age_hours
+                        if args.extraction_audit_github
+                        else None
+                    ),
+                    fail_on_pending_growth=args.fail_on_extraction_pending_growth,
+                ),
+                previous_pending_count=previous_pending_count,
+            )
+            logger.write("extraction_backlog_audit", audit=audit, gate_failures=gate_failures)
+            extraction_backlog_audit.print_audit(audit, gate_failures)
+            if gate_failures:
+                raise OpsError("extraction backlog gate failed: " + "; ".join(gate_failures))
+            return audit, int(audit.get("pending_count") or 0)
+
         if args.resume_run_id:
             report = resume_run(
                 client,
@@ -636,6 +676,8 @@ def main(argv: list[str] | None = None) -> int:
                 max_permanent_other_rate=args.max_permanent_other_rate,
                 stop_on_transient_gate=args.stop_on_transient_gate,
             )
+            if not args.skip_extraction_backlog_audit:
+                audit_extraction_backlog(None)
             logger.write("completed", reports=[report])
             print(f"\nCompleted. JSONL log: {logger.path}")
             return 0
@@ -660,22 +702,26 @@ def main(argv: list[str] | None = None) -> int:
         print_json("Current in-flight directory rows", baseline["in_flight_directory_rows"])
 
         reports = []
+        previous_pending_count: int | None = None
         for limit in batches:
-            reports.append(
-                run_batch(
-                    client,
-                    limit=limit,
-                    apply=args.apply,
-                    options=options,
-                    logger=logger,
-                    timeout_seconds=args.timeout_minutes * 60,
-                    poll_interval_seconds=args.poll_interval_seconds,
-                    stall_timeout_seconds=args.stall_timeout_minutes * 60,
-                    max_transient_rate=args.max_transient_rate,
-                    max_permanent_other_rate=args.max_permanent_other_rate,
-                    stop_on_transient_gate=args.stop_on_transient_gate,
-                )
+            report = run_batch(
+                client,
+                limit=limit,
+                apply=args.apply,
+                options=options,
+                logger=logger,
+                timeout_seconds=args.timeout_minutes * 60,
+                poll_interval_seconds=args.poll_interval_seconds,
+                stall_timeout_seconds=args.stall_timeout_minutes * 60,
+                max_transient_rate=args.max_transient_rate,
+                max_permanent_other_rate=args.max_permanent_other_rate,
+                stop_on_transient_gate=args.stop_on_transient_gate,
             )
+            extraction_audit = None
+            if args.apply and not args.skip_extraction_backlog_audit and report.get("applied"):
+                extraction_audit, previous_pending_count = audit_extraction_backlog(previous_pending_count)
+            report["extraction_backlog_audit"] = extraction_audit
+            reports.append(report)
 
         logger.write("completed", reports=reports)
         print(f"\nCompleted. JSONL log: {logger.path}")

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -75,6 +75,13 @@ class SupabaseClient:
             url = f"{url}?{query}"
         return self._request_json("POST", url, headers=self._headers())
 
+    def post_function_json(self, name: str, body: dict[str, Any], params: dict[str, str] | None = None) -> dict[str, Any]:
+        query = urllib.parse.urlencode(params or {})
+        url = f"{self.supabase_url}/functions/v1/{name}"
+        if query:
+            url = f"{url}?{query}"
+        return self._request_json("POST", url, headers=self._headers(), body=json.dumps(body).encode("utf-8"))
+
     def _headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self.service_role_key}",
@@ -82,8 +89,8 @@ class SupabaseClient:
             "Content-Type": "application/json",
         }
 
-    def _request_json(self, method: str, url: str, *, headers: dict[str, str]) -> Any:
-        request = urllib.request.Request(url, method=method, headers=headers)
+    def _request_json(self, method: str, url: str, *, headers: dict[str, str], body: bytes | None = None) -> Any:
+        request = urllib.request.Request(url, data=body, method=method, headers=headers)
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
                 body = response.read().decode("utf-8")
@@ -223,7 +230,7 @@ def fetch_queue_rows(client: Any, run_id: str) -> list[dict[str, Any]]:
         client,
         "archive_queue",
         {
-            "select": "school_id,school_name,status,last_outcome,processed_at,attempts,last_error",
+            "select": "school_id,school_name,cds_url_hint,status,last_outcome,processed_at,attempts,last_error",
             "source": "eq.institution_directory",
             "enqueued_run_id": f"eq.{run_id}",
             "order": "school_name.asc",

--- a/tools/ops/directory_enqueue_batches.py
+++ b/tools/ops/directory_enqueue_batches.py
@@ -281,7 +281,21 @@ def poll_until_drained(
     last_terminal = -1
 
     while True:
-        rows = fetch_queue_rows(client, run_id)
+        try:
+            rows = fetch_queue_rows(client, run_id)
+        except OpsError as exc:
+            if logger:
+                logger.write("poll_error", run_id=run_id, error=str(exc))
+            elapsed = now() - started
+            stalled = now() - last_progress_at
+            if elapsed >= timeout_seconds:
+                raise TimeoutError(f"Timed out waiting for run_id={run_id} after poll errors") from exc
+            if stalled >= stall_timeout_seconds:
+                raise TimeoutError(f"Queue polling stalled for run_id={run_id} after {int(stalled)} seconds") from exc
+            print(f"Polling read failed for run_id={run_id}; retrying: {exc}")
+            sleep(poll_interval_seconds)
+            continue
+
         summary = summarize_queue_rows(rows)
         if logger:
             logger.write("poll", run_id=run_id, queue=summary)
@@ -409,7 +423,6 @@ def run_batch(
     queue_summary = drained["summary"]
     logger.write("drained", run_id=run_id, queue=queue_summary)
     print_json("Queue drained", queue_summary)
-    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
 
     refresh = refresh_coverage(client)
     after = refresh.get("coverage_status_histogram") or fetch_coverage_histogram(client)
@@ -426,6 +439,7 @@ def run_batch(
     logger.write("refresh", **refresh_report)
     print_histogram("Coverage after", after)
     print_json("Watched status delta", delta)
+    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
 
     return {
         "dry_run": dry_run_report,
@@ -434,6 +448,53 @@ def run_batch(
         "refresh": refresh_report,
         "applied": True,
     }
+
+
+def resume_run(
+    client: Any,
+    *,
+    run_id: str,
+    logger: JsonlLogger,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    stall_timeout_seconds: int,
+    unexpected_outcome_rate: float,
+) -> dict[str, Any]:
+    print(f"\n== Resume run_id={run_id} ==")
+    before = fetch_coverage_histogram(client)
+    logger.write("resume_coverage_before", run_id=run_id, histogram=before)
+    print_histogram("Coverage before resume refresh", before)
+
+    drained = poll_until_drained(
+        client,
+        run_id,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+        logger=logger,
+    )
+    queue_summary = drained["summary"]
+    logger.write("resume_drained", run_id=run_id, queue=queue_summary)
+    print_json("Queue drained", queue_summary)
+
+    refresh = refresh_coverage(client)
+    after = refresh.get("coverage_status_histogram") or fetch_coverage_histogram(client)
+    assert_histogram_plausible(before, after)
+    delta = watched_histogram_delta(before, after)
+    refresh_report = {
+        "run_id": run_id,
+        "rows_written": refresh.get("rows_written"),
+        "refresh_duration_ms": refresh.get("refresh_duration_ms"),
+        "total_duration_ms": refresh.get("total_duration_ms"),
+        "coverage_after": after,
+        "watched_delta": delta,
+    }
+    logger.write("resume_refresh", **refresh_report)
+    print_histogram("Coverage after", after)
+    print_json("Watched status delta", delta)
+    enforce_unexpected_outcome_gate(queue_summary, unexpected_outcome_rate)
+
+    return {"run_id": run_id, "queue": queue_summary, "refresh": refresh_report}
 
 
 def print_queue_progress(run_id: str, summary: dict[str, Any]) -> None:
@@ -475,6 +536,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit", type=int, help="Run one batch with this explicit limit")
     parser.add_argument("--batches", help="Comma-separated staged limits; default: 25,75,150,250")
     parser.add_argument("--apply", action="store_true", help="Actually enqueue, poll, refresh, and gate each batch")
+    parser.add_argument("--resume-run-id", help="Poll, refresh, and gate an already-enqueued directory run")
     parser.add_argument("--min-enrollment", type=int, help="Pass min_enrollment through to directory-enqueue")
     parser.add_argument("--state", help="Pass a two-letter state filter through to directory-enqueue")
     parser.add_argument("--force-recheck", action="store_true", help="Pass force_recheck=true; do not use for first top-500 pass")
@@ -505,6 +567,20 @@ def main(argv: list[str] | None = None) -> int:
             force_recheck=args.force_recheck,
             uniform_cooldown_days=args.uniform_cooldown_days,
         )
+
+        if args.resume_run_id:
+            report = resume_run(
+                client,
+                run_id=args.resume_run_id,
+                logger=logger,
+                timeout_seconds=args.timeout_minutes * 60,
+                poll_interval_seconds=args.poll_interval_seconds,
+                stall_timeout_seconds=args.stall_timeout_minutes * 60,
+                unexpected_outcome_rate=args.unexpected_outcome_rate,
+            )
+            logger.write("completed", reports=[report])
+            print(f"\nCompleted. JSONL log: {logger.path}")
+            return 0
 
         baseline = {
             "coverage": fetch_coverage_histogram(client),

--- a/tools/ops/extraction_backlog_audit.py
+++ b/tools/ops/extraction_backlog_audit.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Audit extraction backlog after archive/directory drains.
+
+This is an operator check, not CI. It reads live Supabase state, reports the
+current `cds_documents.extraction_status='extraction_pending'` backlog, and
+optionally checks the GitHub Actions extraction worker's last successful run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ops import directory_enqueue_batches as batches
+
+
+DEFAULT_OUT_DIR = Path("scratch/extraction-backlog-audits")
+DEFAULT_GITHUB_REPO = "bolewood/collegedata-fyi"
+DEFAULT_GITHUB_WORKFLOW = "Ops extraction worker"
+HIGH_ENROLLMENT_THRESHOLD = 10_000
+
+
+@dataclass(frozen=True)
+class AuditThresholds:
+    max_pending_age_hours: float
+    max_pending_count: int | None
+    max_github_success_age_hours: float | None
+    fail_on_pending_growth: bool
+
+
+def parse_supabase_timestamp(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    value = raw.replace("Z", "+00:00")
+    match = re.match(r"(.*\.)(\d+)([+-]\d\d:\d\d)$", value)
+    if match:
+        value = match.group(1) + match.group(2).ljust(6, "0")[:6] + match.group(3)
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def hours_between(start: datetime | None, end: datetime) -> float | None:
+    if start is None:
+        return None
+    return max(0.0, (end - start).total_seconds() / 3600)
+
+
+def fetch_pending_documents(client: Any) -> list[dict[str, Any]]:
+    return batches.paged_rest_get(
+        client,
+        "cds_documents",
+        {
+            "select": (
+                "id,school_id,cds_year,detected_year,source_format,"
+                "source_provenance,extraction_status,discovered_at,"
+                "created_at,updated_at,source_url,ipeds_id"
+            ),
+            "extraction_status": "eq.extraction_pending",
+            "order": "created_at.asc",
+        },
+    )
+
+
+def fetch_directory_metadata(client: Any, school_ids: list[str]) -> dict[str, dict[str, Any]]:
+    metadata: dict[str, dict[str, Any]] = {}
+    unique_ids = sorted({school_id for school_id in school_ids if school_id})
+    for index in range(0, len(unique_ids), 100):
+        chunk = unique_ids[index:index + 100]
+        rows = client.rest_get(
+            "institution_directory",
+            {
+                "select": "school_id,school_name,state,undergraduate_enrollment,website_url",
+                "school_id": f"in.({','.join(chunk)})",
+                "order": "school_id.asc",
+            },
+        )
+        metadata.update({str(row.get("school_id")): row for row in rows if row.get("school_id")})
+    return metadata
+
+
+def pending_document_key(row: dict[str, Any]) -> datetime:
+    return parse_supabase_timestamp(str(row.get("created_at") or "")) or datetime.max.replace(tzinfo=timezone.utc)
+
+
+def enriched_pending_rows(
+    rows: list[dict[str, Any]],
+    metadata: dict[str, dict[str, Any]],
+    *,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    enriched = []
+    for row in rows:
+        created_at = parse_supabase_timestamp(str(row.get("created_at") or ""))
+        school = metadata.get(str(row.get("school_id") or ""), {})
+        enrollment = school.get("undergraduate_enrollment")
+        try:
+            enrollment_int = int(enrollment)
+        except (TypeError, ValueError):
+            enrollment_int = 0
+        enriched.append({
+            "id": row.get("id"),
+            "school_id": row.get("school_id"),
+            "school_name": school.get("school_name"),
+            "state": school.get("state"),
+            "undergraduate_enrollment": enrollment_int or None,
+            "cds_year": row.get("cds_year"),
+            "detected_year": row.get("detected_year"),
+            "source_format": row.get("source_format") or "unknown",
+            "source_provenance": row.get("source_provenance"),
+            "created_at": row.get("created_at"),
+            "age_hours": hours_between(created_at, now),
+            "source_url": row.get("source_url"),
+        })
+    return enriched
+
+
+def summarize_pending_backlog(
+    rows: list[dict[str, Any]],
+    metadata: dict[str, dict[str, Any]],
+    *,
+    now: datetime | None = None,
+    sample_limit: int = 15,
+) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    enriched = enriched_pending_rows(rows, metadata, now=current_time)
+    oldest = sorted(enriched, key=lambda row: row.get("age_hours") or -1, reverse=True)
+    high_signal = sorted(
+        (
+            row for row in enriched
+            if (row.get("undergraduate_enrollment") or 0) >= HIGH_ENROLLMENT_THRESHOLD
+        ),
+        key=lambda row: (row.get("undergraduate_enrollment") or 0, row.get("age_hours") or 0),
+        reverse=True,
+    )
+    by_format = Counter(row.get("source_format") or "unknown" for row in enriched)
+    by_provenance = Counter(row.get("source_provenance") or "unknown" for row in enriched)
+    by_school = Counter(str(row.get("school_id") or "") for row in enriched)
+    oldest_age = oldest[0].get("age_hours") if oldest else 0.0
+    oldest_created = oldest[0].get("created_at") if oldest else None
+
+    return {
+        "generated_at": current_time.isoformat().replace("+00:00", "Z"),
+        "pending_count": len(enriched),
+        "oldest_pending_age_hours": round(float(oldest_age or 0.0), 2),
+        "oldest_pending_created_at": oldest_created,
+        "by_source_format": dict(sorted(by_format.items())),
+        "by_source_provenance": dict(sorted(by_provenance.items())),
+        "top_schools_by_pending_count": [
+            {"school_id": school_id, "pending_count": count}
+            for school_id, count in by_school.most_common(10)
+            if school_id
+        ],
+        "oldest_pending": oldest[:sample_limit],
+        "high_enrollment_pending": high_signal[:sample_limit],
+    }
+
+
+def fetch_github_workflow_runs(
+    *,
+    repo: str,
+    workflow: str,
+    limit: int,
+    gh_bin: str = "gh",
+) -> dict[str, Any]:
+    if not shutil.which(gh_bin):
+        return {"available": False, "error": f"{gh_bin} not found"}
+
+    command = [
+        gh_bin,
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--workflow",
+        workflow,
+        "--limit",
+        str(limit),
+        "--json",
+        "databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,url",
+    ]
+    try:
+        completed = subprocess.run(command, text=True, capture_output=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": False, "error": str(exc)}
+    if completed.returncode != 0:
+        return {"available": False, "error": completed.stderr.strip() or completed.stdout.strip()}
+    try:
+        runs = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return {"available": False, "error": f"gh returned non-JSON output: {exc}"}
+    return {"available": True, "runs": runs}
+
+
+def summarize_github_runs(raw: dict[str, Any], *, now: datetime | None = None) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    if not raw.get("available"):
+        return {
+            "available": False,
+            "error": raw.get("error") or "unavailable",
+            "last_success": None,
+            "last_success_age_hours": None,
+            "latest_run": None,
+        }
+
+    runs = raw.get("runs") or []
+    latest = runs[0] if runs else None
+    successful = next((run for run in runs if run.get("conclusion") == "success"), None)
+    success_at = parse_supabase_timestamp(str(successful.get("updatedAt") or successful.get("createdAt") or "")) if successful else None
+    age = hours_between(success_at, current_time)
+    return {
+        "available": True,
+        "last_success": successful,
+        "last_success_age_hours": round(age, 2) if age is not None else None,
+        "latest_run": latest,
+    }
+
+
+def evaluate_gates(
+    audit: dict[str, Any],
+    thresholds: AuditThresholds,
+    *,
+    previous_pending_count: int | None = None,
+) -> list[str]:
+    failures: list[str] = []
+    pending_count = int(audit.get("pending_count") or 0)
+    oldest_age = float(audit.get("oldest_pending_age_hours") or 0.0)
+
+    if thresholds.max_pending_count is not None and pending_count > thresholds.max_pending_count:
+        failures.append(
+            f"pending_count {pending_count} exceeds max {thresholds.max_pending_count}"
+        )
+    if pending_count and oldest_age > thresholds.max_pending_age_hours:
+        failures.append(
+            f"oldest pending row is {oldest_age:.1f}h old; max is {thresholds.max_pending_age_hours:.1f}h"
+        )
+    if thresholds.fail_on_pending_growth and previous_pending_count is not None and pending_count > previous_pending_count:
+        failures.append(
+            f"pending_count grew from {previous_pending_count} to {pending_count}"
+        )
+
+    github = audit.get("github_actions") or {}
+    github_max = thresholds.max_github_success_age_hours
+    if github_max is not None:
+        if not github.get("available"):
+            failures.append(f"GitHub workflow status unavailable: {github.get('error') or 'unknown error'}")
+        elif github.get("last_success_age_hours") is None:
+            failures.append("GitHub workflow has no successful runs in the inspected window")
+        elif float(github["last_success_age_hours"]) > github_max:
+            failures.append(
+                f"GitHub workflow last success is {float(github['last_success_age_hours']):.1f}h old; "
+                f"max is {github_max:.1f}h"
+            )
+    return failures
+
+
+def build_audit(
+    client: Any,
+    *,
+    sample_limit: int,
+    include_github: bool,
+    github_repo: str,
+    github_workflow: str,
+    github_limit: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    pending = fetch_pending_documents(client)
+    metadata = fetch_directory_metadata(client, [str(row.get("school_id") or "") for row in pending])
+    audit = summarize_pending_backlog(pending, metadata, now=current_time, sample_limit=sample_limit)
+    if include_github:
+        github_raw = fetch_github_workflow_runs(repo=github_repo, workflow=github_workflow, limit=github_limit)
+        audit["github_actions"] = summarize_github_runs(github_raw, now=current_time)
+    return audit
+
+
+def write_audit(out_dir: Path, audit: dict[str, Any]) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = str(audit.get("generated_at") or datetime.now(timezone.utc).isoformat())
+    safe_stamp = stamp.replace(":", "").replace("-", "").replace("+0000", "Z")
+    path = out_dir / f"extraction-backlog-{safe_stamp}.json"
+    path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def print_audit(audit: dict[str, Any], failures: list[str], path: Path | None = None) -> None:
+    print("\nExtraction backlog audit")
+    print(f"  pending_count: {audit.get('pending_count')}")
+    print(f"  oldest_pending_age_hours: {audit.get('oldest_pending_age_hours')}")
+    print(f"  by_source_format: {json.dumps(audit.get('by_source_format') or {}, sort_keys=True)}")
+    print(f"  high_enrollment_pending: {len(audit.get('high_enrollment_pending') or [])} sampled")
+
+    github = audit.get("github_actions")
+    if github:
+        if github.get("available"):
+            latest = github.get("latest_run") or {}
+            print(
+                "  github_last_success_age_hours: "
+                f"{github.get('last_success_age_hours')} "
+                f"(latest={latest.get('conclusion') or latest.get('status')})"
+            )
+        else:
+            print(f"  github_status: unavailable ({github.get('error')})")
+
+    if audit.get("oldest_pending"):
+        print("\nOldest pending rows")
+        for row in audit["oldest_pending"][:10]:
+            name = row.get("school_name") or row.get("school_id")
+            print(
+                f"  {row.get('age_hours'):.1f}h  {name}  "
+                f"{row.get('cds_year')}  {row.get('source_format')}"
+            )
+
+    if audit.get("high_enrollment_pending"):
+        print("\nHigh-enrollment pending rows")
+        for row in audit["high_enrollment_pending"][:10]:
+            name = row.get("school_name") or row.get("school_id")
+            print(
+                f"  {row.get('undergraduate_enrollment') or 0:>6}  "
+                f"{row.get('age_hours'):.1f}h  {name}  {row.get('cds_year')}"
+            )
+
+    if failures:
+        print("\nGate failures")
+        for failure in failures:
+            print(f"  - {failure}")
+    if path:
+        print(f"\nWrote JSON audit: {path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", default=".env", help="Path to .env containing Supabase credentials")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR), help="Directory for JSON audit reports")
+    parser.add_argument("--sample-limit", type=int, default=15)
+    parser.add_argument("--max-pending-age-hours", type=float, default=24.0)
+    parser.add_argument("--max-pending-count", type=int)
+    parser.add_argument("--previous-pending-count", type=int)
+    parser.add_argument("--fail-on-pending-growth", action="store_true")
+    parser.add_argument("--skip-github", action="store_true")
+    parser.add_argument("--github-repo", default=DEFAULT_GITHUB_REPO)
+    parser.add_argument("--github-workflow", default=DEFAULT_GITHUB_WORKFLOW)
+    parser.add_argument("--github-limit", type=int, default=20)
+    parser.add_argument("--max-github-success-age-hours", type=float, default=30.0)
+    parser.add_argument("--json", action="store_true", help="Print the full audit JSON")
+    parser.add_argument("--no-write", action="store_true", help="Do not write the JSON report to scratch/")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    batches.configure_output_buffering()
+    args = build_parser().parse_args(argv)
+    try:
+        supabase_url, service_key = batches.require_supabase_credentials(Path(args.env))
+        client = batches.SupabaseClient(supabase_url, service_key)
+        audit = build_audit(
+            client,
+            sample_limit=args.sample_limit,
+            include_github=not args.skip_github,
+            github_repo=args.github_repo,
+            github_workflow=args.github_workflow,
+            github_limit=args.github_limit,
+        )
+        github_threshold = None if args.skip_github else args.max_github_success_age_hours
+        failures = evaluate_gates(
+            audit,
+            AuditThresholds(
+                max_pending_age_hours=args.max_pending_age_hours,
+                max_pending_count=args.max_pending_count,
+                max_github_success_age_hours=github_threshold,
+                fail_on_pending_growth=args.fail_on_pending_growth,
+            ),
+            previous_pending_count=args.previous_pending_count,
+        )
+        path = None if args.no_write else write_audit(Path(args.out_dir), audit)
+        if args.json:
+            print(json.dumps({"audit": audit, "gate_failures": failures}, indent=2, sort_keys=True))
+        else:
+            print_audit(audit, failures, path)
+        return 1 if failures else 0
+    except (batches.OpsError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ops/test_directory_enqueue_autopilot.py
+++ b/tools/ops/test_directory_enqueue_autopilot.py
@@ -24,6 +24,23 @@ class DirectoryEnqueueAutopilotTests(unittest.TestCase):
             "undergraduate_enrollment": 1800,
         }, 10000))
 
+    def test_high_signal_scores_state_university_above_generic_college(self):
+        state_university = {
+            "school_name": "Savannah State University",
+            "state": "GA",
+            "undergraduate_enrollment": 2833,
+        }
+        generic_college = {
+            "school_name": "Bismarck State College",
+            "state": "ND",
+            "undergraduate_enrollment": 2839,
+        }
+
+        self.assertGreater(
+            autopilot.high_signal_score(state_university, 5000),
+            autopilot.high_signal_score(generic_college, 5000),
+        )
+
     def test_extract_document_candidates_picks_current_official_pdf(self):
         html = b"""
         <html><body>

--- a/tools/ops/test_directory_enqueue_autopilot.py
+++ b/tools/ops/test_directory_enqueue_autopilot.py
@@ -1,0 +1,77 @@
+import unittest
+
+from tools.ops import directory_enqueue_autopilot as autopilot
+
+
+class DirectoryEnqueueAutopilotTests(unittest.TestCase):
+    def test_root_domain_from_url_normalizes_www(self):
+        self.assertEqual(
+            autopilot.root_domain_from_url("https://www.oregonstate.edu/"),
+            "oregonstate.edu",
+        )
+        self.assertEqual(
+            autopilot.root_domain_from_url("gmu.edu"),
+            "gmu.edu",
+        )
+
+    def test_is_high_signal_prefers_large_enrollment(self):
+        self.assertTrue(autopilot.is_high_signal({
+            "school_name": "Large Regional College",
+            "undergraduate_enrollment": 12000,
+        }, 10000))
+        self.assertFalse(autopilot.is_high_signal({
+            "school_name": "Small College",
+            "undergraduate_enrollment": 1800,
+        }, 10000))
+
+    def test_extract_document_candidates_picks_current_official_pdf(self):
+        html = b"""
+        <html><body>
+          <a href="https://example.com/template.pdf">CDS template</a>
+          <a href="/files/cds_2023-2024.pdf">2023-24</a>
+          <a href="/files/cds_2024-25.pdf">2024-25 Common Data Set</a>
+        </body></html>
+        """
+
+        def fake_fetch(url, *, read_bytes=0, timeout=20):
+            return 200, {"content-type": "text/html"}, html
+
+        old_fetch = autopilot.fetch_bytes
+        try:
+            autopilot.fetch_bytes = fake_fetch
+            candidates = autopilot.extract_document_candidates(
+                "https://example.edu/common-data-set",
+                "example.edu",
+            )
+        finally:
+            autopilot.fetch_bytes = old_fetch
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].url, "https://example.edu/files/cds_2024-25.pdf")
+        self.assertEqual(candidates[0].year, "2024-25")
+
+    def test_extract_document_candidates_rejects_non_official_host(self):
+        html = b"""
+        <html><body>
+          <a href="https://thirdparty.test/cds_2024-25.pdf">2024-25 Common Data Set</a>
+        </body></html>
+        """
+
+        def fake_fetch(url, *, read_bytes=0, timeout=20):
+            return 200, {"content-type": "text/html"}, html
+
+        old_fetch = autopilot.fetch_bytes
+        try:
+            autopilot.fetch_bytes = fake_fetch
+            candidates = autopilot.extract_document_candidates(
+                "https://example.edu/common-data-set",
+                "example.edu",
+            )
+        finally:
+            autopilot.fetch_bytes = old_fetch
+
+        self.assertEqual(candidates, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/test_directory_enqueue_batches.py
+++ b/tools/ops/test_directory_enqueue_batches.py
@@ -107,7 +107,9 @@ class DirectoryEnqueueBatchTests(unittest.TestCase):
                     timeout_seconds=60,
                     poll_interval_seconds=1,
                     stall_timeout_seconds=30,
-                    unexpected_outcome_rate=0.10,
+                    max_transient_rate=0.25,
+                    max_permanent_other_rate=0.05,
+                    stop_on_transient_gate=False,
                 )
 
         self.assertFalse(report["applied"])
@@ -130,7 +132,9 @@ class DirectoryEnqueueBatchTests(unittest.TestCase):
                     timeout_seconds=60,
                     poll_interval_seconds=1,
                     stall_timeout_seconds=30,
-                    unexpected_outcome_rate=0.10,
+                    max_transient_rate=0.25,
+                    max_permanent_other_rate=0.05,
+                    stop_on_transient_gate=False,
                 )
             log_lines = logger.path.read_text(encoding="utf-8").splitlines()
 
@@ -213,6 +217,42 @@ class DirectoryEnqueueBatchTests(unittest.TestCase):
             ),
             {"cds_available_current": 2, "extract_failed": 1, "not_checked": -3},
         )
+
+    def test_transient_gate_warns_without_stopping_by_default(self):
+        summary = batches.summarize_queue_rows(
+            [
+                {"status": "failed_permanent", "last_outcome": "transient"},
+                {"status": "failed_permanent", "last_outcome": "transient"},
+                {"status": "failed_permanent", "last_outcome": "no_pdfs_found"},
+                {"status": "done", "last_outcome": "marked_removed"},
+            ]
+        )
+
+        with redirect_stdout(StringIO()) as out:
+            batches.enforce_outcome_gates(
+                summary,
+                max_transient_rate=0.25,
+                max_permanent_other_rate=0.05,
+                stop_on_transient_gate=False,
+            )
+
+        self.assertIn("WARNING: transient outcomes exceeded", out.getvalue())
+
+    def test_permanent_other_gate_stops(self):
+        summary = batches.summarize_queue_rows(
+            [
+                {"status": "failed_permanent", "last_outcome": "permanent_other"},
+                {"status": "failed_permanent", "last_outcome": "no_pdfs_found"},
+            ]
+        )
+
+        with self.assertRaises(batches.OpsError):
+            batches.enforce_outcome_gates(
+                summary,
+                max_transient_rate=0.25,
+                max_permanent_other_rate=0.05,
+                stop_on_transient_gate=False,
+            )
 
 
 class FakeClock:

--- a/tools/ops/test_directory_enqueue_batches.py
+++ b/tools/ops/test_directory_enqueue_batches.py
@@ -118,6 +118,16 @@ class DirectoryEnqueueBatchTests(unittest.TestCase):
             [("directory-enqueue", {"limit": "25", "dry_run": "true"})],
         )
 
+    def test_cooldown_override_uses_edge_function_param_name(self):
+        params = batches.directory_enqueue_params(
+            25,
+            batches.DirectoryEnqueueOptions(uniform_cooldown_days=1),
+            dry_run=True,
+        )
+
+        self.assertEqual(params["cooldown_days"], "1")
+        self.assertNotIn("uniform_cooldown_days", params)
+
     def test_real_enqueue_records_run_id_and_refreshes_after_drain(self):
         client = FakeClient()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/ops/test_directory_enqueue_batches.py
+++ b/tools/ops/test_directory_enqueue_batches.py
@@ -12,6 +12,7 @@ class FakeClient:
         self.function_calls = []
         self.rest_calls = []
         self.queue_pages = []
+        self.queue_errors = []
         self.coverage_rows = [
             {"coverage_status": "not_checked"},
             {"coverage_status": "not_checked"},
@@ -74,6 +75,8 @@ class FakeClient:
                 }
             ]
         if table == "archive_queue" and "enqueued_run_id" in params:
+            if self.queue_errors:
+                raise self.queue_errors.pop(0)
             if self.queue_pages:
                 return self.queue_pages.pop(0)
             return [
@@ -181,6 +184,26 @@ class DirectoryEnqueueBatchTests(unittest.TestCase):
                     now=clock.now,
                     sleep=clock.sleep,
                 )
+
+    def test_polling_retries_transient_read_error(self):
+        client = FakeClient()
+        client.queue_errors = [batches.OpsError("temporary timeout")]
+        client.queue_pages = [[{"school_id": "school-1", "status": "done", "last_outcome": "no_pdfs_found"}]]
+        clock = FakeClock()
+
+        with redirect_stdout(StringIO()):
+            drained = batches.poll_until_drained(
+                client,
+                "run-id",
+                timeout_seconds=60,
+                poll_interval_seconds=5,
+                stall_timeout_seconds=30,
+                now=clock.now,
+                sleep=clock.sleep,
+            )
+
+        self.assertEqual(drained["summary"]["active"], 0)
+        self.assertEqual(clock.sleeps, [5])
 
     def test_histogram_delta(self):
         self.assertEqual(

--- a/tools/ops/test_directory_enqueue_batches.py
+++ b/tools/ops/test_directory_enqueue_batches.py
@@ -1,0 +1,209 @@
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from tools.ops import directory_enqueue_batches as batches
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.function_calls = []
+        self.rest_calls = []
+        self.queue_pages = []
+        self.coverage_rows = [
+            {"coverage_status": "not_checked"},
+            {"coverage_status": "not_checked"},
+            {"coverage_status": "cds_available_current"},
+        ]
+
+    def post_function(self, name, params):
+        self.function_calls.append((name, params))
+        if name == "directory-enqueue" and params.get("dry_run") == "true":
+            return {
+                "mode": "dry_run",
+                "run_id": "dry-run-id",
+                "considered": 100,
+                "would_enqueue": 1,
+                "sample_school_ids": ["school-1"],
+                "skipped": {"schools_yaml_covered": 3},
+            }
+        if name == "directory-enqueue":
+            return {
+                "mode": "enqueue",
+                "run_id": params.get("run_id", "real-run-id"),
+                "considered": 100,
+                "enqueued": 1,
+                "skipped_existing": 0,
+                "skipped": {"schools_yaml_covered": 3},
+            }
+        if name == "refresh-coverage":
+            return {
+                "rows_written": 3,
+                "refresh_duration_ms": 10,
+                "total_duration_ms": 20,
+                "coverage_status_histogram": {
+                    "not_checked": 1,
+                    "cds_available_current": 1,
+                    "no_public_cds_found": 1,
+                },
+            }
+        raise AssertionError(f"unexpected function call: {name}")
+
+    def rest_get(self, table, params, *, page=None):
+        self.rest_calls.append((table, params, page))
+        if table == "institution_cds_coverage" and params.get("coverage_status") == "eq.not_checked":
+            return [
+                {
+                    "school_id": "school-1",
+                    "school_name": "Example State",
+                    "state": "CA",
+                    "undergraduate_enrollment": 50000,
+                }
+            ]
+        if table == "institution_cds_coverage":
+            return self.coverage_rows
+        if table == "institution_directory":
+            return [
+                {
+                    "school_id": "school-1",
+                    "school_name": "Example State",
+                    "state": "CA",
+                    "undergraduate_enrollment": 50000,
+                }
+            ]
+        if table == "archive_queue" and "enqueued_run_id" in params:
+            if self.queue_pages:
+                return self.queue_pages.pop(0)
+            return [
+                {
+                    "school_id": "school-1",
+                    "school_name": "Example State",
+                    "status": "done",
+                    "last_outcome": "cds_available_current",
+                }
+            ]
+        if table == "archive_queue":
+            return []
+        raise AssertionError(f"unexpected rest call: {table}, {params}")
+
+
+class DirectoryEnqueueBatchTests(unittest.TestCase):
+    def test_dry_run_only_never_enqueues_or_refreshes(self):
+        client = FakeClient()
+        with tempfile.TemporaryDirectory() as tmp:
+            logger = batches.JsonlLogger(Path(tmp))
+            with redirect_stdout(StringIO()):
+                report = batches.run_batch(
+                    client,
+                    limit=25,
+                    apply=False,
+                    options=batches.DirectoryEnqueueOptions(),
+                    logger=logger,
+                    timeout_seconds=60,
+                    poll_interval_seconds=1,
+                    stall_timeout_seconds=30,
+                    unexpected_outcome_rate=0.10,
+                )
+
+        self.assertFalse(report["applied"])
+        self.assertEqual(
+            client.function_calls,
+            [("directory-enqueue", {"limit": "25", "dry_run": "true"})],
+        )
+
+    def test_real_enqueue_records_run_id_and_refreshes_after_drain(self):
+        client = FakeClient()
+        with tempfile.TemporaryDirectory() as tmp:
+            logger = batches.JsonlLogger(Path(tmp))
+            with redirect_stdout(StringIO()):
+                report = batches.run_batch(
+                    client,
+                    limit=25,
+                    apply=True,
+                    options=batches.DirectoryEnqueueOptions(),
+                    logger=logger,
+                    timeout_seconds=60,
+                    poll_interval_seconds=1,
+                    stall_timeout_seconds=30,
+                    unexpected_outcome_rate=0.10,
+                )
+            log_lines = logger.path.read_text(encoding="utf-8").splitlines()
+
+        self.assertTrue(report["applied"])
+        self.assertEqual(report["enqueue"]["run_id"], "dry-run-id")
+        self.assertIn(("refresh-coverage", {}), client.function_calls)
+        self.assertTrue(any('"event": "enqueue"' in line and '"run_id": "dry-run-id"' in line for line in log_lines))
+
+    def test_polling_exits_when_all_rows_are_terminal(self):
+        client = FakeClient()
+        client.queue_pages = [
+            [
+                {"school_id": "school-1", "status": "processing", "last_outcome": None},
+                {"school_id": "school-2", "status": "done", "last_outcome": "no_pdfs_found"},
+            ],
+            [
+                {"school_id": "school-1", "status": "done", "last_outcome": "cds_available_current"},
+                {"school_id": "school-2", "status": "done", "last_outcome": "no_pdfs_found"},
+            ],
+        ]
+        clock = FakeClock()
+
+        with redirect_stdout(StringIO()):
+            drained = batches.poll_until_drained(
+                client,
+                "run-id",
+                timeout_seconds=60,
+                poll_interval_seconds=5,
+                stall_timeout_seconds=30,
+                now=clock.now,
+                sleep=clock.sleep,
+            )
+
+        self.assertEqual(drained["summary"]["active"], 0)
+        self.assertEqual(drained["summary"]["terminal"], 2)
+        self.assertEqual(clock.sleeps, [5])
+
+    def test_polling_timeout_raises(self):
+        client = FakeClient()
+        client.queue_pages = [[{"school_id": "school-1", "status": "ready"}]] * 10
+        clock = FakeClock()
+
+        with self.assertRaises(TimeoutError):
+            with redirect_stdout(StringIO()):
+                batches.poll_until_drained(
+                    client,
+                    "run-id",
+                    timeout_seconds=10,
+                    poll_interval_seconds=5,
+                    stall_timeout_seconds=60,
+                    now=clock.now,
+                    sleep=clock.sleep,
+                )
+
+    def test_histogram_delta(self):
+        self.assertEqual(
+            batches.histogram_delta(
+                {"not_checked": 10, "cds_available_current": 2},
+                {"not_checked": 7, "cds_available_current": 4, "extract_failed": 1},
+            ),
+            {"cds_available_current": 2, "extract_failed": 1, "not_checked": -3},
+        )
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+        self.sleeps = []
+
+    def now(self):
+        return self.value
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.value += seconds
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/test_extraction_backlog_audit.py
+++ b/tools/ops/test_extraction_backlog_audit.py
@@ -1,0 +1,131 @@
+import unittest
+from datetime import datetime, timezone
+
+from tools.ops import extraction_backlog_audit as audit
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.rest_calls = []
+
+    def rest_get(self, table, params, *, page=None):
+        self.rest_calls.append((table, params, page))
+        if table == "cds_documents":
+            return [
+                {
+                    "id": "doc-1",
+                    "school_id": "large-state",
+                    "cds_year": "2024-25",
+                    "detected_year": None,
+                    "source_format": "pdf_flat",
+                    "source_provenance": "school_direct",
+                    "extraction_status": "extraction_pending",
+                    "created_at": "2026-04-30T00:00:00.1+00:00",
+                    "updated_at": "2026-04-30T00:00:00.1+00:00",
+                    "source_url": "https://example.edu/cds.pdf",
+                    "ipeds_id": "1",
+                },
+                {
+                    "id": "doc-2",
+                    "school_id": "small-college",
+                    "cds_year": "2024-25",
+                    "detected_year": None,
+                    "source_format": None,
+                    "source_provenance": "operator_manual",
+                    "extraction_status": "extraction_pending",
+                    "created_at": "2026-04-30T12:00:00+00:00",
+                    "updated_at": "2026-04-30T12:00:00+00:00",
+                    "source_url": "https://small.edu/cds.pdf",
+                    "ipeds_id": "2",
+                },
+            ]
+        if table == "institution_directory":
+            return [
+                {
+                    "school_id": "large-state",
+                    "school_name": "Large State University",
+                    "state": "CA",
+                    "undergraduate_enrollment": 42000,
+                    "website_url": "https://example.edu",
+                },
+                {
+                    "school_id": "small-college",
+                    "school_name": "Small College",
+                    "state": "VT",
+                    "undergraduate_enrollment": 1800,
+                    "website_url": "https://small.edu",
+                },
+            ]
+        raise AssertionError(f"unexpected table {table}")
+
+
+class ExtractionBacklogAuditTests(unittest.TestCase):
+    def test_parse_supabase_timestamp_accepts_short_fractional_seconds(self):
+        parsed = audit.parse_supabase_timestamp("2026-04-15T21:39:49.73+00:00")
+
+        self.assertEqual(parsed, datetime(2026, 4, 15, 21, 39, 49, 730000, tzinfo=timezone.utc))
+
+    def test_summary_counts_formats_and_high_enrollment_pending(self):
+        client = FakeClient()
+        now = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        rows = audit.fetch_pending_documents(client)
+        metadata = audit.fetch_directory_metadata(client, ["large-state", "small-college"])
+        summary = audit.summarize_pending_backlog(rows, metadata, now=now)
+
+        self.assertEqual(summary["pending_count"], 2)
+        self.assertEqual(summary["by_source_format"], {"pdf_flat": 1, "unknown": 1})
+        self.assertEqual(summary["high_enrollment_pending"][0]["school_id"], "large-state")
+        self.assertAlmostEqual(summary["oldest_pending_age_hours"], 24.0, places=1)
+
+    def test_gate_flags_old_pending_count_and_growth(self):
+        failures = audit.evaluate_gates(
+            {
+                "pending_count": 11,
+                "oldest_pending_age_hours": 25.5,
+                "github_actions": {"available": True, "last_success_age_hours": 31.0},
+            },
+            audit.AuditThresholds(
+                max_pending_age_hours=24.0,
+                max_pending_count=10,
+                max_github_success_age_hours=30.0,
+                fail_on_pending_growth=True,
+            ),
+            previous_pending_count=9,
+        )
+
+        self.assertTrue(any("pending_count 11 exceeds" in failure for failure in failures))
+        self.assertTrue(any("oldest pending row" in failure for failure in failures))
+        self.assertTrue(any("pending_count grew" in failure for failure in failures))
+        self.assertTrue(any("GitHub workflow last success" in failure for failure in failures))
+
+    def test_github_summary_uses_last_success(self):
+        summary = audit.summarize_github_runs(
+            {
+                "available": True,
+                "runs": [
+                    {
+                        "databaseId": 2,
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "createdAt": "2026-05-01T09:00:00Z",
+                        "updatedAt": "2026-05-01T09:01:00Z",
+                    },
+                    {
+                        "databaseId": 1,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "createdAt": "2026-05-01T08:00:00Z",
+                        "updatedAt": "2026-05-01T08:30:00Z",
+                    },
+                ],
+            },
+            now=datetime(2026, 5, 1, 10, 30, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(summary["latest_run"]["databaseId"], 2)
+        self.assertEqual(summary["last_success"]["databaseId"], 1)
+        self.assertEqual(summary["last_success_age_hours"], 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add controlled directory-enqueue batch tooling and unattended autopilot repair flow.
- Narrow directory YAML exclusions so only protected active schools block directory fallback.
- Add extraction backlog auditing gates to prevent archive/coverage work from hiding stale extraction debt.
- Update the archive-pipeline runbook for staged directory drains, high-signal repair, and extraction backlog checks.

## Verification
- `python3 -m unittest tools.ops.test_directory_enqueue_batches tools.ops.test_directory_enqueue_autopilot tools.ops.test_extraction_backlog_audit`
- `python3 -m py_compile tools/ops/directory_enqueue_batches.py tools/ops/directory_enqueue_autopilot.py tools/ops/extraction_backlog_audit.py`
- `git diff --check`
- Deno function tests were run during branch work for directory-enqueue/shared helper changes.
- Production `directory-enqueue` was deployed during branch work after the YAML exclusion change.

## Operational Notes
- `tools/ops/extraction_backlog_audit.py` is read-only by default but exits non-zero on stale extraction backlog gates.
- Current live audit found extraction debt: 130 pending rows, oldest around 394h, with UW and Penn State in high-enrollment pending rows.
- GitHub ops extraction worker is now configured with Supabase secrets and has completed a successful bounded Docling run.
