### PR TITLE
Harden XLSX academic profile and Tier 2 warnings

### DIFF
--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -200,62 +200,62 @@ DIRECT_METRIC_DEFINITIONS = {
     "sat_composite_p25": MetricDefinition(
         "sat_composite_p25", DirectAlias("C.905"), "number", True,
         "PRD 012 direct SAT Composite 25th percentile field.",
-        "sat_composite_p25", Decimal("400"), Decimal("1600"), True,
+        "sat_composite_p25", Decimal("400"), Decimal("1600"),
     ),
     "sat_composite_p50": MetricDefinition(
         "sat_composite_p50", DirectAlias("C.906"), "number", True,
         "PRD 012 direct SAT Composite 50th percentile field.",
-        "sat_composite_p50", Decimal("400"), Decimal("1600"), True,
+        "sat_composite_p50", Decimal("400"), Decimal("1600"),
     ),
     "sat_composite_p75": MetricDefinition(
         "sat_composite_p75", DirectAlias("C.907"), "number", True,
         "PRD 012 direct SAT Composite 75th percentile field.",
-        "sat_composite_p75", Decimal("400"), Decimal("1600"), True,
+        "sat_composite_p75", Decimal("400"), Decimal("1600"),
     ),
     "sat_ebrw_p25": MetricDefinition(
         "sat_ebrw_p25", DirectAlias("C.908"), "number", True,
         "PRD 012 direct SAT EBRW 25th percentile field.",
-        "sat_ebrw_p25", Decimal("200"), Decimal("800"), True,
+        "sat_ebrw_p25", Decimal("200"), Decimal("800"),
     ),
     "sat_ebrw_p50": MetricDefinition(
         "sat_ebrw_p50", DirectAlias("C.909"), "number", True,
         "PRD 012 direct SAT EBRW 50th percentile field.",
-        "sat_ebrw_p50", Decimal("200"), Decimal("800"), True,
+        "sat_ebrw_p50", Decimal("200"), Decimal("800"),
     ),
     "sat_ebrw_p75": MetricDefinition(
         "sat_ebrw_p75", DirectAlias("C.910"), "number", True,
         "PRD 012 direct SAT EBRW 75th percentile field.",
-        "sat_ebrw_p75", Decimal("200"), Decimal("800"), True,
+        "sat_ebrw_p75", Decimal("200"), Decimal("800"),
     ),
     "sat_math_p25": MetricDefinition(
         "sat_math_p25", DirectAlias("C.911"), "number", True,
         "PRD 012 direct SAT Math 25th percentile field.",
-        "sat_math_p25", Decimal("200"), Decimal("800"), True,
+        "sat_math_p25", Decimal("200"), Decimal("800"),
     ),
     "sat_math_p50": MetricDefinition(
         "sat_math_p50", DirectAlias("C.912"), "number", True,
         "PRD 012 direct SAT Math 50th percentile field.",
-        "sat_math_p50", Decimal("200"), Decimal("800"), True,
+        "sat_math_p50", Decimal("200"), Decimal("800"),
     ),
     "sat_math_p75": MetricDefinition(
         "sat_math_p75", DirectAlias("C.913"), "number", True,
         "PRD 012 direct SAT Math 75th percentile field.",
-        "sat_math_p75", Decimal("200"), Decimal("800"), True,
+        "sat_math_p75", Decimal("200"), Decimal("800"),
     ),
     "act_composite_p25": MetricDefinition(
         "act_composite_p25", DirectAlias("C.914"), "number", True,
         "PRD 012 direct ACT Composite 25th percentile field.",
-        "act_composite_p25", Decimal("1"), Decimal("36"), True,
+        "act_composite_p25", Decimal("1"), Decimal("36"),
     ),
     "act_composite_p50": MetricDefinition(
         "act_composite_p50", DirectAlias("C.915"), "number", True,
         "PRD 012 direct ACT Composite 50th percentile field.",
-        "act_composite_p50", Decimal("1"), Decimal("36"), True,
+        "act_composite_p50", Decimal("1"), Decimal("36"),
     ),
     "act_composite_p75": MetricDefinition(
         "act_composite_p75", DirectAlias("C.916"), "number", True,
         "PRD 012 direct ACT Composite 75th percentile field.",
-        "act_composite_p75", Decimal("1"), Decimal("36"), True,
+        "act_composite_p75", Decimal("1"), Decimal("36"),
     ),
 }
 
