### PR TITLE
Bump Tier 4 producer for C9 redrain

### DIFF
--- a/tools/extraction_worker/README.md
+++ b/tools/extraction_worker/README.md
@@ -49,8 +49,16 @@ python worker.py --skip-projection-refresh --limit 10
 # Scoped operator re-drain: only 2024+ Tier 4/Tier 5 PDFs
 python worker.py --source-format pdf_flat,pdf_scanned --min-year-start 2024
 
-# Targeted operator re-drain after requeueing specific document IDs
-python worker.py --document-ids <uuid>,<uuid> --limit 2
+# Targeted managed Docling re-drain on an operator laptop.
+# This requeues the documents, processes only those IDs, and refreshes
+# cds_fields/school_browser_rows as each document finishes.
+python worker.py \
+    --env /Users/santhonys/Projects/Owen/colleges/collegedata-fyi/.env \
+    --requeue-document-ids <uuid>,<uuid> \
+    --limit 2 \
+    --min-year-start 2024 \
+    --seed-projection-metadata \
+    --summary-json ../../.context/local-redrain/summary.json
 
 # Fresh-year drain: process the newest archived CDS rows before old backlog
 python worker.py --min-year-start 2025 --include-failed --limit 25
@@ -62,11 +70,23 @@ python worker.py --detect-year-only --write         # backfill detected_year
 
 Env vars (read from `.env` at the repo root): `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `ANTHROPIC_API_KEY` (for the LLM fallback — PRD 006).
 
+## Managed Docling runs
+
+Managed Docling drains should run locally on an operator MacBook by default.
+Local runs have more CPU headroom, no 60-minute GitHub-hosted timeout, and can
+write complete logs under `.context/`. GitHub Actions is for automation: the
+small scheduled backlog drain, CI, and other unattended jobs.
+
+For extractor or cleaner changes, bump the relevant `producer_version` before
+re-draining. The worker is idempotent by `(document_id, producer,
+producer_version, schema_version)` and will otherwise skip matching artifacts as
+`already_extracted`.
+
 ## GitHub Actions ops workflow
 
 `.github/workflows/ops-extraction-worker.yml` is the bounded production-ish
-wrapper around `worker.py`. It is separate from PR CI and is meant for small
-pending-row drains, not corpus-wide Docling/OCR work.
+wrapper around `worker.py`. It is separate from PR CI and is meant for the
+scheduled automation path, not managed Docling re-drains.
 
 The workflow supports both a daily scheduled drain and manual dispatch. Manual
 inputs are `limit`, `school`, `source_format`, `min_year_start`,

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.2"
+PRODUCER_VERSION = "0.3.3"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -1361,6 +1361,16 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--requeue-document-ids",
+        default=None,
+        help=(
+            "Comma-separated cds_documents.id values to mark extraction_pending "
+            "before processing. If --document-ids is omitted, these IDs also "
+            "become the processing filter. Intended for local managed Docling "
+            "redrains."
+        ),
+    )
+    parser.add_argument(
         "--source-format",
         default=None,
         help=(
@@ -1491,6 +1501,29 @@ def main() -> int:
         for value in (args.document_ids or "").split(",")
         if value.strip()
     ]
+    requeue_document_ids = [
+        value.strip()
+        for value in (args.requeue_document_ids or "").split(",")
+        if value.strip()
+    ]
+    if requeue_document_ids and not document_ids:
+        document_ids = requeue_document_ids
+    if requeue_document_ids and not args.dry_run:
+        changed = 0
+        for document_id in requeue_document_ids:
+            result = (
+                client.table("cds_documents")
+                .update({"extraction_status": "extraction_pending"})
+                .eq("id", document_id)
+                .execute()
+            )
+            changed += len(result.data or [])
+        print(f"Requeued {changed} document(s).", flush=True)
+    elif requeue_document_ids:
+        print(
+            f"Would requeue {len(requeue_document_ids)} document(s) (dry run).",
+            flush=True,
+        )
 
     query = client.table("cds_documents").select(
         "id, school_id, cds_year, detected_year, source_format, extraction_status, discovered_at",


### PR DESCRIPTION
## Summary
- Bump `tier4_docling` producer version to `0.3.3` so the merged C9 cleaner changes produce fresh canonical artifacts during targeted redrains

## Why
The first C9 redrain revealed that documents already extracted with `tier4_docling@0.3.2` can be skipped by the worker idempotency guard as `already_extracted`. The cleaner changed in PR #53, so the producer version needs to move for deterministic reprocessing.

## Verification
- `python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'`\n