### PR TITLE
Support Tier 4 PRD 016B redrain

### DIFF
--- a/docs/plans/prd-016b-phase-0-findings.md
+++ b/docs/plans/prd-016b-phase-0-findings.md
@@ -1,29 +1,29 @@
 # PRD 016B Phase 0 Findings
 
-Generated: `2026-05-02T16:32:09.225693+00:00`
+Generated: `2026-05-02T20:54:23.425796+00:00`
 
 ## Summary
 
-- Rows audited: `476`
-- ED-count answerability: `90` / `476` (`18.9%`)
-- ED-offered answerability: `58` / `69` (`84.1%`)
-- EA-offered rows: `31`
-- ED-or-EA-offered rows: `90`; ED-count answerable for `58` (`64.4%`)
-- Top-200-by-applicants answerability: `57` / `200` (`28.5%`)
-- Top-200 ED-offered answerability: `38` / `45` (`84.4%`)
-- Top-200 EA-offered rows: `19`
-- Top-200 ED-or-EA-offered rows: `58`; ED-count answerable for `38` (`65.5%`)
-- ED second-deadline signal: `19` rows (`4.0%`)
-- ED share of admitted distribution: `{'count': 85, 'p25': 0.0257, 'p50': 0.0969, 'p75': 0.2046, 'p90': 0.2941}`
-- Verifier rejections: `{'ed_admitted_gt_ed_applicants': 4}`
+- Rows audited: `469`
+- ED-count answerability: `104` / `469` (`22.2%`)
+- ED-offered answerability: `104` / `145` (`71.7%`)
+- EA-offered rows: `114`
+- ED-or-EA-offered rows: `190`; ED-count answerable for `104` (`54.7%`)
+- Top-200-by-applicants answerability: `68` / `200` (`34.0%`)
+- Top-200 ED-offered answerability: `68` / `97` (`70.1%`)
+- Top-200 EA-offered rows: `82`
+- Top-200 ED-or-EA-offered rows: `128`; ED-count answerable for `68` (`53.1%`)
+- ED second-deadline signal: `67` rows (`14.3%`)
+- ED share of admitted distribution: `{'count': 96, 'p25': 0.0325, 'p50': 0.1002, 'p75': 0.2432, 'p90': 0.3057}`
+- Verifier rejections: `{'ed_admitted_gt_ed_applicants': 6}`
 
 ## Producer Answerability
 
 | Producer | Answerable | Total | Pct |
 |---|---:|---:|---:|
-| tier1_xlsx | 6 | 53 | 11.3% |
-| tier2_acroform | 32 | 85 | 37.6% |
-| tier4_docling | 52 | 337 | 15.4% |
+| tier1_xlsx | 4 | 48 | 8.3% |
+| tier2_acroform | 32 | 81 | 39.5% |
+| tier4_docling | 68 | 339 | 20.1% |
 | tier6_html | 0 | 1 | 0.0% |
 
 ## Threshold Decisions

--- a/docs/tier4-llm-fallback.md
+++ b/docs/tier4-llm-fallback.md
@@ -218,7 +218,7 @@ The cache key columns are grounded in what actually persists today:
 | `model_name` | `claude-haiku-4-5` (or override via `--model`) |
 | `prompt_version` | Defined in `tier4_llm_fallback.PROMPT_VERSION` |
 | `strategy_version` | Defined in `tier4_llm_fallback.STRATEGY_VERSION` |
