### PR TITLE
Fix C9 percentile score extraction

### DIFF
--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -11,6 +11,14 @@ on:
         description: "Optional school_id filter."
         required: false
         default: ""
+      document_ids:
+        description: "Optional comma-separated cds_documents.id filter."
+        required: false
+        default: ""
+      requeue_document_ids:
+        description: "Optional comma-separated cds_documents.id values to mark extraction_pending before draining."
+        required: false
+        default: ""
       include_failed:
         description: "Retry failed rows as well as pending rows."
         type: boolean
@@ -49,6 +57,8 @@ jobs:
     env:
       INPUT_LIMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.limit || '25' }}
       INPUT_SCHOOL: ${{ github.event_name == 'workflow_dispatch' && inputs.school || '' }}
+      INPUT_DOCUMENT_IDS: ${{ github.event_name == 'workflow_dispatch' && inputs.document_ids || '' }}
+      INPUT_REQUEUE_DOCUMENT_IDS: ${{ github.event_name == 'workflow_dispatch' && inputs.requeue_document_ids || '' }}
       INPUT_INCLUDE_FAILED: ${{ github.event_name == 'workflow_dispatch' && inputs.include_failed || false }}
       INPUT_SEED_PROJECTION_METADATA: ${{ github.event_name != 'workflow_dispatch' || inputs.seed_projection_metadata }}
       INPUT_LOW_FIELD_THRESHOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.low_field_threshold || '25' }}
@@ -101,6 +111,32 @@ jobs:
           } > .env.ops
           chmod 600 .env.ops
 
