### PR TITLE
Prioritize fresh CDS extraction rows

### DIFF
--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -25,6 +25,10 @@ on:
         description: "Field-count threshold for low-field docs in the summary."
         required: false
         default: "25"
+      min_year_start:
+        description: "Optional minimum CDS start year for targeted fresh-file drains, e.g. 2025."
+        required: false
+        default: ""
   schedule:
     # Small daily pending-row drain. Full corpus drains belong on manual
     # operator machines or a self-hosted runner, not regular hosted CI.
@@ -48,6 +52,7 @@ jobs:
       INPUT_INCLUDE_FAILED: ${{ github.event_name == 'workflow_dispatch' && inputs.include_failed || false }}
       INPUT_SEED_PROJECTION_METADATA: ${{ github.event_name != 'workflow_dispatch' || inputs.seed_projection_metadata }}
       INPUT_LOW_FIELD_THRESHOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.low_field_threshold || '25' }}
+      INPUT_MIN_YEAR_START: ${{ github.event_name == 'workflow_dispatch' && inputs.min_year_start || '' }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
@@ -84,6 +89,10 @@ jobs:
             echo "low_field_threshold must be an integer" >&2
             exit 2
           fi
+          if [[ -n "${INPUT_MIN_YEAR_START}" ]] && ! [[ "${INPUT_MIN_YEAR_START}" =~ ^[0-9]+$ ]]; then
+            echo "min_year_start must be an integer when provided" >&2
+            exit 2
+          fi
 
           mkdir -p ops-summary
           {
@@ -106,6 +115,9 @@ jobs:
           fi
           if [[ -n "${INPUT_SCHOOL}" ]]; then
             args+=(--school "${INPUT_SCHOOL}")
+          fi
+          if [[ -n "${INPUT_MIN_YEAR_START}" ]]; then
+            args+=(--min-year-start "${INPUT_MIN_YEAR_START}")
           fi
 
           python tools/extraction_worker/worker.py "${args[@]}" | tee ops-summary/worker.log

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -8,6 +8,7 @@ from worker import (
     is_failure_action,
     mean_or_none,
     parsed_field_count,
+    pending_doc_priority_key,
 )
 
 
@@ -33,6 +34,36 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
     def test_summary_mean_rounding(self):
         self.assertEqual(mean_or_none([1, 2, 4]), 2.33)
         self.assertIsNone(mean_or_none([]))
+
+    def test_pending_doc_priority_prefers_recent_cds_year(self):
+        rows = [
+            {"school_id": "aaa-old", "cds_year": "2019-20", "discovered_at": "2026-05-03T00:00:00Z"},
+            {"school_id": "zzz-current", "cds_year": "2025-26", "discovered_at": "2026-04-01T00:00:00Z"},
+            {"school_id": "mid-prior", "detected_year": "2024-25", "cds_year": "2023-24", "discovered_at": "2026-05-01T00:00:00Z"},
+        ]
+
+        ordered = sorted(rows, key=pending_doc_priority_key)
+
+        self.assertEqual([row["school_id"] for row in ordered], [
+            "zzz-current",
+            "mid-prior",
+            "aaa-old",
+        ])
+
+    def test_pending_doc_priority_prefers_newer_discovery_within_year(self):
+        rows = [
+            {"school_id": "yale", "cds_year": "2025-26", "discovered_at": "2026-05-01T02:11:14Z"},
+            {"school_id": "brown", "cds_year": "2025-26", "discovered_at": "2026-05-01T02:14:44Z"},
+            {"school_id": "uw", "cds_year": "2025-26", "discovered_at": "2026-04-15T00:34:39Z"},
+        ]
+
+        ordered = sorted(rows, key=pending_doc_priority_key)
+
+        self.assertEqual([row["school_id"] for row in ordered], [
+            "brown",
+            "yale",
+            "uw",
+        ])
 
 
 if __name__ == "__main__":

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -153,6 +153,29 @@ def mean_or_none(values: list[int]) -> float | None:
     return round(sum(values) / len(values), 2)
 
 
+def row_start_year(row: dict[str, Any]) -> int | None:
+    year = row.get("detected_year") or row.get("cds_year") or ""
+    try:
+        return int(str(year)[:4])
+    except Exception:
+        return None
+
+
+def discovered_at_sort_value(row: dict[str, Any]) -> int:
+    value = str(row.get("discovered_at") or "")
+    digits = "".join(ch for ch in value if ch.isdigit())
+    if not digits:
+        return 0
+    return int(digits[:20])
+
+
+def pending_doc_priority_key(row: dict[str, Any]) -> tuple[int, int, str]:
+    """Sort pending rows so fresh/current files beat older alphabetical backlog."""
+    year = row_start_year(row) or -1
+    school_id = str(row.get("school_id") or "")
+    return (-year, -discovered_at_sort_value(row), school_id)
+
+
 def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
@@ -1388,7 +1411,7 @@ def main() -> int:
     ]
 
     query = client.table("cds_documents").select(
-        "id, school_id, cds_year, detected_year, source_format, extraction_status",
+        "id, school_id, cds_year, detected_year, source_format, extraction_status, discovered_at",
     )
     if args.include_failed:
         query = query.in_("extraction_status", ["extraction_pending", "failed"])
@@ -1403,17 +1426,11 @@ def main() -> int:
     started_at = utc_now_iso()
     docs = query.execute().data or []
     if args.min_year_start is not None:
-        def row_start_year(row: dict[str, Any]) -> int | None:
-            year = row.get("detected_year") or row.get("cds_year") or ""
-            try:
-                return int(str(year)[:4])
-            except Exception:
-                return None
-
         docs = [
             doc for doc in docs
             if (row_start_year(doc) or 0) >= args.min_year_start
         ]
+    docs = sorted(docs, key=pending_doc_priority_key)
     if args.limit:
         docs = docs[:args.limit]
     if not docs:


### PR DESCRIPTION
## Summary
- Prioritize pending extraction rows by CDS year first, then discovery timestamp, so newly published current-year files drain ahead of stale alphabetical backlog.
- Add a manual workflow `min_year_start` input for targeted fresh-file drains.
- Add worker tests covering year and discovery-time ordering.

## Verification
- `PYTHONPATH=tools/extraction_worker:tools python3 -m unittest tools.extraction_worker.test_worker_projection_refresh tools.extraction_worker.test_schema_dispatch`
- `git diff --check`

## Ops note
- I kicked off manual per-school drains for the recent 2025-26 backlog. GitHub Actions concurrency allowed one dispatch to complete and one to continue; the rest were cancelled by the workflow concurrency group. Once this PR lands, a single manual run with `min_year_start=2025` can drain the recent files in priority order without per-school dispatch churn.