### PR TITLE
Fix mobile usability polish and labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,6 @@ tools/mirrors/**/*.jsonl
 
 # Playwright MCP local browser profile / cache
 .playwright-mcp/
+.gstack/
 .vercel
 .env*.local

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { fetchSiteStats } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
+import { CopyButton } from "@/components/CopyButton";
 
 export const metadata: Metadata = {
   title: "API",
@@ -22,9 +23,14 @@ export const revalidate = 3600;
 
 function CodeBlock({ children }: { children: string }) {
   return (
-    <pre className="mt-2 overflow-x-auto rounded border border-gray-200 bg-gray-50 px-4 py-3 text-xs leading-relaxed text-gray-800">
-      <code>{children}</code>
-    </pre>
+    <div className="relative mt-2">
+      <div className="absolute right-2 top-2">
+        <CopyButton text={children} />
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-gray-200 bg-gray-50 px-4 py-3 pr-16 text-xs leading-relaxed text-gray-800">
+        <code>{children}</code>
+      </pre>
+    </div>
   );
 }
 
@@ -46,7 +52,7 @@ export default async function ApiDocsPage() {
           PostgREST
         </a>{" "}
         API at{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm">{BASE}</code>
+        <code className="break-all rounded bg-gray-100 px-1.5 py-0.5 text-sm">{BASE}</code>
         . Every page on this site is built from the same endpoints documented
         below.
       </p>
@@ -605,7 +611,7 @@ const { data } = await supabase
       <p className="mt-2 text-sm leading-relaxed text-gray-700">
         Original CDS files are hosted on Supabase Storage. Once you have a
         manifest row, build the public URL as{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="break-all rounded bg-gray-100 px-1.5 py-0.5 text-xs">
           {BASE}/storage/v1/object/public/sources/&lt;source_storage_path&gt;
         </code>
         . Every file is content-addressed by SHA-256.
@@ -674,8 +680,8 @@ function Resource({
   const extras = allFields?.filter((f) => !highlighted.has(f)) ?? [];
   return (
     <div className="rounded border border-gray-200 p-4">
-      <div className="flex items-baseline justify-between gap-3">
-        <code className="text-sm font-semibold text-gray-900">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <code className="min-w-0 break-all text-sm font-semibold text-gray-900">
           GET /rest/v1/{name}
         </code>
         <a

--- a/web/src/app/browse/page.tsx
+++ b/web/src/app/browse/page.tsx
@@ -72,7 +72,7 @@ export default async function BrowsePage() {
             <BrowserHeroStat label="Schools in scope" value={formatCount(stats.browser_school_count)} />
             <BrowserHeroStat label="Primary rows" value={formatCount(stats.browser_primary_row_count)} />
             <BrowserHeroStat label="Queryable fields" value={formatCount(stats.queryable_field_count)} />
-            <BrowserHeroStat label="Projection refreshed" value={formatShortDate(stats.browser_updated_at)} />
+            <BrowserHeroStat label="Data refreshed" value={formatShortDate(stats.browser_updated_at)} />
           </div>
         </div>
       </section>

--- a/web/src/app/methodology/page.tsx
+++ b/web/src/app/methodology/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Methodology",
+  description:
+    "How collegedata.fyi turns Common Data Set source documents into academic profile, admission strategy, and merit profile cards.",
+  alternates: { canonical: "/methodology" },
+  openGraph: { url: "/methodology" },
+};
+
+const METHODS = [
+  {
+    href: "/methodology/positioning",
+    title: "Academic profile",
+    body: "How SAT and ACT bands are read from the CDS and compared against a student-entered score.",
+  },
+  {
+    href: "/methodology/admission-strategy",
+    title: "Admission rounds",
+    body: "How ED, EA, wait-list, yield, fee, and admissions-factor fields are derived from Section C.",
+  },
+  {
+    href: "/methodology/merit-profile",
+    title: "Merit and need aid",
+    body: "How Section H merit-aid facts are combined with federal affordability and outcome context.",
+  },
+];
+
+export default function MethodologyIndexPage() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6">
+      <div className="meta">§ Methodology</div>
+      <h1 className="serif mt-3 leading-none" style={{ fontSize: "clamp(40px, 6vw, 64px)" }}>
+        How the cards are built.
+      </h1>
+      <p className="mt-5 max-w-2xl text-[17px] leading-relaxed text-[var(--ink-2)]">
+        These notes explain the source fields, derivations, and caveats behind
+        the public cards on each school page. Every method starts from archived
+        Common Data Set documents and keeps the source trail visible.
+      </p>
+
+      <div className="mt-10 grid gap-4 sm:grid-cols-3">
+        {METHODS.map((method) => (
+          <Link
+            key={method.href}
+            href={method.href}
+            className="cd-card p-4 no-underline"
+          >
+            <span className="serif block text-xl leading-tight">
+              {method.title}
+            </span>
+            <span className="mt-3 block text-sm leading-relaxed text-[var(--ink-2)]">
+              {method.body}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -196,7 +196,7 @@ export default async function HomePage() {
             {drain.map((r, i) => (
               <div
                 key={`${r.school}-${i}`}
-                className="rule"
+                className="rule cd-drain-row"
                 style={{
                   display: "grid",
                   gridTemplateColumns: "96px 1fr auto auto",
@@ -222,6 +222,8 @@ export default async function HomePage() {
           .cd-marginalia-left, .cd-marginalia-right { display: none !important; }
           .cd-stat-grid { grid-template-columns: repeat(2, 1fr) !important; gap: 24px !important; }
           .cd-drain { grid-template-columns: 1fr !important; gap: 16px !important; }
+          .cd-drain-row { grid-template-columns: 88px 1fr auto !important; gap: 10px 12px !important; }
+          .cd-drain-row span:nth-child(2) { grid-column: 1 / -1; grid-row: 2; }
         }
       `}</style>
     </div>

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -314,13 +314,14 @@ export default async function SchoolDetailPage({
             {carnegieCode != null && (
               <span
                 className="mono"
+                title="Federal College Scorecard Carnegie basic classification code"
                 style={{
                   fontSize: 11.5,
                   color: "var(--ink-3)",
                   letterSpacing: "0.05em",
                 }}
               >
-                CARNEGIE {carnegieCode}
+                CARNEGIE CLASS {carnegieCode}
               </span>
             )}
           </div>

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -140,9 +140,60 @@
 .cd-nav-links {
   display: flex; gap: 28px; font-size: 14px;
 }
+.cd-nav-secondary {
+  display: contents;
+}
+.cd-nav-more {
+  display: none;
+  position: relative;
+}
 @media (max-width: 640px) {
   .cd-nav-row { flex-wrap: wrap; row-gap: 10px; }
-  .cd-nav-links { width: 100%; justify-content: flex-start; gap: 18px; font-size: 13px; flex-wrap: wrap; }
+  .cd-nav-links { width: 100%; justify-content: flex-start; gap: 18px; font-size: 13px; flex-wrap: wrap; align-items: center; }
+  .cd-nav-secondary { display: none; }
+  .cd-nav-more {
+    display: block;
+    color: var(--ink-3);
+  }
+  .cd-nav-more summary {
+    cursor: pointer;
+    list-style: none;
+  }
+  .cd-nav-more summary::-webkit-details-marker {
+    display: none;
+  }
+  .cd-nav-more > div {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 20;
+    display: grid;
+    gap: 10px;
+    min-width: 150px;
+    padding: 12px;
+    border: 1px solid var(--rule-strong);
+    background: #faf6ec;
+    box-shadow: 0 12px 28px rgba(28, 30, 27, 0.12);
+  }
+  .cd-nav-more a {
+    text-decoration: none;
+  }
+}
+.cd-footer-links {
+  flex-wrap: wrap;
+}
+@media (max-width: 640px) {
+  .cd-footer-inner {
+    grid-template-columns: 1fr !important;
+    gap: 22px !important;
+    padding-bottom: 40px !important;
+  }
+  .cd-footer-links {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px 20px !important;
+    align-self: start !important;
+  }
 }
 
 /* School page header — desktop puts the count + sparkline on the right
@@ -220,6 +271,36 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 10px;
+  }
+}
+.document-card-row {
+  display: grid;
+  grid-template-columns: 96px 1fr auto;
+  gap: 20px;
+  align-items: center;
+  padding: 16px 0;
+}
+.document-card-row__actions {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  font-size: 13px;
+}
+@media (max-width: 640px) {
+  .document-card-row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  .document-card-row__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+  .document-card-row__actions a {
+    border: 1px solid var(--rule-strong);
+    padding: 8px 10px;
+    text-align: center;
+    text-decoration: none;
   }
 }
 
@@ -498,12 +579,22 @@
   text-transform: uppercase;
   color: var(--ink-3);
 }
+.card-source-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: baseline;
+}
 @media (max-width: 820px) {
   .positioning-card__body { padding: 24px 20px 20px; }
   .positioning-card__grid { grid-template-columns: 1fr; gap: 24px; }
   .positioning-profile__details { grid-template-columns: 1fr; }
   .positioning-form { grid-template-columns: 1fr; }
   .positioning-form__actions .cd-btn { width: 100%; justify-content: center; }
+  .card-source-actions {
+    display: grid;
+    gap: 8px;
+  }
 }
 
 /* Admission strategy card. Keeps the presentation source-like: counts,
@@ -711,6 +802,13 @@
   border-top: 1px solid var(--rule);
   padding-top: 8px;
 }
+.merit-profile-missing {
+  margin: 14px 0 0;
+  max-width: 620px;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
 .merit-profile-context {
   border-left: 1px solid var(--rule-strong);
   padding-left: 20px;
@@ -872,6 +970,15 @@
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--ink-3);
+}
+.match-form label small,
+.match-filter-form label small {
+  color: var(--ink-3);
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 1.35;
+  text-transform: none;
 }
 .match-form input,
 .match-form select,

--- a/web/src/components/AdmissionStrategyCard.tsx
+++ b/web/src/components/AdmissionStrategyCard.tsx
@@ -242,16 +242,17 @@ export function AdmissionStrategyCard({
           )}
         </div>
 
-        <div className="admission-strategy-card__source rule mono">
-          § SOURCE: COMMON DATA SET {school.cdsYear} · §C.21 §C.22 §C.2 §C.7 §C.13 ·{" "}
-          <Link href="/methodology/admission-strategy">METHOD →</Link>
+        <div className="admission-strategy-card__source card-source-actions rule mono">
+          <span>§ SOURCE: COMMON DATA SET {school.cdsYear} · §C.21 §C.22 §C.2 §C.7 §C.13</span>
+          <span>
+            <Link href="/methodology/admission-strategy">METHOD →</Link>
+          </span>
           {sourceHref ? (
-            <>
-              {" "}·{" "}
+            <span>
               <a href={sourceHref} target="_blank" rel="noopener noreferrer">
                 ARCHIVED SOURCE →
               </a>
-            </>
+            </span>
           ) : null}
         </div>
       </div>

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="rounded border border-gray-300 bg-white px-2 py-1 text-[11px] font-medium text-gray-700 hover:bg-gray-100"
+    >
+      {copied ? "Copied" : label}
+    </button>
+  );
+}

--- a/web/src/components/DocumentCard.tsx
+++ b/web/src/components/DocumentCard.tsx
@@ -23,6 +23,23 @@ function statusChipClass(status: string): string {
   }
 }
 
+function downloadLabel(format: string | null): string {
+  switch (format) {
+    case "xlsx":
+      return "Download XLSX";
+    case "docx":
+      return "Download DOCX";
+    case "html":
+      return "Download HTML";
+    case "pdf_fillable":
+    case "pdf_flat":
+    case "pdf_scanned":
+      return "Download PDF";
+    default:
+      return "Download source";
+  }
+}
+
 // One row of the documents ledger. Year sits in display serif; the format
 // and status are mono chips; download/view actions are right-aligned. Last
 // row drops the dashed separator so the ledger ends on a hairline rule.
@@ -45,19 +62,15 @@ export function DocumentCard({
     ? formatBadgeLabel(doc.source_format)
     : null;
 
-  const rowStyle: React.CSSProperties = {
-    display: "grid",
-    gridTemplateColumns: "96px 1fr auto",
-    gap: 20,
-    alignItems: "center",
-    padding: "16px 0",
-    borderBottom: isLast
-      ? "1px solid var(--rule)"
-      : "1px dashed var(--rule)",
-  };
-
   return (
-    <div style={rowStyle}>
+    <div
+      className="document-card-row"
+      style={{
+        borderBottom: isLast
+          ? "1px solid var(--rule)"
+          : "1px dashed var(--rule)",
+      }}
+    >
       <span
         className="serif nums"
         style={{ fontSize: 24, letterSpacing: "-0.01em" }}
@@ -97,14 +110,7 @@ export function DocumentCard({
         )}
       </div>
 
-      <div
-        style={{
-          display: "flex",
-          gap: 18,
-          alignItems: "center",
-          fontSize: 13,
-        }}
-      >
+      <div className="document-card-row__actions">
         {canLink && (
           <Link href={`/schools/${doc.school_id}/${doc.canonical_year}`}>
             View fields →
@@ -112,7 +118,7 @@ export function DocumentCard({
         )}
         {pdfUrl ? (
           <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
-            Download PDF
+            {downloadLabel(doc.source_format)}
           </a>
         ) : sourceUrl ? (
           <a href={sourceUrl} target="_blank" rel="noopener noreferrer">

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
       }}
     >
       <div
-        className="mx-auto max-w-5xl"
+        className="mx-auto max-w-5xl cd-footer-inner"
         style={{
           padding: "32px 24px 56px",
           display: "grid",
@@ -28,7 +28,7 @@ export function Footer() {
             CDS Initiative template.
           </div>
         </div>
-        <div style={{ display: "flex", gap: 24, alignSelf: "end" }}>
+        <div className="cd-footer-links" style={{ display: "flex", gap: 24, alignSelf: "end" }}>
           <a href="https://github.com/bolewood/collegedata-fyi" target="_blank" rel="noopener noreferrer">
             GitHub
           </a>

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -179,8 +179,9 @@ export function MatchListBuilder({
             <input name="act" type="number" inputMode="numeric" min="1" max="36" step="1" defaultValue={profile?.act ?? ""} />
           </label>
           <label>
-            <span>Home state</span>
+            <span>Student home state</span>
             <input name="state" type="text" maxLength={2} placeholder="OK" defaultValue={profile?.state ?? ""} />
+            <small>Used for residency context, not school location.</small>
           </label>
           <label>
             <span>Intended major</span>
@@ -194,7 +195,7 @@ export function MatchListBuilder({
         <form className="match-filter-form rule" onChange={onFilterChange}>
           <div className="meta">Filters</div>
           <label>
-            <span>Control</span>
+            <span>School type</span>
             <select name="control" defaultValue={filters.control}>
               <option value="all">All</option>
               <option value={"public" as SchoolControl}>Public</option>

--- a/web/src/components/MeritProfileCard.tsx
+++ b/web/src/components/MeritProfileCard.tsx
@@ -29,6 +29,16 @@ function yesNo(value: boolean | null): string {
   return "n/a";
 }
 
+function hasCoreMeritFacts(profile: MeritProfileRow): boolean {
+  return (
+    profile.nonNeedAidRecipientsFirstYearFt != null ||
+    profile.nonNeedAidShareFirstYearFt != null ||
+    profile.avgNonNeedGrantFirstYearFt != null ||
+    profile.avgAidPackageFirstYearFt != null ||
+    profile.avgNeedGrantFirstYearFt != null
+  );
+}
+
 function recipientShareLine(profile: MeritProfileRow): string {
   if (profile.nonNeedAidShareFirstYearFt != null) {
     return `${percent(profile.nonNeedAidShareFirstYearFt)} of first-year full-time students`;
@@ -70,6 +80,40 @@ export function MeritProfileCard({ profile, sourceHref }: MeritProfileCardProps)
         : profile.meritProfileQuality === "limited"
           ? "Limited merit profile"
           : "Merit profile unavailable";
+  const meritStats = [
+    profile.avgNonNeedGrantFirstYearFt == null
+      ? null
+      : {
+          label: "Avg no-need grant",
+          value: currency(profile.avgNonNeedGrantFirstYearFt),
+          note: "H2A first-year full-time students with no financial need",
+        },
+    profile.avgAidPackageFirstYearFt == null
+      ? null
+      : {
+          label: "Avg aid package",
+          value: currency(profile.avgAidPackageFirstYearFt),
+          note: "H2 first-year full-time aid recipients",
+        },
+    profile.avgNeedGrantFirstYearFt == null
+      ? null
+      : {
+          label: "Avg need grant",
+          value: currency(profile.avgNeedGrantFirstYearFt),
+          note: "H2 first-year full-time need-based grant aid",
+        },
+    profile.avgNetPrice == null
+      ? null
+      : {
+          label: "Avg net price",
+          value: currency(profile.avgNetPrice),
+          note: "Federal Scorecard, all aided students",
+          muted: true,
+        },
+  ].filter(
+    (stat): stat is { label: string; value: string; note: string; muted?: boolean } =>
+      stat != null,
+  );
 
   return (
     <section className="merit-profile-card rule-2" aria-labelledby="merit-profile-title">
@@ -80,6 +124,12 @@ export function MeritProfileCard({ profile, sourceHref }: MeritProfileCardProps)
             <h2 id="merit-profile-title" className="serif merit-profile-card__title">
               What this school reports giving.
             </h2>
+            {!hasCoreMeritFacts(profile) && (
+              <p className="merit-profile-missing">
+                This CDS does not report the core H2A no-need grant fields. Federal
+                affordability context is still shown below when available.
+              </p>
+            )}
             <div className="merit-profile-flags mono">
               <span>{qualityLabel}</span>
               {profile.institutionalAidAcademics === true && (
@@ -93,35 +143,21 @@ export function MeritProfileCard({ profile, sourceHref }: MeritProfileCardProps)
           <div className="merit-profile-context">
             <span className="meta">No-need grant recipients</span>
             <strong className="serif stat-num">
-              {count(profile.nonNeedAidRecipientsFirstYearFt)}
+              {profile.nonNeedAidRecipientsFirstYearFt == null
+                ? "Not reported"
+                : count(profile.nonNeedAidRecipientsFirstYearFt)}
             </strong>
             <small>{recipientShareLine(profile)}</small>
           </div>
         </div>
 
-        <div className="merit-profile-stats">
-          <StatBlock
-            label="Avg no-need grant"
-            value={currency(profile.avgNonNeedGrantFirstYearFt)}
-            note="H2A first-year full-time students with no financial need"
-          />
-          <StatBlock
-            label="Avg aid package"
-            value={currency(profile.avgAidPackageFirstYearFt)}
-            note="H2 first-year full-time aid recipients"
-          />
-          <StatBlock
-            label="Avg need grant"
-            value={currency(profile.avgNeedGrantFirstYearFt)}
-            note="H2 first-year full-time need-based grant aid"
-          />
-          <StatBlock
-            label="Avg net price"
-            value={currency(profile.avgNetPrice)}
-            note="Federal Scorecard, all aided students"
-            muted
-          />
-        </div>
+        {meritStats.length > 0 && (
+          <div className="merit-profile-stats">
+            {meritStats.map((stat) => (
+              <StatBlock key={stat.label} {...stat} />
+            ))}
+          </div>
+        )}
 
         <div className="merit-profile-grid">
           <div className="merit-profile-panel">
@@ -152,16 +188,17 @@ export function MeritProfileCard({ profile, sourceHref }: MeritProfileCardProps)
           income, assets, residency, application round, program, and school policy.
         </div>
 
-        <div className="merit-profile-card__source rule mono">
-          § SOURCE: COMMON DATA SET {profile.cdsYear} · §H.2 §H.2A §H.6 §H.14 ·{" "}
-          <Link href="/methodology/merit-profile">METHOD →</Link>
+        <div className="merit-profile-card__source card-source-actions rule mono">
+          <span>§ SOURCE: COMMON DATA SET {profile.cdsYear} · §H.2 §H.2A §H.6 §H.14</span>
+          <span>
+            <Link href="/methodology/merit-profile">METHOD →</Link>
+          </span>
           {sourceHref ? (
-            <>
-              {" "}·{" "}
+            <span>
               <a href={sourceHref} target="_blank" rel="noopener noreferrer">
                 ARCHIVED SOURCE →
               </a>
-            </>
+            </span>
           ) : null}
         </div>
       </div>

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -4,14 +4,17 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Wordmark } from "./Wordmark";
 
-const NAV_LINKS = [
+const PRIMARY_NAV_LINKS = [
   { href: "/match", label: "Match" },
   { href: "/browse", label: "Browser" },
   { href: "/schools", label: "Schools" },
+  { href: "/api", label: "API" },
+];
+
+const SECONDARY_NAV_LINKS = [
   { href: "/coverage", label: "Coverage" },
   { href: "/recipes", label: "Recipes" },
   { href: "/about", label: "About" },
-  { href: "/api", label: "API" },
 ];
 
 // A nav link is "active" when the user is on that section. Section pages
@@ -41,7 +44,7 @@ export function Nav() {
           <Wordmark variant="dotted" size={20} />
         </Link>
         <div className="cd-nav-links">
-          {NAV_LINKS.map((l) => {
+          {PRIMARY_NAV_LINKS.map((l) => {
             const active = isActive(pathname, l.href);
             return (
               <Link
@@ -62,36 +65,82 @@ export function Nav() {
               </Link>
             );
           })}
-          <a
-            href="https://github.com/bolewood/collegedata-fyi"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="GitHub (opens in new tab)"
-            style={{
-              textDecoration: "none",
-              color: "var(--ink-3)",
-              paddingBottom: 2,
-              borderBottom: "1px solid transparent",
-              display: "inline-flex",
-              alignItems: "baseline",
-              gap: 4,
-            }}
-            className="nav-link"
-          >
-            GitHub
-            <span
-              aria-hidden="true"
-              style={{
-                fontSize: "0.75em",
-                color: "var(--ink-4)",
-                lineHeight: 1,
-              }}
-            >
-              ↗
-            </span>
-          </a>
+          <span className="cd-nav-secondary">
+            {SECONDARY_NAV_LINKS.map((l) => {
+              const active = isActive(pathname, l.href);
+              return (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  aria-current={active ? "page" : undefined}
+                  style={{
+                    textDecoration: "none",
+                    color: active ? "var(--ink)" : "var(--ink-3)",
+                    paddingBottom: 2,
+                    borderBottom: active
+                      ? "1px solid var(--ink)"
+                      : "1px solid transparent",
+                  }}
+                  className="nav-link"
+                >
+                  {l.label}
+                </Link>
+              );
+            })}
+            <GitHubNavLink />
+          </span>
+          <details className="cd-nav-more">
+            <summary>More</summary>
+            <div>
+              {SECONDARY_NAV_LINKS.map((l) => (
+                <Link key={l.href} href={l.href}>
+                  {l.label}
+                </Link>
+              ))}
+              <a
+                href="https://github.com/bolewood/collegedata-fyi"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub ↗
+              </a>
+            </div>
+          </details>
         </div>
       </div>
     </nav>
+  );
+}
+
+function GitHubNavLink() {
+  return (
+    <a
+      href="https://github.com/bolewood/collegedata-fyi"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="GitHub (opens in new tab)"
+      style={{
+        textDecoration: "none",
+        color: "var(--ink-3)",
+        paddingBottom: 2,
+        borderBottom: "1px solid transparent",
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: 4,
+      }}
+      className="nav-link"
+    >
+      GitHub
+      <span
+        aria-hidden="true"
+        style={{
+          fontSize: "0.75em",
+          color: "var(--ink-4)",
+          lineHeight: 1,
+        }}
+      >
+        ↗
+      </span>
+    </a>
   );
 }

--- a/web/src/components/OutcomesBand.tsx
+++ b/web/src/components/OutcomesBand.tsx
@@ -72,12 +72,12 @@ export function OutcomesBand({ scorecard }: { scorecard: ScorecardSummary }) {
 
   return (
     <div
-      className="rule-2"
+      className="rule-2 outcomes-band"
       style={{
         marginTop: 20,
         paddingTop: 24,
         display: "grid",
-        gridTemplateColumns: `repeat(${cards.length}, 1fr)`,
+        gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
         gap: 32,
       }}
     >

--- a/web/src/components/OutcomesSection.tsx
+++ b/web/src/components/OutcomesSection.tsx
@@ -142,7 +142,7 @@ export function OutcomesSection({
               marginTop: 14,
               paddingTop: 20,
               display: "grid",
-              gridTemplateColumns: `repeat(${Math.min(completion.length, 6)}, 1fr)`,
+              gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
               gap: 24,
             }}
           >

--- a/web/src/components/PositioningCard.tsx
+++ b/web/src/components/PositioningCard.tsx
@@ -18,6 +18,12 @@ function formatScore(value: number | null): string {
   return value == null ? "-" : value.toLocaleString();
 }
 
+function submitRateCaption(submitRate: number | null): string {
+  return submitRate == null
+    ? "SUBMIT RATE NOT REPORTED"
+    : `FROM THE ${formatPercent(submitRate)} OF ADMITS WHO SUBMITTED SCORES`;
+}
+
 function RangeStrip({
   label,
   p25,
@@ -50,7 +56,7 @@ function RangeStrip({
       <div className="positioning-range__caption">
         {hasRange ? (
           <>
-            § FROM THE {formatPercent(submitRate)} OF ADMITS WHO SUBMITTED SCORES · {year} CDS ·{" "}
+            § {submitRateCaption(submitRate)} · {year} CDS ·{" "}
             <Link href="/methodology/positioning">METHOD →</Link>
           </>
         ) : (
@@ -104,15 +110,14 @@ export function PositioningCard({ school, sourceHref }: PositioningCardProps) {
           <PositioningCardProfile school={school} />
         </div>
 
-        <div className="positioning-card__source rule mono">
-          § SOURCE: COMMON DATA SET {school.cdsYear} · §C.7 §C.9 §C.11 §C.12
+        <div className="positioning-card__source card-source-actions rule mono">
+          <span>§ SOURCE: COMMON DATA SET {school.cdsYear} · §C.7 §C.9 §C.11 §C.12</span>
           {sourceHref ? (
-            <>
-              {" "}·{" "}
+            <span>
               <a href={sourceHref} target="_blank" rel="noopener noreferrer">
                 ARCHIVED SOURCE →
               </a>
-            </>
+            </span>
           ) : null}
         </div>
       </div>

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -249,31 +249,31 @@ export function SchoolBrowser() {
           className="browser-filter-grid"
         >
           <FilterInput
-            label="Enrollment at least"
+            label="Minimum undergrad enrollment"
             value={filters.undergradMin}
             onChange={(v) => updateFilter("undergradMin", v)}
             suffix="students"
           />
           <FilterInput
-            label="Acceptance at most"
+            label="Maximum acceptance rate"
             value={filters.acceptanceMax}
             onChange={(v) => updateFilter("acceptanceMax", v)}
             suffix="%"
           />
           <FilterInput
-            label="Yield at least"
+            label="Minimum yield"
             value={filters.yieldMin}
             onChange={(v) => updateFilter("yieldMin", v)}
             suffix="%"
           />
           <FilterInput
-            label="Net price at most"
+            label="Maximum average net price"
             value={filters.netPriceMax}
             onChange={(v) => updateFilter("netPriceMax", v)}
             suffix="$"
           />
           <FilterInput
-            label="Retention at least"
+            label="Minimum retention"
             value={filters.retentionMin}
             onChange={(v) => updateFilter("retentionMin", v)}
             suffix="%"
@@ -341,9 +341,11 @@ export function SchoolBrowser() {
           <MetaStat label="With required fields" value={metadata ? metadata.schools_with_required_fields.toLocaleString() : "..."} />
           <MetaStat label="Missing fields" value={metadata ? metadata.schools_missing_required_fields.toLocaleString() : "..."} />
         </div>
-        <p className="meta" style={{ marginTop: 14 }}>
-          Latest primary school-year rows, 2024-25+. Required for answerability: {requiredLabels}.
-          {metadata ? ` Failed active filters: ${metadata.schools_failing_filters.toLocaleString()}.` : ""}
+        <p className="meta" style={{ marginTop: 14, lineHeight: 1.55 }}>
+          Latest primary school-year rows, 2024-25+. Fields needed for the current filters: {requiredLabels}.
+          {metadata ? ` Filtered out by your criteria: ${metadata.schools_failing_filters.toLocaleString()}.` : ""}
+          {" "}
+          <Link href="/match">Looking for fit ranking? Use Match.</Link>
         </p>
       </section>
 
@@ -354,7 +356,13 @@ export function SchoolBrowser() {
         </div>
       )}
 
-      <div style={{ overflowX: "auto", opacity: loading ? 0.62 : 1 }}>
+      <div className="browser-mobile-results" style={{ opacity: loading ? 0.62 : 1 }}>
+        {rows.map((row) => (
+          <BrowserResultCard key={row.document_id} row={row} />
+        ))}
+      </div>
+
+      <div className="browser-table-wrap" style={{ overflowX: "auto", opacity: loading ? 0.62 : 1 }}>
         <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 940, fontSize: 14 }}>
           <thead>
             <tr className="meta" style={{ textAlign: "left", borderBottom: "1px solid var(--rule-strong)" }}>
@@ -461,13 +469,75 @@ export function SchoolBrowser() {
             grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
           }
         }
+        .browser-mobile-results {
+          display: none;
+        }
         @media (max-width: 560px) {
           .browser-filter-grid,
           .browser-meta-grid {
             grid-template-columns: 1fr !important;
           }
+          .browser-table-wrap {
+            display: none;
+          }
+          .browser-mobile-results {
+            display: grid;
+            gap: 12px;
+          }
         }
       `}</style>
+    </div>
+  );
+}
+
+function BrowserResultCard({ row }: { row: BrowserRow }) {
+  return (
+    <article className="cd-card" style={{ padding: 14 }}>
+      <div style={{ display: "flex", gap: 10, alignItems: "flex-start", justifyContent: "space-between" }}>
+        <div style={{ minWidth: 0 }}>
+          <Link href={`/schools/${row.school_id}`} style={{ fontFamily: "var(--serif)", fontSize: 19, lineHeight: 1.15 }}>
+            {row.school_name}
+          </Link>
+          {row.sub_institutional && (
+            <div className="meta" style={{ marginTop: 4 }}>{row.sub_institutional}</div>
+          )}
+        </div>
+        <span className="mono" style={{ flexShrink: 0, color: "var(--ink-3)", fontSize: 12 }}>
+          {row.canonical_year}
+        </span>
+      </div>
+      {row.data_quality_flag && (
+        <div className="cd-chip" style={{ marginTop: 8 }}>{row.data_quality_flag.replaceAll("_", " ")}</div>
+      )}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          gap: "10px 12px",
+          marginTop: 14,
+        }}
+      >
+        <CardMetric label="Enrollment" value={row.undergrad_enrollment_scorecard == null ? "-" : Math.round(row.undergrad_enrollment_scorecard).toLocaleString()} />
+        <CardMetric label="Accept" value={formatPercent(row.acceptance_rate, 1) || "-"} />
+        <CardMetric label="Yield" value={formatPercent(row.yield_rate, 1) || "-"} />
+        <CardMetric label="Net price" value={formatCurrency(row.avg_net_price) || "-"} />
+        <CardMetric label="Applied" value={row.applied == null ? "-" : Math.round(row.applied).toLocaleString()} />
+        <CardMetric label="Admitted" value={row.admitted == null ? "-" : Math.round(row.admitted).toLocaleString()} />
+      </div>
+      <div className="rule" style={{ marginTop: 12, paddingTop: 10 }}>
+        <a href={row.archive_url} target="_blank" rel="noopener noreferrer" className="cd-chip">
+          {formatBadgeLabel(row.source_format)} source
+        </a>
+      </div>
+    </article>
+  );
+}
+
+function CardMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ borderTop: "1px solid var(--rule)", paddingTop: 7 }}>
+      <div className="meta" style={{ marginBottom: 4 }}>{label}</div>
+      <div className="nums" style={{ fontFamily: "var(--serif)", fontSize: 22, lineHeight: 1 }}>{value}</div>
     </div>
   );
 }

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -407,7 +407,13 @@ export function SchoolBrowser() {
                   {formatCurrency(row.avg_net_price) || "-"}
                 </td>
                 <td style={{ padding: "12px 0 12px 10px" }}>
-                  <a href={row.archive_url} target="_blank" rel="noopener noreferrer" className="cd-chip">
+                  <a
+                    href={row.archive_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="cd-chip"
+                    data-testid="browser-source-link"
+                  >
                     {formatBadgeLabel(row.source_format)}
                   </a>
                 </td>
@@ -525,7 +531,13 @@ function BrowserResultCard({ row }: { row: BrowserRow }) {
         <CardMetric label="Admitted" value={row.admitted == null ? "-" : Math.round(row.admitted).toLocaleString()} />
       </div>
       <div className="rule" style={{ marginTop: 12, paddingTop: 10 }}>
-        <a href={row.archive_url} target="_blank" rel="noopener noreferrer" className="cd-chip">
+        <a
+          href={row.archive_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cd-chip"
+          data-testid="browser-source-link"
+        >
           {formatBadgeLabel(row.source_format)} source
         </a>
       </div>

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -174,14 +174,17 @@ export function SchoolSearch() {
                   <div
                     className="mono"
                     style={{
+                      display: "flex",
+                      gap: 8,
+                      flexWrap: "wrap",
                       fontSize: 11,
                       color: "var(--ink-3)",
                       marginTop: 2,
                     }}
                   >
-                    {[r.city, r.state].filter(Boolean).join(", ")}
+                    <span>{[r.city, r.state].filter(Boolean).join(", ")}</span>
                     {r.latest_available_cds_year && (
-                      <span style={{ marginLeft: 12 }}>
+                      <span>
                         CDS {r.latest_available_cds_year}
                       </span>
                     )}

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -45,7 +45,7 @@ test("browser loads live rows and source links resolve", async ({ page, request 
   await expect(page.getByText("Browser query failed")).toHaveCount(0);
   await expect(page.getByText(/Showing 1-/)).toBeVisible();
 
-  const source = page.locator("tbody a.cd-chip").first();
+  const source = page.locator('[data-testid="browser-source-link"]:visible').first();
   await expect(source).toBeVisible();
   const href = await source.getAttribute("href");
   expect(href).toBeTruthy();


### PR DESCRIPTION
## Summary
- Replace the mobile school browser table with compact result cards and clarify browse filter/status copy.
- Fix mobile overflow in school outcome metrics, API docs snippets, source history rows, source/method links, footer, nav, and latest-drain rows.
- Add a methodology index page, format-aware source download labels, clearer match/profile labels, and better missing-data copy.

## Verification
- `npm run test` — 29 tests passed across 4 files.
- `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... npm run build` — production build passed.
- Playwright mobile pass on `/`, `/browse`, `/api`, `/match`, `/methodology`, `/schools/yale`, `/schools/purdue`: all 200, no console errors, no horizontal overflow at 390px.
- Visual spot checks captured under local `.gstack/qa-reports/collegedata-fyi-2026-05-03/post-fix/`.

## Notes
- `.gstack/` is now ignored so local QA screenshots/reports do not leak into repo commits.
- No version or changelog files exist in this repo, so no release bookkeeping was updated.