### PR TITLE
Harden CDS source routing and XLSX extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: python -m unittest tools.browser_backend.project_browser_data_test
       - name: Run Tier 4 cleaner tests
         run: python -m unittest discover -s tools/extraction_worker -p "test_*.py"
+      - name: Run archive/extractor routing tests
+        run: |
+          python -m unittest tools.tier_probe.test_probe
+          python -m unittest tools.tier1_extractor.test_extract
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
 

--- a/supabase/functions/_shared/storage.test.ts
+++ b/supabase/functions/_shared/storage.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "jsr:@std/assert";
+import { extForResponse } from "./storage.ts";
+
+Deno.test("extForResponse: rejects HTML challenge bytes at PDF URL", () => {
+  const bytes = new TextEncoder().encode(
+    "<!DOCTYPE html><html><title>Just a moment...</title></html>",
+  );
+
+  assertEquals(
+    extForResponse("text/html; charset=UTF-8", "https://example.edu/cds.pdf", bytes),
+    null,
+  );
+});
+
+Deno.test("extForResponse: bytes beat misleading content type", () => {
+  const bytes = new TextEncoder().encode("%PDF-1.7\n");
+
+  assertEquals(
+    extForResponse("text/html; charset=UTF-8", "https://example.edu/cds.pdf", bytes),
+    "pdf",
+  );
+});

--- a/supabase/functions/_shared/storage.ts
+++ b/supabase/functions/_shared/storage.ts
@@ -17,13 +17,16 @@ export function buildSourcePath(
   return `${schoolId}/${cdsYear}/${sha256}.${ext}`;
 }
 
