### PR TITLE
Fix Match coverage for top schools

### DIFF
--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -277,6 +277,19 @@ DERIVED_TOTAL_FALLBACK_FIELDS = {
     ("2024-25", "first_year_enrolled"): "C.119",
 }
 
+DERIVED_COMPONENT_FALLBACK_FIELDS = {
+    ("2025-26", "applied"): (
+        ("C.101", "C.102", "C.103"),
+    ),
+    ("2025-26", "admitted"): (
+        ("C.104", "C.105", "C.106"),
+    ),
+    ("2025-26", "first_year_enrolled"): (
+        ("C.107", "C.108", "C.109"),
+        ("C.110", "C.111", "C.112", "C.113", "C.114", "C.115"),
+    ),
+}
+
 
 def load_env(env_path: Path = REPO_ROOT / ".env") -> dict[str, str]:
     env: dict[str, str] = {}
@@ -968,8 +981,13 @@ def evaluate_metric(
     ]
     if isinstance(metric.source_spec, DerivedFormula):
         reported_values = [value for value in values if value is not None]
+        component_fallback_value = evaluate_component_fallback_metric(
+            metric,
+            selected,
+            schema_defs,
+        )
         if not reported_values:
-            return None
+            return component_fallback_value
         if len(reported_values) != len(values):
             fallback_field_id = DERIVED_TOTAL_FALLBACK_FIELDS.get(
                 (selected.schema_version, metric.canonical_metric)
@@ -980,10 +998,34 @@ def evaluate_metric(
                 )
                 if fallback_value is not None:
                     return fallback_value
-        return sum(reported_values, Decimal("0"))
+        total = sum(reported_values, Decimal("0"))
+        if total == 0 and component_fallback_value is not None and component_fallback_value > 0:
+            return component_fallback_value
+        return total
     if any(value is None for value in values):
         return None
     return sum(values, Decimal("0"))
+
+
+def evaluate_component_fallback_metric(
+    metric: MetricDefinition,
+    selected: SelectedExtractionResult,
+    schema_defs: dict[str, FieldDefinition],
+) -> Optional[Decimal]:
+    fallback_groups = DERIVED_COMPONENT_FALLBACK_FIELDS.get(
+        (selected.schema_version, metric.canonical_metric)
+    )
+    if not fallback_groups:
+        return None
+    for field_ids in fallback_groups:
+        values = [
+            parse_metric_component(field_id, selected, schema_defs, metric)
+            for field_id in field_ids
+        ]
+        reported_values = [value for value in values if value is not None]
+        if reported_values:
+            return sum(reported_values, Decimal("0"))
+    return None
 
 
 def build_projection_rows(

--- a/tools/browser_backend/project_browser_data_test.py
+++ b/tools/browser_backend/project_browser_data_test.py
@@ -58,6 +58,21 @@ def defs():
             "C.901": FieldDefinition("2024-25", "C.901", "Submitting SAT Scores", "Admission", "Profile", "Whole Number or Round to Nearest Tenths"),
         },
         "2025-26": {
+            "C.101": FieldDefinition("2025-26", "C.101", "Males applied", "Admission", "Applications", "Number"),
+            "C.102": FieldDefinition("2025-26", "C.102", "Females applied", "Admission", "Applications", "Number"),
+            "C.103": FieldDefinition("2025-26", "C.103", "Unknown sex applied", "Admission", "Applications", "Number"),
+            "C.104": FieldDefinition("2025-26", "C.104", "Males admitted", "Admission", "Applications", "Number"),
+            "C.105": FieldDefinition("2025-26", "C.105", "Females admitted", "Admission", "Applications", "Number"),
+            "C.106": FieldDefinition("2025-26", "C.106", "Unknown sex admitted", "Admission", "Applications", "Number"),
+            "C.107": FieldDefinition("2025-26", "C.107", "Males enrolled", "Admission", "Applications", "Number"),
+            "C.108": FieldDefinition("2025-26", "C.108", "Females enrolled", "Admission", "Applications", "Number"),
+            "C.109": FieldDefinition("2025-26", "C.109", "Unknown sex enrolled", "Admission", "Applications", "Number"),
+            "C.110": FieldDefinition("2025-26", "C.110", "Males full-time enrolled", "Admission", "Applications", "Number"),
+            "C.111": FieldDefinition("2025-26", "C.111", "Males part-time enrolled", "Admission", "Applications", "Number"),
+            "C.112": FieldDefinition("2025-26", "C.112", "Females full-time enrolled", "Admission", "Applications", "Number"),
+            "C.113": FieldDefinition("2025-26", "C.113", "Females part-time enrolled", "Admission", "Applications", "Number"),
+            "C.114": FieldDefinition("2025-26", "C.114", "Unknown sex full-time enrolled", "Admission", "Applications", "Number"),
+            "C.115": FieldDefinition("2025-26", "C.115", "Unknown sex part-time enrolled", "Admission", "Applications", "Number"),
             "C.116": FieldDefinition("2025-26", "C.116", "Applied", "Admission", "Applications", "Number"),
             "C.117": FieldDefinition("2025-26", "C.117", "Admitted", "Admission", "Applications", "Number"),
             "C.118": FieldDefinition("2025-26", "C.118", "Enrolled", "Admission", "Applications", "Number"),
@@ -219,6 +234,51 @@ class BrowserProjectionTests(unittest.TestCase):
         self.assertEqual(browser["enrolled_first_year"], 240)
         self.assertIsNone(browser["acceptance_rate"])
         self.assertIsNone(browser["yield_rate"])
+
+    def test_2025_admissions_metrics_fall_back_to_gender_split_components(self):
+        _fields, browser = build_projection_rows(
+            doc(canonical_year="2025-26"),
+            [
+                artifact(values={
+                    "C.101": {"value": "22,819"},
+                    "C.102": {"value": "27,445"},
+                    "C.103": {"value": "0"},
+                    "C.104": {"value": "1,189"},
+                    "C.105": {"value": "1,198"},
+                    "C.106": {"value": "0"},
+                    "C.107": {"value": "799"},
+                    "C.108": {"value": "834"},
+                    "C.109": {"value": "0"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 50264)
+        self.assertEqual(browser["admitted"], 2387)
+        self.assertEqual(browser["enrolled_first_year"], 1633)
+        self.assertEqual(browser["acceptance_rate"], "0.047489")
+        self.assertEqual(browser["yield_rate"], "0.684122")
+
+    def test_2025_zero_total_fields_defer_to_positive_gender_components(self):
+        _fields, browser = build_projection_rows(
+            doc(canonical_year="2025-26"),
+            [
+                artifact(values={
+                    "C.101": {"value": "100"},
+                    "C.102": {"value": "120"},
+                    "C.104": {"value": "10"},
+                    "C.105": {"value": "12"},
+                    "C.116": {"value": "0"},
+                    "C.117": {"value": "0"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 220)
+        self.assertEqual(browser["admitted"], 22)
+        self.assertEqual(browser["acceptance_rate"], "0.100000")
 
     def test_sat_act_promoted_fields_project_to_browser_columns(self):
         fields, browser = build_projection_rows(

--- a/web/src/components/SchoolListItem.tsx
+++ b/web/src/components/SchoolListItem.tsx
@@ -30,13 +30,15 @@ function caveatLabel(caveat: Caveat): string {
       return "no test data";
     case "data_incomplete":
       return "incomplete data";
+    case "no_admit_rate":
+      return "no admit rate";
   }
 }
 
 export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
   const caveats = school.result.caveats
     .filter((caveat) =>
-      ["low_sat_submit_rate", "stale_cds", "sub_15_admit_rate_suppression", "data_incomplete"].includes(caveat),
+      ["low_sat_submit_rate", "stale_cds", "sub_15_admit_rate_suppression", "data_incomplete", "no_admit_rate"].includes(caveat),
     )
     .slice(0, 2);
 

--- a/web/src/lib/list-builder.test.ts
+++ b/web/src/lib/list-builder.test.ts
@@ -90,6 +90,24 @@ describe("match list helpers", () => {
     expect(rows[0].result.tier).toBe("likely");
   });
 
+  it("keeps schools with score bands even when admit rate is missing", () => {
+    const rows = rankMatchSchools({ act: 36 }, [
+      {
+        ...baseSchool,
+        schoolId: "missing-rate",
+        schoolName: "Missing Rate Institute",
+        acceptanceRate: null,
+        actCompositeP25: 34,
+        actCompositeP50: 35,
+        actCompositeP75: 36,
+      },
+    ]);
+
+    expect(rows.map((row) => row.schoolId)).toEqual(["missing-rate"]);
+    expect(rows[0].result.tier).toBe("unknown");
+    expect(rows[0].result.caveats).toContain("no_admit_rate");
+  });
+
   it("puts strong-fit schools before likely schools by default", () => {
     const rows = rankMatchSchools({ sat: 1350 }, [
       { ...baseSchool, schoolId: "likely", schoolName: "Likely College", acceptanceRate: 0.65 },

--- a/web/src/lib/list-builder.ts
+++ b/web/src/lib/list-builder.ts
@@ -164,7 +164,7 @@ export function testPolicySignal(
 
 export function isRankableSchool(school: MatchBuilderSchool): boolean {
   const hasTestData = school.satCompositeP50 != null || school.actCompositeP50 != null;
-  return hasTestData && school.acceptanceRate != null;
+  return hasTestData;
 }
 
 export function applyMatchFilters(

--- a/web/src/lib/positioning.ts
+++ b/web/src/lib/positioning.ts
@@ -39,6 +39,7 @@ export type Caveat =
   | "stale_cds"
   | "student_not_submitting"
   | "data_incomplete"
+  | "no_admit_rate"
   | "sub_15_admit_rate_suppression";
 
 export type PositionResult = {
@@ -181,6 +182,7 @@ export function scorePosition(
   if (!hasSatAnchors && !hasActAnchors) caveats.add("no_test_data");
   if ((school.satSubmitRate ?? 1) < LOW_SUBMIT_RATE) caveats.add("low_sat_submit_rate");
   if (!sat && !act) caveats.add("student_not_submitting");
+  if (school.acceptanceRate == null) caveats.add("no_admit_rate");
 
   const satPercentile =
     sat != null && hasSatAnchors

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -492,10 +492,27 @@ export const fetchMatchBuilderSchools = cache(
           .order("year_start", { ascending: false }),
     );
 
-    const latestBySchool = new Map<string, BrowserRow>();
+    function hasMatchTestData(row: BrowserRow): boolean {
+      return numberOrNull(row.sat_composite_p50) != null || numberOrNull(row.act_composite_p50) != null;
+    }
+
+    function hasMatchAdmitRate(row: BrowserRow): boolean {
+      return normalizeRate(row.acceptance_rate) != null;
+    }
+
+    const rowsBySchool = new Map<string, BrowserRow[]>();
     for (const row of browserRows) {
       if (!row.school_id) continue;
-      if (!latestBySchool.has(row.school_id)) latestBySchool.set(row.school_id, row);
+      const rows = rowsBySchool.get(row.school_id) ?? [];
+      rows.push(row);
+      rowsBySchool.set(row.school_id, rows);
+    }
+
+    const latestBySchool = new Map<string, BrowserRow>();
+    for (const [schoolId, rows] of rowsBySchool) {
+      const completeMatchRow = rows.find((row) => hasMatchTestData(row) && hasMatchAdmitRate(row));
+      const testOnlyRow = rows.find(hasMatchTestData);
+      latestBySchool.set(schoolId, completeMatchRow ?? testOnlyRow ?? rows[0]);
     }
 
     const schoolIds = Array.from(latestBySchool.keys());


### PR DESCRIPTION
## Summary
- Keep Match schools visible when score bands exist but CDS admit rate is missing, labeling them with a no-admit-rate caveat instead of dropping them.
- Prefer the newest complete Match row per school so fresh partial CDS rows do not hide older complete rows.
- Add 2025-26 projection fallback from C1 gender-split applied/admitted/enrolled components when total fields are missing or zero.

## Live data repair performed
- Reclassified Columbia General Studies 2024-25, 2023-24, and 2022-23 rows as `sub_institutional=general-studies`.
- Archived and extracted Columbia College + Engineering 2024-25 as the primary Columbia row.
- Reprojected 16 affected 2025-26 rows, including Yale, Stanford, Claremont McKenna, and Swarthmore.

## Verification
- `python3 -m unittest tools.browser_backend.project_browser_data_test`
- `npm run test`
- `npm run typecheck`
- `NEXT_PUBLIC_SUPABASE_URL=https://api.collegedata.fyi NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon> npm run build`
- `NEXT_PUBLIC_SUPABASE_URL=https://api.collegedata.fyi NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon> npx playwright test`
- Manual Match browser check for 4.0 unweighted / 36 ACT / Engineering: MIT, Columbia, Yale, and Stanford render; Columbia admit rate now shows 4%, Yale 5%, Stanford 4%.