+          if [[ -n "${INPUT_REQUEUE_DOCUMENT_IDS}" ]]; then
+            python - <<'PY'
+import os
+from supabase import create_client
+
+url = os.environ["SUPABASE_URL"]
+key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+document_ids = [
+    value.strip()
+    for value in os.environ["INPUT_REQUEUE_DOCUMENT_IDS"].split(",")
+    if value.strip()
+]
+client = create_client(url, key)
+changed = 0
+for document_id in document_ids:
+    result = (
+        client.table("cds_documents")
+        .update({"extraction_status": "extraction_pending"})
+        .eq("id", document_id)
+        .execute()
+    )
+    changed += len(result.data or [])
+print(f"Requeued {changed} document(s).")
+PY
+          fi
+
           args=(
             --env .env.ops
             --limit "${INPUT_LIMIT}"
@@ -115,6 +151,9 @@ jobs:
           fi
           if [[ -n "${INPUT_SCHOOL}" ]]; then
             args+=(--school "${INPUT_SCHOOL}")
+          fi
+          if [[ -n "${INPUT_DOCUMENT_IDS}" ]]; then
+            args+=(--document-ids "${INPUT_DOCUMENT_IDS}")
           fi
           if [[ -n "${INPUT_MIN_YEAR_START}" ]]; then
             args+=(--min-year-start "${INPUT_MIN_YEAR_START}")

--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -112,29 +112,29 @@ jobs:
           chmod 600 .env.ops
 
           if [[ -n "${INPUT_REQUEUE_DOCUMENT_IDS}" ]]; then
-            python - <<'PY'
-import os
-from supabase import create_client
+          python - <<'PY'
+          import os
+          from supabase import create_client
 
-url = os.environ["SUPABASE_URL"]
-key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
-document_ids = [
-    value.strip()
-    for value in os.environ["INPUT_REQUEUE_DOCUMENT_IDS"].split(",")
-    if value.strip()
-]
-client = create_client(url, key)
-changed = 0
-for document_id in document_ids:
-    result = (
-        client.table("cds_documents")
-        .update({"extraction_status": "extraction_pending"})
-        .eq("id", document_id)
-        .execute()
-    )
-    changed += len(result.data or [])
-print(f"Requeued {changed} document(s).")
-PY
+          url = os.environ["SUPABASE_URL"]
+          key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+          document_ids = [
+              value.strip()
+              for value in os.environ["INPUT_REQUEUE_DOCUMENT_IDS"].split(",")
+              if value.strip()
+          ]
+          client = create_client(url, key)
+          changed = 0
+          for document_id in document_ids:
+              result = (
+                  client.table("cds_documents")
+                  .update({"extraction_status": "extraction_pending"})
+                  .eq("id", document_id)
+                  .execute()
+              )
+              changed += len(result.data or [])
+          print(f"Requeued {changed} document(s).")
+          PY
           fi
 
           args=(

--- a/tools/extraction_worker/README.md
+++ b/tools/extraction_worker/README.md
@@ -49,6 +49,9 @@ python worker.py --skip-projection-refresh --limit 10
 # Scoped operator re-drain: only 2024+ Tier 4/Tier 5 PDFs
 python worker.py --source-format pdf_flat,pdf_scanned --min-year-start 2024
 
+# Targeted operator re-drain after requeueing specific document IDs
+python worker.py --document-ids <uuid>,<uuid> --limit 2
+
 # Fresh-year drain: process the newest archived CDS rows before old backlog
 python worker.py --min-year-start 2025 --include-failed --limit 25
 

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -98,6 +98,84 @@ Submitting ACT Scores
         self.assertNotIn("C.958", values)
         self.assertEqual(values["C.959"]["value"], "100.00")
 
+    def test_c9_percentile_table_uses_header_order(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+| Assessment    | 25th Percentile | 75th Percentile | 50th Percentile | Average (Mean) |
+|---------------|-----------------|-----------------|-----------------|----------------|
+| SAT Composite | 1310            | 1490            | 1410            | 1388           |
+| ACT Composite | 28              | 33              | 32              | 31             |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.905"]["value"], "1310")
+        self.assertEqual(values["C.906"]["value"], "1410")
+        self.assertEqual(values["C.907"]["value"], "1490")
+        self.assertEqual(values["C.914"]["value"], "28")
+        self.assertEqual(values["C.915"]["value"], "32")
+        self.assertEqual(values["C.916"]["value"], "33")
+
+    def test_c9_percentile_schema_fixed_lines_skip_totals(self):
+        markdown = """
+## C9 First-time, first-year students submitted test scores
+
+C905 SAT Composite: 25th Percentile 1410
+C906 SAT Composite: 50th Percentile 1450
+C907 SAT Composite: 75th Percentile 1490
+C914 ACT Composite: 25th Percentile 32
+C915 ACT Composite: 50th Percentile 33
+C916 ACT Composite: 75th Percentile 34
+C917 ACT Math: 25th Percentile 100.00
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.905"]["value"], "1410")
+        self.assertEqual(values["C.906"]["value"], "1450")
+        self.assertEqual(values["C.907"]["value"], "1490")
+        self.assertEqual(values["C.914"]["value"], "32")
+        self.assertEqual(values["C.915"]["value"], "33")
+        self.assertEqual(values["C.916"]["value"], "34")
+        self.assertNotIn("C.917", values)
+
+    def test_c9_percentile_layout_rows_without_codes(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+Assessment 25th Percentile 50th Percentile 75th Percentile
+SAT Composite (400 - 1600) 1370 1440 1500
+ACT Composite (0 - 36) 31 32 34
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.905"]["value"], "1370")
+        self.assertEqual(values["C.906"]["value"], "1440")
+        self.assertEqual(values["C.907"]["value"], "1500")
+        self.assertEqual(values["C.914"]["value"], "31")
+        self.assertEqual(values["C.915"]["value"], "32")
+        self.assertEqual(values["C.916"]["value"], "34")
+
+    def test_c9_percentile_layout_rows_use_single_line_header_order(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+Assessment 25th Percentile 75th Percentile 50th Percentile Average (Mean)
+SAT Composite 1310 1490 1410 1388
+ACT Composite 28 33 32 31
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.905"]["value"], "1310")
+        self.assertEqual(values["C.906"]["value"], "1410")
+        self.assertEqual(values["C.907"]["value"], "1490")
+        self.assertEqual(values["C.914"]["value"], "28")
+        self.assertEqual(values["C.915"]["value"], "32")
+        self.assertEqual(values["C.916"]["value"], "33")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -141,7 +141,11 @@ def _parse_markdown_tables(markdown: str) -> list[dict]:
             nominal_header_cells = [
                 c.strip() for c in table_lines[0].split("|")[1:-1]
             ]
-            header_looks_like_data = any(
+            has_percentile_headers = any(
+                re.search(r"\b(?:25|50|75)(?:th)?\s+percentile\b", c, re.IGNORECASE)
+                for c in nominal_header_cells[1:]
+            )
+            header_looks_like_data = not has_percentile_headers and any(
                 re.search(r"\d", c) for c in nominal_header_cells[1:]
             )
             if header_looks_like_data:
@@ -224,6 +228,58 @@ def _extract_number(value_str: str) -> str | None:
         return s
     except ValueError:
         return None
+
+
+def _c9_percentile_header_roles(headers_norm: list[str]) -> dict[int, str]:
+    roles: dict[int, str] = {}
+    for value_idx, header in enumerate(headers_norm[1:]):
+        if "mean" in header or "average" in header:
+            continue
+        if re.search(r"\b25(?:th)?\b", header):
+            roles[value_idx] = "p25"
+        elif re.search(r"\b50(?:th)?\b", header):
+            roles[value_idx] = "p50"
+        elif re.search(r"\b75(?:th)?\b", header):
+            roles[value_idx] = "p75"
+    return roles
+
+
+def _c9_percentile_qn(
+    label_norm: str,
+    col_idx: int,
+    headers_norm: list[str],
+) -> str | None:
+    roles_by_col = _c9_percentile_header_roles(headers_norm)
+    if roles_by_col:
+        role = roles_by_col.get(col_idx)
+        if not role:
+            return None
+    else:
+        fallback_roles = ("p25", "p50", "p75")
+        if col_idx >= len(fallback_roles):
+            return None
+        role = fallback_roles[col_idx]
+
+    for row_label, qns in _PERCENTILE_QNS.items():
+        if _normalize_label(row_label) in label_norm:
+            return qns[role]
+    return None
+
+
+def _is_plausible_c9_percentile_value(qnum: str, value: str) -> bool:
+    try:
+        num = float(value)
+    except ValueError:
+        return False
+
+    field_num = int(qnum.split(".")[1])
+    if 905 <= field_num <= 907:
+        return 400 <= num <= 1600
+    if 908 <= field_num <= 913:
+        return 200 <= num <= 800
+    if 914 <= field_num <= 922:
+        return 0 <= num <= 36
+    return True
 
 
 # Mapping from schema question text fragments to question numbers.
@@ -321,29 +377,17 @@ _SCHEMA_FIXED_C1_FIELD_MAP_QNS = {
     f"C.{n:03d}" for n in range(101, 119)
 }
 
-# Percentile table: matched by assessment name + column position.
-_PERCENTILE_MAP: list[tuple[str, int, str]] = [
-    # (row_label_substring, value_column_index, question_number)
-    # Column order in C9 percentile table: 25th, 50th, 75th
-    ("sat composite", 0, "C.905"),       # 25th
-    ("sat composite", 1, "C.906"),       # 50th
-    ("sat composite", 2, "C.907"),       # 75th
-    ("sat evidence-based reading", 0, "C.908"),
-    ("sat evidence-based reading", 1, "C.909"),
-    ("sat evidence-based reading", 2, "C.910"),
-    ("sat math", 0, "C.911"),
-    ("sat math", 1, "C.912"),
-    ("sat math", 2, "C.913"),
-    ("act composite", 0, "C.914"),
-    ("act composite", 1, "C.915"),
-    ("act composite", 2, "C.916"),
-    ("act math", 0, "C.917"),
-    ("act math", 1, "C.918"),
-    ("act math", 2, "C.919"),
-    ("act english", 0, "C.920"),
-    ("act english", 1, "C.921"),
-    ("act english", 2, "C.922"),
-]
+# C9 percentile tables normally use 25th/50th/75th columns, but some schools
+# publish 25th/75th/50th/mean. Keep row matching by assessment label while
+# mapping columns by header role whenever Docling preserves the headers.
+_PERCENTILE_QNS: dict[str, dict[str, str]] = {
+    "sat composite": {"p25": "C.905", "p50": "C.906", "p75": "C.907"},
+    "sat evidence-based reading": {"p25": "C.908", "p50": "C.909", "p75": "C.910"},
+    "sat math": {"p25": "C.911", "p50": "C.912", "p75": "C.913"},
+    "act composite": {"p25": "C.914", "p50": "C.915", "p75": "C.916"},
+    "act math": {"p25": "C.917", "p50": "C.918", "p75": "C.919"},
+    "act english": {"p25": "C.920", "p50": "C.921", "p75": "C.922"},
+}
 
 
 # Inline-regex patterns for fields that aren't in table rows. Each entry is
@@ -2797,6 +2841,110 @@ def resolve_c9_submission_rates(
     return out
 
 
+# --- Resolver: C9 percentile anchors from layout text ---
+
+_C9_PERCENTILE_CODE_QNS = {
+    str(n): f"C.{n:03d}" for n in range(905, 923)
+}
+
+
+def _c9_section_text(markdown: str) -> str:
+    start_match = re.search(
+        r"(?:^|\n)\s*(?:#{1,4}\s*)?C9\b|Percent and number of .*SAT/ACT.*test scores",
+        markdown,
+        re.IGNORECASE,
+    )
+    if not start_match:
+        return markdown
+    section = markdown[start_match.start():]
+    end_match = re.search(r"(?:^|\n)\s*(?:#{1,4}\s*)?C10\b", section, re.IGNORECASE)
+    if end_match:
+        section = section[:end_match.start()]
+    return section
+
+
+def _c9_percentile_roles_from_context(context: str) -> list[str]:
+    def line_roles(line: str) -> list[str]:
+        roles: list[str] = []
+        for match in re.finditer(
+            r"\b(25(?:th)?|50(?:th)?|75(?:th)?)\s+percentile\b|\b(?:average|mean)\b",
+            line,
+            re.IGNORECASE,
+        ):
+            token = match.group(1)
+            if token:
+                if token.startswith("25"):
+                    roles.append("p25")
+                elif token.startswith("50"):
+                    roles.append("p50")
+                else:
+                    roles.append("p75")
+            else:
+                roles.append("mean")
+        return roles
+
+    for line in reversed(context.splitlines()[-8:]):
+        roles = line_roles(line)
+        if {"p25", "p50", "p75"}.issubset(set(roles)):
+            return roles
+    return ["p25", "p50", "p75"]
+
+
+def resolve_c9_percentile_anchors(
+    tables: list[dict], markdown: str, schema: SchemaIndex
+) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    section = _c9_section_text(markdown)
+
+    # Schema-fixed exports sometimes preserve the C905/C914 codes as text
+    # even when markdown table reconstruction is noisy. Use the final number
+    # on the line and reject impossible score values such as 100.00 totals.
+    for line in section.splitlines():
+        code_match = re.search(r"\bC\.?\s*(90[5-9]|91[0-9]|92[0-2])\b", line, re.IGNORECASE)
+        if not code_match:
+            continue
+        qn = _C9_PERCENTILE_CODE_QNS[code_match.group(1)]
+        tail = line[code_match.end():]
+        numbers = re.findall(r"\b\d+(?:\.\d+)?\b", tail.replace(",", ""))
+        if not numbers:
+            continue
+        value = numbers[-1]
+        if _is_plausible_c9_percentile_value(qn, value):
+            out.setdefault(qn, {"value": value, "source": "tier4_cleaner"})
+
+    # Layout text can contain clean rows without C-codes, for example:
+    #   ACT Composite (0 - 36) 31 32 34
+    # Infer column roles from the closest preceding percentile header.
+    section_no_ranges = re.sub(r"\(\s*\d+\s*[-–—]\s*\d+\s*\)", " ", section)
+    for line_match in re.finditer(r"^.*$", section_no_ranges, re.MULTILINE):
+        line = line_match.group(0)
+        if re.search(r"\bC\.?\s*(?:90[5-9]|91[0-9]|92[0-2])\b", line, re.IGNORECASE):
+            continue
+        label_norm = _normalize_label(line)
+        if not label_norm or "submitting" in label_norm or "score range" in label_norm:
+            continue
+
+        qns_by_role = None
+        for row_label, candidate in _PERCENTILE_QNS.items():
+            if _normalize_label(row_label) in label_norm:
+                qns_by_role = candidate
+                break
+        if not qns_by_role:
+            continue
+
+        numbers = re.findall(r"\b\d+(?:\.\d+)?\b", line.replace(",", ""))
+        if len(numbers) < 3:
+            continue
+        context = section_no_ranges[max(0, line_match.start() - 600):line_match.start()]
+        roles = _c9_percentile_roles_from_context(context)
+        for value, role in zip(numbers, roles):
+            qn = qns_by_role.get(role)
+            if qn and _is_plausible_c9_percentile_value(qn, value):
+                out.setdefault(qn, {"value": value, "source": "tier4_cleaner"})
+
+    return out
+
+
 # --- Resolver: C9 score distributions ---
 
 _C9_DISTRIBUTION_QNS = {
@@ -5038,6 +5186,7 @@ _RESOLVERS = [
     resolve_c7_basis_for_selection,
     resolve_c8_entrance_exams,
     resolve_c9_submission_rates,
+    resolve_c9_percentile_anchors,
     resolve_c9_score_distributions,
     resolve_c11_gpa_profile,
     resolve_c12_gpa_summary,
@@ -5080,7 +5229,6 @@ def clean(
     def _norm_hint(ch):
         return _normalize_label(ch) if isinstance(ch, str) else ch
     field_map_norm = [(_normalize_label(s), qn, _norm_hint(ch)) for s, qn, ch in _FIELD_MAP]
-    percentile_map_norm = [(_normalize_label(s), ci, qn) for s, ci, qn in _PERCENTILE_MAP]
 
     for table in tables:
         section_norm = _normalize_label(table["section"])
@@ -5134,13 +5282,17 @@ def clean(
                     values[qnum] = {"value": num, "source": "tier4_cleaner"}
 
             # --- Percentile table ---
-            for substr, col_idx, qnum in percentile_map_norm:
-                if substr not in label_norm:
+            for col_idx, value in enumerate(row["values"]):
+                qnum = _c9_percentile_qn(label_norm, col_idx, headers_norm)
+                if not qnum:
                     continue
-                if col_idx < len(row["values"]):
-                    num = _extract_number(row["values"][col_idx])
-                    if num and qnum not in values:
-                        values[qnum] = {"value": num, "source": "tier4_cleaner"}
+                num = _extract_number(value)
+                if (
+                    num is not None
+                    and _is_plausible_c9_percentile_value(qnum, num)
+                    and qnum not in values
+                ):
+                    values[qnum] = {"value": num, "source": "tier4_cleaner"}
 
     # --- Inline patterns (non-table fields) ---
     # Runs after table extraction so table matches take precedence.
@@ -5172,6 +5324,7 @@ def clean(
             resolve_b5_graduation,
             resolve_c2_waitlist,
             resolve_c8_entrance_exams,
+            resolve_c9_percentile_anchors,
             resolve_c12_gpa_summary,
             resolve_c13_application_fee,
             resolve_i_faculty,

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -1352,6 +1352,15 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--school", default=None, help="Only process this school_id")
     parser.add_argument(
+        "--document-ids",
+        default=None,
+        help=(
+            "Comma-separated cds_documents.id values to process. Still honors "
+            "extraction_status filtering, so use after requeueing extracted "
+            "documents to extraction_pending."
+        ),
+    )
+    parser.add_argument(
         "--source-format",
         default=None,
         help=(
@@ -1477,6 +1486,11 @@ def main() -> int:
         for value in (args.source_format or "").split(",")
         if value.strip()
     ]
+    document_ids = [
+        value.strip()
+        for value in (args.document_ids or "").split(",")
+        if value.strip()
+    ]
 
     query = client.table("cds_documents").select(
         "id, school_id, cds_year, detected_year, source_format, extraction_status, discovered_at",
@@ -1487,6 +1501,8 @@ def main() -> int:
         query = query.eq("extraction_status", "extraction_pending")
     if args.school:
         query = query.eq("school_id", args.school)
+    if document_ids:
+        query = query.in_("id", document_ids)
     if source_formats:
         query = query.in_("source_format", source_formats)
     query = query.order("school_id")


### PR DESCRIPTION
## Summary
- Fix Tier 4 C9 percentile extraction to map score columns by percentile headers instead of assuming fixed 25/50/75 order
- Add C9 layout/text fallbacks for schema-coded and plain SAT/ACT score rows, with score-range validation to avoid leaked totals
- Add targeted extraction redrain controls to the ops workflow and worker for explicit document IDs

## Verification
- `python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'`\n- `python3 -m unittest tools/extraction_worker/test_schema_dispatch.py tools/extraction_worker/test_worker_projection_refresh.py tools/extraction_worker/test_tier4_cleaner_c9.py`\n- Spot checked local source text recovery for Oberlin, Villanova, and Rose-Hulman\n\n## Ops\n- Started targeted 35-document C9 redrain on this branch: https://github.com/bolewood/collegedata-fyi/actions/runs/25326245319\n- That ops run was still in progress when the PR was opened\n- Canceled accidental one-row default-branch dispatch: https://github.com/bolewood/collegedata-fyi/actions/runs/25326131110\n