@@ -697,6 +697,15 @@ def int_from_decimal(value: Optional[Decimal]) -> Optional[int]:
         return None
 
 
+def rounded_int_from_decimal(value: Optional[Decimal]) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    except (InvalidOperation, ValueError, OverflowError):
+        return None
+
+
 def selected_parsed_value(
     selected: SelectedExtractionResult,
     schema_defs: dict[str, FieldDefinition],
@@ -1121,18 +1130,18 @@ def build_browser_row(
         "pell_rate": decimal_to_json(quantize_rate(scorecard.get("pell_grant_rate"))),
         "sat_submit_rate": decimal_to_json(metric_values.get("sat_submit_rate")),
         "act_submit_rate": decimal_to_json(metric_values.get("act_submit_rate")),
-        "sat_composite_p25": int_from_decimal(metric_values.get("sat_composite_p25")),
-        "sat_composite_p50": int_from_decimal(metric_values.get("sat_composite_p50")),
-        "sat_composite_p75": int_from_decimal(metric_values.get("sat_composite_p75")),
-        "sat_ebrw_p25": int_from_decimal(metric_values.get("sat_ebrw_p25")),
-        "sat_ebrw_p50": int_from_decimal(metric_values.get("sat_ebrw_p50")),
-        "sat_ebrw_p75": int_from_decimal(metric_values.get("sat_ebrw_p75")),
-        "sat_math_p25": int_from_decimal(metric_values.get("sat_math_p25")),
-        "sat_math_p50": int_from_decimal(metric_values.get("sat_math_p50")),
-        "sat_math_p75": int_from_decimal(metric_values.get("sat_math_p75")),
-        "act_composite_p25": int_from_decimal(metric_values.get("act_composite_p25")),
-        "act_composite_p50": int_from_decimal(metric_values.get("act_composite_p50")),
-        "act_composite_p75": int_from_decimal(metric_values.get("act_composite_p75")),
+        "sat_composite_p25": rounded_int_from_decimal(metric_values.get("sat_composite_p25")),
+        "sat_composite_p50": rounded_int_from_decimal(metric_values.get("sat_composite_p50")),
+        "sat_composite_p75": rounded_int_from_decimal(metric_values.get("sat_composite_p75")),
+        "sat_ebrw_p25": rounded_int_from_decimal(metric_values.get("sat_ebrw_p25")),
+        "sat_ebrw_p50": rounded_int_from_decimal(metric_values.get("sat_ebrw_p50")),
+        "sat_ebrw_p75": rounded_int_from_decimal(metric_values.get("sat_ebrw_p75")),
+        "sat_math_p25": rounded_int_from_decimal(metric_values.get("sat_math_p25")),
+        "sat_math_p50": rounded_int_from_decimal(metric_values.get("sat_math_p50")),
+        "sat_math_p75": rounded_int_from_decimal(metric_values.get("sat_math_p75")),
+        "act_composite_p25": rounded_int_from_decimal(metric_values.get("act_composite_p25")),
+        "act_composite_p50": rounded_int_from_decimal(metric_values.get("act_composite_p50")),
+        "act_composite_p75": rounded_int_from_decimal(metric_values.get("act_composite_p75")),
         **admission_strategy,
     }
 

--- a/tools/browser_backend/project_browser_data_test.py
+++ b/tools/browser_backend/project_browser_data_test.py
@@ -360,25 +360,44 @@ class BrowserProjectionTests(unittest.TestCase):
             [
                 artifact(values={
                     "C.905": {"value": "399"},
-                    "C.906": {"value": "1450.5"},
                     "C.907": {"value": "1601"},
                     "C.914": {"value": "0"},
-                    "C.915": {"value": "33.5"},
                     "C.916": {"value": "37"},
                 })
             ],
             defs(),
         )
         by_field = {row["field_id"]: row for row in fields}
-        for field_id in ("C.905", "C.906", "C.907", "C.914", "C.915", "C.916"):
+        for field_id in ("C.905", "C.907", "C.914", "C.916"):
             self.assertEqual(by_field[field_id]["value_status"], "parse_error")
             self.assertIsNone(by_field[field_id]["value_num"])
         self.assertIsNone(browser["sat_composite_p25"])