-export function extForContentType(contentType: string | null, fallbackUrl: string): string | null {
+export function extForContentTypeOnly(contentType: string | null): "pdf" | "xlsx" | "docx" | "html" | null {
   const ct = (contentType ?? "").toLowerCase();
   if (ct.includes("application/pdf")) return "pdf";
   if (ct.includes("officedocument.spreadsheetml.sheet")) return "xlsx";
   if (ct.includes("officedocument.wordprocessingml.document")) return "docx";
   if (ct.includes("text/html")) return "html";
+  return null;
+}
 
+export function extForUrl(fallbackUrl: string): "pdf" | "xlsx" | "docx" | "html" | null {
   const lower = fallbackUrl.toLowerCase();
   if (lower.endsWith(".pdf") || lower.includes(".pdf?")) return "pdf";
   if (lower.endsWith(".xlsx") || lower.includes(".xlsx?")) return "xlsx";
@@ -31,6 +34,10 @@ export function extForContentType(contentType: string | null, fallbackUrl: strin
   if (lower.endsWith(".html") || lower.endsWith(".htm") ||
       lower.includes(".html?") || lower.includes(".htm?")) return "html";
   return null;
+}
+
+export function extForContentType(contentType: string | null, fallbackUrl: string): string | null {
+  return extForContentTypeOnly(contentType) ?? extForUrl(fallbackUrl);
 }
 
 // Magic-byte sniffer. Used as a last-resort fallback when content-type
@@ -98,11 +105,18 @@ export function extForResponse(
   finalUrl: string,
   bytes: Uint8Array,
 ): "pdf" | "xlsx" | "docx" | "html" | null {
-  const fromCt = extForContentType(contentType, finalUrl);
-  if (fromCt === "pdf" || fromCt === "xlsx" || fromCt === "docx" || fromCt === "html") {
-    return fromCt;
+  const fromBytes = sniffBytesForExt(bytes);
+  const fromCt = extForContentTypeOnly(contentType);
+  const fromUrl = extForUrl(finalUrl);
+
+  // WAF / auth challenges commonly return an HTML page at a URL ending in
+  // .pdf. Bytes are authoritative; do not archive those pages as PDFs.
+  if (fromBytes === "html" && (fromCt !== "html" || fromUrl !== "html")) {
+    return null;
   }
-  return sniffBytesForExt(bytes);
+
+  if (fromBytes) return fromBytes;
+  return fromCt ?? fromUrl;
 }
 
 // XSS mitigation (PRD 008): the `sources` Storage bucket is public-read,

--- a/tools/extraction_worker/test_docx_sniff.py
+++ b/tools/extraction_worker/test_docx_sniff.py
@@ -10,6 +10,7 @@ import unittest
 import zipfile
 
 from worker import (
+    choose_source_format,
     detect_year_from_bytes,
     detect_year_from_docx_bytes,
     sniff_format_from_bytes,
@@ -103,6 +104,19 @@ class SniffFormatFromBytesTest(unittest.TestCase):
 
     def test_unknown_bytes_route_other(self):
         self.assertEqual(sniff_format_from_bytes(b"\x00\x01garbage"), "other")
+
+    def test_choose_source_format_prefers_html_bytes_over_stale_pdf_label(self):
+        fmt, corrected = choose_source_format(
+            "pdf_flat",
+            b"<!DOCTYPE html><html><body>challenge</body></html>",
+        )
+        self.assertEqual(fmt, "html")
+        self.assertTrue(corrected)
+
+    def test_choose_source_format_keeps_declared_when_sniff_unknown(self):
+        fmt, corrected = choose_source_format("pdf_flat", b"\x00\x01garbage")
+        self.assertEqual(fmt, "pdf_flat")
+        self.assertFalse(corrected)
 
 
 class DetectYearFromDocxBytesTest(unittest.TestCase):

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -29,6 +29,7 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
         self.assertFalse(is_failure_action("tier4_extracted (289 fields, 48 pages)"))
         self.assertTrue(is_failure_action("tier4_error: boom"))
         self.assertTrue(is_failure_action("stub_docx"))
+        self.assertTrue(is_failure_action("tier1_low_fields (0 fields)"))
         self.assertTrue(is_failure_action("no_source_artifact"))
 
     def test_summary_mean_rounding(self):

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -112,6 +112,7 @@ from html_to_markdown import html_to_markdown  # noqa: E402 (PRD 008 Tier 6)
 
 SCHEMA_DIR = _TOOLS_ROOT.parent / "schemas"
 TEMPLATE_DIR = SCHEMA_DIR / "templates"
+MIN_TIER1_FIELDS = 5
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,8 @@ def is_failure_action(action: str) -> bool:
     if action == "already_extracted":
         return False
     if action == "no_source_artifact" or action.startswith("stub_"):
+        return True
+    if "_low_fields" in action:
         return True
     if "_error" in action or action.endswith("_no_tables"):
         return True
@@ -612,6 +615,14 @@ def sniff_format_from_bytes(data: bytes) -> str:
     return "other"
 
 
+def choose_source_format(declared: Optional[str], data: bytes) -> tuple[str, bool]:
+    """Choose the extraction route, preferring byte sniff over stale DB labels."""
+    sniffed = sniff_format_from_bytes(data)
+    if sniffed != "other" and sniffed != declared:
+        return sniffed, True
+    return declared or sniffed, False
+
+
 def artifact_already_extracted(
     client: Client,
     document_id: str,
@@ -678,6 +689,12 @@ def _run_tier1(
 
     producer = canonical["producer"]
     producer_version = canonical["producer_version"]
+    fields = canonical.get("stats", {}).get("schema_fields_populated", 0)
+
+    if fields < MIN_TIER1_FIELDS:
+        if not dry_run:
+            mark_extraction_status(client, document_id, "failed", source_format)
+        return extraction_no_project(f"tier1_low_fields ({fields} fields)")
 
     if not dry_run:
         if artifact_already_extracted(
@@ -694,7 +711,6 @@ def _run_tier1(
 
         mark_extraction_status(client, document_id, "extracted", source_format)
 
-    fields = canonical.get("stats", {}).get("schema_fields_populated", 0)
     return extraction_success(f"tier1_extracted ({fields} fields)")
 
 
@@ -1014,7 +1030,13 @@ def extract_one(
             flush=True,
         )
 
-    source_format = doc.get("source_format") or sniff_format_from_bytes(pdf_bytes)
+    source_format, format_corrected = choose_source_format(doc.get("source_format"), pdf_bytes)
+    if format_corrected:
+        print(
+            f"    format_correction: school={school_id} document={document_id} "
+            f"stored={doc.get('source_format') or 'null'} detected={source_format}",
+            flush=True,
+        )
 
     cell_map = (cell_maps or {}).get(resolution.schema_version)
     if source_format == "xlsx" and cell_map:

--- a/tools/finder/headless_download.py
+++ b/tools/finder/headless_download.py
@@ -37,7 +37,9 @@ import re
 import sys
 import time
 import yaml
+import zipfile
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 from typing import Optional
 
@@ -45,8 +47,12 @@ _TOOLS_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_TOOLS_ROOT / "extraction_worker"))
 from worker import load_env
 
-from playwright.sync_api import sync_playwright
 from supabase import create_client
+
+try:
+    from playwright.sync_api import sync_playwright
+except ModuleNotFoundError:  # pragma: no cover - exercised by operator envs
+    sync_playwright = None
 
 
 UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
@@ -58,16 +64,28 @@ DOCX_MAGIC = XLSX_MAGIC
 
 
 def detect_ext(body: bytes, content_type: str, url: str) -> Optional[str]:
-    """Same semantics as archive.ts extForResponse — content-type first,
-    URL suffix second, magic bytes third."""
+    """Same semantics as archive.ts extForResponse: bytes are authoritative."""
+    byte_ext = sniff_ext_from_bytes(body)
     ct = (content_type or "").lower()
+    url_ext = ext_from_url(url)
+
+    # Cloudflare/WAF challenges often come back as HTML at a .pdf URL. Never
+    # let the URL suffix turn those bytes into a source PDF.
+    if byte_ext == "html":
+        return None
+    if byte_ext:
+        return byte_ext
+
     if "application/pdf" in ct:
         return "pdf"
     if "officedocument.spreadsheetml.sheet" in ct:
         return "xlsx"
     if "officedocument.wordprocessingml.document" in ct:
         return "docx"
-    # URL suffix
+    return url_ext
+
+
+def ext_from_url(url: str) -> Optional[str]:
     u = url.lower().split("?")[0].split("#")[0]
     if u.endswith(".pdf"):
         return "pdf"
@@ -75,15 +93,34 @@ def detect_ext(body: bytes, content_type: str, url: str) -> Optional[str]:
         return "xlsx"
     if u.endswith(".docx"):
         return "docx"
-    # Magic bytes
+    if u.endswith(".html") or u.endswith(".htm"):
+        return "html"
+    return None
+
+
+def sniff_ext_from_bytes(body: bytes) -> Optional[str]:
     if body.startswith(PDF_MAGIC):
         return "pdf"
     if body.startswith(XLSX_MAGIC):
-        # xlsx vs docx distinguished by internal zip structure; skip for now.
-        # Peek at the central directory filename to tell them apart.
-        if b"word/" in body[:4096]:
+        try:
+            names = zipfile.ZipFile(BytesIO(body)).namelist()
+        except (zipfile.BadZipFile, ValueError, EOFError):
+            return None
+        has_word = any(n.startswith("word/") for n in names)
+        has_xl = any(n.startswith("xl/") for n in names)
+        if has_word and not has_xl:
             return "docx"
-        return "xlsx"
+        if has_xl and not has_word:
+            return "xlsx"
+        return None
+    head = body[:512].decode("utf-8", errors="ignore").lower().lstrip()
+    if (
+        head.startswith("<!doctype html")
+        or head.startswith("<html")
+        or head.startswith("<head")
+        or (head.startswith("<?xml") and "<html" in head)
+    ):
+        return "html"
     return None
 
 
@@ -287,6 +324,12 @@ def main() -> int:
 
     env = load_env(Path(args.env))
     sb = create_client(env["SUPABASE_URL"], env["SUPABASE_SERVICE_ROLE_KEY"])
+    if sync_playwright is None:
+        print(
+            "ERROR: playwright not installed. Run: pip install playwright && playwright install chromium",
+            file=sys.stderr,
+        )
+        return 2
 
     total_attempted = 0
     total_inserted = 0

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -44,10 +44,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import openpyxl
+from openpyxl.utils import get_column_letter
 
 
 PRODUCER_NAME = "tier1_xlsx"
-PRODUCER_VERSION = "0.1.0"
+PRODUCER_VERSION = "0.2.0"
+MIN_TEMPLATE_FIELDS_BEFORE_FALLBACK = 25
 
 # Default template path relative to the repo root.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -140,11 +142,58 @@ def load_schema(schema_path: Path) -> dict:
 def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]]) -> dict:
     """Extract values from a filled CDS XLSX using the template cell map."""
     wb = openpyxl.load_workbook(str(xlsx_path), data_only=True, read_only=True)
-    available_sheets = set(wb.sheetnames)
-
-    # Build question_number → schema field lookup.
     qnum_to_field = {f["question_number"]: f for f in schema["fields"]}
+    values, missing_sheets, empty_count = extract_values_from_cell_map(
+        wb,
+        cell_map,
+        qnum_to_field,
+    )
+    extraction_layout = "template_cell_map"
 
+    # Some schools publish populated workbooks where the hidden lookup layer
+    # itself is filled as a tabular export: Question Number / Question /
+    # Answer columns, often in AA/AB/AC. The standard template cell map points
+    # to the visible input cells and can produce zero coverage there. If that
+    # happens, fall back to the workbook's own answer columns.
+    if len(values) < MIN_TEMPLATE_FIELDS_BEFORE_FALLBACK:
+        embedded_map = build_embedded_answer_cell_map(wb)
+        if embedded_map:
+            fallback_values, fallback_missing, fallback_empty = extract_values_from_cell_map(
+                wb,
+                embedded_map,
+                qnum_to_field,
+            )
+            if len(fallback_values) > len(values):
+                values = fallback_values
+                missing_sheets = fallback_missing
+                empty_count = fallback_empty
+                extraction_layout = "embedded_answer_columns"
+
+    wb.close()
+
+    return {
+        "producer": PRODUCER_NAME,
+        "producer_version": PRODUCER_VERSION,
+        "schema_version": schema.get("schema_version"),
+        "source_xlsx": xlsx_path.name,
+        "extracted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "stats": {
+            "cell_map_fields_total": len(cell_map),
+            "schema_fields_populated": len(values),
+            "empty_cells": empty_count,
+            "missing_sheets": sorted(missing_sheets),
+            "extraction_layout": extraction_layout,
+        },
+        "values": values,
+    }
+
+
+def extract_values_from_cell_map(
+    wb,
+    cell_map: dict[str, tuple[str, str]],
+    qnum_to_field: dict[str, dict],
+) -> tuple[dict, set[str], int]:
+    available_sheets = set(wb.sheetnames)
     values = {}
     missing_sheets = set()
     empty_count = 0
@@ -179,22 +228,43 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
             "value_type": field.get("value_type"),
         }
 
-    wb.close()
+    return values, missing_sheets, empty_count
 
-    return {
-        "producer": PRODUCER_NAME,
-        "producer_version": PRODUCER_VERSION,
-        "schema_version": schema.get("schema_version"),
-        "source_xlsx": xlsx_path.name,
-        "extracted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "stats": {
-            "cell_map_fields_total": len(cell_map),
-            "schema_fields_populated": len(values),
-            "empty_cells": empty_count,
-            "missing_sheets": sorted(missing_sheets),
-        },
-        "values": values,
-    }
+
+def build_embedded_answer_cell_map(wb) -> dict[str, tuple[str, str]]:
+    """Build qnum → answer-cell map from workbook-native answer columns."""
+    cell_map: dict[str, tuple[str, str]] = {}
+    for sheet_name in wb.sheetnames:
+        if not sheet_name.startswith("CDS-"):
+            continue
+        ws = wb[sheet_name]
+        header_row, qnum_col, answer_col = find_question_answer_columns(ws)
+        if not header_row:
+            continue
+        for row_idx in range(header_row + 1, ws.max_row + 1):
+            raw_qnum = ws.cell(row=row_idx, column=qnum_col).value
+            if not raw_qnum:
+                continue
+            qnum = normalize_question_number(str(raw_qnum))
+            cell_map[qnum] = (sheet_name, f"{get_column_letter(answer_col)}{row_idx}")
+    return cell_map
+
+
+def find_question_answer_columns(ws) -> tuple[int | None, int | None, int | None]:
+    max_col = min(ws.max_column, 40)
+    for row_idx in range(1, min(ws.max_row, 10) + 1):
+        labels: dict[str, int] = {}
+        for col_idx in range(1, max_col + 1):
+            value = ws.cell(row=row_idx, column=col_idx).value
+            if value is None:
+                continue
+            label = re.sub(r"\s+", " ", str(value).strip().lower())
+            labels[label] = col_idx
+        qnum_col = labels.get("question number") or labels.get("question numer")
+        answer_col = labels.get("answer")
+        if qnum_col and answer_col:
+            return row_idx, qnum_col, answer_col
+    return None, None, None
 
 
 def extract_from_bytes(

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+import openpyxl
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from extract import extract
+
+
+class Tier1ExtractTests(unittest.TestCase):
+    def test_falls_back_to_embedded_answer_columns(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "CDS-C"
+        ws["AA1"] = "Question Number"
+        ws["AB1"] = "Question"
+        ws["AC1"] = "Answer"
+        ws["AA2"] = "C.101"
+        ws["AB2"] = "Total first-time, first-year males who applied"
+        ws["AC2"] = 1234
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            schema = {
+                "schema_version": "2025-26",
+                "fields": [{
+                    "question_number": "C.101",
+                    "word_tag": "c1_male_applicants",
+                    "question": "Total first-time, first-year males who applied",
+                    "section": "First-Time, First-Year Admission",
+                    "subsection": "Applications",
+                    "value_type": "Number",
+                }],
+            }
+            result = extract(
+                Path(tmp.name),
+                schema,
+                {"C.101": ("CDS-C", "D4")},
+            )
+
+        self.assertEqual(result["stats"]["extraction_layout"], "embedded_answer_columns")
+        self.assertEqual(result["stats"]["schema_fields_populated"], 1)
+        self.assertEqual(result["values"]["C.101"]["value"], "1234")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tier_probe/probe.py
+++ b/tools/tier_probe/probe.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import zipfile
 from collections import Counter
 from io import BytesIO
 from pathlib import Path
@@ -95,12 +96,19 @@ def detect_format(storage_path: str, data: bytes) -> tuple[str, dict]:
     if "." in storage_path:
         ext = storage_path.rsplit(".", 1)[-1].lower()
 
-    if ext == "xlsx":
-        return "xlsx", {"bytes": len(data)}
-    if ext == "docx":
-        return "docx", {"bytes": len(data)}
-    if ext != "pdf":
-        return "other", {"reason": f"unknown extension '{ext}'", "bytes": len(data)}
+    byte_format = sniff_format_from_bytes(data)
+    if byte_format == "html":
+        return "other", {
+            "reason": f"html bytes archived at .{ext or 'unknown'} path",
+            "bytes": len(data),
+        }
+    if byte_format in {"xlsx", "docx"}:
+        return byte_format, {"bytes": len(data)}
+    if byte_format == "other":
+        return "other", {
+            "reason": f"unknown bytes for extension '{ext or 'none'}'",
+            "bytes": len(data),
+        }
 
     try:
         reader = pypdf.PdfReader(BytesIO(data))
@@ -154,6 +162,32 @@ def detect_format(storage_path: str, data: bytes) -> tuple[str, dict]:
     if total_text >= TEXT_SCANNED_THRESHOLD:
         return "pdf_flat", diag
     return "pdf_scanned", diag
+
+
+def sniff_format_from_bytes(data: bytes) -> str:
+    if data.startswith(b"%PDF"):
+        return "pdf"
+    if data.startswith(b"PK\x03\x04"):
+        try:
+            names = zipfile.ZipFile(BytesIO(data)).namelist()
+        except (zipfile.BadZipFile, ValueError, EOFError):
+            return "other"
+        has_word = any(n.startswith("word/") for n in names)
+        has_xl = any(n.startswith("xl/") for n in names)
+        if has_word and not has_xl:
+            return "docx"
+        if has_xl and not has_word:
+            return "xlsx"
+        return "other"
+    head = data[:512].decode("utf-8", errors="ignore").lower().lstrip()
+    if (
+        head.startswith("<!doctype html")
+        or head.startswith("<html")
+        or head.startswith("<head")
+        or (head.startswith("<?xml") and "<html" in head)
+    ):
+        return "html"
+    return "other"
 
 
 def fetch_latest_source_artifact(client: Client, document_id: str) -> dict | None:

--- a/tools/tier_probe/test_probe.py
+++ b/tools/tier_probe/test_probe.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from probe import detect_format
+
+
+def _build_zip(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in entries.items():
+            zf.writestr(name, payload)
+    return buf.getvalue()
+
+
+class ProbeDetectFormatTests(unittest.TestCase):
+    def test_html_challenge_at_pdf_path_is_other(self):
+        fmt, diag = detect_format(
+            "school/2025-26/challenge.pdf",
+            b"<!DOCTYPE html><html><title>Just a moment...</title></html>",
+        )
+
+        self.assertEqual(fmt, "other")
+        self.assertIn("html bytes", diag["reason"])
+
+    def test_docx_bytes_at_xlsx_path_are_docx(self):
+        data = _build_zip({
+            "[Content_Types].xml": b"<Types/>",
+            "word/document.xml": b"<w:document/>",
+        })
+
+        fmt, _diag = detect_format("school/2025-26/source.xlsx", data)
+
+        self.assertEqual(fmt, "docx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject HTML challenge pages when a document URL claims to be a PDF/XLSX/DOCX, including the Playwright headless downloader path.
- Make probe and extraction routing byte-authoritative so stale `source_format` labels do not misroute real files.
- Improve Tier 1 XLSX extraction for workbooks with embedded Question Number / Answer columns, and fail near-empty Tier 1 output instead of marking it extracted.
- Add CI coverage for source routing, tier probe, and Tier 1 fallback extraction.

## Verification
- `PYTHONPATH=tools/extraction_worker:tools python3 -m unittest tools.extraction_worker.test_docx_sniff tools.extraction_worker.test_worker_projection_refresh tools.extraction_worker.test_schema_dispatch`
- `python3 -m unittest tools.tier_probe.test_probe tools.tier1_extractor.test_extract`
- `deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts`
- `git diff --check`

## Ops follow-up
After this branch is available to Actions, I will run targeted failed-row drains for Stanford and Virginia Tech to clear the failures that this patch directly addresses.