### PR TITLE
Clear blank XLSX C9 score rows

### DIFF
--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -48,7 +48,7 @@ from openpyxl.utils import get_column_letter
 
 
 PRODUCER_NAME = "tier1_xlsx"
-PRODUCER_VERSION = "0.2.0"
+PRODUCER_VERSION = "0.2.1"
 MIN_TEMPLATE_FIELDS_BEFORE_FALLBACK = 25
 
 # Default template path relative to the repo root.
@@ -274,7 +274,7 @@ def recover_c9_academic_profile_values(
             for col_idx in range(1, min(ws.max_column, 12) + 1)
         ]
         row_text = " ".join(_norm_label(v) for v in row_values if v is not None)
-        if "percent and number of first time first year students" in row_text and "sat act" in row_text:
+        if _is_c9_header(row_text):
             in_c9 = True
             continue
         if in_c9 and ("c10" in row_text or "class rank" in row_text):
@@ -295,22 +295,25 @@ def recover_c9_academic_profile_values(
         if not label_col:
             continue
 
-        right_values = [
-            ws.cell(row=row_idx, column=col_idx).value
-            for col_idx in range(label_col + 1, min(ws.max_column, label_col + 8) + 1)
-        ]
-        usable = [value for value in right_values if _is_c9_value(value)]
-        if label in submit_rows and len(usable) >= 2:
+        if label in submit_rows:
             percent_q, count_q = submit_rows[label]
-            recovered[percent_q] = usable[0]
-            recovered[count_q] = usable[1]
-        elif label in score_rows and len(usable) >= 3:
-            for qnum, value in zip(score_rows[label], usable[:3]):
-                recovered[qnum] = value
+            percent_value = ws.cell(row=row_idx, column=label_col + 1).value
+            count_value = ws.cell(row=row_idx, column=label_col + 2).value
+            recovered[percent_q] = percent_value if _is_c9_value(percent_value) else None
+            recovered[count_q] = count_value if _is_c9_value(count_value) else None
+        elif label in score_rows:
+            for offset, qnum in enumerate(score_rows[label], start=1):
+                raw_value = ws.cell(row=row_idx, column=label_col + offset).value
+                recovered[qnum] = raw_value if _is_c9_value(raw_value) else None
 
     count = 0
     for qnum, raw_value in recovered.items():
         if qnum not in qnum_to_field:
+            continue
+        if raw_value is None:
+            if qnum in values:
+                del values[qnum]
+                count += 1
             continue
         value = str(raw_value).strip()
         if not value:
@@ -320,6 +323,15 @@ def recover_c9_academic_profile_values(
         values[qnum] = _field_record(qnum, value, qnum_to_field)
         count += 1
     return count
+
+
+def _is_c9_header(row_text: str) -> bool:
+    return (
+        "percent and number" in row_text
+        and "first time first year" in row_text
+        and "students" in row_text
+        and "sat act" in row_text
+    )
 
 
 def _field_record(qnum: str, value: str, qnum_to_field: dict[str, dict]) -> dict:

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -113,6 +113,52 @@ class Tier1ExtractTests(unittest.TestCase):
         self.assertEqual(result["values"]["C.916"]["value"], "29")
         self.assertEqual(result["stats"]["academic_profile_fields_recovered"], 16)
 
+    def test_recovers_freshman_c9_header_and_clears_blank_visible_rows(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "CDS-C"
+        ws["B10"] = "Percent and number of first-time, first-year (freshman) students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores."
+        ws["B13"] = "SAT Evidence-Based Reading and Writing"
+        ws["C13"] = 600
+        ws["D13"] = 660
+        ws["E13"] = 720
+        ws["B14"] = "SAT Math"
+        ws["B20"] = "C10: Class Rank"
+        ws["C30"] = "2025-05-01 00:00:00"
+        ws["D30"] = 60
+
+        schema = {
+            "schema_version": "2024-25",
+            "fields": [
+                {
+                    "question_number": f"C.{i}",
+                    "word_tag": None,
+                    "question": f"C.{i}",
+                    "section": "First-Time, First-Year Admission",
+                    "subsection": "First-time, first-year Profile",
+                    "value_type": "Number",
+                }
+                for i in range(908, 914)
+            ],
+        }
+        cell_map = {
+            "C.910": ("CDS-C", "D30"),
+            "C.911": ("CDS-C", "C30"),
+            "C.912": ("CDS-C", "C30"),
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(Path(tmp.name), schema, cell_map)
+
+        self.assertEqual(result["values"]["C.908"]["value"], "600")
+        self.assertEqual(result["values"]["C.909"]["value"], "660")
+        self.assertEqual(result["values"]["C.910"]["value"], "720")
+        self.assertNotIn("C.911", result["values"])
+        self.assertNotIn("C.912", result["values"])
+        self.assertNotIn("C.913", result["values"])
+        self.assertEqual(result["stats"]["academic_profile_fields_recovered"], 5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- broaden Tier 1 C9 recovery to recognize older headers that include first-year (freshman) wording
- treat visible C9 score rows as authoritative, clearing stale template-mapped values when the visible row is blank
- bump tier1_xlsx producer version to 0.2.1 so the two residual XLSX documents can be redrained cleanly

## Verification
- python3 -m unittest tools/tier1_extractor/test_extract.py
- python3 -m py_compile tools/tier1_extractor/extract.py tools/tier1_extractor/test_extract.py

## Ops note
After merge, rerun targeted Tier 1 extraction for:
- grand-valley-state-university 2024-25 (4c97ab1e-c248-4897-aae9-633107d2ecfe)
- purdue 2024-25 (5a07340a-dc1d-4248-9465-ff5e28a55577)