-        self.assertIsNone(browser["sat_composite_p50"])
         self.assertIsNone(browser["sat_composite_p75"])
         self.assertIsNone(browser["act_composite_p25"])
-        self.assertIsNone(browser["act_composite_p50"])
         self.assertIsNone(browser["act_composite_p75"])
+
+    def test_sat_act_decimal_scores_are_preserved_and_browser_rounded(self):
+        fields, browser = build_projection_rows(
+            doc(),
+            [
+                artifact(values={
+                    "C.906": {"value": "1450.5"},
+                    "C.908": {"value": "477.5"},
+                    "C.915": {"value": "33.5"},
+                })
+            ],
+            defs(),
+        )
+        by_field = {row["field_id"]: row for row in fields}
+        self.assertEqual(by_field["C.906"]["value_status"], "reported")
+        self.assertEqual(by_field["C.906"]["value_num"], "1450.5")
+        self.assertEqual(by_field["C.908"]["value_status"], "reported")
+        self.assertEqual(by_field["C.908"]["value_num"], "477.5")
+        self.assertEqual(by_field["C.915"]["value_status"], "reported")
+        self.assertEqual(by_field["C.915"]["value_num"], "33.5")
+        self.assertEqual(browser["sat_composite_p50"], 1451)
+        self.assertEqual(browser["sat_ebrw_p25"], 478)
+        self.assertEqual(browser["act_composite_p50"], 34)
 
     def test_admission_strategy_columns_project_from_2025_schema(self):
         _fields, browser = build_projection_rows(

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 from worker import (
+    annotate_tier2_unmapped_fields,
     extraction_no_project,
     extraction_success,
     is_failure_action,
@@ -65,6 +66,32 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
             "yale",
             "uw",
         ])
+
+    def test_tier2_unmapped_fields_get_quality_warning(self):
+        canonical = {
+            "stats": {"unmapped_acroform_fields": 2},
+            "unmapped_fields": [
+                {"pdf_tag": "custom_field_1", "value": "x"},
+                {"pdf_tag": "legacy_tag", "value": "y"},
+            ],
+        }
+
+        count = annotate_tier2_unmapped_fields(canonical)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(canonical["quality_warnings"][0]["code"], "tier2_unmapped_acroform_fields")
+        self.assertEqual(canonical["quality_warnings"][0]["sample_pdf_tags"], [
+            "custom_field_1",
+            "legacy_tag",
+        ])
+
+    def test_tier2_unmapped_fields_noops_when_clean(self):
+        canonical = {"stats": {"unmapped_acroform_fields": 0}}
+
+        count = annotate_tier2_unmapped_fields(canonical)
+
+        self.assertEqual(count, 0)
+        self.assertNotIn("quality_warnings", canonical)
 
 
 if __name__ == "__main__":

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -668,6 +668,38 @@ def run_tier2(pdf_bytes: bytes, schema: dict) -> dict:
         return tier2_extract(Path(tmp.name), schema)
 
 
