### PR TITLE
Fix bot_challenged_documents view (archive_queue column name)

### DIFF
--- a/supabase/migrations/20260505160000_archive_observability.sql
+++ b/supabase/migrations/20260505160000_archive_observability.sql
@@ -107,7 +107,12 @@ select
   d.last_verified_at,
   d.updated_at as document_updated_at,
   q.last_outcome,
-  q.last_attempted_at as last_challenge_at,
+  -- archive_queue's terminal-state timestamp is processed_at (set when
+  -- the row transitions to status='done' or 'failed_permanent'). For a
+  -- bot-challenge row this records when we last confirmed the WAF wall
+  -- was still in place. The view is named for the operator-facing
+  -- meaning ("last challenge at"), not the underlying column.
+  q.processed_at as last_challenge_at,
   q.last_error
 from public.cds_documents d
 left join public.archive_queue q


### PR DESCRIPTION
## Summary

Hotfix for PR #56. The original migration referenced `q.last_attempted_at` on `archive_queue`, but the actual terminal-state timestamp column is `processed_at` (created in `20260414170000_archive_pipeline.sql:112`).

## Production state

The push to production failed at the `CREATE VIEW` statement (`SQLSTATE 42703: column q.last_attempted_at does not exist`) and the whole migration rolled back transactionally. Verified:

- `cds_documents` does NOT have the new metadata columns (PostgREST returns 400 on unknown column query)
- `bot_challenged_documents` view does NOT exist (404)
- Migration history shows REMOTE column blank for `20260505160000`

So production is in its pre-PR-56 state. This PR replaces the migration content; the next `supabase db push --linked` will apply the corrected version.

## Why edit in place vs. follow-up migration

The original migration is on `main` but has not been applied to any environment, so changing its content can't drift from any prod state. `Migration filename hygiene` CI passes because the filename is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)