### PR TITLE
Simplify nav and add header school search

### DIFF
--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -131,53 +131,151 @@
 /* tabular nums anywhere numbers appear */
 .cd-theme .nums, .cd-theme table, .cd-theme .stat-num { font-variant-numeric: tabular-nums; }
 
-/* Nav layout with a responsive breakpoint. At narrow viewports the link
-   cluster wraps under the wordmark instead of colliding with it. */
+/* Nav layout with a responsive breakpoint. At narrow viewports the search
+   wraps under the wordmark instead of colliding with links. */
 .cd-nav-row {
   display: flex; align-items: center; justify-content: space-between;
   gap: 16px;
 }
 .cd-nav-links {
-  display: flex; gap: 28px; font-size: 14px;
-}
-.cd-nav-secondary {
-  display: contents;
+  display: flex; gap: 24px; font-size: 14px; align-items: center;
 }
 .cd-nav-more {
-  display: none;
+  display: block;
   position: relative;
+  color: var(--ink-3);
 }
-@media (max-width: 640px) {
+.cd-nav-more summary {
+  cursor: pointer;
+  list-style: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+.cd-nav-more summary::-webkit-details-marker {
+  display: none;
+}
+.cd-nav-more[data-active="true"] summary {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+.cd-nav-more > div {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  z-index: 30;
+  display: grid;
+  gap: 10px;
+  min-width: 154px;
+  padding: 12px;
+  border: 1px solid var(--rule-strong);
+  background: #faf6ec;
+  box-shadow: 0 12px 28px rgba(28, 30, 27, 0.12);
+}
+.cd-nav-more a {
+  text-decoration: none;
+  color: var(--ink-3);
+}
+.cd-nav-more a:hover {
+  color: var(--ink);
+}
+.cd-header-search {
+  position: relative;
+  flex: 1 1 260px;
+  max-width: 360px;
+  min-width: 210px;
+}
+.cd-header-search input {
+  width: 100%;
+  height: 34px;
+  padding: 0 11px;
+  border: 1px solid var(--rule);
+  background: #faf6ec;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 34px;
+  border-radius: 2px;
+  outline: none;
+}
+.cd-header-search input:focus {
+  border-color: var(--forest);
+}
+.cd-header-search__results {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 40;
+  max-height: 340px;
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--rule-strong);
+  background: #faf6ec;
+  box-shadow: 0 14px 34px rgba(28, 30, 27, 0.14);
+}
+.cd-header-search__empty {
+  padding: 11px 12px;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.cd-header-search__result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-top: 1px solid var(--rule);
+}
+.cd-header-search__result:first-child {
+  border-top: 0;
+}
+.cd-header-search__result[data-active="true"] {
+  background: var(--paper-2);
+}
+.cd-header-search__school {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.cd-header-search__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 15px;
+  line-height: 1.15;
+}
+.cd-header-search__meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.2;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (max-width: 820px) {
   .cd-nav-row { flex-wrap: wrap; row-gap: 10px; }
-  .cd-nav-links { width: 100%; justify-content: flex-start; gap: 18px; font-size: 13px; flex-wrap: wrap; align-items: center; }
-  .cd-nav-secondary { display: none; }
-  .cd-nav-more {
-    display: block;
-    color: var(--ink-3);
-  }
-  .cd-nav-more summary {
-    cursor: pointer;
-    list-style: none;
-  }
-  .cd-nav-more summary::-webkit-details-marker {
-    display: none;
-  }
-  .cd-nav-more > div {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 8px);
-    z-index: 20;
-    display: grid;
-    gap: 10px;
-    min-width: 150px;
-    padding: 12px;
-    border: 1px solid var(--rule-strong);
-    background: #faf6ec;
-    box-shadow: 0 12px 28px rgba(28, 30, 27, 0.12);
-  }
-  .cd-nav-more a {
-    text-decoration: none;
-  }
+  .cd-header-search { order: 3; flex-basis: 100%; max-width: none; min-width: 0; }
+  .cd-header-search__results { position: static; margin-top: 8px; }
+  .cd-nav-links { justify-content: flex-start; gap: 18px; font-size: 13px; flex-wrap: wrap; align-items: center; }
+  .cd-nav-more > div { right: 0; }
 }
 .cd-footer-links {
   flex-wrap: wrap;

--- a/web/src/components/HeaderSchoolSearch.tsx
+++ b/web/src/components/HeaderSchoolSearch.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+import type { InstitutionSearchResult } from "@/lib/types";
+import { CoverageBadge } from "./CoverageBadge";
+
+const DEBOUNCE_MS = 180;
+
+export function HeaderSchoolSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<InstitutionSearchResult[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const router = useRouter();
+  const genRef = useRef(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      genRef.current += 1;
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const gen = ++genRef.current;
+    setIsLoading(true);
+    const timer = setTimeout(async () => {
+      const rpcClient = supabase as unknown as {
+        rpc: (
+          fn: string,
+          args: Record<string, unknown>,
+        ) => Promise<{
+          data: InstitutionSearchResult[] | null;
+          error: { message: string } | null;
+        }>;
+      };
+      const { data, error } = await rpcClient.rpc("search_institutions", {
+        p_query: trimmed,
+        p_limit: 7,
+      });
+      if (gen !== genRef.current) return;
+      setIsLoading(false);
+      if (error) {
+        setResults([]);
+        return;
+      }
+      setResults(data ?? []);
+      setSelectedIndex(0);
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  function handleSelect(schoolId: string) {
+    setIsOpen(false);
+    setQuery("");
+    setResults([]);
+    router.push(`/schools/${schoolId}`);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!isOpen || results.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      handleSelect(results[selectedIndex].school_id);
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+    }
+  }
+
+  const showDropdown = isOpen && (results.length > 0 || (isLoading && query.trim().length > 0));
+
+  return (
+    <div className="cd-header-search">
+      <label className="sr-only" htmlFor="header-school-search">
+        Search for a school
+      </label>
+      <input
+        id="header-school-search"
+        type="search"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setIsOpen(true);
+        }}
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => setTimeout(() => setIsOpen(false), 160)}
+        onKeyDown={handleKeyDown}
+        placeholder="Jump to a school"
+        autoComplete="off"
+      />
+      {showDropdown && (
+        <ul className="cd-header-search__results">
+          {results.length === 0 && isLoading && (
+            <li className="cd-header-search__empty">Searching...</li>
+          )}
+          {results.map((result, index) => (
+            <li
+              key={result.school_id}
+              className="cd-header-search__result"
+              data-active={index === selectedIndex ? "true" : "false"}
+              onMouseDown={() => handleSelect(result.school_id)}
+            >
+              <span className="cd-header-search__school">
+                <span className="cd-header-search__name">{result.school_name}</span>
+                <span className="cd-header-search__meta">
+                  {[result.city, result.state].filter(Boolean).join(", ") || "Institution profile"}
+                  {result.latest_available_cds_year ? ` - CDS ${result.latest_available_cds_year}` : ""}
+                </span>
+              </span>
+              <CoverageBadge
+                status={result.coverage_status}
+                label={result.coverage_label}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -2,16 +2,17 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { HeaderSchoolSearch } from "./HeaderSchoolSearch";
 import { Wordmark } from "./Wordmark";
 
 const PRIMARY_NAV_LINKS = [
   { href: "/match", label: "Match" },
-  { href: "/browse", label: "Browser" },
   { href: "/schools", label: "Schools" },
   { href: "/api", label: "API" },
 ];
 
 const SECONDARY_NAV_LINKS = [
+  { href: "/browse", label: "Browser" },
   { href: "/coverage", label: "Coverage" },
   { href: "/recipes", label: "Recipes" },
   { href: "/about", label: "About" },
@@ -28,6 +29,7 @@ function isActive(pathname: string | null, href: string): boolean {
 
 export function Nav() {
   const pathname = usePathname();
+  const secondaryActive = SECONDARY_NAV_LINKS.some((l) => isActive(pathname, l.href));
 
   return (
     <nav
@@ -43,6 +45,7 @@ export function Nav() {
         <Link href="/" style={{ textDecoration: "none" }}>
           <Wordmark variant="dotted" size={20} />
         </Link>
+        <HeaderSchoolSearch />
         <div className="cd-nav-links">
           {PRIMARY_NAV_LINKS.map((l) => {
             const active = isActive(pathname, l.href);
@@ -65,32 +68,8 @@ export function Nav() {
               </Link>
             );
           })}
-          <span className="cd-nav-secondary">
-            {SECONDARY_NAV_LINKS.map((l) => {
-              const active = isActive(pathname, l.href);
-              return (
-                <Link
-                  key={l.href}
-                  href={l.href}
-                  aria-current={active ? "page" : undefined}
-                  style={{
-                    textDecoration: "none",
-                    color: active ? "var(--ink)" : "var(--ink-3)",
-                    paddingBottom: 2,
-                    borderBottom: active
-                      ? "1px solid var(--ink)"
-                      : "1px solid transparent",
-                  }}
-                  className="nav-link"
-                >
-                  {l.label}
-                </Link>
-              );
-            })}
-            <GitHubNavLink />
-          </span>
-          <details className="cd-nav-more">
-            <summary>More</summary>
+          <details className="cd-nav-more" data-active={secondaryActive ? "true" : "false"}>
+            <summary aria-current={secondaryActive ? "page" : undefined}>More</summary>
             <div>
               {SECONDARY_NAV_LINKS.map((l) => (
                 <Link key={l.href} href={l.href}>
@@ -109,38 +88,5 @@ export function Nav() {
         </div>
       </div>
     </nav>
-  );
-}
-
-function GitHubNavLink() {
-  return (
-    <a
-      href="https://github.com/bolewood/collegedata-fyi"
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label="GitHub (opens in new tab)"
-      style={{
-        textDecoration: "none",
-        color: "var(--ink-3)",
-        paddingBottom: 2,
-        borderBottom: "1px solid transparent",
-        display: "inline-flex",
-        alignItems: "baseline",
-        gap: 4,
-      }}
-      className="nav-link"
-    >
-      GitHub
-      <span
-        aria-hidden="true"
-        style={{
-          fontSize: "0.75em",
-          color: "var(--ink-4)",
-          lineHeight: 1,
-        }}
-      >
-        ↗
-      </span>
-    </a>
   );
 }


### PR DESCRIPTION
## Summary
- Simplifies the primary nav to Match, Schools, API, with Browser/Coverage/Recipes/About/GitHub under More.
- Adds a persistent header school search that uses the existing `search_institutions` RPC and navigates directly to `/schools/[school_id]`, including directory-only schools.
- Adds responsive header/search styling and fixes tablet/mobile layout so the dropdown does not collide with page content.

## Review Notes
Codex adversarial review found two P2s before push, both fixed in this branch:
- stale async header-search results after clearing the query
- tablet-width nav overflow between the old mobile breakpoint and desktop layout

## Verification
- `npm run typecheck`
- `npm test` (36 tests)
- `npm run build` with local Supabase env loaded
- Playwright smoke check at 1280, 768, and 390 widths: no horizontal overflow; no tablet/mobile search-result overlap