+def annotate_tier2_unmapped_fields(canonical: dict) -> int:
+    """Promote Tier 2 unmapped AcroForm tags into an explicit warning.
+
+    The Tier 2 extractor already preserves `unmapped_fields` and a stats count
+    in the artifact notes. This annotation gives operators and downstream
+    consumers a stable quality-warning hook without introducing a new
+    extraction status enum.
+    """
+    stats = canonical.get("stats") or {}
+    unmapped_count = int(stats.get("unmapped_acroform_fields") or 0)
+    if unmapped_count <= 0:
+        return 0
+    unmapped_fields = canonical.get("unmapped_fields") or []
+    sample_tags = [
+        str(item.get("pdf_tag"))
+        for item in unmapped_fields[:10]
+        if isinstance(item, dict) and item.get("pdf_tag")
+    ]
+    warnings_list = canonical.setdefault("quality_warnings", [])
+    warnings_list.append({
+        "code": "tier2_unmapped_acroform_fields",
+        "severity": "warning",
+        "count": unmapped_count,
+        "sample_pdf_tags": sample_tags,
+        "message": (
+            "Populated AcroForm fields were present in the source PDF but did "
+            "not map to the selected CDS schema."
+        ),
+    })
+    return unmapped_count
+
+
 def _run_tier1(
     client: Client,
     document_id: str,
@@ -1083,6 +1115,20 @@ def extract_one(
     try:
         canonical = run_tier2(pdf_bytes, resolution.schema)
         attach_schema_metadata(canonical, resolution)
+        unmapped_count = annotate_tier2_unmapped_fields(canonical)
+        if unmapped_count:
+            sample_tags = [
+                item.get("pdf_tag")
+                for item in (canonical.get("unmapped_fields") or [])[:5]
+                if isinstance(item, dict)
+            ]
+            print(
+                f"    tier2_unmapped_warning: school={school_id} "
+                f"document={document_id} count={unmapped_count} "
+                f"sample_tags={sample_tags}",
+                file=sys.stderr,
+                flush=True,
+            )
     except Exception as e:
         if not dry_run:
             mark_extraction_status(client, document_id, "failed", source_format)

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -169,6 +169,12 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
                 empty_count = fallback_empty
                 extraction_layout = "embedded_answer_columns"
 
+    academic_profile_recovered = recover_c9_academic_profile_values(
+        wb,
+        qnum_to_field,
+        values,
+    )
+
     wb.close()
 
     return {
@@ -183,6 +189,7 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
             "empty_cells": empty_count,
             "missing_sheets": sorted(missing_sheets),
             "extraction_layout": extraction_layout,
+            "academic_profile_fields_recovered": academic_profile_recovered,
         },
         "values": values,
     }
@@ -229,6 +236,119 @@ def extract_values_from_cell_map(
         }
 
     return values, missing_sheets, empty_count
+
+
+def recover_c9_academic_profile_values(
+    wb,
+    qnum_to_field: dict[str, dict],
+    values: dict,
+) -> int:
+    """Recover C9 SAT/ACT profile fields from visible row labels.
+
+    Some school-published XLSX files preserve the CDS-C visible tables but shift
+    row positions relative to the official template. For academic profile rows,
+    the visible row labels and column order are stable enough to use as the
+    deterministic source of truth, and this avoids publishing application-date
+    cells as SAT Math percentiles when a workbook removed earlier template rows.
+    """
+    if "CDS-C" not in wb.sheetnames:
+        return 0
+    ws = wb["CDS-C"]
+    recovered: dict[str, object] = {}
+
+    submit_rows = {
+        "submitting sat scores": ("C.901", "C.903"),
+        "submitting act scores": ("C.902", "C.904"),
+    }
+    score_rows = {
+        "sat composite": ("C.905", "C.906", "C.907"),
+        "sat evidence based reading and writing": ("C.908", "C.909", "C.910"),
+        "sat math": ("C.911", "C.912", "C.913"),
+        "act composite": ("C.914", "C.915", "C.916"),
+    }
+
+    in_c9 = False
+    for row_idx in range(1, ws.max_row + 1):
+        row_values = [
+            ws.cell(row=row_idx, column=col_idx).value
+            for col_idx in range(1, min(ws.max_column, 12) + 1)
+        ]
+        row_text = " ".join(_norm_label(v) for v in row_values if v is not None)
+        if "percent and number of first time first year students" in row_text and "sat act" in row_text:
+            in_c9 = True
+            continue
+        if in_c9 and ("c10" in row_text or "class rank" in row_text):
+            break
+        if not in_c9:
+            continue
+
+        label_col = None
+        label = ""
+        for col_idx, value in enumerate(row_values, start=1):
+            normalized = _norm_label(value)
+            if not normalized:
+                continue
+            if normalized in submit_rows or normalized in score_rows:
+                label_col = col_idx
+                label = normalized
+            break
+        if not label_col:
+            continue
+
+        right_values = [
+            ws.cell(row=row_idx, column=col_idx).value
+            for col_idx in range(label_col + 1, min(ws.max_column, label_col + 8) + 1)
+        ]
+        usable = [value for value in right_values if _is_c9_value(value)]
+        if label in submit_rows and len(usable) >= 2:
+            percent_q, count_q = submit_rows[label]
+            recovered[percent_q] = usable[0]
+            recovered[count_q] = usable[1]
+        elif label in score_rows and len(usable) >= 3:
+            for qnum, value in zip(score_rows[label], usable[:3]):
+                recovered[qnum] = value
+
+    count = 0
+    for qnum, raw_value in recovered.items():
+        if qnum not in qnum_to_field:
+            continue
+        value = str(raw_value).strip()
+        if not value:
+            continue
+        if values.get(qnum, {}).get("value") == value:
+            continue
+        values[qnum] = _field_record(qnum, value, qnum_to_field)
+        count += 1
+    return count
+
+
+def _field_record(qnum: str, value: str, qnum_to_field: dict[str, dict]) -> dict:
+    field = qnum_to_field.get(qnum, {})
+    return {
+        "value": value,
+        "word_tag": field.get("word_tag"),
+        "question": field.get("question"),
+        "section": field.get("section"),
+        "subsection": field.get("subsection"),
+        "value_type": field.get("value_type"),
+    }
+
+
+def _norm_label(value) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    text = text.replace("&", " and ")
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_c9_value(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return False
+    return bool(str(value).strip())
 
 
 def build_embedded_answer_cell_map(wb) -> dict[str, tuple[str, str]]:

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -46,6 +46,73 @@ class Tier1ExtractTests(unittest.TestCase):
         self.assertEqual(result["stats"]["schema_fields_populated"], 1)
         self.assertEqual(result["values"]["C.101"]["value"], "1234")
 
+    def test_recovers_shifted_c9_academic_profile_rows_by_label(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "CDS-C"
+        ws["B10"] = "Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores."
+        ws["C12"] = "Percent"
+        ws["D12"] = "Number"
+        ws["B13"] = "Submitting SAT Scores"
+        ws["C13"] = 0.043
+        ws["D13"] = 299
+        ws["B14"] = "Submitting ACT Scores"
+        ws["C14"] = 0.002
+        ws["D14"] = 13
+        ws["B17"] = "Assessment"
+        ws["C17"] = "25th Percentile"
+        ws["D17"] = "50th Percentile"
+        ws["E17"] = "75th Percentile"
+        ws["B18"] = "SAT Composite"
+        ws["C18"] = 860
+        ws["D18"] = 950
+        ws["E18"] = 1050
+        ws["B19"] = "SAT Evidence-Based Reading and Writing"
+        ws["C19"] = 450
+        ws["D19"] = 490
+        ws["E19"] = 540
+        ws["B20"] = "SAT Math"
+        ws["C20"] = 410
+        ws["D20"] = 470
+        ws["E20"] = 530
+        ws["B21"] = "ACT Composite"
+        ws["C21"] = 21.5
+        ws["D21"] = 25
+        ws["E21"] = 29
+        ws["A30"] = "C14"
+        ws["B30"] = "Application closing date (fall)"
+        ws["C30"] = "2025-11-30 00:00:00"
+
+        schema = {
+            "schema_version": "2024-25",
+            "fields": [
+                {
+                    "question_number": f"C.{i}",
+                    "word_tag": None,
+                    "question": f"C.{i}",
+                    "section": "First-Time, First-Year Admission",
+                    "subsection": "First-time, first-year Profile",
+                    "value_type": "Number",
+                }
+                for i in range(901, 917)
+            ],
+        }
+        cell_map = {
+            "C.911": ("CDS-C", "C30"),
+            "C.912": ("CDS-C", "C30"),
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(Path(tmp.name), schema, cell_map)
+
+        self.assertEqual(result["values"]["C.901"]["value"], "0.043")
+        self.assertEqual(result["values"]["C.903"]["value"], "299")
+        self.assertEqual(result["values"]["C.911"]["value"], "410")
+        self.assertEqual(result["values"]["C.912"]["value"], "470")
+        self.assertEqual(result["values"]["C.916"]["value"], "29")
+        self.assertEqual(result["stats"]["academic_profile_fields_recovered"], 16)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add label-based C9 academic-profile recovery for shifted XLSX workbooks so SAT/ACT fields come from visible table labels instead of stale template coordinates
- surface Tier 2 populated-but-unmapped AcroForm fields as explicit quality warnings, with worker stderr samples for operator visibility
- preserve decimal SAT/ACT percentile values in long-form cds_fields and round only when projecting into integer school_browser_rows columns
- cover all three paths with focused unit tests

## Verification
- python3 -m py_compile tools/browser_backend/project_browser_data.py tools/browser_backend/project_browser_data_test.py tools/tier1_extractor/extract.py tools/extraction_worker/worker.py
- python3 -m unittest tools/browser_backend/project_browser_data_test.py
- python3 -m unittest tools/tier1_extractor/test_extract.py
- (cd tools/extraction_worker && python3 -m unittest test_worker_projection_refresh.py test_docx_sniff.py)