### PR TITLE
Deduplicate Match alias schools

### DIFF
--- a/web/src/lib/list-builder.test.ts
+++ b/web/src/lib/list-builder.test.ts
@@ -18,6 +18,7 @@ const baseSchool: MatchBuilderSchool = {
   cdsYear: "2025-26",
   yearStart: 2025,
   archiveUrl: "https://example.com/base.pdf",
+  ipedsId: "100001",
   acceptanceRate: 0.4,
   satSubmitRate: 0.6,
   actSubmitRate: 0.4,
@@ -77,6 +78,54 @@ describe("match list helpers", () => {
         sort: "fit",
       }).map((school) => school.schoolId),
     ).toEqual(["base"]);
+  });
+
+  it("dedupes stale alias rows when the match profile is identical", () => {
+    const rows = rankMatchSchools({ act: 33 }, [
+      {
+        ...baseSchool,
+        documentId: "alias-doc",
+        schoolId: "georgia-institute-of-technology-main-campus",
+        schoolName: "Georgia Institute of Technology",
+        schoolUrl: "/schools/georgia-institute-of-technology-main-campus",
+        ipedsId: null,
+        acceptanceRate: 0.133386,
+        satCompositeP25: 1370,
+        satCompositeP50: 1460,
+        satCompositeP75: 1530,
+        actCompositeP25: 31,
+        actCompositeP50: 33,
+        actCompositeP75: 35,
+      },
+      {
+        ...baseSchool,
+        documentId: "canonical-doc",
+        schoolId: "georgia-tech",
+        schoolName: "Georgia Institute of Technology",
+        schoolUrl: "/schools/georgia-tech",
+        ipedsId: "139755",
+        acceptanceRate: 0.133386,
+        satCompositeP25: 1370,
+        satCompositeP50: 1460,
+        satCompositeP75: 1530,
+        actCompositeP25: 31,
+        actCompositeP50: 33,
+        actCompositeP75: 35,
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].schoolId).toBe("georgia-tech");
+    expect(rows[0].documentId).toBe("canonical-doc");
+  });
+
+  it("keeps same-name schools separate when their IPEDS IDs differ", () => {
+    const rows = rankMatchSchools({ sat: 1350 }, [
+      { ...baseSchool, schoolId: "same-name-a", schoolName: "Example College", ipedsId: "100001" },
+      { ...baseSchool, schoolId: "same-name-b", schoolName: "Example College", ipedsId: "200002" },
+    ]);
+
+    expect(rows.map((row) => row.schoolId).sort()).toEqual(["same-name-a", "same-name-b"]);
   });
 
   it("keeps very selective schools visible when the academic fit is strong", () => {

--- a/web/src/lib/list-builder.ts
+++ b/web/src/lib/list-builder.ts
@@ -24,6 +24,7 @@ export type MatchBuilderSchool = SchoolAcademicProfile & {
   archiveUrl: string | null;
   yearStart: number | null;
   schoolUrl: string;
+  ipedsId: string | null;
   state: string | null;
   control: SchoolControl;
   region: Region;
@@ -175,6 +176,64 @@ export function isRankableSchool(school: MatchBuilderSchool): boolean {
   return hasTestData;
 }
 
+function normalizedSchoolName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function nearlyEqual(a: number | null, b: number | null): boolean {
+  if (a == null || b == null) return a == null && b == null;
+  return Math.abs(a - b) < 0.000001;
+}
+
+function sameMatchProfile(a: MatchBuilderSchool, b: MatchBuilderSchool): boolean {
+  return (
+    nearlyEqual(a.acceptanceRate, b.acceptanceRate) &&
+    nearlyEqual(a.satCompositeP25, b.satCompositeP25) &&
+    nearlyEqual(a.satCompositeP50, b.satCompositeP50) &&
+    nearlyEqual(a.satCompositeP75, b.satCompositeP75) &&
+    nearlyEqual(a.actCompositeP25, b.actCompositeP25) &&
+    nearlyEqual(a.actCompositeP50, b.actCompositeP50) &&
+    nearlyEqual(a.actCompositeP75, b.actCompositeP75)
+  );
+}
+
+function shouldCollapseAliasDuplicate(a: MatchBuilderSchool, b: MatchBuilderSchool): boolean {
+  if (normalizedSchoolName(a.schoolName) !== normalizedSchoolName(b.schoolName)) return false;
+  if (!sameMatchProfile(a, b)) return false;
+  if (a.ipedsId != null && b.ipedsId != null && a.ipedsId !== b.ipedsId) return false;
+  return true;
+}
+
+function preferMatchDuplicate(a: MatchBuilderSchool, b: MatchBuilderSchool): MatchBuilderSchool {
+  if (a.ipedsId != null && b.ipedsId == null) return a;
+  if (b.ipedsId != null && a.ipedsId == null) return b;
+  const yearDelta = (b.yearStart ?? -1) - (a.yearStart ?? -1);
+  if (yearDelta > 0) return b;
+  if (yearDelta < 0) return a;
+  return a.schoolId.localeCompare(b.schoolId) <= 0 ? a : b;
+}
+
+export function dedupeMatchSchools(schools: MatchBuilderSchool[]): MatchBuilderSchool[] {
+  const groups = new Map<string, MatchBuilderSchool[]>();
+  for (const school of schools) {
+    const key = normalizedSchoolName(school.schoolName);
+    const siblings = groups.get(key) ?? [];
+    const duplicateIndex = siblings.findIndex((sibling) => shouldCollapseAliasDuplicate(sibling, school));
+    if (duplicateIndex === -1) {
+      siblings.push(school);
+    } else {
+      siblings[duplicateIndex] = preferMatchDuplicate(siblings[duplicateIndex], school);
+    }
+    groups.set(key, siblings);
+  }
+  return Array.from(groups.values()).flat();
+}
+
 export function applyMatchFilters(
   schools: MatchBuilderSchool[],
   filters: MatchFilters,
@@ -209,7 +268,7 @@ export function rankMatchSchools(
   schools: MatchBuilderSchool[],
   filters: MatchFilters = DEFAULT_MATCH_FILTERS,
 ): RankedMatchSchool[] {
-  return applyMatchFilters(schools, filters)
+  return dedupeMatchSchools(applyMatchFilters(schools, filters))
     .map((school) => {
       const result = scorePosition(profile, school);
       const bestPercentile = Math.max(result.satPercentile ?? -1, result.actPercentile ?? -1);

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -597,6 +597,7 @@ export const fetchMatchBuilderSchools = cache(
           schoolId,
           schoolName: String(row.school_name ?? schoolId),
           schoolUrl: `/schools/${schoolId}`,
+          ipedsId: row.ipeds_id ?? null,
           cdsYear: String(row.canonical_year),
           yearStart: numberOrNull(row.year_start),
           archiveUrl: row.archive_url ?? null,


### PR DESCRIPTION
## Summary
- Adds a Match-layer dedupe pass for stale alias rows with the same displayed school name and identical admissions/test profile
- Prefers the row with IPEDS/Scorecard enrichment, which keeps canonical schools like `georgia-tech`, `uva`, and `uw`
- Adds regression coverage that collapses a Georgia Tech alias while keeping same-name schools with different IPEDS IDs separate

## Investigation
Prod currently has three duplicate-name Match groups after selecting latest/rankable rows:
- Georgia Institute of Technology: `georgia-institute-of-technology-main-campus` and `georgia-tech`
- University of Virginia: `university-of-virginia-main-campus` and `uva`
- University of Washington: `university-of-washington-seattle-campus` and `uw`

The root cause is stale alias `cds_documents`/`school_browser_rows` rows from Scorecard-style slugs. The institution crosswalk already marks the short schools.yaml slugs as primary, but the prior launch cleanup skipped conflicting documents when the canonical school already had the same source/year. This PR fixes the Match symptom defensively; a broader data cleanup can migrate or retire the duplicate alias documents/projections.

## Tests
- `PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0bqmGnU:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web test`
- `PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0bqmGnU:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web run typecheck`
- `git diff --check`

## Notes
- Local `next build` compiled and typechecked with public Supabase env, then failed while prerendering `/api` because live Supabase fetches returned `TypeError: fetch failed`. CI should provide the authoritative Next build gate.