-| `cleaner_version` | Operator-supplied (`--cleaner-version`, default `0.3.0`) |
+| `cleaner_version` | Operator-supplied (`--cleaner-version`, default `0.3.1`) |
 | `missing_fields_sha256` | sha256 of the sorted list of question numbers the cleaner left blank |
 
 Uniqueness is enforced by a dedicated unique index (not a table UNIQUE

--- a/tools/browser_backend/prd016b_phase0_audit.py
+++ b/tools/browser_backend/prd016b_phase0_audit.py
@@ -147,7 +147,8 @@ def selected_values_with_tier4_rerun(
 def fetch_browser_rows(client: Any, limit: int | None) -> list[dict[str, Any]]:
     select_cols = (
         "document_id,school_id,school_name,canonical_year,year_start,producer,"
-        "applied,admitted,acceptance_rate"
+        "applied,admitted,acceptance_rate,ed_offered,ea_offered,ea_restrictive,"
+        "ed_applicants,ed_admitted,ed_has_second_deadline"
     )
     page_size = 1000
     offset = 0
@@ -172,23 +173,17 @@ def fetch_browser_rows(client: Any, limit: int | None) -> list[dict[str, Any]]:
 
 
 def audit_row(client: Any, row: dict[str, Any]) -> AuditRow | None:
-    artifacts = pbd.fetch_artifacts(client, str(row["document_id"]))
-    selected = pbd.select_extraction_result(
-        str(row["document_id"]),
-        artifacts,
-        expected_schema_version=str(row.get("canonical_year") or ""),
-    )
-    if selected is None:
-        return None
-
-    values = selected_values_with_tier4_rerun(selected, artifacts)
-    canonical = canonical_values(selected.schema_version, values)
-
-    ed_offered = bool_from_text(canonical.get("C.2101"))
-    ea_offered = bool_from_text(canonical.get("C.2201"))
-    ea_restrictive = bool_from_text(canonical.get("C.2206"))
-    ed_applicants = decimal_int(canonical.get(CANONICAL_ED_APPLICANTS))
-    ed_admitted = decimal_int(canonical.get(CANONICAL_ED_ADMITTED))
+    ed_offered = row.get("ed_offered")
+    if not isinstance(ed_offered, bool):
+        ed_offered = bool_from_text(ed_offered)
+    ea_offered = row.get("ea_offered")
+    if not isinstance(ea_offered, bool):
+        ea_offered = bool_from_text(ea_offered)
+    ea_restrictive = row.get("ea_restrictive")
+    if not isinstance(ea_restrictive, bool):
+        ea_restrictive = bool_from_text(ea_restrictive)
+    ed_applicants = decimal_int(row.get("ed_applicants"))
+    ed_admitted = decimal_int(row.get("ed_admitted"))
     applied = decimal_int(row.get("applied"))
     admitted = decimal_int(row.get("admitted"))
     verifier_rejection = None
@@ -203,7 +198,7 @@ def audit_row(client: Any, row: dict[str, Any]) -> AuditRow | None:
         school_id=str(row["school_id"]),
         school_name=str(row["school_name"]),
         canonical_year=str(row["canonical_year"]),
-        producer=selected.base_producer,
+        producer=str(row.get("producer") or "unknown"),
         applied=applied,
         admitted=admitted,
         ed_offered=ed_offered,
@@ -211,7 +206,7 @@ def audit_row(client: Any, row: dict[str, Any]) -> AuditRow | None:
         ea_restrictive=ea_restrictive,
         ed_applicants=ed_applicants,
         ed_admitted=ed_admitted,
-        ed_has_second_deadline=has_second_deadline(selected.schema_version, values),
+        ed_has_second_deadline=bool(row.get("ed_has_second_deadline")),
         ed_answerable=(
             ed_applicants is not None
             and ed_admitted is not None

--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -1210,9 +1210,35 @@ def project_document_id(
     return project_document(client, docs[0], definitions, apply)
 
 
+def fetch_projected_document_ids(client: Any, table: str) -> set[str]:
+    document_ids: set[str] = set()
+    page_size = 1000
+    offset = 0
+    while True:
+        result = (
+            client.table(table)
+            .select("document_id")
+            .gte("year_start", MIN_YEAR_START)
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        batch = result.data or []
+        for row in batch:
+            document_id = row.get("document_id")
+            if document_id:
+                document_ids.add(str(document_id))
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return document_ids
+
+
 def clear_projection_tables(client: Any) -> None:
-    client.table("cds_fields").delete().gte("year_start", MIN_YEAR_START).execute()
-    client.table("school_browser_rows").delete().gte("year_start", MIN_YEAR_START).execute()
+    document_ids = fetch_projected_document_ids(client, "school_browser_rows")
+    document_ids.update(fetch_projected_document_ids(client, "cds_fields"))
+    print(f"clearing projection rows for {len(document_ids)} document(s)")
+    for document_id in sorted(document_ids):
+        replace_projection_rows(client, document_id, [], None)
 
 
 def fetch_artifacts(client: Any, document_id: str) -> list[dict[str, Any]]:

--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -675,6 +675,13 @@ def quantize_rate(value: Any) -> Optional[Decimal]:
     return decimal.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
 
 
+def quantize_fractional_rate(value: Any) -> Optional[Decimal]:
+    rate = quantize_rate(value)
+    if rate is None or rate < 0 or rate > 1:
+        return None
+    return rate
+
+
 def decimal_to_json(value: Optional[Decimal]) -> Optional[str]:
     if value is None:
         return None
@@ -1068,11 +1075,11 @@ def build_browser_row(
 
     acceptance_rate = None
     if applied and admitted is not None and applied > 0:
-        acceptance_rate = quantize_rate(Decimal(admitted) / Decimal(applied))
+        acceptance_rate = quantize_fractional_rate(Decimal(admitted) / Decimal(applied))
 
     yield_rate = None
     if admitted and enrolled is not None and admitted > 0:
-        yield_rate = quantize_rate(Decimal(enrolled) / Decimal(admitted))
+        yield_rate = quantize_fractional_rate(Decimal(enrolled) / Decimal(admitted))
 
     admission_strategy = admission_strategy_values(
         selected,

--- a/tools/browser_backend/project_browser_data_test.py
+++ b/tools/browser_backend/project_browser_data_test.py
@@ -201,6 +201,25 @@ class BrowserProjectionTests(unittest.TestCase):
         self.assertEqual(browser["acceptance_rate"], "0.200000")
         self.assertEqual(browser["yield_rate"], "0.500000")
 
+    def test_impossible_derived_rates_are_omitted_from_browser_row(self):
+        _fields, browser = build_projection_rows(
+            doc(),
+            [
+                artifact(values={
+                    "C.116": {"value": "100"},
+                    "C.117": {"value": "120"},
+                    "C.118": {"value": "240"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 100)
+        self.assertEqual(browser["admitted"], 120)
+        self.assertEqual(browser["enrolled_first_year"], 240)
+        self.assertIsNone(browser["acceptance_rate"])
+        self.assertIsNone(browser["yield_rate"])
+
     def test_sat_act_promoted_fields_project_to_browser_columns(self):
         fields, browser = build_projection_rows(
             doc(),

--- a/tools/extraction_worker/README.md
+++ b/tools/extraction_worker/README.md
@@ -43,6 +43,9 @@ python worker.py --limit 25 \
 # Isolate extraction from browser serving-table writes
 python worker.py --skip-projection-refresh --limit 10
 
+# Scoped operator re-drain: only 2024+ Tier 4/Tier 5 PDFs
+python worker.py --source-format pdf_flat,pdf_scanned --min-year-start 2024
+
 # Content-based year detection only, no extraction writes
 python worker.py --detect-year-only                 # report
 python worker.py --detect-year-only --write         # backfill detected_year

--- a/tools/extraction_worker/llm_fallback_worker.py
+++ b/tools/extraction_worker/llm_fallback_worker.py
@@ -635,7 +635,7 @@ def main() -> int:
     ap.add_argument("--mode", choices=["shadow", "fill_gaps"], default="fill_gaps",
                     help="shadow = write artifact with values but don't merge; "
                          "fill_gaps = values merge (deterministic wins).")
-    ap.add_argument("--cleaner-version", default="0.3.0",
+    ap.add_argument("--cleaner-version", default="0.3.1",
                     help="Used in the cache key. Bump to invalidate cache on "
                          "cleaner changes that shrink the gap set.")
     ap.add_argument("--low-coverage-threshold", type=int, default=200,

--- a/tools/extraction_worker/prd014_m5_drain.py
+++ b/tools/extraction_worker/prd014_m5_drain.py
@@ -32,8 +32,8 @@ DEFAULT_OUT_DIR = REPO_ROOT / ".context" / "prd-014-m5"
 PRODUCER_BY_FORMAT = {
     "xlsx": ("tier1_xlsx", "0.1.0"),
     "pdf_fillable": ("tier2_acroform", "0.2.0"),
-    "pdf_flat": ("tier4_docling", "0.3.0"),
-    "pdf_scanned": ("tier4_docling", "0.3.0"),
+    "pdf_flat": ("tier4_docling", "0.3.1"),
+    "pdf_scanned": ("tier4_docling", "0.3.1"),
     "html": ("tier6_html", "0.1.0"),
 }
 

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.0"
+PRODUCER_VERSION = "0.3.1"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -1260,6 +1260,23 @@ def main() -> int:
     )
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--school", default=None, help="Only process this school_id")
+    parser.add_argument(
+        "--source-format",
+        default=None,
+        help=(
+            "Comma-separated source_format filter, e.g. "
+            "pdf_flat,pdf_scanned. Useful for scoped operator re-drains."
+        ),
+    )
+    parser.add_argument(
+        "--min-year-start",
+        type=int,
+        default=None,
+        help=(
+            "Only process rows whose detected_year/cds_year starts at or after "
+            "this year, e.g. 2024. Applied before --limit."
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
         "--skip-projection-refresh",
@@ -1364,6 +1381,11 @@ def main() -> int:
         )
 
     cell_maps = build_cell_maps_for_schemas(schema_registry)
+    source_formats = [
+        value.strip()
+        for value in (args.source_format or "").split(",")
+        if value.strip()
+    ]
 
     query = client.table("cds_documents").select(
         "id, school_id, cds_year, detected_year, source_format, extraction_status",
@@ -1374,12 +1396,26 @@ def main() -> int:
         query = query.eq("extraction_status", "extraction_pending")
     if args.school:
         query = query.eq("school_id", args.school)
+    if source_formats:
+        query = query.in_("source_format", source_formats)
     query = query.order("school_id")
-    if args.limit:
-        query = query.limit(args.limit)
 
     started_at = utc_now_iso()
     docs = query.execute().data or []
+    if args.min_year_start is not None:
+        def row_start_year(row: dict[str, Any]) -> int | None:
+            year = row.get("detected_year") or row.get("cds_year") or ""
+            try:
+                return int(str(year)[:4])
+            except Exception:
+                return None
+
+        docs = [
+            doc for doc in docs
+            if (row_start_year(doc) or 0) >= args.min_year_start
+        ]
+    if args.limit:
+        docs = docs[:args.limit]
     if not docs:
         print(
             "No rows to process. Try --include-failed to re-process earlier failures.",


### PR DESCRIPTION
## Summary
- bump Tier 4 producer defaults to tier4_docling 0.3.1 for the PRD 016B re-drain
- add scoped extraction worker filters for source format and minimum year so production drains can target 2024+ PDF rows
- harden browser projection rebuilds by clearing per document and nulling impossible derived rates instead of overflowing numeric columns
- refresh the PRD 016B audit to read projected browser rows and update the findings doc after the production rebuild

## Production run
- queued 343 runnable 2024+ Tier 4 PDF rows; 340 extracted successfully as tier4_docling 0.3.1
- 3 rows still fail because the source PDFs are invalid/malformed: Johns Hopkins 2025-26, Williams 2025-26, Williams 2024-25
- rebuilt browser projection: 197,856 fields and 469 browser rows from 502 documents
- final PRD 016B audit: ED true 145, EA true 114, early-plan true 190, ED answerable 104, top-200 answerable 68, waitlist true 210

## Verification
- python3 -m unittest tools.browser_backend.project_browser_data_test
- PYTHONPATH=tools/extraction_worker python3 -m unittest tools/extraction_worker/test_worker_projection_refresh.py tools/extraction_worker/test_schema_dispatch.py
- tests/api/admission_strategy_contract.sh
- tests/api/positioning_contract.sh

Refs #39