### PR TITLE
Add Match fit section navigation

### DIFF
--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -1054,8 +1054,85 @@
   color: var(--ink-2);
   line-height: 1.5;
 }
+.match-fit-summary {
+  position: sticky;
+  top: 10px;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+  padding: 10px 0;
+  background: linear-gradient(180deg, var(--paper) 82%, rgba(241, 236, 225, 0));
+}
+.match-fit-summary__item {
+  --match-fit-accent: var(--forest);
+  --match-fit-bg: rgba(63, 91, 58, 0.12);
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  min-height: 58px;
+  align-content: center;
+  border-top: 3px solid var(--match-fit-accent);
+  background: var(--match-fit-bg);
+  color: var(--ink);
+  padding: 9px 10px;
+  text-decoration: none !important;
+}
+.match-fit-summary__item:hover {
+  color: var(--ink);
+  background: rgba(250, 246, 236, 0.92);
+  outline: 1px solid var(--match-fit-accent);
+  outline-offset: -1px;
+}
+.match-fit-summary__item--empty {
+  opacity: 0.45;
+}
+.match-fit-summary__item--empty:hover {
+  background: var(--match-fit-bg);
+  outline: 0;
+}
+.match-fit-summary__count {
+  color: var(--match-fit-accent);
+  font-size: 18px;
+  line-height: 1;
+  letter-spacing: 0;
+}
+.match-fit-summary__item span:last-child {
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 12px;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
 .match-tier-group {
+  --match-fit-accent: var(--forest);
+  --match-fit-bg: rgba(63, 91, 58, 0.08);
   margin-top: 24px;
+  padding: 14px 16px 4px;
+  border-left: 4px solid var(--match-fit-accent);
+  background: linear-gradient(90deg, var(--match-fit-bg), rgba(250, 246, 236, 0) 76%);
+  scroll-margin-top: 96px;
+}
+.match-fit-summary__item--above_range,
+.match-tier-group--above_range {
+  --match-fit-accent: var(--ochre);
+  --match-fit-bg: rgba(138, 106, 43, 0.12);
+}
+.match-fit-summary__item--in_range,
+.match-tier-group--in_range {
+  --match-fit-accent: #586a58;
+  --match-fit-bg: rgba(88, 106, 88, 0.12);
+}
+.match-fit-summary__item--below_range,
+.match-tier-group--below_range {
+  --match-fit-accent: var(--brick);
+  --match-fit-bg: rgba(140, 42, 31, 0.1);
+}
+.match-fit-summary__item--unknown,
+.match-tier-group--unknown {
+  --match-fit-accent: var(--ink-3);
+  --match-fit-bg: rgba(28, 30, 27, 0.07);
 }
 .match-tier-group__head {
   display: flex;
@@ -1163,6 +1240,9 @@
     grid-template-columns: 1fr;
     gap: 12px;
   }
+  .match-fit-summary {
+    top: 0;
+  }
 }
 @media (max-width: 640px) {
   .match-form,
@@ -1174,6 +1254,17 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 8px;
+  }
+  .match-fit-summary {
+    position: static;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .match-fit-summary__item {
+    min-height: 50px;
+  }
+  .match-tier-group {
+    padding-left: 12px;
+    padding-right: 10px;
   }
   .match-actions .cd-btn {
     flex: 1 1 100%;

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -27,6 +27,10 @@ const ACADEMIC_FIT_SEQUENCE: AcademicFit[] = [
   "unknown",
 ];
 
+function fitSectionId(fit: AcademicFit): string {
+  return `match-fit-${fit.replace(/_/g, "-")}`;
+}
+
 type MatchProfile = StudentProfile & {
   state?: string;
   intendedMajor?: string;
@@ -98,6 +102,15 @@ export function MatchListBuilder({
     [filters, hasScoreInput, profile, schools],
   );
   const grouped = useMemo(() => groupRankedSchools(ranked), [ranked]);
+  const fitSummaries = useMemo(
+    () =>
+      ACADEMIC_FIT_SEQUENCE.map((fit) => ({
+        fit,
+        count: grouped[fit].length,
+        id: fitSectionId(fit),
+      })),
+    [grouped],
+  );
   const shareCode = profile ? encodeProfileCode(profile) : null;
   const shareHref =
     typeof window === "undefined" || !shareCode
@@ -297,23 +310,50 @@ export function MatchListBuilder({
             <p>Add a SAT or ACT score to rank schools against published CDS score bands.</p>
           </div>
         ) : (
-          ACADEMIC_FIT_SEQUENCE.map((fit) => {
-            const rows = grouped[fit];
-            if (rows.length === 0) return null;
-            return (
-              <section key={fit} className="match-tier-group">
-                <div className="match-tier-group__head">
-                  <h3 className="serif">{academicFitLabel(fit)}</h3>
-                  <span className="mono">{rows.length}</span>
-                </div>
-                <div className="match-tier-group__rows">
-                  {rows.map((school) => (
-                    <SchoolListItem key={school.documentId} school={school} />
-                  ))}
-                </div>
-              </section>
-            );
-          })
+          <>
+            <nav className="match-fit-summary" aria-label="Academic fit sections">
+              {fitSummaries.map(({ fit, count, id }) => {
+                const className = `match-fit-summary__item match-fit-summary__item--${fit}`;
+                const contents = (
+                  <>
+                    <span className="match-fit-summary__count mono">{count}</span>
+                    <span>{academicFitLabel(fit)}</span>
+                  </>
+                );
+                return count > 0 ? (
+                  <a key={fit} href={`#${id}`} className={className}>
+                    {contents}
+                  </a>
+                ) : (
+                  <span key={fit} className={`${className} match-fit-summary__item--empty`}>
+                    {contents}
+                  </span>
+                );
+              })}
+            </nav>
+
+            {ACADEMIC_FIT_SEQUENCE.map((fit) => {
+              const rows = grouped[fit];
+              if (rows.length === 0) return null;
+              return (
+                <section
+                  key={fit}
+                  id={fitSectionId(fit)}
+                  className={`match-tier-group match-tier-group--${fit}`}
+                >
+                  <div className="match-tier-group__head">
+                    <h3 className="serif">{academicFitLabel(fit)}</h3>
+                    <span className="mono">{rows.length}</span>
+                  </div>
+                  <div className="match-tier-group__rows">
+                    {rows.map((school) => (
+                      <SchoolListItem key={school.documentId} school={school} />
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </>
         )}
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Adds a sticky academic-fit summary bar above Match results with live counts for each fit bucket
- Links non-empty summary items to their corresponding long-list section anchors
- Adds restrained section tinting and left color rails so long Match lists are easier to scan
- Keeps mobile layout compact with a two-column summary grid and static positioning

## Tests
- PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0Z3Q4LY:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web test
- PATH=/opt/homebrew/bin:/Users/santhonys/.codex/tmp/arg0/codex-arg0Z3Q4LY:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/santhonys/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/santhonys/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk/bin:/Users/santhonys/.local/bin:/Users/santhonys/.cargo/bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin:/Users/santhonys/Programming/flutter/bin:/Users/santhonys/Library/Application Support/com.conductor.app/./bin npm --prefix web run typecheck
- git diff --check

## Notes
- Local dev server reached /match, but server-side Supabase fetch failed with TypeError: fetch failed before the form rendered. CI/Vercel preview should be the browser-rendered gate.