### PR TITLE
Add academic positioning PRDs (016 v1, 017 v2, 018 v3)

### DIFF
--- a/docs/design/positioning-card-skeleton.md
+++ b/docs/design/positioning-card-skeleton.md
@@ -1,0 +1,551 @@
+# Per-school positioning card + methodology page — UX skeleton
+
+**Status:** Skeleton, awaiting design pass with Claude Design.
+**Created:** 2026-05-01 (autoplan)
+**Implements:** [PRD 016 — Academic positioning card](../prd/016-academic-positioning-card.md)
+**Voice/tokens:** [`web/DESIGN_SYSTEM.md`](../../web/DESIGN_SYSTEM.md), [`web/src/app/tokens.css`](../../web/src/app/tokens.css)
+
+> **Audience for this doc:** a senior designer about to wireframe. The
+> heaviest constraint is honesty about uncertainty: every visual element
+> on the card has to be defensible against the reviewers' charge that
+> *any* positioning UI risks looking more precise than CDS C.9/C.11
+> support. Lead with the caveats; let the geometry serve them.
+>
+> **Two questions are deliberately left open** for the design pass —
+> see §8. The rest of the doc has enough structure that the design
+> conversation can productively riff on exactly those two open
+> questions without renegotiating the rest.
+
+The page this lives on (`web/src/app/schools/[school_id]/page.tsx`) is
+already an editorial archive — serif headline, mono call-numbers,
+ledger of archived CDS docs, federal Scorecard outcomes. The brand
+voice is "paper, ink, and one quiet green," which is exactly the right
+voice for a positioning card that is supposed to read as a footnote on
+public data, not a verdict. We are *adding a margin annotation* to a
+catalog card, not bolting a SaaS widget onto a library page.
+
+---
+
+## 1. Per-school positioning card — anatomy and states
+
+### Placement on `/schools/[school_id]`
+
+Current section order on a school page with archived CDS:
+
+1. Header (school name, IPEDS, Carnegie, archive count + sparkline)
+2. Documents ledger (`rule-2` divider, then per-year `DocumentCard`s)
+3. `OutcomesSection` (federal Scorecard)
+4. `ScorecardVintageNote`
+
+The positioning card slots in **between the documents ledger and the
+OutcomesSection**, under a `rule-2` divider that mirrors the ledger
+divider above it. Rationale:
+
+- The ledger establishes provenance ("we have this school's CDS for
+  these years"). The positioning card *reads from* that ledger and
+  should sit immediately downstream of it so the visual chain is:
+  *here are the source PDFs → here is what they say about your fit →
+  here is the federal outcomes baseline.*
+- Putting it above the ledger would make positioning feel like the
+  primary product of the page; the existing PRD positions it as
+  feature #2 to the archive, not the headline. The archive is the
+  credibility moat.
+- Putting it below `OutcomesSection` would bury it; visitors arriving
+  from a "[School] common data set" SEO query stop reading after the
+  Scorecard.
+
+So: ledger → **positioning card** → outcomes → vintage note.
+
+### Empty state (no profile entered)
+
+This is the default state for nearly every page view, and it has to
+stand on its own as a useful "here's what this school's published
+academic profile looks like" panel — even if the user never enters
+anything. Components inside the card:
+
+- A mono caption above the card: `§ ACADEMIC PROFILE` (matches the
+  ledger and outcomes voice).
+- A serif sub-head: *"Where you'd land in this school's admitted
+  class."* Italic on the second clause per voice convention.
+- A horizontal SAT range strip showing 25th / 50th / 75th anchors with
+  the school's actual numbers labeled in tabular mono — e.g. for
+  Bowdoin's 2024 CDS: `1430 — 1500 — 1540`. The strip is ink-on-paper
+  with hairline rules at the anchor points. No score plotted.
+- A GPA bucket distribution rendered as a vertical bar mini-chart, ink
+  bars on `--paper-2` ground, with the bucket labels in mono on the
+  x-axis (`4.0`, `3.75–3.99`, `3.50–3.74`, …).
+- A single-line stat row: `ADMIT RATE 9% · TEST POLICY OPTIONAL · % SUBMITTING SAT 47%`.
+  All forest, mono, uppercase, tracked.
+- A primary CTA button (`.cd-btn`) — *"Add your scores to see where you fit"* —
+  that opens the profile form (see §2).
+
+The empty state is intentionally **almost as informative as the filled
+state**. If the user never enters a profile, they still leave with
+"Bowdoin's middle-50% is 1430–1540 and only ~half their admits even
+submitted scores" — which is the most defensible sentence the data
+supports anyway.
+
+### Filled state (profile entered)
+
+Same anatomy, with three additions:
+
+- A small ink tick mark plotted on the SAT strip at the student's
+  composite score, labeled below in mono (`YOU 1480`). The tick is a
+  vertical hairline, not a dot or pin — pins look like a precise GPS
+  coordinate, ticks look like a margin annotation. Brick (`--brick`)
+  if below 25th, ink if inside 25–75, forest if above 75th. **Use
+  hue sparingly** — the tick itself stays ink; the *label color* is
+  what shifts.
+- A bucket highlight on the GPA chart: the user's bucket bar gets the
+  forest fill, all others stay ink at 60% opacity. Above the chart in
+  mono: `YOUR GPA 3.7 → 3.50–3.74 BUCKET (24% OF ADMITS)`.
+- A positioning sentence rendered in body serif, not as a label badge.
+  The sentence form is load-bearing — a sentence reads as
+  interpretation, a badge reads as verdict. Examples:
+  - "Your SAT is **above the 75th percentile** of admitted students who
+    submitted scores. Your GPA falls in the modal admit bucket. This
+    school admits 9% of applicants."
+  - "Your SAT is **within the middle 50%** of submitting admits."
+  - "Your SAT is **below the 25th percentile** of submitting admits."
+
+The reach/target/safety label appears as a *secondary* mono caption
+beneath the sentence, in the form `§ TIER · TARGET (RATIONALE: SAT in mid-50%, admit rate 9%)` —
+not as a hero badge. See §3 for when the tier line is suppressed
+entirely.
+
+### Loading state
+
+Skeleton on the card outline at the same height the filled card will
+occupy (prevents layout shift when the user lands from search). Use
+`--paper-2` blocks where bars/numbers will go. No spinner — the rest
+of the page already loads progressively.
+
+### Error state
+
+If `school_academic_profile` returns 5xx or malformed: render the
+empty-state shell with a mono note in `--ink-3`: `§ PROFILE DATA TEMPORARILY UNAVAILABLE — TRY AGAIN OR VIEW THE SOURCE CDS BELOW`.
+Link "view the source CDS" to the latest doc in the ledger above. Do
+*not* render an empty range bar; partial geometry implies precision we
+don't have.
+
+### "This school has no current CDS" state
+
+Reuse the existing `CoverageBadge` pattern. The card collapses to a
+single sentence: *"We don't have a current Common Data Set for this
+school. Federal outcomes below give a partial picture."* Linked
+"federal outcomes below" anchor-jumps to `OutcomesSection`. No range
+bar, no tier label, no CTA to enter a profile. (Entering a profile on
+a no-CDS school produces nothing useful, so we don't invite it.)
+
+### Test-optional disclosure
+
+When `test_policy = optional` AND the student has *not* entered a SAT
+or has explicitly checked "not submitting":
+
+- The SAT strip renders at 30% opacity (`--ink-4` text, ink-at-30%
+  bars) with a diagonal hatch overlay at low opacity. Not grayed to
+  the point of unreadable — the school's published numbers stay
+  legible — but visibly demoted.
+- Above the strip, mono caption in ochre (`--ochre`): `§ TEST-OPTIONAL · BAND REFLECTS SUBMITTING ADMITS ONLY (47%)`.
+  Ochre is "rare emphasis"; this is exactly the case it's reserved for.
+- The positioning sentence drops the SAT clause: "Your GPA falls in the
+  modal admit bucket. This school is test-optional; without test
+  scores, position is GPA-only."
+
+### "X% of admits submitted" caveat
+
+This is the headline caveat from the legal/research review and it must
+be **inline with the SAT strip**, not buried in a footnote. Two surfaces:
+
+1. A mono caption directly under the strip: `§ FROM THE 47% OF ADMITS WHO SUBMITTED SCORES · 2024–25 CDS`.
+2. The methodology link sits at the end of that caption: `· METHOD →`,
+   anchoring to the methodology page section on test-optional drift.
+
+This caption is present in **every state** of the card except "no
+current CDS" and the loading skeleton.
+
+### Source-link footer
+
+Bottom of the card, hairline rule above it (`.rule`), mono only:
+
+```
+§ SOURCE: COMMON DATA SET 2024–25 · §C.7 §C.9 §C.11 · ARCHIVED PDF →
+```
+
+The "ARCHIVED PDF" link points to the actual `cds_artifacts` document
+on Supabase storage — the same URL the `DocumentCard` above already
+exposes. The §-prefixed question numbers cite which CDS cells the card
+read.
+
+### Mobile vs desktop
+
+Desktop (≥ 768px): two-column layout inside the card. Left column =
+SAT strip + GPA chart stacked. Right column = stat row + positioning
+sentence + tier caption. Card max-width inherits `max-w-5xl` from the
+page wrapper.
+
+Mobile: single column, stacked in this order — caption, sub-head, SAT
+strip, test-optional caption (when applicable), GPA chart, stat row,
+positioning sentence, tier caption, source footer. CTA button
+full-width at the bottom of the empty state. The SAT strip stays
+full-bleed inside the card; the GPA bars resize but keep the same
+bucket labels — no responsive label-hiding (numeric labels are the
+point of the chart).
+
+The existing page already wraps at `max-w-5xl px-4 sm:px-6` — match
+that and the card will breathe correctly at all widths.
+
+---
+
+## 2. Profile entry UI
+
+**Inline mini-form on the card itself**, not a modal, not a sidebar. A
+modal interrupts the reading flow on a page that's primarily about
+reading; a sidebar competes with the document ledger. The form lives
+inside the same card, replacing the CTA button when invoked.
+
+Anatomy:
+
+- Three labeled inputs in a row on desktop, stacked on mobile:
+  - **GPA** (number, 0.00–5.00, one decimal of precision shown as a
+    suggestion; freeform underneath). Required.
+  - **SAT composite** (number, 400–1600, optional). Helper text:
+    *"Leave blank if you're not submitting scores."*
+  - **ACT composite** (number, 1–36, optional). Helper text: *"We'll
+    convert to SAT-equivalent for the range bar."*
+- A subtle "not submitting scores" checkbox below the test inputs,
+  pre-checked when both test fields are blank.
+- A submit button (`.cd-btn`) reading *"Show my position"*. Submission
+  is client-side only — the form just writes to localStorage and
+  re-renders the card.
+- A ghost "Cancel" button (`.cd-btn--ghost`) reverts to the empty
+  state.
+
+**Deferred to v1 by design:** state, intended major, residency,
+rigor multiplier. The reviewers explicitly flagged these as scope
+that would look foolish in 6 months given CDS doesn't publish
+state- or major-stratified percentiles. The form must be obviously
+short — three fields — so the absence of those knobs reads as
+*deliberate restraint*, not a missing feature.
+
+### Persistence
+
+- localStorage key `cdfyi_profile_v1`, JSON-encoded, no PII beyond GPA
+  / SAT / ACT / submitting-flag. Set TTL (1 year) and surface a "this
+  was saved 3 weeks ago" note above the card when re-rendered.
+- Shareable URL parameters: `?gpa=3.7&sat=1480` (and `?act=33`) on the
+  school URL itself. Reading from URL params *overrides* localStorage
+  for that pageview but does not persist them — share-link recipients
+  see the position the sender saw without overwriting their own
+  saved profile. This is how a counselor sends a student a specific
+  view in a v1 world without saved profiles.
+- "Clear my profile" affordance: small mono link in the source footer
+  area: `§ CLEAR SAVED PROFILE`. Confirmation inline (button morphs
+  to "Are you sure? · Yes / Cancel"), not a system dialog.
+
+### Persistence across schools
+
+Once entered on one school page, the profile auto-fills on every other
+school page in the same browser. No cross-school list view in v1;
+that's the v2 list builder. But a small mono row at the top of the
+card, when a saved profile is present, reads:
+
+```
+§ USING YOUR SAVED PROFILE · GPA 3.7 · SAT 1480 · EDIT · CLEAR
+```
+
+`EDIT` opens the inline form pre-filled.
+
+---
+
+## 3. Tier label semantics and caveat hierarchy
+
+The reviewers' concern is real: hard reach/target/safety labels on a
+9%-admit school whose admit decisions are 70% holistic factors *over*-
+state the data. The skeleton answer is a two-tier semantic where the
+*sentence* form leads and the *label* form is secondary and
+suppressible.
+
+### Primary: positional sentence
+
+Always rendered when a profile exists. Three forms:
+
+- **Above the 75th percentile of submitting admits** ("you'd be a
+  high scorer in this admit class")
+- **Within the middle 50% range of submitting admits** ("your scores
+  are typical for admits")
+- **Below the 25th percentile of submitting admits** ("you'd be a
+  low scorer in this admit class")
+
+Combined with a one-line GPA clause (above/within/below modal bucket)
+and an admit-rate clause. This is the durable, defensible artifact.
+It maps directly onto cells in CDS C.9 and C.11; anyone can audit it
+against the source PDF.
+
+### Secondary: tier label, with rationale
+
+A small mono caption beneath the sentence:
+`§ TIER · TARGET · BASIS: SAT IN MID-50%, ADMIT RATE 9%`.
+
+Tier mapping (publishable rubric, not opaque ML):
+
+- **Likely** — admit rate ≥ 50% AND scores at-or-above mid-50%.
+- **Strong fit** — admit rate ≥ 25% AND scores in or above mid-50%.
+- **Possible** — scores in mid-50% range, admit rate 10–25%.
+- **Unlikely** — scores below mid-50% OR admit rate < 10%.
+- **Long shot** — scores below 25th *and* admit rate < 25%, or admit
+  rate < 10% regardless of scores.
+
+We use "Likely / Strong fit / Possible / Unlikely / Long shot" instead
+of "safety / target / reach / hard reach" because the latter family
+implies a counselor-style decision, while the former describes
+probability bands. This keeps the labels useful for the data-curious
+audience without overpromising counselor-grade calibration.
+
+### When the tier label is suppressed
+
+The tier caption is **not rendered** when:
+
+- The school's admit rate is below 15% AND the student's scores are
+  inside the mid-50%. Rationale: at 15-and-under admit rates, the
+  numerical position barely moves the outcome; rendering "Possible"
+  vs "Unlikely" implies a precision the data can't support. Render
+  the positional sentence + admit-rate sentence, then a mono caption:
+  `§ AT THIS SELECTIVITY, NUMERICAL POSITION IS A SMALL FACTOR · METHOD →`.
+- C.9 SAT/ACT data is missing or stale (older than 3 years). Render
+  the GPA-only positional sentence and a `§ SAT/ACT FIGURES UNAVAILABLE FOR THIS SCHOOL`
+  caption.
+- Test-optional school + non-submitting student + no GPA distribution
+  in the latest CDS. Render only the admit-rate sentence and skip
+  the tier caption entirely.
+
+The empty state never renders tier labels at all (there's no profile
+to position against).
+
+### Caveat hierarchy, top to bottom
+
+1. Test-optional submitter-only caveat (under the SAT strip, **always**
+   when applicable).
+2. Selectivity caveat (under the tier caption, **always** for sub-15%
+   admit-rate schools).
+3. CDS year + source link (in the footer, **always**).
+4. "This is positioning, not a prediction" — single line in the
+   methodology link footer (**always**).
+
+---
+
+## 4. Methodology page — anatomy
+
+Route: `/methodology/positioning` (not `/positioning/methodology` — the
+parent `/methodology/` route gives us a place for future sibling docs:
+extraction, scorecard mapping, etc.).
+
+### Top: one-line explainer
+
+Serif lede paragraph, italic accent on the second half:
+
+> *"This page shows where your scores would land in a school's
+> admitted-class numbers. It is not a chance-me, and it does not
+> predict admissions decisions."*
+
+Below, a mono caption: `§ LAST UPDATED 2026-05-01 · OPEN-SOURCE METHOD`.
+
+### "What we use" section
+
+Subsections, each tied to a CDS question number:
+
+- **§C.9 — SAT/ACT 25th/50th/75th percentiles.** We linearly interpolate
+  between the published anchors to estimate where any single score
+  falls. Worked example: Bowdoin 2024 published 1430 / 1500 / 1540.
+  A 1480 sits between the 25th and 50th — specifically, ~42nd
+  percentile by linear interpolation. Show the math inline: `(1480 − 1430) / (1500 − 1430) × 25 + 25 = 42.9`.
+  Disclose the assumption ("scores are uniformly distributed between
+  anchors, which is approximately but not exactly true").
+- **§C.11 — GPA bucket distribution.** Direct lookup, no
+  interpolation. Worked example: Bowdoin's 2024 C.11 shows 24% of
+  admits in the 3.50–3.74 bucket. A student with a 3.7 GPA falls in
+  that bucket.
+- **§C.12 — mean GPA, % submitting GPA.** Used for the "modal admit
+  bucket" determination and the "% submitting GPA" caveat.
+- **§C.7 — admission factor importance.** When a school marks GPA or
+  test scores as "considered" rather than "very important," we surface
+  that as a one-line note ("This school marks test scores as
+  *considered*, not *very important*"). We do not numerically
+  re-weight the position score on this — too easy to overreach.
+- **§C.8 — test policy.** Drives the test-optional disclosure.
+- **§C.1/§C.2 — admit rate.** Drives the tier rubric and the
+  selectivity-based suppression rule.
+
+Each subsection has a "see this in Bowdoin's PDF" link to the actual
+archived source.
+
+### "What we don't use" section
+
+Bulleted, unapologetic. Each bullet is a one-liner with rationale:
+
+- **Legacy / donor / institutional priorities** — not in CDS.
+- **Athletic recruitment** — not in CDS at the granularity that would
+  matter.
+- **Geographic balance** — schools may publish enrollment-by-state in
+  CDS but not admit-by-state; positioning at that granularity is not
+  defensible.
+- **Demonstrated interest** — captured in §C.7 as a yes/no factor
+  weight, but not numerically positionable.
+- **Intended major** — institution-wide CDS only; major-level
+  admit profiles are tribal.
+- **In/out-of-state for publics** — CDS does not publish state-stratified
+  admit percentiles. We do not estimate.
+- **Essays, recommendations, interview** — qualitative, not in the
+  position calculation.
+- **Application timing (ED/EA)** — known to shift outcomes
+  significantly; not in v1.
+
+### "Why this isn't a chance-me" section
+
+Three-paragraph plain-English explanation:
+
+1. A *position* says where you sit on a published distribution. A
+   *prediction* says how the school will decide. Those are different
+   questions and the data on this site can only answer the first.
+2. Even at the median scores, holistic schools admit 9% of applicants
+   — meaning 91% of applicants who looked numerically identical to
+   admits did not get in. Numbers describe the bar, not the verdict.
+3. We publish the rubric so you can audit it. If you disagree with the
+   tier mapping, you can read the source PDFs above and form your own
+   read. That's the point.
+
+### "Sources and audit trail"
+
+Every claim links to a CDS question number. The page itself ends with
+a link to the worked-example school's PDF in the archive.
+
+---
+
+## 5. Information hierarchy on `/schools/[school_id]`
+
+After the card lands, the section order a visitor reads top-to-bottom:
+
+1. **Header** — school name, IPEDS / Carnegie / archive count.
+   Provenance and identity.
+2. **Documents ledger** — the catalog of archived CDS years. The
+   archive is the moat; lead with it.
+3. **Positioning card** — empty by default, becomes useful with a
+   profile. Reads downstream of the ledger so the source chain is
+   visible.
+4. **OutcomesSection** — federal Scorecard, completion rates, post-grad
+   earnings. Different question (outcomes), still useful.
+5. **ScorecardVintageNote** — provenance footer.
+
+The directory-only stub (no archived CDS) keeps its current order and
+**does not** render the positioning card. Empty positioning on a
+no-data school is worse than no positioning at all.
+
+---
+
+## 6. States and edge-cases inventory
+
+| State | Card behavior |
+|---|---|
+| Loading | Skeleton at filled-card height. |
+| Empty (no profile) | Published 25/50/75 + GPA dist + admit rate + CTA. |
+| Filled, complete profile, normal school | Full card with sentence + tier caption. |
+| Filled, complete profile, sub-15% admit | Sentence shown, tier caption suppressed, selectivity caveat. |
+| Filled, GPA only (no SAT/ACT) | GPA bucket + modal-bucket sentence; no SAT strip plot, just school's published range. |
+| Filled, SAT only (no GPA) | SAT strip plotted; GPA chart shows distribution unhighlighted; sentence drops GPA clause. |
+| Test-optional + not submitting | SAT strip demoted; sentence is GPA-only. |
+| No current CDS | Single-sentence collapsed card, no inputs, link to outcomes. |
+| Stale CDS (> 3 years old) | Render with a `§ DATA FROM 2021–22 · MAY BE OUT OF DATE` mono caption above the source footer. |
+| C.9 missing for this school | SAT strip absent, mono note. GPA + admit-rate sentence still possible. |
+| C.11 missing for this school | GPA chart absent, mono note. SAT + admit-rate sentence still possible. |
+| Both missing | Empty-state shell with a "we have a CDS but couldn't extract academic profile fields" coverage note. |
+| School removed by takedown | Whole school page already 404s under the existing takedown flow; positioning card never renders. |
+| Very high admit rate (≥ 80%) | Tier rubric maps almost everyone to "Likely"; that's accurate. Render normally. |
+| Very low admit rate (< 5%) | Tier suppressed always; sentence + selectivity caveat only. |
+| Profile entered but invalid (GPA > 5.0, SAT < 400) | Form rejects with inline mono error: `§ ENTER A GPA BETWEEN 0.0 AND 5.0`. |
+| URL params override saved profile | Mono caption: `§ VIEWING WITH PROFILE FROM SHARED LINK · USE YOURS INSTEAD?`. |
+
+---
+
+## 7. Accessibility skeleton
+
+- **Range bar.** Render as a `<div role="img">` with an `aria-label`
+  that reads, e.g., "SAT range: 25th percentile 1430, median 1500,
+  75th percentile 1540. Your score 1480 falls between the 25th and
+  50th percentile." A visually-hidden `<p>` sibling carries the same
+  text for screen readers in case `role="img"` is suppressed.
+- **GPA chart.** A `<table>` with `aria-hidden="false"` carrying the
+  bucket / percent rows beneath the visual chart. Visual chart marked
+  `aria-hidden="true"`. The table is visually hidden but readable by
+  AT — uses `.sr-only` style.
+- **Form.** Each input has a `<label>` with `for=`, plus inline helper
+  text via `aria-describedby`. Errors via `aria-invalid` and
+  `aria-errormessage`.
+- **Focus order.** Header → ledger documents → "Add your scores" CTA
+  (when empty) → form fields in DOM order → submit → outcomes. The
+  card's interactive surface is one logical group; tab through it
+  before tabbing into outcomes.
+- **Keyboard.** All interactive elements (CTA, form fields, edit/clear
+  links, source PDF link, methodology link) reachable by Tab. No
+  custom keyboard handlers — native form semantics only.
+- **Touch targets.** Buttons and links inside the card are ≥ 44 px
+  tap-targets on mobile. Inline mono links (`EDIT`, `CLEAR`,
+  `METHOD →`) get padded hit-areas via `padding: 8px 4px` even though
+  visually they sit on the baseline.
+- **Contrast.** `--ink` on `--paper` exceeds WCAG AA. `--ink-3` on
+  `--paper` for mono captions hits AA at 12px+ but **not** AAA — that's
+  fine for mono captions, not for primary content. Brick (`--brick`)
+  on `--paper` for the "below 25th" label clears AA. Ochre
+  (`--ochre`) on `--paper` for the test-optional caveat clears AA at
+  12px+.
+- **Reduced motion.** No motion in v1. The card has no animations to
+  honor `prefers-reduced-motion` against.
+- **Screen reader announcement on submit.** When the form submits and
+  the card re-renders, a `role="status"` live region inside the card
+  announces the positioning sentence.
+
+---
+
+## 8. Two open design questions
+
+**Q1: What is the visual treatment for the SAT range strip?** The
+honest geometry options are: (a) a horizontal hairline with three tick
+marks at 25/50/75 and a fourth tick for the user's score, all the same
+weight; (b) a thin filled bar between 25 and 75 with hairline anchors
+at 25/50/75 and a separate user-score tick above or below; (c) a
+distribution sketch that hints at the implied curve without committing
+to one (a faint bell-ish shadow). Each carries a different precision
+implication. (a) reads most as marginalia and least as "chart", which
+matches the brand voice; (c) is the most informative but risks looking
+like we know the underlying distribution shape, which we don't. The
+designer should pick this with full awareness of the precision
+trade-off.
+
+**Q2: Where does the test-optional submitter-only caveat physically
+sit, and how loud is it?** Options: (a) tightly bound to the SAT
+strip, ochre-cased mono caption directly under it, always present
+when applicable. (b) Promoted to a card-level banner above the
+positioning sentence when test-optional + non-submitting, demoted to
+inline when test-optional + submitting. (c) A sticky footer line on
+the card that follows scroll. The reviewers were specific that this
+caveat must be visible, not buried — but "visible" is a wide range.
+The designer should call the loudness level given that almost half of
+the Top 200 are test-optional now and over-loud caveats start reading
+as boilerplate the user banner-blinds past.
+
+---
+
+## Notes for implementation handoff
+
+- The card itself should be one component (`web/src/components/PositioningCard.tsx`)
+  that accepts `(profile, schoolAcademicProfile)` and a render mode.
+  The scoring lives in `web/src/lib/positioning.ts` and is called
+  client-side; the card receives the school profile from the page's
+  server-side fetch but does the score computation in the browser
+  to keep student profile data off the server (consistent with the
+  PRD's "no profile data leaves the browser by default" stance).
+- Reuse `.cd-card`, `.rule-2`, `.cd-btn`, `.cd-btn--ghost`,
+  `.mono`, `.serif`, `.nums`. Do not introduce new tokens for v1.
+- The positioning sentence is the load-bearing artifact. Every other
+  visual element exists to support it. If a designer is in doubt
+  about a treatment, they should ask: *does this make the sentence
+  more honest or less honest?*

--- a/docs/prd/016-academic-positioning-card.md
+++ b/docs/prd/016-academic-positioning-card.md
@@ -1,0 +1,289 @@
+# PRD 016: Academic positioning card (v1)
+
+**Status:** Approved 2026-05-01, ready to implement
+**Created:** 2026-05-01
+**Author:** Anthony + Claude (autoplan-reviewed)
+**Related:** [PRD 010](010-queryable-data-browser.md), [PRD 012](012-browser-field-expansion-after-v03.md), [PRD 015](015-institution-directory-and-cds-coverage.md), [PRD 017](017-match-list-builder.md) (deferred), [PRD 018](018-open-college-fit-data.md) (deferred), [Design skeleton](../design/positioning-card-skeleton.md), [autoplan record](../../.claude/plans/system-instruction-you-are-working-starry-candle.md)
+
+---
+
+## Context
+
+A student or parent visiting a `/schools/[school_id]` page today sees the school's archived Common Data Set documents, federal Scorecard outcomes, and coverage status. What they cannot see, even though the data is in our database, is: *where would my numbers land in this school's admitted class?*
+
+That question is one of the highest-search-volume queries in the college-admissions space. PRD 012 already shipped the SAT/ACT percentile columns into `school_browser_rows` and exposes them via PostgREST. This PRD spends that data into a per-school positioning surface on the existing school detail page.
+
+The strategic frame: collegedata.fyi's posture (per ADR 0004) is that no free public CDS API existed and we built one. Several paid tools in the academic-positioning category sell some version of "where you'd fit," and free entrants in the space ship it without source links. The defensible niche for this project is the **open, source-linked, methodology-transparent** version of the same primitive — every claim auditable against the school's own published CDS PDF.
+
+The autoplan strategic review (CEO + Eng + Design) established the v1 shape:
+
+1. Positioning is a commodity feature in this category; the more defensible asset is open data with linked sources (see PRD 018 for the deeper data layer).
+2. A per-school card on existing SEO-ranked school pages beats a destination microsite (microsite deferred to PRD 017).
+3. The data layer needs zero migrations because PRD 012 already shipped it.
+4. GPA stays out of cross-school percentile scoring because scale comparability is unresolved (PRD 012 explicitly held this out).
+
+## Problem
+
+The reviewers' hardest constraint: **any positioning UI risks looking more precise than CDS C.9/C.11/C.12 actually support.** Test-optional schools publish percentiles only for the ~50% of admits who submitted scores. GPA scales are inconsistent. Holistic admit decisions weight institutional priorities (legacy, athletics, geographic balance, intended major) that are nowhere in CDS. The card must be honest about all of this without disappearing into caveats.
+
+## What ships in v1
+
+A per-school positioning card on `/schools/[school_id]` between the documents ledger (line 337 in `web/src/app/schools/[school_id]/page.tsx`) and `<OutcomesSection>` (line 339).
+
+### Card behavior
+
+- **Server-renders** the school's published 25/50/75 SAT and ACT bars, % submitting captions, CDS year, and a source link to the archived PDF. SEO-meaningful.
+- **Progressively enhances** with a client component (`'use client'`) that takes a student profile (GPA, SAT, ACT) via inline mini-form, persists in localStorage as `cdfyi.positioningProfile.v1`, and renders the student's position against the school's bands.
+- **Lead with a positional sentence**, not a tier badge. Sentence form: *"Your SAT is above the 75th percentile of admitted students who submitted scores. Your GPA falls in the modal admit bucket. This school admits 9% of applicants."* The sentence reads as interpretation; a badge reads as verdict.
+- **Tier label is secondary** — small mono caption beneath the sentence in the form `§ TIER · STRONG FIT · BASIS: SAT IN MID-50%, ADMIT RATE 25%`. Vocabulary: **Likely / Strong fit / Possible / Unlikely / Long shot.** Not safety/target/reach (which implies counselor-grade calibration the data doesn't support).
+- **Tier label suppressed** when admit rate < 15% AND scores are inside the school's mid-50%. At that selectivity, numerical position barely moves the outcome, and showing a tier overstates precision. Render the sentence + admit rate only.
+- **Test-optional caveat** is mandatory and inline with the SAT strip in every applicable state: `§ FROM THE 47% OF ADMITS WHO SUBMITTED SCORES · 2024-25 CDS · METHOD →`.
+- **Graceful degradation** for missing fields: card hides itself entirely for schools with no row in `school_browser_rows` or with `data_quality_flag IN ('wrong_file', 'blank_template', 'low_coverage')`. Existing page renders unaffected.
+
+### GPA in v1 — soft tiebreaker only
+
+The card reads `cds_fields` for `C.1201` (avg HS GPA) and `C.1202` (% submitting GPA) per-school via a new `fetchAvgGpaBySchoolId` helper. Renders a side-by-side display: *"School avg HS GPA 3.91 — your entered 3.85."* No percentile claim, no contribution to the tier label.
+
+**Mandatory follow-up — track separately as a focused sprint.** PRD 012 held GPA out of `school_browser_rows` because weighted vs unweighted vs unknown scales make cross-school comparison unsound. v1's soft tiebreaker is the cheapest defensible thing to ship. The system fix is a separate workstream:
+
+1. Extract scale evidence from CDS source PDFs where available (some schools state the scale explicitly, most do not).
+2. Define an `unknown_scale` fallback and a normalization rule.
+3. Manually audit a sample of 100 schools across selectivity tiers.
+4. Decide whether `school_browser_rows` can ever responsibly carry GPA in normalized form.
+
+This sprint is a precondition for any v1.1 GPA promotion and any v2 list-builder GPA filter. Track in `docs/backlog.md`.
+
+### Methodology page
+
+`/methodology/positioning` (under `web/src/app/methodology/positioning/page.tsx`). Static SSR. Anatomy:
+
+- **One-line lede:** "This page shows where your scores would land in a school's admitted-class numbers. It is not a chance-me, and it does not predict admissions decisions."
+- **What we use:** sub-sections per CDS field (C.7 / C.8 / C.9 / C.11 / C.12 / C.1 / C.2), each with the specific use and a worked example. Use one real school (e.g. Bowdoin's 2024-25 CDS) for the worked-example numbers.
+- **What we don't use:** legacy, athletic recruitment, geographic balance, demonstrated interest, intended major, in/out-of-state stratification, essays, ED/EA timing. Each bullet is one sentence with a one-clause rationale.
+- **Why this isn't a chance-me:** three plain-English paragraphs explaining the difference between a position and a prediction.
+- **Sources and audit trail:** every claim links to a CDS question number; the worked example links to the school's archived PDF.
+
+### Public API documentation
+
+The "public API endpoint" deliverable is **already shipped** — PostgREST serves `school_browser_rows` today. This PRD adds documentation only:
+
+- A curl example block on the methodology page showing how to fetch `school_browser_rows` filtered by `school_id`.
+- A note in `web/src/app/api/page.tsx` (the existing public API doc page) referring to the academic-positioning endpoint specifically.
+
+No API code change, no new resource.
+
+## What does NOT ship
+
+This list is load-bearing. Eng review will hold the line on it:
+
+- **No list builder.** No `/list-builder` route, no cross-school filtering by tier. Per-school only. Reserved for PRD 017.
+- **No counselor accounts.** No Supabase auth wiring, no saved profiles server-side. localStorage only.
+- **No URL-shareable profiles in v1.** No `?sat=1450&act=33` deep-linking. v2 introduces a "save game code" pattern (PRD 017).
+- **No PDF or CSV export.** The existing `/browse` export is unaffected.
+- **No reach/target/safety SQL function.** Tier classification is pure TS, client-side. Postgres stays out of the scoring path.
+- **No merit-aid layer.** Codex flagged this is the actual moat; deferred to PRD 018.
+- **No microsite, no `match.collegedata.fyi`** in v1. Reserved for PRD 017.
+- **No GPA percentile scoring.** PRD 012's holdout reason still applies. v1 ships soft tiebreaker only (see above).
+- **No major-level / residency-stratified scoring.** CDS doesn't publish it; methodology page calls this out as a known limitation by name.
+- **No ML scoring.** Pure publishable rubric, auditable line-by-line.
+- **No new schema columns.** Migration count for v1 = 0.
+- **No new public API resource.** PostgREST on `school_browser_rows` already serves it.
+- **No third-party product names in copy.** Surface and methodology language uses neutral terms ("academic positioning," "where you'd fit"). Do not reference, parody, or reproduce the naming or visual layout of any specific competitor product.
+
+## Architecture
+
+```
+[arrows marked * already exist; arrow ! is the only new wiring]
+
+CDS PDF (school IR site)
+   |  *  discovery + mirror (Edge Function on cron)
+   v
+cds_documents + Storage archive
+   |  *  tools/extraction_worker/  -> tier1/tier2/tier4/tier6
+   v
+cds_artifacts (canonical_json keyed to C.901..C.916, etc.)
+   |  *  tools/browser_backend/project_browser_data.py
+   v
+cds_fields (long-form)              <-- read here for GPA tiebreaker
+   |  *  PRD 012 projection logic
+   v
+school_browser_rows                 <-- SAT/ACT columns from PRD 012
+   |  *  PostgREST (api.collegedata.fyi)
+   v
+   +- *  /browse  (existing SchoolBrowser)
+   |
+   +- !  fetchBrowserRowBySchoolId(school_id)             [NEW]
+   +- !  fetchAvgGpaBySchoolId(school_id)                 [NEW]
+        |
+        v
+    web/src/app/schools/[school_id]/page.tsx
+        |
+        |  *  ssr passes typed row
+        v
+    <PositioningCard> (RSC)        <-- NEW
+        +- 25/50/75 range bars rendered server-side (SEO)
+        +- <PositioningCardProfile> (client)
+              | reads localStorage 'cdfyi.positioningProfile.v1'
+              v
+          scorePosition(profile, school)                  [NEW pure fn]
+              v
+          tier label + score plotted
+```
+
+Every upstream arrow already exists. New wiring is one server query helper + one optional `cds_fields` query helper + one server component + one client sub-component + one pure TS module + one static methodology page.
+
+## Critical files
+
+**New:**
+- `web/src/lib/positioning.ts` — pure scoring functions + types (~150 LOC)
+- `web/src/lib/positioning.test.ts` — vitest unit tests with 10 inline-fixture schools
+- `web/src/components/PositioningCard.tsx` — server component
+- `web/src/components/PositioningCardProfile.tsx` — `'use client'` component
+- `web/src/app/methodology/positioning/page.tsx` — static SSR
+- `web/tests/e2e/positioning-card.spec.ts` — Playwright e2e
+- `tests/api/positioning_contract.sh` — PostgREST contract guard
+
+**Modified:**
+- `web/src/app/schools/[school_id]/page.tsx` (+5 lines, +1 import)
+- `web/src/lib/queries.ts` (add `fetchBrowserRowBySchoolId` + `fetchAvgGpaBySchoolId` helpers, ~30 lines)
+- `web/src/app/api/page.tsx` (add positioning endpoint reference)
+- `docs/ARCHITECTURE.md` (note the new pipeline node)
+- `docs/backlog.md` (track GPA scale-resolution sprint)
+
+**Reused (do not rewrite):**
+- `cds_artifacts.canonical_json` — extraction output already keyed to CDS questions
+- `school_browser_rows` (PRD 012 migration `20260428120000_browser_academic_profile_fields.sql`) — SAT/ACT columns already present with range checks
+- `cds_fields` — long-form substrate for the GPA soft-tiebreaker read
+- `institution_cds_coverage` — coverage states for the staleness micro-copy
+- Design tokens in `web/src/app/tokens.css`; `.cd-card`, `.rule-2`, `.cd-btn`, `.mono`, `.serif`, `.nums`
+
+## Scoring function contract
+
+```ts
+// web/src/lib/positioning.ts
+export type StudentProfile = {
+  sat?: number;            // 400-1600
+  act?: number;            // 1-36
+  gpa?: number;            // 0.0-5.0 raw
+  gpaScale?: 'unweighted_4' | 'weighted' | 'unknown';
+};
+
+export type SchoolAcademicProfile = {
+  schoolId: string;
+  schoolName: string;
+  cdsYear: string;            // e.g. "2024-25"
+  acceptanceRate: number | null;
+  satSubmitRate: number | null;     // 0..1
+  actSubmitRate: number | null;
+  satCompositeP25: number | null;
+  satCompositeP50: number | null;
+  satCompositeP75: number | null;
+  actCompositeP25: number | null;
+  actCompositeP50: number | null;
+  actCompositeP75: number | null;
+  avgHsGpa: number | null;          // from cds_fields C.1201
+  hsGpaSubmitRate: number | null;   // from cds_fields C.1202
+  dataQualityFlag: string | null;
+};
+
+export type Tier =
+  | 'likely' | 'strong_fit' | 'possible' | 'unlikely' | 'long_shot' | 'unknown';
+
+export type Caveat =
+  | 'no_sat_data' | 'no_act_data' | 'low_sat_submit_rate'
+  | 'no_test_data' | 'stale_cds' | 'student_not_submitting'
+  | 'data_incomplete' | 'sub_15_admit_rate_suppression';
+
+export type PositionResult = {
+  satPercentile: number | null;     // clamped to [5, 95] outside published anchors
+  actPercentile: number | null;
+  tier: Tier;
+  caveats: Caveat[];
+  cdsYear: string;
+  positionalSentence: string;       // pre-rendered, ready to display
+};
+
+export function scorePosition(
+  profile: StudentProfile,
+  school: SchoolAcademicProfile,
+): PositionResult;
+
+export function interpolatePercentile(
+  score: number,
+  p25: number,
+  p50: number,
+  p75: number,
+): number;  // piecewise-linear, clamped to [5, 95]
+
+export function classifyTier(
+  satPct: number | null,
+  actPct: number | null,
+  acceptanceRate: number | null,
+): Tier;
+```
+
+Tier rubric (publishable, in methodology page):
+
+- **Likely** — admit rate ≥ 50% AND scores at-or-above mid-50%.
+- **Strong fit** — admit rate ≥ 25% AND scores in or above mid-50%.
+- **Possible** — scores in mid-50%, admit rate 10–25%.
+- **Unlikely** — scores below mid-50% OR admit rate < 10%.
+- **Long shot** — scores below 25th AND admit rate < 25%, or admit rate < 10% regardless of scores.
+- **Unknown** — caveat-suppressed (test-optional non-submitter, missing data, sub-15% admit + mid-50%).
+
+## Failure modes
+
+| # | Failure mode | Detection | Mitigation |
+|---|---|---|---|
+| 1 | Non-monotonic 25/50/75 (extraction error) | `p25 > p50 \|\| p50 > p75` in scorer | `satPercentile=null`, caveat `data_incomplete`, "range published, position not computable" microcopy |
+| 2 | Test-optional + low submit rate | `satSubmitRate < threshold` | Pair every percentile with submit-rate caption; suppress percentile + emit `student_not_submitting` if profile has no SAT/ACT |
+| 3 | SAT populated, ACT NULL (or vice versa) | per-test null check | Render only the populated bar; "ACT not reported in this CDS year" microcopy |
+| 4 | Old CDS year with schema drift | gate on `year_start >= 2024` | Card hides if year_start < 2024; methodology page documents the floor |
+| 5 | GPA scale ambiguity | per PRD 012 — held out of school_browser_rows | v1 does not score GPA percentile; soft tiebreaker only |
+| 6 | Withdrawn school | `participation_status='withdrawn'` already filtered by `PUBLIC_EXCLUDED_STATUSES` (queries.ts:21) | Card never renders; defense-in-depth check in helper |
+| 7 | localStorage profile schema versioning | versioned key `cdfyi.positioningProfile.v1` | Future v2 readers migrate forward; never break v1 |
+| 8 | URL-encoded profile XSS | not in v1 (no URL deep-linking) | n/a until v2 |
+| 9 | School with no `school_browser_rows` row | `fetchBrowserRowBySchoolId` returns null | Card returns null; existing page renders unaffected |
+| 10 | Schema drift in `school_browser_rows` | CI contract test (`tests/api/positioning_contract.sh`) | Fails CI at PR time |
+| 11 | `data_quality_flag='wrong_file'` row | check in card | Card hides itself |
+| 12 | `acceptance_rate` NULL | tier classifier handles null | tier=`unknown`; percentile rendering still works |
+
+## Verification
+
+End-to-end test plan:
+
+1. **Unit tests (vitest):** `cd web && npm run test`. 10 fixture schools spanning selectivity tiers + test-optional/required mix. Specifically test interpolation correctness, non-monotonic guard, test-optional caveat firing, and tier classification at boundaries.
+2. **Component tests:** RTL snapshots for empty / loaded / ACT-NULL / test-optional / stale-CDS / wrong-file states.
+3. **Contract test:** `bash tests/api/positioning_contract.sh` — fails CI if any column disappears from PostgREST.
+4. **Playwright e2e:** load `/schools/university-of-maryland-college-park`, verify SAT bars render server-side (view-source check), enter SAT=1450, verify tier label + percentile, navigate to `/schools/mit`, verify profile auto-populates.
+5. **Manual spot checks:** 5 named schools at PR-review time:
+   - **Bowdoin** — test-optional, low submit rate. Verify caveat prominence.
+   - **MIT** — test-required, ultra-selective. Most realistic profiles → `long_shot`.
+   - **UMD** — mid-selectivity, test-optional, public. Methodology worked example.
+   - **Cal Poly SLO** — public, residency-stratified in reality (card cannot reflect; methodology page calls this out).
+   - **Howard** — HBCU, mid-selectivity, lower sample sizes. Stress-test edge cases.
+6. **Build + lint:** `cd web && npm run build && npm run lint && npm run typecheck` clean.
+
+## Coverage audit (parallel, non-blocking)
+
+The card degrades gracefully when fields are missing for a given school, so this PRD does not gate ship on coverage. In parallel, run a coverage audit during the v1 month:
+
+- Re-run `tools/browser_backend/project_browser_data.py --full-rebuild` weekly.
+- Output a JSON report to `scratch/positioning-coverage/` listing schools where `sat_composite_p50` is null but a 2024-25+ CDS document exists, schools with non-monotonic percentiles, and schools where `act_submit_rate` looks implausible.
+- Track on `docs/extraction-quality.md`. Feeds extraction-quality work; does not block PRD 016.
+
+## Rollout plan
+
+- **No feature flag.** Single PR. Blast radius is bounded to one page; rollback is the one-line revert of the slot insertion in `page.tsx`.
+- **Post-ship telemetry:** basic page-view counter for `/methodology/positioning` and a no-PII counter for "profile entered" via Vercel analytics. Validates demand without saving anything.
+
+## Open questions deferred to Claude Design
+
+The full UX skeleton lives at `docs/design/positioning-card-skeleton.md`. Two open design questions explicitly left for the design pass:
+
+- **D1.** SAT range strip geometry — hairline ticks at 25/50/75, filled bar between 25–75, or distribution sketch? Each carries a different precision implication.
+- **D2.** Test-optional submitter-only caveat loudness — tight inline, card-level banner, or sticky? Tradeoff: visible vs. boilerplate-blindness when ~50% of the Top 200 fires the caveat.
+
+## Effort
+
+~1 week (1 person, CC+gstack pace). The original 2-3 week estimate collapsed once eng review confirmed PRD 012 already shipped the data layer.

--- a/docs/prd/017-match-list-builder.md
+++ b/docs/prd/017-match-list-builder.md
@@ -1,0 +1,143 @@
+# PRD 017: Match list-builder microsite (v2)
+
+**Status:** Defined, not started. Activates after PRD 016 hits the engagement gate.
+**Created:** 2026-05-01
+**Author:** Anthony + Claude (autoplan)
+**Related:** [PRD 016](016-academic-positioning-card.md), [PRD 018](018-open-college-fit-data.md), [autoplan record](../../.claude/plans/system-instruction-you-are-working-starry-candle.md)
+
+---
+
+## Context
+
+PRD 016 ships per-school positioning on the existing `/schools/[school_id]` page. This PRD scopes the next surface: a destination list builder at `match.collegedata.fyi` that lets a user (most likely a counselor or anxious parent) enter a profile once and see a ranked list of schools across the corpus, grouped by tier, with the per-school card embedded inline.
+
+The autoplan strategic review concluded this surface is the *second* deliverable, not the first, because:
+
+1. The per-school card on existing SEO traffic is a smaller, more defensible artifact.
+2. A destination microsite cold-starts its own SEO and dilutes the archive's authority.
+3. Counselor adoption is unverified at v1 ship time. v2 should be conditional on engagement signal.
+4. Destination list-builders are a crowded category with several entrenched competitors competing on distribution; entering it without an engagement signal from PRD 016 is premature.
+
+This PRD therefore exists as a defined, pre-conditioned, deferred backlog item — so the future direction is documented but the build doesn't start until the data justifies it.
+
+## Pre-conditions to activate this PRD
+
+All three must be true before implementation begins:
+
+1. **PRD 016 reaches >500 weekly active users on the positioning card.** Measured by Vercel analytics page-view + profile-entry counters. Validates that positioning is a real-user demand, not just a hypothesis.
+2. **At least one IEC pilot has used the v1 surface with 3+ real students.** Direct outreach: 5-10 IECs in the user's network are given the PRD 016 surface plus a Google Sheet template. If 1+ uses it on a real list within 30 days, counselor demand is signaled. If 0 use it, audience hypothesis was wrong; revisit before building v2.
+3. **Top-500 academic-profile coverage audit lands at >70% completeness.** The card on a single school can degrade per-school. The list builder cannot — partial data degrades the entire ranking.
+
+If any pre-condition fails, do not build PRD 017. Consider PRD 018 (merit-aid intelligence) as the alternative next move.
+
+## What ships in v2 (when activated)
+
+### List-builder UI at `match.collegedata.fyi`
+
+- **Side panel:** student profile entry (GPA + scale, SAT, ACT, optional state, optional intended-major). Reuses the same `StudentProfile` type from PRD 016's `positioning.ts`.
+- **Main panel:** filterable, sortable list of schools across the full corpus, grouped by tier (Likely / Strong fit / Possible / Unlikely / Long shot). Each row uses the per-school positioning card from PRD 016 in a compact horizontal layout.
+- **Filters:** public/private, region, admit-rate range, test-optional vs required, has-current-CDS, Carnegie classification.
+- **Counselor-friendly export (CSV).** One row per school, columns covering tier, percentile, admit rate, source CDS year, source PDF URL. Matches what a counselor would paste into a Google Doc or share with a family.
+- **Print-friendly view.** PDF generated client-side via `window.print()` with a print-only stylesheet. No server-side PDF rendering — simpler.
+
+### Data layer
+
+Reuses `school_browser_rows` (already shipped by PRD 012) and `cds_fields` (for the GPA tiebreaker if PRD 016's GPA scale-resolution sprint has landed). The list builder queries `school_browser_rows` filtered to rows with sufficient data (`sat_composite_p50 IS NOT NULL OR act_composite_p50 IS NOT NULL` AND `acceptance_rate IS NOT NULL`).
+
+Performance gate: the list query must return ranked results in <500ms p95. If `school_browser_rows` row count exceeds a threshold where in-memory ranking becomes slow (~5,000 rows), introduce a server-side ranked view; otherwise rank client-side.
+
+### Sharing — "save game code"
+
+Instead of `?sat=1450&act=33` URL params (which leak scores through referrers, search history, browser sync), v2 introduces a short shareable code pattern modeled on the Porsche configurator:
+
+A 6-7 character alphanumeric code, e.g. `K9F-3XQ`, encodes the profile. Two implementation candidates, picked at v2 design time:
+
+- **Stateless (default).** Base32-encoded packed integer of `(gpa × 100, sat, act, flags)`. Fully client-side, no server lookup, no PII storage. ~30 bits of payload covers GPA(0-450), SAT(400-1600), ACT(1-36), 4 boolean flags. Code is decoded on the receiving end purely in the browser.
+- **Stateful.** Server-side lookup keyed on the code; allows richer profiles (state, major, intended ED/EA, etc.) but requires a Supabase table and brings COPPA/FERPA posture back into scope.
+
+Default to stateless unless v2's feature set demands more capacity than ~40 bits of packed state. The stateless pattern is the cleanest privacy posture: a code can be shared in a Slack message or text without ever leaving a server-side trail.
+
+### Optional saved counselor profiles
+
+**Only if** PRD 016 telemetry shows counselor-driven traffic. If counselor demand is unproven, ship localStorage-only and skip this surface entirely.
+
+If counselor accounts ship:
+
+- Supabase Auth, magic-link only (no password handling).
+- Counselor-asserted "I have parental consent for any minors" checkbox at signup, stored as a boolean on the user row.
+- Saved cohorts: a counselor can name a list, save profiles by student initials only (no full names, no DOB beyond grade level), and track multiple students.
+- Privacy policy update: data minimization, deletion-on-request, no third-party sale.
+
+### Naming
+
+`match.collegedata.fyi`. The user explicitly accepted the brand-collision cost with collegedata.com's "College Match" tool. "match" is non-proprietary and used by dozens of services in the category. Subdomain SEO cold-start cost is the price of audience separation.
+
+DNS + Vercel project setup is operational, not a code concern. The microsite is a separate Next.js app or a Vercel rewrite to a subdirectory of the main app. Pick at implementation time based on bundle weight.
+
+## What does NOT ship in v2
+
+Deferred to v3 or beyond:
+
+- **In/out-of-state stratification for publics.** CDS does not publish state-stratified percentiles. The list-builder cannot reflect this; methodology page calls this out by name.
+- **Per-program / per-major calibration.** CDS only publishes institution-wide numbers. Major-level competitiveness is tribal knowledge; we don't have it.
+- **Saved profiles server-side without proven counselor demand.** Default is localStorage + save-game-code only. Auth is conditional.
+- **Reach/target/safety hard labels.** Same vocabulary as PRD 016 (Likely / Strong fit / Possible / Unlikely / Long shot). The reviewers' constraint about implying counselor-grade calibration applies in v2 as much as v1.
+- **Merit-aid layer.** Lives in PRD 018.
+
+## Critical files (when implementation begins)
+
+This section is illustrative, not final. Re-scope at activation time.
+
+**New:**
+- `web/src/app/(match)/...` — separate route group for the microsite, OR a new Next.js app under `match/` if Vercel rewrites are too costly
+- `web/src/lib/savecode.ts` — encode/decode for the save-game-code pattern
+- `web/src/components/SchoolListItem.tsx` — compact horizontal positioning card for the list view
+- `web/src/components/ListBuilderFilters.tsx` — filter panel
+- `web/src/lib/list-builder.ts` — ranking + filtering logic (pure TS)
+- `docs/prd/017-match-list-builder.md` — this file, expanded into implementation detail
+- DNS/Vercel: `match.collegedata.fyi` configured as a subdomain or rewrite
+
+**Modified:**
+- `docs/ARCHITECTURE.md` — note the new microsite surface
+- `web/src/app/page.tsx` — link to the microsite from the main site nav (lightly, to avoid muddying the archive's brand)
+
+**Reused:**
+- `web/src/lib/positioning.ts` — same scoring function as PRD 016
+- `web/src/components/PositioningCard.tsx` — embedded per-row in the list
+
+## Failure modes (deferred)
+
+- **Coverage drops mid-list.** Schools with NULL percentiles must render visibly degraded inside the list, not silently mis-ranked.
+- **Save-game-code collisions.** Stateless codes have no collision concern; stateful codes need a UNIQUE check on insert and a regenerate-on-collision retry.
+- **Counselor session leak.** If saved profiles ship, a stale session token must not expose another counselor's cohort. Standard auth hygiene.
+- **PDF print fidelity.** Client-side `window.print()` produces inconsistent output across browsers; build with explicit print stylesheets and test on Chrome / Safari / Firefox at PR time.
+
+## Verification (deferred)
+
+To be filled in at activation time. Sketch:
+
+1. Unit tests for save-game-code encode/decode round-trip across 1000 random profiles.
+2. List ranking correctness against the same 10 fixture schools used in PRD 016.
+3. Filter combinations: public + test-optional + admit rate < 25% returns the expected subset.
+4. CSV export round-trips: paste into Google Sheets, verify columns + values.
+5. Save-game-code share: encode in browser A, decode in browser B, verify identical render.
+
+## Effort estimate (rough, refine at activation)
+
+2-3 weeks (1 person, CC+gstack pace). Most of the cost is the list-builder UI itself — the data layer reuses PRD 016 + PRD 012 entirely.
+
+## Decision tree at activation
+
+```
+PRD 016 telemetry + counselor pilot signal
+    |
+    +-- positioning has demand AND coverage > 70%? --- YES --> build PRD 017
+    |
+    +-- positioning has demand BUT coverage < 70%?   --- spend a sprint on extraction quality first
+    |
+    +-- positioning lacks demand, API has demand?    --- skip PRD 017, jump to PRD 018
+    |
+    +-- neither has demand?                          --- stop. The hypothesis was wrong. Revisit.
+```
+
+This decision tree is the actual deliverable of this PRD. The build is conditional, not committed.

--- a/docs/prd/018-open-college-fit-data.md
+++ b/docs/prd/018-open-college-fit-data.md
@@ -1,0 +1,178 @@
+# PRD 018: Open college fit data — merit-aid + Scorecard intelligence (v3)
+
+**Status:** Defined, not started. Pursue **after** PRD 016, **possibly instead of** PRD 017.
+**Created:** 2026-05-01
+**Author:** Anthony + Claude (autoplan)
+**Related:** [PRD 016](016-academic-positioning-card.md), [PRD 017](017-match-list-builder.md), [PRD 010](010-queryable-data-browser.md), [PRD 012](012-browser-field-expansion-after-v03.md), [Scorecard pipeline](../../tools/scorecard/README.md), [autoplan record](../../.claude/plans/system-instruction-you-are-working-starry-candle.md)
+
+---
+
+## Context
+
+The autoplan strategic review surfaced a load-bearing observation: **academic positioning is the commodity surface in this category, not the defensible one.** Several paid college-planning platforms compete on positioning + merit + cost together, and the recurring revenue in those products is mostly tied to the financial intelligence layer (predicted aid, award comparison, net-cost transparency), not the positioning layer alone. Several free entrants in the space already ship positioning without source links. Where this project has a real advantage is the open archive of source-linked CDS extracts — and the higher-leverage application of that asset is **open, source-linked, machine-queryable college fit data** spanning academics, aid, and outcomes.
+
+This PRD scopes that data asset.
+
+## Why this might leapfrog PRD 017
+
+If counselor adoption of PRD 016 is weak but the public API gets used by other tool builders — measured by the "give 5 tool builders the endpoint and see if they build" test — the right move is to skip the v2 microsite and go straight to merit-aid as the next data asset. The microsite competes where category incumbents are strongest (destination match/chance UIs); the data asset competes where this project's actual advantage is (open archive of source-linked extracts).
+
+Decision tree at activation time, copied from PRD 017:
+
+- PRD 016 has demand + tool-builder API adoption is weak → build PRD 017 (microsite).
+- PRD 016 has demand + tool-builder API adoption is strong → skip PRD 017, build PRD 018.
+- Both signals strong → build both, in parallel if budget allows, sequenced otherwise.
+- Neither signal → stop and revisit the audience hypothesis.
+
+## What ships (when activated)
+
+### `school_merit_profile` denormalized view
+
+A new Postgres view (or materialized table, if performance demands) on top of `cds_artifacts.canonical_json` aggregating CDS section H fields per school per year:
+
+- **H1** — average annual freshman financial aid package
+- **H2** — number receiving aid
+- **H5** — average need-based scholarship/grant aid
+- **H6** — average need-based self-help aid
+- **H7** — average non-need-based scholarship/grant aid (the "merit" number)
+- **H8** — average institutional grants
+
+Plus, joined from `scorecard_summary`:
+
+- Net-price-by-income-bracket (5 brackets: $0-30k, $30-48k, $48-75k, $75-110k, $110k+)
+- Median federal debt at graduation
+- Median debt monthly payment
+- 6-year graduation rate
+- Median earnings 6/8/10 years post-enrollment
+- Pell share
+
+The view exposes a single row per (school, latest-CDS-year) with both the CDS-derived merit numbers and the federal Scorecard outcome data side-by-side. This is the same pattern PRD 012's `school_browser_rows` follows for academic profile, applied to financial fit.
+
+### Public PostgREST endpoint + documentation
+
+Same pattern as PRD 016's API documentation:
+
+- `school_merit_profile` exposed read-only via PostgREST at `api.collegedata.fyi/rest/v1/school_merit_profile`.
+- Methodology page at `/methodology/merit-profile` with worked examples.
+- Curl examples + a Google Sheets template that pulls live from the API. The Sheets template is the lightest counselor-facing surface possible — it costs us 1 day of doc work and gives counselors a tool they can use today without us building any UI.
+
+### Static "fit profile" pages per school
+
+Lightweight UI: `/schools/[school_id]/fit` (or merge into the existing school detail page if the surface area stays small). Shows the academic + merit data side-by-side:
+
+- Section 1: PRD 016's positioning card (academic fit).
+- Section 2: merit profile — average non-need aid, % receiving, distribution if available.
+- Section 3: net-price-by-income-bracket chart, with the user's family income (if entered) highlighting the relevant bracket.
+- Section 4: outcomes — 6-year graduation, median earnings, median debt.
+
+The focus is on the data layer being machine-queryable. The UI is a thin presentation; if a third party builds a better one, they should be able to.
+
+### Methodology page extension
+
+`/methodology/merit-profile`:
+
+- "What is need-based vs non-need-based aid?" — plain-English explainer.
+- "How does net price by income work?" — Scorecard's IRS-derived methodology, linked to ED's documentation.
+- "Why do CDS H values vary so much across schools?" — practical guide to interpreting reported numbers.
+- "What we don't capture" — outside scholarships, year-to-year aid changes, special-circumstance appeals, etc.
+
+## Open question — extraction quality on CDS section H
+
+**This is the critical pre-condition.** PRD 012's phase-0 audit measured C.9, C.11, C.12 (academic profile). Section H (financial aid) was not measured. The v3 scoping spike (1 week, before any v3 PRD work) must establish:
+
+1. Section H field-by-field answerability across the latest 365 schools.
+2. Which H fields are reliably extracted vs which the Tier 4 cleaner mangles.
+3. Whether the LLM fallback (PRD 006) covers H gaps reliably enough to ship.
+4. Coverage by selectivity tier — top 100 vs full corpus.
+
+If H extraction quality is below ~60%, prioritize an H-section extraction sprint before building the data asset. Otherwise the merit profile will look more precise than the data supports — the same trap PRD 016 deliberately avoided.
+
+## What does NOT ship
+
+- **No merit prediction.** Some commercial tools in this space promise "what you might receive" as a personalized estimate. We promise "what this school reported giving on average," based on published CDS values. Different question, much smaller legal exposure, much easier to defend.
+- **No appeal-letter generation.** Generating appeal letters tuned to a specific student's case is a separate product surface. Out of scope for v3; revisit if counselor demand pulls.
+- **No financial-need calculator.** FAFSA / EFC calculation is a separate, complex domain. Link to authoritative public tools (e.g. the federal Net Price Calculator on each school's site).
+- **No school-vs-school side-by-side comparison view in v3.** That's a v4 product surface.
+- **No third-party tracking pixels or affiliate links.** Methodology page may link to public, authoritative resources for FAFSA help; no monetization.
+
+## Architecture (sketch)
+
+```
+[arrows marked * already exist; arrow ! is new]
+
+cds_artifacts (canonical_json)
+   |  *  tools/browser_backend/project_browser_data.py
+   v
+cds_fields                                 <-- read for H-section fields
+   |  !  new aggregation: tools/merit_backend/project_merit_data.py
+   v
+school_merit_profile                       <-- NEW denormalized view
+   |  *  PostgREST
+   |
+scorecard_summary                          <-- already populated by tools/scorecard/refresh_summary.py
+   |  *  joined into school_merit_profile via UNITID
+   v
+school_merit_profile (final)
+   |  *  PostgREST
+   v
+   +- !  /schools/[id]/fit                 <-- NEW thin UI
+   +- !  Google Sheets template            <-- NEW doc artifact
+   +- *  third-party tools build their own UIs against the API
+```
+
+The pattern is identical to PRD 010 / 012 — a denormalized view on top of `cds_fields` plus Scorecard, served via PostgREST, documented, with thin UI on top.
+
+## Critical files (when implementation begins)
+
+This is illustrative; re-scope at activation.
+
+**New:**
+- `tools/merit_backend/project_merit_data.py` — projection script
+- `supabase/migrations/<ts>_school_merit_profile.sql` — view or materialized table
+- `web/src/app/methodology/merit-profile/page.tsx` — methodology
+- `web/src/app/schools/[school_id]/fit/page.tsx` — thin UI (or section in existing page)
+- `web/src/components/MeritProfileCard.tsx` — visual
+- `web/src/components/NetPriceByIncomeChart.tsx` — visual
+- `tools/sheets/merit-profile-template.csv` — Google Sheets template seed
+- `docs/prd/018-open-college-fit-data.md` — this file, expanded
+
+**Modified:**
+- `docs/ARCHITECTURE.md` — note the new pipeline node
+- `web/src/app/api/page.tsx` — document the new endpoint
+
+**Reused:**
+- `cds_artifacts.canonical_json` — H-section data already extracted by tier1/tier2/tier4/tier4_llm_fallback
+- `scorecard_summary` — net-price-by-income, earnings, debt all already populated
+- `school_browser_rows` — for the academic-fit join on the per-school fit page
+
+## Failure modes (deferred)
+
+- **H-section extraction quality is low.** Discovered by the scoping spike. Mitigation: H extraction sprint before v3 build.
+- **CDS H values are reported on different scales across schools.** Some schools report aid as a fraction, some as dollars, some include institutional vs federal aid differently. Methodology page must call this out by name. The denormalized view normalizes where possible and flags where not.
+- **Net-price calculator embeds.** Some schools' NPCs are linked from CDS section H; we can surface those links but cannot embed them (TOS varies per school).
+- **Student-PII risk on a calculator surface.** If we ever add an income input, that's PII-adjacent. Default in v3: no income input; show all 5 brackets and let the user identify their own.
+
+## Verification (deferred)
+
+To be filled in at activation time. Sketch:
+
+1. The scoping spike completes and reports H-section answerability.
+2. Projection script produces a `school_merit_profile` populated for 200+ schools at >60% field completeness.
+3. PostgREST endpoint returns expected shapes; contract test passes.
+4. Google Sheets template imports the API correctly via `IMPORTDATA()`.
+5. Manual spot checks: 5 schools across selectivity (Bowdoin, MIT, UMD, Texas A&M, Berea) — verify the merit profile matches the published CDS PDF.
+
+## Effort estimate
+
+4-8 weeks at the high end if H extraction quality is poor and we need a sprint first. 2-3 weeks if H extraction is already solid (likely for the schools where Tier 1 XLSX extraction or Tier 2 fillable PDF extraction worked — those producers tend to capture H reliably).
+
+## Why this PRD is "deferred" not "cancelled"
+
+The autoplan review's strongest claim was that this is the actual moat. We're shipping PRD 016 first because it's smaller and more defensible. PRD 018 stays defined and reviewable so:
+
+1. Future contributors can see the full direction without re-deriving it.
+2. If PRD 017 fails to activate (counselor signal weak), this PRD is the alternative next move.
+3. If a contributor wants to drive H-extraction quality, they have a target use case to optimize for.
+4. If a category incumbent expands a free tier to undercut PRD 016, this PRD is the response.
+
+Don't let PRD 018 rot. Re-evaluate quarterly against PRD 016 telemetry.


### PR DESCRIPTION
## Summary

Three new PRDs scoping a per-school academic positioning surface, plus a UX skeleton for the v1 card.

- **PRD 016 (v1, ~1 week of work)** — per-school positioning card on `/schools/[school_id]`, pure-TS scoring, methodology page. Reuses the SAT/ACT columns from PRD 012's `school_browser_rows`. Zero migrations, zero new API resources.
- **PRD 017 (v2, deferred)** — match list-builder microsite at `match.collegedata.fyi`. Pre-conditioned on PRD 016 engagement signal and counselor pilot feedback.
- **PRD 018 (v3, deferred)** — open college fit data: merit-aid (CDS section H) plus Scorecard net-price-by-income, exposed as `school_merit_profile` via PostgREST.
- **UX skeleton** at `docs/design/positioning-card-skeleton.md` (540 lines) — starting point for the design pass with two genuinely-open questions (SAT range geometry, test-optional caveat loudness).

This is a docs-only PR. No code, no migrations, no behavior change on the live site.

## Why this scope

The original idea — a free counselor microsite with positioning + list-builder — was workshopped through a CEO/Eng/Design review pass. Both review voices independently recommended a sharper v1: per-school card on the existing site (which already has SEO equity), no microsite cold-start, no list builder until engagement is proven. PRD 016 is that sharper v1.

The deferred PRDs document the longer-arc direction (microsite, merit-aid intelligence) so future contributors don't have to re-derive the strategy.

## Test plan

- [x] Markdown renders cleanly on GitHub for all four files
- [x] Internal cross-links between PRDs resolve
- [x] No competitor product names in the public PRDs (audited pre-commit)
- [ ] Reviewer sanity-check on the PRD 016 file paths and verification commands
- [ ] Confirm PRD 016's claim that `supabase/migrations/20260428120000_browser_academic_profile_fields.sql` already covers the data layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)