### PR TITLE
Refine match academic fit ranking

### DIFF
--- a/web/src/app/match/page.tsx
+++ b/web/src/app/match/page.tsx
@@ -7,7 +7,7 @@ export const revalidate = 3600;
 export const metadata: Metadata = {
   title: "Match List Builder",
   description:
-    "Build a college match list from Common Data Set score bands, admit rates, and archived source documents.",
+    "Build a college match list from Common Data Set score bands, academic fit, admit rates, and archived source documents.",
   alternates: { canonical: "/match" },
 };
 
@@ -24,8 +24,8 @@ export default async function MatchPage({
         <div className="meta">Match list builder</div>
         <h1 className="serif">Build a school list from source-backed admissions data.</h1>
         <p>
-          Enter one profile, filter the corpus, and export a counselor-friendly list with fit tier,
-          percentile, admit rate, CDS year, and source PDF.
+          Enter one profile, filter the corpus, and export a counselor-friendly list with academic
+          fit, admissions outlook, percentile, admit rate, CDS year, and source PDF.
         </p>
       </header>
 

--- a/web/src/app/methodology/positioning/page.tsx
+++ b/web/src/app/methodology/positioning/page.tsx
@@ -77,8 +77,8 @@ export default function PositioningMethodologyPage() {
           </FieldUse>
           <FieldUse field="C.12" title="High-school GPA">
             C.12 provides average high-school GPA and the percent submitting GPA. v1 displays
-            the school average beside your entered GPA, but GPA never contributes to a tier
-            because weighted and unweighted scales are not consistently documented.
+            the school average beside your entered GPA, but GPA never contributes to academic
+            fit because weighted and unweighted scales are not consistently documented.
           </FieldUse>
           <FieldUse field="C.1 / C.2" title="Applicant, admitted, and enrolled counts">
             C.1 and C.2 supply applicant and admit counts. The serving layer derives admit
@@ -116,9 +116,9 @@ export default function PositioningMethodologyPage() {
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
           Selective admissions also include institutional priorities that are absent from
-          CDS. When an admit rate is under 15% and a score is inside the middle 50%, the
-          card suppresses the tier label because a small numeric edge would overstate what
-          the public data can say.
+          CDS. The match list separates academic fit from admissions outlook, so a student
+          can be a strong academic fit at a school that remains a high reach because of its
+          admit rate.
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
           Current cards read 2024-25 or newer CDS rows. If a future card uses a CDS

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -1099,9 +1099,16 @@
   line-height: 1.4;
   text-transform: uppercase;
 }
+.match-school-row__fitline {
+  margin-top: 7px;
+  color: var(--forest);
+  font-size: 11px;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
 .match-school-row__metrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
   gap: 10px;
 }
 .match-school-row__metrics > div {
@@ -1119,9 +1126,10 @@
   display: block;
   margin-top: 4px;
   font-family: var(--serif);
-  font-size: 22px;
+  font-size: 18px;
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.08;
+  overflow-wrap: anywhere;
 }
 .match-school-row__actions {
   grid-column: 1 / -1;
@@ -1198,6 +1206,6 @@
     grid-template-columns: 1.2fr 1.8fr;
   }
   .match-school-row__metrics {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
   }
 }

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -15,11 +15,17 @@ import {
   type TestPolicySignal,
 } from "@/lib/list-builder";
 import { decodeProfileCode, encodeProfileCode } from "@/lib/savecode";
-import { tierLabel, type StudentProfile, type Tier } from "@/lib/positioning";
+import { academicFitLabel, type AcademicFit, type StudentProfile } from "@/lib/positioning";
 import { SchoolListItem } from "./SchoolListItem";
 
 const STORAGE_KEY = "cdfyi.matchProfile.v1";
-const TIER_SEQUENCE: Tier[] = ["strong_fit", "likely", "possible", "unlikely", "long_shot", "unknown"];
+const ACADEMIC_FIT_SEQUENCE: AcademicFit[] = [
+  "strong_academic_fit",
+  "above_range",
+  "in_range",
+  "below_range",
+  "unknown",
+];
 
 type MatchProfile = StudentProfile & {
   state?: string;
@@ -279,7 +285,7 @@ export function MatchListBuilder({
         <div className="match-results-head">
           <div>
             <div className="meta">Ranked list</div>
-            <h2 className="serif">Schools grouped by fit tier.</h2>
+            <h2 className="serif">Schools grouped by academic fit.</h2>
           </div>
           <div className="match-results-count mono">
             {hasScoreInput ? `${ranked.length} schools` : "Enter SAT or ACT"}
@@ -291,13 +297,13 @@ export function MatchListBuilder({
             <p>Add a SAT or ACT score to rank schools against published CDS score bands.</p>
           </div>
         ) : (
-          TIER_SEQUENCE.map((tier) => {
-            const rows = grouped[tier];
+          ACADEMIC_FIT_SEQUENCE.map((fit) => {
+            const rows = grouped[fit];
             if (rows.length === 0) return null;
             return (
-              <section key={tier} className="match-tier-group">
+              <section key={fit} className="match-tier-group">
                 <div className="match-tier-group__head">
-                  <h3 className="serif">{tierLabel(tier)}</h3>
+                  <h3 className="serif">{academicFitLabel(fit)}</h3>
                   <span className="mono">{rows.length}</span>
                 </div>
                 <div className="match-tier-group__rows">

--- a/web/src/components/SchoolListItem.tsx
+++ b/web/src/components/SchoolListItem.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { tierLabel, type Caveat } from "@/lib/positioning";
+import { academicFitLabel, admissionsOutlookLabel, type Caveat } from "@/lib/positioning";
 import type { RankedMatchSchool } from "@/lib/list-builder";
 
 function formatPercent(value: number | null): string {
@@ -21,7 +21,7 @@ function caveatLabel(caveat: Caveat): string {
     case "stale_cds":
       return "stale CDS";
     case "sub_15_admit_rate_suppression":
-      return "tier suppressed";
+      return "selectivity caution";
     case "no_sat_data":
       return "no SAT";
     case "no_act_data":
@@ -51,12 +51,19 @@ export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
         <div className="match-school-row__meta mono">
           {school.state ?? "state n/a"} · {school.cdsYear} CDS · admit {formatPercent(school.acceptanceRate)}
         </div>
+        <div className="match-school-row__fitline mono">
+          {academicFitLabel(school.result.academicFit)} · {admissionsOutlookLabel(school.result.admissionsOutlook)}
+        </div>
       </div>
 
       <div className="match-school-row__metrics">
         <div>
-          <span className="mono">Tier</span>
-          <strong>{tierLabel(school.result.tier)}</strong>
+          <span className="mono">Academic</span>
+          <strong>{academicFitLabel(school.result.academicFit)}</strong>
+        </div>
+        <div>
+          <span className="mono">Outlook</span>
+          <strong>{admissionsOutlookLabel(school.result.admissionsOutlook)}</strong>
         </div>
         <div>
           <span className="mono">Best pct</span>

--- a/web/src/lib/list-builder.test.ts
+++ b/web/src/lib/list-builder.test.ts
@@ -79,15 +79,43 @@ describe("match list helpers", () => {
     ).toEqual(["base"]);
   });
 
-  it("ranks schools into the same tier model as positioning", () => {
+  it("keeps very selective schools visible when the academic fit is strong", () => {
+    const rows = rankMatchSchools({ act: 36 }, [
+      {
+        ...baseSchool,
+        schoolId: "mit",
+        schoolName: "Massachusetts Institute of Technology",
+        acceptanceRate: 0.04,
+        actCompositeP25: 35,
+        actCompositeP50: 35,
+        actCompositeP75: 36,
+      },
+      {
+        ...baseSchool,
+        schoolId: "likely",
+        schoolName: "Likely College",
+        acceptanceRate: 0.65,
+        actCompositeP25: 24,
+        actCompositeP50: 27,
+        actCompositeP75: 30,
+      },
+    ]);
+
+    expect(rows.map((row) => row.schoolId)).toEqual(["mit", "likely"]);
+    expect(rows[0].result.academicFit).toBe("strong_academic_fit");
+    expect(rows[0].result.admissionsOutlook).toBe("high_reach");
+    expect(rows[0].result.tier).toBe("unknown");
+  });
+
+  it("sorts equal academic fits by selectivity by default", () => {
     const rows = rankMatchSchools({ sat: 1350 }, [
       { ...baseSchool, schoolId: "likely", schoolName: "Likely College", acceptanceRate: 0.65 },
       { ...baseSchool, schoolId: "possible", schoolName: "Possible College", acceptanceRate: 0.2 },
       { ...baseSchool, schoolId: "long", schoolName: "Long Shot College", acceptanceRate: 0.08 },
     ]);
 
-    expect(rows.map((row) => row.schoolId)).toEqual(["likely", "possible", "long"]);
-    expect(rows[0].result.tier).toBe("likely");
+    expect(rows.map((row) => row.schoolId)).toEqual(["long", "possible", "likely"]);
+    expect(rows.map((row) => row.result.academicFit)).toEqual(["in_range", "in_range", "in_range"]);
   });
 
   it("keeps schools with score bands even when admit rate is missing", () => {
@@ -105,10 +133,12 @@ describe("match list helpers", () => {
 
     expect(rows.map((row) => row.schoolId)).toEqual(["missing-rate"]);
     expect(rows[0].result.tier).toBe("unknown");
+    expect(rows[0].result.academicFit).toBe("strong_academic_fit");
+    expect(rows[0].result.admissionsOutlook).toBe("unknown");
     expect(rows[0].result.caveats).toContain("no_admit_rate");
   });
 
-  it("puts strong-fit schools before likely schools by default", () => {
+  it("puts possible-outlook schools before likely schools within the same academic fit", () => {
     const rows = rankMatchSchools({ sat: 1350 }, [
       { ...baseSchool, schoolId: "likely", schoolName: "Likely College", acceptanceRate: 0.65 },
       { ...baseSchool, schoolId: "strong", schoolName: "Strong Fit College", acceptanceRate: 0.35 },
@@ -143,9 +173,11 @@ describe("match list helpers", () => {
   it("exports counselor-friendly CSV rows", () => {
     const csv = rankedSchoolsCsv(rankMatchSchools({ sat: 1350 }, [baseSchool]));
     expect(csv.split("\n")[0]).toBe(
-      "school_name,school_url,tier,best_percentile,admit_rate,cds_year,source_pdf_url",
+      "school_name,school_url,academic_fit,admissions_outlook,tier,best_percentile,admit_rate,cds_year,source_pdf_url",
     );
     expect(csv).toContain("Base College");
+    expect(csv).toContain("in_range");
+    expect(csv).toContain("possible");
     expect(csv).toContain("strong_fit");
   });
 });

--- a/web/src/lib/list-builder.ts
+++ b/web/src/lib/list-builder.ts
@@ -1,9 +1,10 @@
 import {
   scorePosition,
+  type AcademicFit,
+  type AdmissionsOutlook,
   type PositionResult,
   type SchoolAcademicProfile,
   type StudentProfile,
-  type Tier,
 } from "./positioning";
 
 export type SchoolControl = "public" | "private_nonprofit" | "private_for_profit" | "unknown";
@@ -57,13 +58,20 @@ export const DEFAULT_MATCH_FILTERS: MatchFilters = {
   sort: "fit",
 };
 
-const TIER_ORDER: Record<Tier, number> = {
-  strong_fit: 0,
-  likely: 1,
+const ACADEMIC_FIT_ORDER: Record<AcademicFit, number> = {
+  strong_academic_fit: 0,
+  above_range: 1,
+  in_range: 2,
+  below_range: 3,
+  unknown: 4,
+};
+
+const OUTLOOK_ORDER: Record<AdmissionsOutlook, number> = {
+  high_reach: 0,
+  reach: 1,
   possible: 2,
-  unlikely: 3,
-  long_shot: 4,
-  unknown: 5,
+  likely: 3,
+  unknown: 4,
 };
 
 const REGION_BY_STATE: Record<string, Region> = {
@@ -219,8 +227,8 @@ export function rankMatchSchools(
       };
     })
     .sort((a, b) => {
-      const tierDelta = TIER_ORDER[a.result.tier] - TIER_ORDER[b.result.tier];
-      if (tierDelta !== 0) return tierDelta;
+      const fitDelta = ACADEMIC_FIT_ORDER[a.result.academicFit] - ACADEMIC_FIT_ORDER[b.result.academicFit];
+      if (fitDelta !== 0) return fitDelta;
       if (filters.sort === "admit_rate") {
         const admitDelta = (b.acceptanceRate ?? -1) - (a.acceptanceRate ?? -1);
         if (admitDelta !== 0) return admitDelta;
@@ -228,26 +236,29 @@ export function rankMatchSchools(
       if (filters.sort === "name") {
         return a.schoolName.localeCompare(b.schoolName);
       }
+      const outlookDelta = OUTLOOK_ORDER[a.result.admissionsOutlook] - OUTLOOK_ORDER[b.result.admissionsOutlook];
+      if (outlookDelta !== 0) return outlookDelta;
+      const selectivityDelta = (a.acceptanceRate ?? 1) - (b.acceptanceRate ?? 1);
+      if (selectivityDelta !== 0) return selectivityDelta;
       const scoreDelta = b.rankScore - a.rankScore;
       if (scoreDelta !== 0) return scoreDelta;
       return a.schoolName.localeCompare(b.schoolName);
     });
 }
 
-export function groupRankedSchools(rows: RankedMatchSchool[]): Record<Tier, RankedMatchSchool[]> {
+export function groupRankedSchools(rows: RankedMatchSchool[]): Record<AcademicFit, RankedMatchSchool[]> {
   return rows.reduce(
     (groups, row) => {
-      groups[row.result.tier].push(row);
+      groups[row.result.academicFit].push(row);
       return groups;
     },
     {
-      likely: [],
-      strong_fit: [],
-      possible: [],
-      unlikely: [],
-      long_shot: [],
+      strong_academic_fit: [],
+      above_range: [],
+      in_range: [],
+      below_range: [],
       unknown: [],
-    } as Record<Tier, RankedMatchSchool[]>,
+    } as Record<AcademicFit, RankedMatchSchool[]>,
   );
 }
 
@@ -262,6 +273,8 @@ export function rankedSchoolsCsv(rows: RankedMatchSchool[]): string {
   const header = [
     "school_name",
     "school_url",
+    "academic_fit",
+    "admissions_outlook",
     "tier",
     "best_percentile",
     "admit_rate",
@@ -271,6 +284,8 @@ export function rankedSchoolsCsv(rows: RankedMatchSchool[]): string {
   const body = rows.map((row) => [
     row.schoolName,
     row.schoolUrl,
+    row.result.academicFit,
+    row.result.admissionsOutlook,
     row.result.tier,
     row.bestPercentile,
     row.acceptanceRate == null ? null : Number((row.acceptanceRate * 100).toFixed(1)),

--- a/web/src/lib/positioning.test.ts
+++ b/web/src/lib/positioning.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyAcademicFit,
+  classifyAdmissionsOutlook,
   classifyTier,
   interpolatePercentile,
   scorePosition,
@@ -62,11 +64,48 @@ describe("classifyTier", () => {
   });
 });
 
+describe("academic fit and admissions outlook", () => {
+  it("separates test-band strength from admit-rate selectivity", () => {
+    const school = {
+      ...baseSchool,
+      acceptanceRate: 0.045,
+      actCompositeP25: 34,
+      actCompositeP50: 35,
+      actCompositeP75: 35,
+    };
+
+    expect(classifyAcademicFit(null, 36, school)).toBe("strong_academic_fit");
+    expect(classifyAdmissionsOutlook(school.acceptanceRate)).toBe("high_reach");
+
+    const result = scorePosition({ act: 36 }, school);
+    expect(result.academicFit).toBe("strong_academic_fit");
+    expect(result.admissionsOutlook).toBe("high_reach");
+    expect(result.tier).toBe("long_shot");
+  });
+
+  it("flags scores two ACT points above the 75th percentile as above range", () => {
+    expect(classifyAcademicFit(null, 34, baseSchool)).toBe("above_range");
+  });
+
+  it("keeps academic fit even when admit rate is missing", () => {
+    const result = scorePosition(
+      { act: 32 },
+      { ...baseSchool, acceptanceRate: null },
+    );
+
+    expect(result.academicFit).toBe("strong_academic_fit");
+    expect(result.admissionsOutlook).toBe("unknown");
+    expect(result.caveats).toContain("no_admit_rate");
+  });
+});
+
 describe("scorePosition", () => {
   it("scores SAT and emits a positional sentence", () => {
     const result = scorePosition({ sat: 1350, gpa: 3.7 }, baseSchool);
     expect(result.satPercentile).toBe(63);
     expect(result.tier).toBe("strong_fit");
+    expect(result.academicFit).toBe("in_range");
+    expect(result.admissionsOutlook).toBe("possible");
     expect(result.positionalSentence).toContain("within the middle 50%");
     expect(result.positionalSentence).toContain("admits 30%");
   });

--- a/web/src/lib/positioning.ts
+++ b/web/src/lib/positioning.ts
@@ -31,6 +31,20 @@ export type Tier =
   | "long_shot"
   | "unknown";
 
+export type AcademicFit =
+  | "strong_academic_fit"
+  | "above_range"
+  | "in_range"
+  | "below_range"
+  | "unknown";
+
+export type AdmissionsOutlook =
+  | "likely"
+  | "possible"
+  | "reach"
+  | "high_reach"
+  | "unknown";
+
 export type Caveat =
   | "no_sat_data"
   | "no_act_data"
@@ -46,6 +60,8 @@ export type PositionResult = {
   satPercentile: number | null;
   actPercentile: number | null;
   tier: Tier;
+  academicFit: AcademicFit;
+  admissionsOutlook: AdmissionsOutlook;
   caveats: Caveat[];
   cdsYear: string;
   positionalSentence: string;
@@ -144,11 +160,89 @@ export function tierLabel(tier: Tier): string {
   }
 }
 
+export function academicFitLabel(fit: AcademicFit): string {
+  switch (fit) {
+    case "strong_academic_fit":
+      return "Strong academic fit";
+    case "above_range":
+      return "Above typical range";
+    case "in_range":
+      return "In range";
+    case "below_range":
+      return "Below range";
+    case "unknown":
+      return "Unknown";
+  }
+}
+
+export function admissionsOutlookLabel(outlook: AdmissionsOutlook): string {
+  switch (outlook) {
+    case "likely":
+      return "Likely";
+    case "possible":
+      return "Possible";
+    case "reach":
+      return "Reach";
+    case "high_reach":
+      return "High reach";
+    case "unknown":
+      return "Unknown";
+  }
+}
+
 export function percentileBand(percentile: number | null): string {
   if (percentile == null) return "not computable";
   if (percentile < 25) return "below the 25th percentile";
   if (percentile <= 75) return "within the middle 50%";
   return "above the 75th percentile";
+}
+
+function classifyAcademicFitForScore(
+  score: number | null,
+  p25: number | null,
+  p75: number | null,
+  aboveDelta: number,
+): AcademicFit | null {
+  if (score == null || !isFiniteNumber(p25) || !isFiniteNumber(p75) || p25 >= p75) {
+    return null;
+  }
+  if (score >= p75 + aboveDelta) return "above_range";
+  if (score >= p75) return "strong_academic_fit";
+  if (score >= p25) return "in_range";
+  return "below_range";
+}
+
+export function classifyAcademicFit(
+  sat: number | null,
+  act: number | null,
+  school: SchoolAcademicProfile,
+): AcademicFit {
+  const order: Record<AcademicFit, number> = {
+    strong_academic_fit: 0,
+    above_range: 1,
+    in_range: 2,
+    below_range: 3,
+    unknown: 4,
+  };
+  const fits = [
+    hasMonotonicAnchors(school.satCompositeP25, school.satCompositeP50, school.satCompositeP75)
+      ? classifyAcademicFitForScore(sat, school.satCompositeP25, school.satCompositeP75, 100)
+      : null,
+    hasMonotonicAnchors(school.actCompositeP25, school.actCompositeP50, school.actCompositeP75)
+      ? classifyAcademicFitForScore(act, school.actCompositeP25, school.actCompositeP75, 2)
+      : null,
+  ].filter((fit): fit is AcademicFit => fit != null);
+
+  if (fits.length === 0) return "unknown";
+  return fits.sort((a, b) => order[a] - order[b])[0];
+}
+
+export function classifyAdmissionsOutlook(acceptanceRate: number | null): AdmissionsOutlook {
+  if (acceptanceRate == null) return "unknown";
+  if (acceptanceRate < 0.1) return "high_reach";
+  if (acceptanceRate < 0.25) return "reach";
+  if (acceptanceRate < 0.5) return "possible";
+  return "likely";
 }
 
 export function scorePosition(
@@ -207,6 +301,8 @@ export function scorePosition(
         )
       : null;
 
+  const academicFit = classifyAcademicFit(sat, act, school);
+  const admissionsOutlook = classifyAdmissionsOutlook(school.acceptanceRate);
   let tier = classifyTier(satPercentile, actPercentile, school.acceptanceRate);
   const bestPct = Math.max(satPercentile ?? -1, actPercentile ?? -1);
   if (
@@ -245,6 +341,8 @@ export function scorePosition(
     satPercentile,
     actPercentile,
     tier,
+    academicFit,
+    admissionsOutlook,
     caveats: Array.from(caveats),
     cdsYear: school.cdsYear,
     positionalSentence,


### PR DESCRIPTION
## Summary
- Split Match positioning into academic fit and admissions outlook labels
- Group/sort the Match list by academic fit first so top-score profiles surface selective schools as strong academic fits
- Update row UI, CSV export, methodology copy, and tests for the new model

## Tests
- PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0bqmGnU:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web test
- PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0bqmGnU:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web run typecheck

## Notes
- Local `npm --prefix web run build` compiled and typechecked, then failed during page-data collection because this workspace has no `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` env configured.