### PR TITLE
Add PRD 019 spike and extraction recovery fixes

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -99,6 +99,23 @@ Sections are ordered **Open → Resolved → Strategic context**. Every open ite
 
 ### Larger features / future tiers
 
+- **PRD 019 — CDS change intelligence and reporting gaps.** Track material
+  year-over-year CDS deltas, newly missing fields, recovered fields, and
+  watchlist freshness for an operator-curated Top 200 panel. Strategic goal:
+  turn collegedata.fyi from a source archive into a source-backed early-warning
+  system for admissions, aid, international-enrollment, and reporting changes.
+  Before building the full projector, run a two-day spike over five
+  high-leverage admissions/reporting fields to prove there are enough real,
+  surprising deltas to justify the annual-report/op-ed framing. The PRD now
+  treats producer changes, schema-version renames, source-provenance crossings,
+  and section-quality regressions as explicit comparability gates before any
+  "newly missing" event can become reportable.
+  External macro context comes from WICHE's high-school graduate projections,
+  Census birth-trend data, and IIE/NAFSA international-student enrollment
+  reporting; the product evidence layer remains deterministic CDS comparisons.
+  See [PRD 019](prd/019-cds-change-intelligence.md). **Effort:** ~1-2 weeks for
+  first projector + school-page card; ~2-4 weeks for publication-grade report.
+
 - **Tier 3 DOCX extractor (PRD 007).** Revised plan shipped 2026-04-29 in [PRD 007](prd/007-tier3-docx-extraction.md). Primary path is a deterministic OOXML SDT reader keyed by schema `word_tag` values, same lookup pattern as Tier 2. Fallback path is a measured Docling DOCX structural adapter that reuses Tier 4 cleaner/table logic for SDT-stripped Word files before considering any bespoke Word-table parser. Addressable corpus today is ~30-50 documents (Kent State's 14 SDT-preserving files are the largest family). The format sniffer now routes DOCX correctly; the remaining work is the extractor itself.
 
 - **Tier 4 cleaner — continue resolver coverage beyond the core product surfaces.** [PRD 005](prd/005-full-schema-extraction.md)'s Phase 6 architecture shipped 2026-04-20 (commit `aecca9b`): the section-family resolver framework backed by a shared `SchemaIndex` took the cleaner from 72 -> ~380 fields (Harvard 382, Yale 390, Dartmouth 343). PRD 016B and PRD 018 added targeted C21/C22 and H1/H2/H2A coverage. Remaining work is continuing to add resolvers for thinner sections as specific schools surface gaps; the ceiling is 1,105 fields, but full-schema parity is not urgent.

--- a/docs/prd/019-cds-change-intelligence.md
+++ b/docs/prd/019-cds-change-intelligence.md
@@ -1,0 +1,666 @@
+# PRD 019: CDS change intelligence and reporting gaps
+
+**Status:** Draft, candidate next strategic PRD.
+**Created:** 2026-05-05
+**Author:** Anthony + Codex
+**Related:** [PRD 014](014-cross-year-canonical-schema.md), [PRD 016B](016B-admission-strategy-card.md), [PRD 017](017-match-list-builder.md), [PRD 018](018-open-college-fit-data.md), [Queryable browser backend](../queryable-browser-backend.md)
+
+---
+
+## Context
+
+The strongest next narrative for collegedata.fyi is not "we archived more PDFs."
+It is: **we can see what American colleges changed, stopped reporting, and started
+emphasizing before families, counselors, and journalists can track it manually.**
+
+This matters because the 2025-26 and 2026-27 admissions cycles sit at the
+intersection of several external pressures:
+
+- The U.S. high-school graduate count is projected to peak around 2025 and then
+  decline through 2041. WICHE's 2024 _Knocking at the College Door_ release
+  reports 3.9 million high-school graduates in 2025, falling to 3.4 million by
+  2041, a 13% decline. The Census Bureau separately notes that U.S. births have
+  declined every year since 2008 except 2014, giving the post-Great-Recession
+  demographic cliff its underlying cohort shape.
+- International-student demand is now a live policy variable, not background
+  noise. IIE's Fall 2025 Snapshot reports new international enrollments down
+  17% year over year, while NAFSA's fall 2025 outlook modeled up to 150,000
+  fewer international students under visa-processing and travel-restriction
+  pressure.
+- Many college responses to pressure will show up first in CDS deltas: admit
+  rates, early-round behavior, test-score reporting, international enrollment,
+  aid allocation, yield, retention, class-size distribution, and reporting gaps.
+
+The aspirational editorial goal is concrete: **generate enough fresh,
+source-backed insight that Anthony could credibly pitch an op-ed or data essay
+to a national outlet.** The implementation goal is a data product that makes that
+essay repeatable every year.
+
+## Pre-PRD spike — prove the editorial signal exists
+
+Before Phase 0 begins, run a two-day spike. The goal is not infrastructure; the
+goal is to answer whether the data contains enough surprising signal to justify
+the full change-intelligence build.
+
+Scope:
+
+- Pick the 50-100 schools that already have both 2024-25 and 2025-26 primary CDS
+  rows.
+- Compare only five highest-leverage fields:
+  - admit rate
+  - yield rate
+  - ED admit rate or ED volume, where available
+  - SAT/ACT submit rate
+  - C9 SAT/ACT range reporting, especially newly missing 25th/50th/75th
+    percentile values
+- Export a CSV with `school_id`, `field_key`, prior-year value, latest-year
+  value, absolute delta, and source URLs.
+- Manually inspect the top 50 deltas.
+
+Decision gate:
+
+- If at least five deltas are real, source-backed, and editorially interesting,
+  proceed to Phase 0.
+- If not, demote the annual-report/op-ed framing and re-scope v1 as a small
+  school-page "What Changed" card.
+
+## External sources to cite in product/editorial work
+
+These are not product dependencies, but they define the macro frame. Keep them
+out of the extraction pipeline; cite them in methodology/reporting pages.
+
+- WICHE, _Knocking at the College Door_, 11th edition release:
+  https://www.wiche.edu/resources/report-u-s-high-school-graduates-will-peak-next-year-then-most-states-will-see-steady-declines-through-2041/
+- WICHE PDF, _Projections of High School Graduates_, December 2024:
+  https://www.wiche.edu/wp-content/uploads/2024/12/2024-Knocking-at-the-College-Door-final.pdf
+- Census Bureau, "U.S. Births Declined During the Pandemic" (contains the
+  post-2008 birth-decline summary):
+  https://www.census.gov/library/stories/2021/09/united-states-births-declined-during-pandemic.html
+- IIE, Fall 2025 Snapshot on International Student Enrollment:
+  https://www.iie.org/publications/fall-2025-snapshot-on-international-student-enrollment/
+- IIE, "Four Things To Know About the Fall 2025 Snapshot":
+  https://www.iie.org/blog/four-things-to-know-about-the-fall-2025-snapshot/
+- NAFSA, Fall 2025 International Student Enrollment Outlook and Economic Impact:
+  https://www.nafsa.org/fall-2025-international-student-enrollment-outlook-and-economic-impact
+
+## Strategic thesis
+
+CDS transparency is voluntary, uneven, and changing. A school communicates not
+only through the numbers it reports, but also through what it stops reporting.
+
+The product should therefore track three classes of signal:
+
+1. **Material changes** — values that moved enough to matter.
+2. **Reporting gaps / silences** — fields that were previously reported but are
+   now missing, suppressed, or no longer machine-extractable from a newer CDS.
+3. **Recovered signals** — fields that were absent and then reappear. These are
+   first-class editorial signals, not cleanup trivia: the return of data can
+   reflect internal reporting changes, compliance pressure, or a strategic
+   decision to make a metric visible again.
+
+This is not a claim that every silence is suspicious. The UI and editorial copy
+must stay neutral: "newly missing from the reported CDS" is a fact; "the school
+is hiding this" is an interpretation that should almost never ship.
+
+## Launch scope
+
+### School panel
+
+Start with an operator-curated **Top 200 Watchlist**, not the full corpus.
+
+The watchlist should combine:
+
+- Highly recognizable national universities and liberal arts colleges.
+- Flagship publics.
+- Schools with strong counselor/family search demand.
+- Schools where 2025-26 CDS publication is likely or already detected.
+
+Seed the launch watchlist without proprietary rankings:
+
+- Top 100 schools by latest available CDS C1 application volume.
+- 50 flagship state universities.
+- 50 high-endowment or high-recognition liberal arts colleges, sourced from
+  non-proprietary public data where possible and operator-reviewed for launch.
+
+The Top 200 Watchlist is **operator-only until the first report ships**. Public
+launch can expose aggregate coverage and selected findings, but not the full
+watchlist membership before there is enough evidence to defend inclusion and
+exclusion decisions.
+
+The launch gate is:
+
+> For at least 80% of the Top 200 Watchlist schools with an available 2025-26 CDS,
+> collegedata.fyi can show a year-over-year change report comparing the latest
+> primary CDS against the prior primary CDS, with material deltas, disappeared
+> fields, recovered fields, and source-backed evidence.
+
+### Launch field families
+
+Do not attempt all 1,105 CDS fields in v1. Do not even attempt the full 50-80
+field candidate set in the first projector. Launch with a tight 15-20 field
+set, then expand only after the calibration subset is clean.
+
+**Admissions pressure**
+
+- C1 applicants, admits, enrolled first-years.
+- Admit rate and yield rate derived from C1.
+- C2/C21/C22 early decision, early action, wait-list, and deferral fields where
+  available.
+- C7 application-factor importance changes for a small initial subset only:
+  academic GPA, standardized test scores, class rank, and first-generation
+  status if reliably mapped.
+- C9/C10/C11/C12 test-score and GPA reporting.
+- Test-submit rates and score-range disappearance/reappearance.
+
+**International pressure**
+
+- B1/B2/B3 enrollment fields that expose nonresident-alien / international
+  student counts and shares where available.
+- C1 applicant/admit/enroll fields only if international-specific counts are
+  present in school-specific variants. This is not universal; flag as
+  school-specific evidence only.
+- J / study-abroad fields are Phase 4+, not launch blocking.
+
+**Affordability and aid pressure**
+
+- H2A institutional grant recipients and dollars.
+- H1/H2/H5/H6/H7/H8 average aid package, need grant, non-need grant, and
+  institutional grant values.
+- Percent receiving institutional grant aid.
+- Net-price/outcome fields from Scorecard may contextualize, but CDS change
+  events should remain CDS-sourced unless explicitly labeled.
+
+**Student experience / institutional health**
+
+- Retention and graduation fields, class-size distribution, student/faculty
+  ratio, housing, and Greek participation are Phase 4+. They are valuable but
+  too broad for the first deterministic projector.
+
+## What ships
+
+### `cds_field_observations`
+
+Ship as a **view only** in v1. Do not create a new materialized write path unless
+query-time measurements later require it. The view records one normalized
+observation per school, primary CDS year, canonical field, and selected document:
+
+- `school_id`
+- `document_id`
+- `canonical_year`
+- `year_start`
+- `field_key`
+- `value_numeric`
+- `value_text`
+- `normalized_value`
+- `unit`
+- `source_producer`
+- `source_producer_version`
+- `source_page` / `source_locator` if available
+- `archive_url`
+- `observed_at`
+- `quality_flag`
+
+The view is derived from `cds_fields` plus `cds_manifest` / selected-primary
+document logic. If this ever becomes materialized, it must be refreshed by the
+same projection flow that refreshes `cds_fields`, not independently.
+
+### `cds_field_change_events`
+
+A generated table of year-over-year events. One row per meaningful event:
+
+- `school_id`
+- `field_key`
+- `field_family`
+- `from_document_id`
+- `to_document_id`
+- `from_year`
+- `to_year`
+- `event_type`
+- `severity`
+- `from_value`
+- `to_value`
+- `absolute_delta`
+- `relative_delta`
+- `threshold_rule`
+- `summary`
+- `from_producer`
+- `to_producer`
+- `from_producer_version`
+- `to_producer_version`
+- `from_source_provenance`
+- `to_source_provenance`
+- `evidence_json`
+- `created_at`
+
+Event types:
+
+- `material_delta`
+- `newly_missing`
+- `newly_reported`
+- `reappeared`
+- `format_changed`
+- `producer_changed`
+- `quality_regression`
+- `quality_recovered`
+- `card_quality_changed`
+
+Severity levels:
+
+- `watch` — visible on school page but not report-worthy.
+- `notable` — included in watchlist digest.
+- `major` — candidate for editorial/reporting surface.
+
+### Producer, schema, and provenance comparability
+
+The hardest credibility risk is false change events caused by extraction drift,
+not school behavior. The projector must classify comparability before computing
+events.
+
+Hard rules:
+
+- `field_key` must be resolved through PRD 014's canonical equivalence tables
+  before any comparison. Raw schema-version-specific IDs are not allowed in
+  change rules.
+- A schema rename must not emit `newly_missing` or `newly_reported`.
+- `newly_missing` requires same producer family and compatible producer version
+  between prior and latest observations. If the producer family or material
+  version changed, emit `producer_changed` or `quality_regression` instead.
+- Producer downgrades, such as `tier1_xlsx` -> `tier4_docling`, are editorially
+  neutral until a human confirms the field is truly absent from the newer source
+  document.
+- Producer upgrades, such as a Tier 4 cleaner redrain that recovers fields, are
+  `quality_recovered` unless the school-side source also changed in a way that
+  justifies `newly_reported`.
+- Source provenance crossings, such as `school_direct` -> `mirror`, must be
+  tagged. A `material_delta` across provenance can be visible, but its severity
+  is capped at `watch` unless human-reviewed.
+- The prior year's value determines the selectivity band for threshold rules,
+  even if the latest year crosses a band boundary.
+
+Required tests:
+
+- A field renamed across CDS schema versions does not fire `newly_missing`.
+- `tier1_xlsx` -> `tier4_docling` missing fields produce `producer_changed`, not
+  `newly_missing`.
+- A prior admit rate of 19% and latest admit rate of 24% uses the prior-year
+  `high_selectivity` band.
+
+### Evidence schema
+
+`evidence_json` must have a typed shape. It is not a generic notes bucket.
+
+```ts
+type ChangeEventEvidence = {
+  from_value: { num?: number; text?: string; status: "reported" | "missing" };
+  to_value: { num?: number; text?: string; status: "reported" | "missing" };
+  from_producer: string;
+  to_producer: string;
+  from_source_provenance: string | null;
+  to_source_provenance: string | null;
+  threshold_rule_fired: string;
+  computed_delta: {
+    absolute?: number;
+    percentage_points?: number;
+    relative_pct?: number;
+  };
+  comparability: {
+    same_canonical_field: boolean;
+    same_producer_family: boolean;
+    compatible_producer_version: boolean;
+    same_source_provenance: boolean;
+  };
+  caveats: string[];
+};
+```
+
+### Field-specific threshold rules
+
+Thresholds must be field-aware and institution-aware. A four-point yield move
+does not mean the same thing at a school with a 5% admit rate as it does at a
+regional public with a 75% admit rate. Rules should support baseline bands:
+
+- `high_selectivity`: prior admit rate < 20%.
+- `selective`: prior admit rate >= 20% and < 50%.
+- `broad_access`: prior admit rate >= 50%.
+- `unknown_selectivity`: no reliable prior admit rate.
+
+Delta semantics:
+
+- Probability/rate/share fields use percentage-point deltas as the primary
+  metric. Do not use `(new - old) / old` as a default report trigger for admit
+  rate, yield, submit rates, or enrollment shares.
+- Dollar fields may use both absolute-dollar deltas and relative percentage
+  deltas, with inflation adjustment where practical.
+- Count fields use absolute deltas and relative percentage deltas, but rules
+  must define minimum denominator floors to avoid noisy small-N swings.
+
+Examples:
+
+- Admit rate: major if absolute change >= 3 percentage points; stricter review
+  for `high_selectivity` schools.
+- Yield rate: notable if absolute change >= 4 percentage points, but major
+  thresholds vary by baseline band and historical volatility.
+- International enrollment share: notable if absolute change >= 2 percentage
+  points; major if >= 5 percentage points.
+- Institutional grant recipient share: notable if absolute change >= 5
+  percentage points.
+- Average institutional/non-need grant dollars: notable if inflation-adjusted
+  delta >= 10%; major if >= 20%.
+- C9 SAT/ACT range: newly missing is notable if the school reported the field
+  in at least two prior primary CDS years.
+- Test-submit rate: notable if absolute change >= 5 percentage points.
+- C7 importance factor: notable if a factor moves across a semantic boundary
+  (`not considered` -> `considered`, `considered` -> `important`,
+  `important` -> `very important`).
+
+Thresholds live in config, not code paths scattered through the app:
+
+```
+tools/change_intelligence/rules.yaml
+```
+
+The rules engine must also compute historical volatility where enough prior years
+exist. A small raw movement can be major if it is far outside the school's own
+recent pattern; a larger movement can remain `watch` if the field has always
+been volatile.
+
+### Human verification gate
+
+Any event with `severity = major`, and any `newly_missing` event that is eligible
+for public/reporting output, must pass a human verification step before it can be
+included in the annual report artifact or public digest.
+
+Verification records:
+
+- `event_id`
+- `reviewer`
+- `reviewed_at`
+- `verdict`: `confirmed`, `extractor_noise`, `ambiguous`, `not_reportable`
+- `notes`
+- `source_pages_checked`
+
+The pipeline may generate candidate silences. It may not publish them as
+reportable silences until a human has inspected the newer source document and,
+where needed, the prior document. This is the credibility gate for the whole
+feature.
+
+Phase 0 must estimate verification capacity in operator hours. If the projected
+annual review queue is greater than 40 hours, v1 must reduce the watchlist,
+tighten thresholds, or both.
+
+### Section quality gate
+
+A field can only become `newly_missing` when the newer document is otherwise
+high-quality for the relevant section/subsection. This should reuse existing
+quality signals before inventing new ones:
+
+- `data_quality_flag`
+- `admission_strategy_card_quality`
+- `merit_profile_quality`
+- section/subsection answerability from the Phase 0 audit
+- producer compatibility from the comparability rules above
+
+Phase 0 must define initial section-quality thresholds. Sketch:
+
+- section/subsection answerability >= 70% for the relevant launch field family,
+  or an existing card-quality flag indicating the section is usable.
+- no `wrong_file`, `blank_template`, or `low_coverage` document flag.
+- no producer downgrade unless human-reviewed.
+
+### School-page "What Changed" module
+
+Add a compact school-page section:
+
+- Latest CDS year compared with prior primary year.
+- 3-5 highest-salience changes.
+- Explicit "newly missing" / "newly reported" labels.
+- Source links to both PDFs.
+- Caveat line: "A missing field can mean the school omitted it, changed format,
+  or our extractor could not recover it. We flag extractor-quality regressions
+  separately where detected."
+
+### Watchlist digest
+
+Add an operator-facing or public `/changes` surface:
+
+- Top 200 Watchlist completion status.
+- Newly published CDS files.
+- Biggest admissions changes.
+- Biggest aid changes.
+- International-enrollment movement.
+- Newly missing test-score or aid fields.
+- Schools with extraction-quality regressions that block a clean comparison.
+
+Public launch can start as a static page generated from the latest change-event
+projection. Do not overbuild filters before the first editorial report is written.
+
+For v1, `/changes` is operator-only. Public launch happens after threshold
+calibration and editorial review.
+
+### Annual report seed
+
+Generate a Markdown report artifact:
+
+```
+.context/reports/cds-change-intelligence-2025-26.md
+```
+
+Sections:
+
+- Freshness / coverage status for the Top 200 Watchlist.
+- Biggest admissions-pressure signals.
+- International-student signals visible in CDS.
+- Aid and affordability shifts.
+- Reporting gaps / silences worth asking about.
+- Methodology and caveats.
+- Query appendix with source links.
+
+This is the bridge from data product to op-ed/reporting.
+
+Report generation must exclude unverified `major` and `newly_missing` events by
+default. It may include an appendix of unverified candidates only if they are
+clearly labeled as candidates and excluded from editorial claims.
+
+Editorial review must explicitly check for adjacency-driven implied causation.
+Macro context from WICHE, Census, IIE, and NAFSA should frame the report, but
+school-specific change tables should not be positioned so close to macro-policy
+claims that readers infer causation the data does not prove.
+
+## What does NOT ship
+
+- No claim that missing data proves intentional concealment.
+- No automated accusation language.
+- No full 1,105-field diff UI in v1.
+- No use of proprietary rankings as a hard-coded public source unless licensing
+  is reviewed. The Top 200 Watchlist is operator-curated for launch.
+- No LLM-only change events. LLMs may summarize events after deterministic
+  detection, but the event record must come from structured field comparisons.
+- No policy-causation claims. CDS deltas can be discussed alongside WICHE, IIE,
+  NAFSA, Census, and policy context, but the app should not infer causation.
+- No unreviewed silences in publication-grade reports. Machine-generated
+  `newly_missing` candidates are not reportable until verified.
+
+## Architecture sketch
+
+```
+cds_documents / cds_manifest
+        |
+        v
+cds_fields  + selected primary document logic
+        |
+        v
+cds_field_observations
+        |
+        v
+tools/change_intelligence/project_change_events.py
+        |
+        +--> cds_field_change_events
+        |
+        +--> .context/reports/cds-change-intelligence-2025-26.md
+        |
+        +--> school page What Changed module
+        |
+        +--> /changes watchlist digest
+```
+
+## Implementation phases
+
+### Phase 0 — Field and watchlist scoping
+
+- Create Top 200 Watchlist seed file:
+  `data/watchlists/top_200_change_intelligence.yaml`.
+- Create a ground-truth calibration subset:
+  `data/watchlists/change_intelligence_calibration.yaml`.
+- Select a tight 15-20 launch field list and map raw schema-version fields to
+  canonical schema keys through PRD 014 equivalence tables.
+- Write `rules.yaml` with threshold rules.
+- Run an answerability audit for launch fields across 2024-25 and 2025-26
+  documents already in the corpus.
+- Estimate human-verification queue size in operator hours.
+
+Exit gate: at least 70% of watchlist schools with both latest and prior primary
+CDS have enough launch fields for a useful change report, and the estimated
+verification queue is <= 40 operator hours.
+
+### Calibration subset
+
+Before applying thresholds to the whole watchlist, calibrate on an intentionally
+mixed 30-school subset:
+
+- 10 high-selectivity private universities and liberal arts colleges.
+- 10 flagship or high-application public universities.
+- 5 international-heavy universities.
+- 5 broad-access or regional institutions with available multi-year CDS history.
+
+The subset should include schools where the operator already has domain intuition
+and schools where the pipeline is likely to struggle. It should deliberately
+include Ivies/top privates, large publics, LACs, and schools with known extraction
+edge cases.
+
+Candidate seed, subject to document availability at implementation time:
+
+- High-selectivity private / LAC: Harvard, Yale, Princeton, MIT, Stanford, Duke,
+  Northwestern, Vanderbilt, Amherst, Bowdoin.
+- Flagship / high-application public: UC Berkeley, UCLA, Michigan, Virginia,
+  North Carolina, Georgia Tech, Texas A&M, Ohio State, Wisconsin, Florida.
+- International-heavy universities: Columbia, NYU, Northeastern, USC, Boston
+  University.
+- Broad-access / regional / extraction-edge calibration: Arizona State,
+  Cincinnati, George Mason, Kent State, UT Dallas.
+
+Threshold rules are not considered launch-ready until every `major` and
+`newly_missing` event in this subset has been manually reviewed and classified.
+
+### Phase 1 — Observation and event projection
+
+- Implement `cds_field_observations` as a view.
+- Implement change-event projector.
+- Persist events into Supabase.
+- Add unit tests for threshold rules and event classification.
+- Spot-check at least 20 schools, including Ivies, flagship publics, LACs, and
+  international-heavy private universities.
+
+Exit gate: projector produces deterministic, source-linked events with no known
+false-positive major events in the 20-school spot check.
+
+### Phase 2 — School-page and digest UI
+
+- Add `WhatChangedCard` to school pages.
+- Add `/changes` digest page.
+- Add methodology copy explaining material deltas, reporting gaps, and extractor
+  quality.
+- Ensure every visible event links back to source PDFs and years.
+
+Exit gate: a counselor or journalist can understand the event without knowing
+CDS field names.
+
+### Phase 3 — Report generation
+
+- Generate first annual Markdown report.
+- Export CSV of all watchlist events.
+- Add charts for a small number of high-confidence cross-school trends.
+- Run human verification for every `major` and report-bound `newly_missing`
+  event.
+- Draft an editorial memo with claims separated into:
+  `strongly supported`, `suggestive`, and `needs external corroboration`.
+
+Exit gate: at least five publishable insights have source-backed evidence and
+clear caveats.
+
+## Verification
+
+- Unit tests for field-specific threshold rules.
+- Fixture tests for:
+  - material numeric delta
+  - newly missing after one prior year
+  - newly missing severity raised after two-plus prior years
+  - newly reported
+  - reappeared
+  - extraction quality regression
+  - producer changed
+  - schema rename with no event
+  - source provenance crossing
+  - categorical C7 movement
+  - prior-year selectivity boundary
+- Snapshot test for a known school with stable historic CDS rows.
+- Manual spot-check of 20 watchlist schools against source PDFs.
+- Human verification coverage: 100% of `major` and report-bound
+  `newly_missing` events have `confirmed` or `not_reportable` decisions.
+- Cross-check the annual report summary counts against raw `cds_field_change_events`.
+- Confirm no public copy claims causation from demographic or immigration-policy
+  context without external citation.
+
+## Failure modes
+
+- **Extractor miss misclassified as school silence.** Mitigation: event type
+  `quality_regression` and public caveat. A field should only become
+  `newly_missing` when the newer document is otherwise high-quality for that
+  section.
+- **Producer drift fabricates school behavior.** Mitigation: explicit producer
+  comparability rules, `producer_changed` events, and no `newly_missing` events
+  across producer downgrades without human review.
+- **Schema drift fabricates field disappearance.** Mitigation: canonical
+  equivalence mapping from PRD 014 before comparisons, plus rename fixture tests.
+- **Top 200 freshness too low.** Mitigation: recency-first discovery/drain,
+  targeted watchlist re-drain, and a public freshness denominator.
+- **Thresholds generate noise.** Mitigation: start conservative and manually
+  review every `major` event before it appears in the first report; use baseline
+  selectivity bands and historical volatility where possible.
+- **Year pairing is wrong.** Mitigation: compare selected primary documents only,
+  never sub-institutional rows unless explicitly supported.
+- **Editorial overreach.** Mitigation: separate "what changed in CDS" from "why
+  it changed." External sources frame the macro context; CDS events are the
+  evidence layer.
+
+## Effort estimate
+
+1-2 weeks for a first deterministic event projector and school-page card if the
+field list stays tight and the watchlist is curated manually.
+
+2-4 weeks for a publication-grade annual report with enough spot-checking,
+charts, caveats, and top-200 freshness work to support a serious external pitch.
+
+This estimate excludes the mandatory two-day pre-PRD editorial spike.
+
+## Open questions
+
+- Exact 30-school calibration subset.
+- Whether every confirmed `newly_missing` event should appear on school pages,
+  or only those above `notable`.
+- How much of the human verification workflow belongs in Supabase tables vs.
+  `.context` report-review artifacts for v1.
+- Whether the first public launch should lead with `/changes`, an annual report,
+  or a single flagship essay with `/changes` as supporting evidence.
+
+## Decisions made from initial review
+
+- Top 200 Watchlist is operator-only until the first report ships.
+- Watchlist seed avoids proprietary rankings: C1 application volume, flagship
+  publics, and public/operator-reviewed LAC recognition.
+- One prior year is enough to flag a launch `newly_missing` event, but the label
+  must say "vs. prior year." Two-plus prior years can raise severity.
+- Phase 1 international-student pressure uses CDS-visible fields first. IIE,
+  NAFSA, IPEDS, and Scorecard context belong in the report layer, not
+  `cds_field_change_events`.
+- `/changes` starts operator-only and becomes public after threshold calibration
+  and the first editorial review.

--- a/tools/change_intelligence/prd019_spike_admissions_reporting.py
+++ b/tools/change_intelligence/prd019_spike_admissions_reporting.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""PRD 019 pre-PRD spike: admissions/reporting deltas.
+
+This intentionally uses the existing public school_browser_rows projection
+instead of raw cds_fields. The spike goal is editorial signal discovery, not a
+new production projector.
+
+Outputs:
+  .context/reports/prd019_admissions_reporting_spike.csv
+  .context/reports/prd019_admissions_reporting_spike.md
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUT_DIR = REPO_ROOT / ".context" / "reports"
+CSV_OUT = OUT_DIR / "prd019_admissions_reporting_spike.csv"
+MD_OUT = OUT_DIR / "prd019_admissions_reporting_spike.md"
+
+PUBLIC_SUPABASE_URL = "https://api.collegedata.fyi"
+YEARS = (2024, 2025)
+
+SELECT_COLUMNS = [
+    "document_id",
+    "school_id",
+    "school_name",
+    "sub_institutional",
+    "canonical_year",
+    "year_start",
+    "source_format",
+    "producer",
+    "producer_version",
+    "data_quality_flag",
+    "archive_url",
+    "applied",
+    "admitted",
+    "enrolled_first_year",
+    "acceptance_rate",
+    "yield_rate",
+    "sat_submit_rate",
+    "act_submit_rate",
+    "sat_composite_p25",
+    "sat_composite_p50",
+    "sat_composite_p75",
+    "act_composite_p25",
+    "act_composite_p50",
+    "act_composite_p75",
+    "ed_offered",
+    "ed_applicants",
+    "ed_admitted",
+    "admission_strategy_card_quality",
+]
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    env: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def load_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for path in (
+        REPO_ROOT / ".env",
+        REPO_ROOT / "web" / ".env.local",
+        Path("/Users/santhonys/Projects/Owen/colleges/collegedata-fyi/web/.env.local"),
+    ):
+        for key, value in read_env_file(path).items():
+            env.setdefault(key, value)
+    return env
+
+
+def fetch_rows() -> list[dict[str, Any]]:
+    env = load_env()
+    base_url = (
+        env.get("SUPABASE_URL")
+        or env.get("NEXT_PUBLIC_SUPABASE_URL")
+        or PUBLIC_SUPABASE_URL
+    ).rstrip("/")
+    anon_key = env.get("SUPABASE_ANON_KEY") or env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    if not anon_key:
+        raise SystemExit(
+            "Missing SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY. "
+            "Set it in env or web/.env.local."
+        )
+
+    params = {
+        "select": ",".join(SELECT_COLUMNS),
+        "year_start": f"in.({','.join(str(y) for y in YEARS)})",
+        "sub_institutional": "is.null",
+        "order": "school_id.asc,year_start.asc",
+    }
+    url = f"{base_url}/rest/v1/school_browser_rows?{urlencode(params)}"
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    page_size = 1000
+    while True:
+        req = Request(
+            url,
+            headers={
+                "apikey": anon_key,
+                "Authorization": f"Bearer {anon_key}",
+                "Range-Unit": "items",
+                "Range": f"{offset}-{offset + page_size - 1}",
+            },
+        )
+        with urlopen(req, timeout=60) as res:
+            page = json.loads(res.read().decode("utf-8"))
+        if not page:
+            break
+        rows.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+    return rows
+
+
+def as_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(n):
+        return None
+    return n
+
+
+def as_int(value: Any) -> int | None:
+    n = as_float(value)
+    return int(n) if n is not None else None
+
+
+def pp(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value * 100:.1f}%"
+
+
+def fmt_num(value: float | int | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and not value.is_integer():
+        return f"{value:.4f}"
+    return str(int(value))
+
+
+def has_any(row: dict[str, Any], keys: list[str]) -> bool:
+    return any(row.get(key) is not None for key in keys)
+
+
+@dataclass
+class Event:
+    school_id: str
+    school_name: str
+    ipeds_id: str
+    metric: str
+    event_type: str
+    prior_year: str
+    latest_year: str
+    prior_value: str
+    latest_value: str
+    delta: str
+    abs_delta_for_sort: float
+    prior_source_format: str
+    latest_source_format: str
+    prior_producer: str
+    latest_producer: str
+    prior_quality: str
+    latest_quality: str
+    prior_archive_url: str
+    latest_archive_url: str
+    comparability: str
+    notes: str
+
+
+def event_base(prior: dict[str, Any], latest: dict[str, Any], metric: str, event_type: str) -> dict[str, Any]:
+    return {
+        "school_id": latest["school_id"],
+        "school_name": latest["school_name"],
+        "ipeds_id": latest.get("ipeds_id") or "",
+        "metric": metric,
+        "event_type": event_type,
+        "prior_year": prior["canonical_year"],
+        "latest_year": latest["canonical_year"],
+        "prior_source_format": prior.get("source_format") or "",
+        "latest_source_format": latest.get("source_format") or "",
+        "prior_producer": prior.get("producer") or "",
+        "latest_producer": latest.get("producer") or "",
+        "prior_quality": prior.get("data_quality_flag") or "",
+        "latest_quality": latest.get("data_quality_flag") or "",
+        "prior_archive_url": prior.get("archive_url") or "",
+        "latest_archive_url": latest.get("archive_url") or "",
+        "comparability": comparability(prior, latest),
+    }
+
+
+def comparability(prior: dict[str, Any], latest: dict[str, Any]) -> str:
+    bad_flags = {"wrong_file", "blank_template", "low_coverage"}
+    if prior.get("data_quality_flag") in bad_flags or latest.get("data_quality_flag") in bad_flags:
+        return "quality_flagged"
+    if (prior.get("producer") or "") != (latest.get("producer") or ""):
+        return "producer_changed"
+    if (prior.get("source_format") or "") != (latest.get("source_format") or ""):
+        return "format_changed"
+    return "clean"
+
+
+def rate_event(prior: dict[str, Any], latest: dict[str, Any], metric: str, column: str) -> Event | None:
+    old = as_float(prior.get(column))
+    new = as_float(latest.get(column))
+    if old is None or new is None:
+        return None
+    delta = new - old
+    return Event(
+        **event_base(prior, latest, metric, "rate_delta"),
+        prior_value=pp(old),
+        latest_value=pp(new),
+        delta=f"{delta * 100:+.1f} pp",
+        abs_delta_for_sort=abs(delta),
+        notes="",
+    )
+
+
+def count_event(prior: dict[str, Any], latest: dict[str, Any], metric: str, column: str) -> Event | None:
+    old = as_int(prior.get(column))
+    new = as_int(latest.get(column))
+    if old is None or new is None:
+        return None
+    delta = new - old
+    return Event(
+        **event_base(prior, latest, metric, "count_delta"),
+        prior_value=fmt_num(old),
+        latest_value=fmt_num(new),
+        delta=f"{delta:+d}",
+        abs_delta_for_sort=abs(delta),
+        notes="",
+    )
+
+
+def ed_admit_rate_event(prior: dict[str, Any], latest: dict[str, Any]) -> Event | None:
+    old_apps = as_int(prior.get("ed_applicants"))
+    old_admits = as_int(prior.get("ed_admitted"))
+    new_apps = as_int(latest.get("ed_applicants"))
+    new_admits = as_int(latest.get("ed_admitted"))
+    if not old_apps or old_admits is None or not new_apps or new_admits is None:
+        return None
+    old = old_admits / old_apps
+    new = new_admits / new_apps
+    delta = new - old
+    return Event(
+        **event_base(prior, latest, "ED admit rate", "rate_delta"),
+        prior_value=pp(old),
+        latest_value=pp(new),
+        delta=f"{delta * 100:+.1f} pp",
+        abs_delta_for_sort=abs(delta),
+        notes=f"prior ED {old_admits}/{old_apps}; latest ED {new_admits}/{new_apps}",
+    )
+
+
+def reporting_event(
+    prior: dict[str, Any],
+    latest: dict[str, Any],
+    metric: str,
+    keys: list[str],
+) -> Event | None:
+    old = has_any(prior, keys)
+    new = has_any(latest, keys)
+    if old == new:
+        return None
+    event_type = "newly_missing" if old and not new else "newly_reported"
+    return Event(
+        **event_base(prior, latest, metric, event_type),
+        prior_value="reported" if old else "missing",
+        latest_value="reported" if new else "missing",
+        delta=event_type,
+        abs_delta_for_sort=1.0,
+        notes="candidate only; requires source-PDF human review",
+    )
+
+
+def score_range_delta(
+    prior: dict[str, Any],
+    latest: dict[str, Any],
+    metric: str,
+    keys: list[str],
+) -> Event | None:
+    old_values = [as_int(prior.get(k)) for k in keys]
+    new_values = [as_int(latest.get(k)) for k in keys]
+    if any(v is None for v in old_values + new_values):
+        return None
+    deltas = [n - o for o, n in zip(old_values, new_values) if o is not None and n is not None]
+    max_abs = max(abs(d) for d in deltas)
+    if max_abs == 0:
+        return None
+    return Event(
+        **event_base(prior, latest, metric, "score_range_delta"),
+        prior_value="/".join(fmt_num(v) for v in old_values),
+        latest_value="/".join(fmt_num(v) for v in new_values),
+        delta="/".join(f"{d:+d}" for d in deltas),
+        abs_delta_for_sort=float(max_abs),
+        notes="",
+    )
+
+
+def entity_id(row: dict[str, Any]) -> str:
+    return str(row.get("ipeds_id") or row["school_id"])
+
+
+def dedupe_years(rows: list[dict[str, Any]]) -> dict[tuple[str, int], dict[str, Any]]:
+    # school_browser_rows is one row per document. If a school has more than one
+    # primary row for a year, prefer non-low-quality rows, then newer updated_at
+    # is unavailable from the public select, so fall back to lexical document id.
+    out: dict[tuple[str, int], dict[str, Any]] = {}
+    for row in rows:
+        key = (entity_id(row), int(row["year_start"]))
+        current = out.get(key)
+        if current is None:
+            out[key] = row
+            continue
+        current_bad = current.get("data_quality_flag") in {"wrong_file", "blank_template", "low_coverage"}
+        row_bad = row.get("data_quality_flag") in {"wrong_file", "blank_template", "low_coverage"}
+        if current_bad and not row_bad:
+            out[key] = row
+    return out
+
+
+def build_events(rows: list[dict[str, Any]]) -> tuple[list[Event], int]:
+    by_year = dedupe_years(rows)
+    schools = sorted({school for school, _year in by_year})
+    comparable = 0
+    events: list[Event] = []
+    for school_id in schools:
+        prior = by_year.get((school_id, 2024))
+        latest = by_year.get((school_id, 2025))
+        if not prior or not latest:
+            continue
+        comparable += 1
+        candidates = [
+            rate_event(prior, latest, "Admit rate", "acceptance_rate"),
+            rate_event(prior, latest, "Yield rate", "yield_rate"),
+            count_event(prior, latest, "ED applicants", "ed_applicants"),
+            count_event(prior, latest, "ED admits", "ed_admitted"),
+            ed_admit_rate_event(prior, latest),
+            rate_event(prior, latest, "SAT submit rate", "sat_submit_rate"),
+            rate_event(prior, latest, "ACT submit rate", "act_submit_rate"),
+            reporting_event(
+                prior,
+                latest,
+                "SAT composite range reporting",
+                ["sat_composite_p25", "sat_composite_p50", "sat_composite_p75"],
+            ),
+            reporting_event(
+                prior,
+                latest,
+                "ACT composite range reporting",
+                ["act_composite_p25", "act_composite_p50", "act_composite_p75"],
+            ),
+            score_range_delta(
+                prior,
+                latest,
+                "SAT composite range",
+                ["sat_composite_p25", "sat_composite_p50", "sat_composite_p75"],
+            ),
+            score_range_delta(
+                prior,
+                latest,
+                "ACT composite range",
+                ["act_composite_p25", "act_composite_p50", "act_composite_p75"],
+            ),
+        ]
+        events.extend(e for e in candidates if e is not None)
+    return events, comparable
+
+
+def write_csv(events: list[Event]) -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(Event.__dataclass_fields__.keys())
+    with CSV_OUT.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for event in events:
+            writer.writerow(event.__dict__)
+
+
+def top_by_metric(events: list[Event], metric: str, limit: int = 10) -> list[Event]:
+    subset = [e for e in events if e.metric == metric]
+    return sorted(subset, key=lambda e: e.abs_delta_for_sort, reverse=True)[:limit]
+
+
+def is_clean(event: Event) -> bool:
+    return event.comparability == "clean"
+
+
+def write_summary(events: list[Event], comparable: int, total_rows: int) -> None:
+    reporting = [e for e in events if e.event_type in {"newly_missing", "newly_reported"}]
+    clean_events = [e for e in events if is_clean(e)]
+    top = sorted(clean_events, key=lambda e: e.abs_delta_for_sort, reverse=True)[:50]
+    noisy = [e for e in events if not is_clean(e)]
+    lines = [
+        "# PRD 019 admissions/reporting spike",
+        "",
+        "This is a cheap signal-discovery pass over public `school_browser_rows`, not the final change-intelligence projector.",
+        "",
+        f"- Source rows fetched: {total_rows}",
+        f"- Schools with primary 2024-25 and 2025-26 rows: {comparable}",
+        f"- Candidate events written: {len(events)}",
+        f"- Clean comparable events: {len(clean_events)}",
+        f"- Noisy/provenance/quality-gated events: {len(noisy)}",
+        f"- Reporting-status candidate events requiring human review: {len(reporting)}",
+        f"- CSV: `{CSV_OUT.relative_to(REPO_ROOT)}`",
+        "",
+        "## Top 50 candidate events",
+        "",
+        "This table only includes events where producer, source format, and document quality are comparable. Noisy events remain in the CSV.",
+        "",
+        "| School | Metric | Event | Prior | Latest | Delta | Notes |",
+        "|---|---:|---|---:|---:|---:|---|",
+    ]
+    for e in top:
+        lines.append(
+            f"| {e.school_name} | {e.metric} | {e.event_type} | "
+            f"{e.prior_value} | {e.latest_value} | {e.delta} | {e.notes} |"
+        )
+    for metric in ["Admit rate", "Yield rate", "SAT submit rate", "ACT submit rate"]:
+        metric_top = top_by_metric(clean_events, metric, 8)
+        if not metric_top:
+            continue
+        lines.extend(["", f"## Largest {metric} moves", ""])
+        for e in metric_top:
+            lines.append(f"- {e.school_name}: {e.prior_value} -> {e.latest_value} ({e.delta})")
+    if reporting:
+        lines.extend(["", "## Reporting-status candidates", ""])
+        for e in sorted(reporting, key=lambda item: (item.comparability, item.metric, item.school_name))[:50]:
+            lines.append(
+                f"- {e.school_name}: {e.metric} {e.prior_value} -> {e.latest_value} "
+                f"({e.comparability})"
+            )
+    if noisy:
+        lines.extend(["", "## Noisy top events gated out of the clean table", ""])
+        for e in sorted(noisy, key=lambda item: item.abs_delta_for_sort, reverse=True)[:20]:
+            lines.append(
+                f"- {e.school_name}: {e.metric} {e.prior_value} -> {e.latest_value} "
+                f"({e.delta}; {e.comparability}; {e.prior_producer} -> {e.latest_producer})"
+            )
+    MD_OUT.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    rows = fetch_rows()
+    events, comparable = build_events(rows)
+    events = sorted(events, key=lambda e: e.abs_delta_for_sort, reverse=True)
+    write_csv(events)
+    write_summary(events, comparable, len(rows))
+    print(f"fetched_rows={len(rows)}")
+    print(f"comparable_schools={comparable}")
+    print(f"events={len(events)}")
+    print(f"csv={CSV_OUT}")
+    print(f"summary={MD_OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/extraction_worker/test_tier4_cleaner_a_general.py
+++ b/tools/extraction_worker/test_tier4_cleaner_a_general.py
@@ -6,6 +6,28 @@ from tier4_cleaner import clean
 
 
 class Tier4CleanerAGeneralTest(unittest.TestCase):
+    def test_question_number_led_export_rows(self):
+        markdown = """
+## 2024-2025 Common Data Set Pittsburgh Campus
+## A. GENERAL INFORMATION
+| A1   | Address Information Address Information | Response Text Response Text |
+|------|-----------------------------------------|-----------------------------|
+| A101 | Name of College/University:             | University of Pittsburgh    |
+| A102 | Mailing Address:                        | 4200 Fifth Avenue           |
+
+| A2   | Source of institutional control (Check only one): | Response 'x' |
+|------|---------------------------------------------------|--------------|
+| A201 | Public                                            | X            |
+| A202 | Private (nonprofit)                               |              |
+
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["A.101"]["value"], "University of Pittsburgh")
+        self.assertEqual(values["A.102"]["value"], "4200 Fifth Avenue")
+        self.assertEqual(values["A.201"]["value"], "X")
+
     def test_page_one_general_information_from_layout_text(self):
         supplemental = """
 A0   Respondent Information (Not for Publication)

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -7,6 +7,7 @@ from worker import (
     extraction_no_project,
     extraction_success,
     is_failure_action,
+    low_field_quality_flag,
     mean_or_none,
     parsed_field_count,
     pending_doc_priority_key,
@@ -36,6 +37,11 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
     def test_summary_mean_rounding(self):
         self.assertEqual(mean_or_none([1, 2, 4]), 2.33)
         self.assertIsNone(mean_or_none([]))
+
+    def test_low_field_quality_flag(self):
+        self.assertEqual(low_field_quality_flag(0), "blank_template")
+        self.assertEqual(low_field_quality_flag(24), "low_coverage")
+        self.assertIsNone(low_field_quality_flag(25))
 
     def test_pending_doc_priority_prefers_recent_cds_year(self):
         rows = [

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 
 from worker import (
     annotate_tier2_unmapped_fields,
+    artifact_already_extracted,
+    attach_source_metadata,
     extraction_no_project,
     extraction_success,
     is_failure_action,
@@ -12,6 +15,31 @@ from worker import (
     parsed_field_count,
     pending_doc_priority_key,
 )
+
+
+class _FakeArtifactQuery:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def select(self, _columns):
+        return self
+
+    def eq(self, _column, _value):
+        return self
+
+    def limit(self, _count):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.rows)
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def table(self, _name):
+        return _FakeArtifactQuery(self.rows)
 
 
 class WorkerProjectionRefreshTests(unittest.TestCase):
@@ -42,6 +70,41 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
         self.assertEqual(low_field_quality_flag(0), "blank_template")
         self.assertEqual(low_field_quality_flag(24), "low_coverage")
         self.assertIsNone(low_field_quality_flag(25))
+
+    def test_attach_source_metadata_records_latest_source(self):
+        canonical = {}
+
+        attach_source_metadata(canonical, {
+            "sha256": "abc123",
+            "storage_path": "upitt/2025-26/abc123.pdf",
+        })
+
+        self.assertEqual(canonical["source_sha256"], "abc123")
+        self.assertEqual(canonical["source_storage_path"], "upitt/2025-26/abc123.pdf")
+        self.assertEqual(canonical["source_artifact"]["sha256"], "abc123")
+
+    def test_artifact_idempotency_requires_matching_source_sha_when_known(self):
+        client = _FakeClient([
+            {"id": "old", "notes": {"source_sha256": "old-sha"}},
+            {"id": "new", "notes": {"source_artifact": {"sha256": "new-sha"}}},
+        ])
+
+        self.assertTrue(artifact_already_extracted(
+            client, "doc", "tier4_docling", "0.3.4", "2025-26", "new-sha",
+        ))
+        self.assertFalse(artifact_already_extracted(
+            client, "doc", "tier4_docling", "0.3.4", "2025-26", "missing-sha",
+        ))
+
+    def test_artifact_idempotency_treats_legacy_notes_as_stale_when_source_known(self):
+        client = _FakeClient([{"id": "legacy", "notes": {"stats": {}}}])
+
+        self.assertFalse(artifact_already_extracted(
+            client, "doc", "tier4_docling", "0.3.4", "2025-26", "current-sha",
+        ))
+        self.assertTrue(artifact_already_extracted(
+            client, "doc", "tier4_docling", "0.3.4", "2025-26",
+        ))
 
     def test_pending_doc_priority_prefers_recent_cds_year(self):
         rows = [

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -88,6 +88,42 @@ def _normalize_label_without_gender_rewrite(text: str) -> str:
     return t
 
 
+def _normalize_compact_question_number(text: str) -> str | None:
+    """Normalize CDS export row IDs like A101 or C901 to schema qnums."""
+    m = re.match(r"^\s*([A-J])\.?(\d{1,3}[A-Z]?)\s*$", str(text).strip(), re.IGNORECASE)
+    if not m:
+        return None
+    section, rest = m.groups()
+    rest = rest.upper()
+    if rest.isdigit():
+        rest = rest.zfill(3)
+    return f"{section.upper()}.{rest}"
+
+
+def _direct_qnum_value(row: dict) -> str | None:
+    """Choose the response cell from a question-number-led table row."""
+    values = [str(v).strip() for v in row.get("values", [])]
+    headers = [str(h).strip().lower() for h in row.get("headers", [])]
+    if not values:
+        return None
+
+    for header_idx, header in enumerate(headers[1:], start=0):
+        if header_idx >= len(values):
+            continue
+        if "response" in header or "answer" in header:
+            value = values[header_idx]
+            if value:
+                return value
+
+    # Pitt-style exports usually put the prompt in values[0] and the answer
+    # in the last populated cell. Walking backward avoids treating the prompt
+    # text as the value.
+    for value in reversed(values[1:] if len(values) > 1 else values):
+        if value:
+            return value
+    return None
+
+
 _NO_WRAP_EMPTY_LABELS = {
     "sat composite",
     "sat evidence based reading and writing",
@@ -5229,6 +5265,7 @@ def clean(
     def _norm_hint(ch):
         return _normalize_label(ch) if isinstance(ch, str) else ch
     field_map_norm = [(_normalize_label(s), qn, _norm_hint(ch)) for s, qn, ch in _FIELD_MAP]
+    schema_qnums = {f["question_number"] for f in idx.fields}
 
     for table in tables:
         section_norm = _normalize_label(table["section"])
@@ -5236,6 +5273,19 @@ def clean(
         for row in table["rows"]:
             label_norm = _normalize_label(row["label"])
             headers_norm = [_normalize_label(h) for h in row.get("headers", [])]
+
+            # --- Direct question-number rows ---
+            # Some school exports use compact CDS row IDs as the first column
+            # (e.g. A101, C901) instead of natural-language labels. Normalize
+            # those to schema keys (A.101, C.901) and read the response cell.
+            direct_qnum = _normalize_compact_question_number(row["label"])
+            if direct_qnum in schema_qnums and direct_qnum not in values:
+                direct_value = _direct_qnum_value(row)
+                if direct_value:
+                    values[direct_qnum] = {
+                        "value": direct_value,
+                        "source": "tier4_cleaner",
+                    }
 
             # --- Standard field map ---
             for substr, qnum, col_hint in field_map_norm:

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.3"
+PRODUCER_VERSION = "0.3.4"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -113,6 +113,7 @@ from html_to_markdown import html_to_markdown  # noqa: E402 (PRD 008 Tier 6)
 SCHEMA_DIR = _TOOLS_ROOT.parent / "schemas"
 TEMPLATE_DIR = SCHEMA_DIR / "templates"
 MIN_TIER1_FIELDS = 5
+MIN_TIER4_FIELDS = 25
 
 
 @dataclass(frozen=True)
@@ -148,6 +149,12 @@ def is_failure_action(action: str) -> bool:
     if "_error" in action or action.endswith("_no_tables"):
         return True
     return False
+
+
+def low_field_quality_flag(fields: int, threshold: int = MIN_TIER4_FIELDS) -> str | None:
+    if fields >= threshold:
+        return None
+    return "blank_template" if fields == 0 else "low_coverage"
 
 
 def mean_or_none(values: list[int]) -> float | None:
@@ -733,6 +740,7 @@ def _run_tier1(
             client, document_id, producer, producer_version, resolution.schema_version,
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
+            clear_recoverable_quality_flag(client, document_id)
             return extraction_no_project("already_extracted")
 
         try:
@@ -742,6 +750,7 @@ def _run_tier1(
             return extraction_no_project(f"artifact_insert_error: {e}")
 
         mark_extraction_status(client, document_id, "extracted", source_format)
+        clear_recoverable_quality_flag(client, document_id)
 
     return extraction_success(f"tier1_extracted ({fields} fields)")
 
@@ -813,12 +822,19 @@ def _run_tier6(
 
     producer = canonical["producer"]
     producer_version = canonical["producer_version"]
+    stats = canonical.get("stats", {})
+    fields = int(stats.get("schema_fields_populated") or 0)
+    quality_flag = low_field_quality_flag(fields)
 
     if not dry_run:
         if artifact_already_extracted(
             client, document_id, producer, producer_version, resolution.schema_version,
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
+            if quality_flag:
+                mark_document_quality_flag(client, document_id, quality_flag)
+            else:
+                clear_recoverable_quality_flag(client, document_id)
             return extraction_no_project("already_extracted")
 
         try:
@@ -828,6 +844,10 @@ def _run_tier6(
             return extraction_no_project(f"artifact_insert_error: {e}")
 
         mark_extraction_status(client, document_id, "extracted", source_format)
+        if quality_flag:
+            mark_document_quality_flag(client, document_id, quality_flag)
+        else:
+            clear_recoverable_quality_flag(client, document_id)
 
     return extraction_success(f"tier6_extracted ({len(values)} fields, {len(markdown)} md chars)")
 
@@ -869,12 +889,19 @@ def _run_tier4(
 
     producer = canonical["producer"]
     producer_version = canonical["producer_version"]
+    stats = canonical.get("stats", {})
+    fields = int(stats.get("schema_fields_populated") or 0)
+    quality_flag = low_field_quality_flag(fields)
 
     if not dry_run:
         if artifact_already_extracted(
             client, document_id, producer, producer_version, resolution.schema_version,
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
+            if quality_flag:
+                mark_document_quality_flag(client, document_id, quality_flag)
+            else:
+                clear_recoverable_quality_flag(client, document_id)
             return extraction_no_project("already_extracted")
 
         try:
@@ -884,11 +911,13 @@ def _run_tier4(
             return extraction_no_project(f"artifact_insert_error: {e}")
 
         mark_extraction_status(client, document_id, "extracted", source_format)
+        if quality_flag:
+            mark_document_quality_flag(client, document_id, quality_flag)
+        else:
+            clear_recoverable_quality_flag(client, document_id)
 
-    stats = canonical.get("stats", {})
     md_len = stats.get("markdown_length", 0)
     pages = stats.get("page_count", 0)
-    fields = stats.get("schema_fields_populated", 0)
     return extraction_success(f"tier4_extracted ({fields} fields, {md_len} chars, {pages} pages)")
 
 
@@ -902,6 +931,24 @@ def mark_extraction_status(
     if source_format is not None:
         update["source_format"] = source_format
     client.table("cds_documents").update(update).eq("id", document_id).execute()
+
+
+def mark_document_quality_flag(
+    client: Client,
+    document_id: str,
+    flag: str | None,
+) -> None:
+    client.table("cds_documents").update(
+        {"data_quality_flag": flag},
+    ).eq("id", document_id).execute()
+
+
+def clear_recoverable_quality_flag(client: Client, document_id: str) -> None:
+    client.table("cds_documents").update(
+        {"data_quality_flag": None},
+    ).eq("id", document_id).in_(
+        "data_quality_flag", ["blank_template", "low_coverage"],
+    ).execute()
 
 
 def write_detected_year(

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -313,10 +313,10 @@ def build_cell_maps_for_schemas(
     return cell_maps
 
 
-def fetch_latest_source_path(client: Client, document_id: str) -> Optional[str]:
+def fetch_latest_source_artifact(client: Client, document_id: str) -> Optional[dict]:
     result = (
         client.table("cds_artifacts")
-        .select("storage_path")
+        .select("storage_path,sha256")
         .eq("document_id", document_id)
         .eq("kind", "source")
         .order("created_at", desc=True)
@@ -324,7 +324,12 @@ def fetch_latest_source_path(client: Client, document_id: str) -> Optional[str]:
         .execute()
     )
     rows = result.data or []
-    return rows[0]["storage_path"] if rows else None
+    return rows[0] if rows else None
+
+
+def fetch_latest_source_path(client: Client, document_id: str) -> Optional[str]:
+    artifact = fetch_latest_source_artifact(client, document_id)
+    return artifact["storage_path"] if artifact else None
 
 
 def download_source(client: Client, storage_path: str) -> bytes:
@@ -636,12 +641,18 @@ def artifact_already_extracted(
     producer: str,
     producer_version: str,
     schema_version: Optional[str] = None,
+    source_sha256: Optional[str] = None,
 ) -> bool:
     """Idempotency: if an artifact with the same (document, kind, producer,
-    version) tuple already exists, skip writing a duplicate."""
+    version, schema, source sha) tuple already exists, skip writing a duplicate.
+
+    The source sha check matters when a document row is refreshed in place with
+    a corrected or republished PDF. Older canonical artifacts may not carry
+    source provenance; those are treated as stale when source_sha256 is known.
+    """
     query = (
         client.table("cds_artifacts")
-        .select("id")
+        .select("id,notes")
         .eq("document_id", document_id)
         .eq("kind", "canonical")
         .eq("producer", producer)
@@ -649,8 +660,34 @@ def artifact_already_extracted(
     )
     if schema_version:
         query = query.eq("schema_version", schema_version)
-    result = query.limit(1).execute()
-    return bool(result.data)
+    result = query.limit(10).execute()
+    rows = result.data or []
+    if not source_sha256:
+        return bool(rows)
+    for row in rows:
+        notes = row.get("notes") or {}
+        if notes.get("source_sha256") == source_sha256:
+            return True
+        source_artifact = notes.get("source_artifact")
+        if isinstance(source_artifact, dict) and source_artifact.get("sha256") == source_sha256:
+            return True
+    return False
+
+
+def attach_source_metadata(canonical: dict, source_artifact: dict) -> None:
+    source_sha256 = source_artifact.get("sha256")
+    source_storage_path = source_artifact.get("storage_path")
+    if source_sha256:
+        canonical["source_sha256"] = source_sha256
+    if source_storage_path:
+        canonical["source_storage_path"] = source_storage_path
+    if source_sha256 or source_storage_path:
+        canonical["source_artifact"] = {
+            k: v for k, v in {
+                "sha256": source_sha256,
+                "storage_path": source_storage_path,
+            }.items() if v
+        }
 
 
 def attach_schema_metadata(canonical: dict, resolution: SchemaResolution) -> dict:
@@ -715,12 +752,14 @@ def _run_tier1(
     source_format: str,
     resolution: SchemaResolution,
     cell_map: dict,
+    source_artifact: dict,
     dry_run: bool,
 ) -> ExtractionOutcome:
     """Tier 1 path: read filled CDS XLSX via template cell-position map."""
     try:
         canonical = tier1_extract(xlsx_bytes, resolution.schema, cell_map)
         attach_schema_metadata(canonical, resolution)
+        attach_source_metadata(canonical, source_artifact)
     except Exception as e:
         if not dry_run:
             mark_extraction_status(client, document_id, "failed", source_format)
@@ -737,7 +776,8 @@ def _run_tier1(
 
     if not dry_run:
         if artifact_already_extracted(
-            client, document_id, producer, producer_version, resolution.schema_version,
+            client, document_id, producer, producer_version,
+            resolution.schema_version, canonical.get("source_sha256"),
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
             clear_recoverable_quality_flag(client, document_id)
@@ -763,6 +803,7 @@ def _run_tier6(
     source_format: str,
     resolution: SchemaResolution,
     schema_index,
+    source_artifact: dict,
     dry_run: bool,
 ) -> ExtractionOutcome:
     """Tier 6 path (PRD 008): HTML → markdown → tier4_cleaner.
@@ -819,6 +860,7 @@ def _run_tier6(
         canonical["schema_fallback_reason"] = resolution.fallback_reason
         if resolution.canonical_year:
             canonical["schema_year_proxy_for"] = resolution.canonical_year
+    attach_source_metadata(canonical, source_artifact)
 
     producer = canonical["producer"]
     producer_version = canonical["producer_version"]
@@ -828,7 +870,8 @@ def _run_tier6(
 
     if not dry_run:
         if artifact_already_extracted(
-            client, document_id, producer, producer_version, resolution.schema_version,
+            client, document_id, producer, producer_version,
+            resolution.schema_version, canonical.get("source_sha256"),
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
             if quality_flag:
@@ -860,6 +903,7 @@ def _run_tier4(
     source_format: str,
     resolution: SchemaResolution,
     schema_index,
+    source_artifact: dict,
     dry_run: bool,
 ) -> ExtractionOutcome:
     """Tier 4 path: Docling baseline → markdown artifact.
@@ -882,6 +926,7 @@ def _run_tier4(
             canonical["schema_fallback_reason"] = resolution.fallback_reason
             if resolution.canonical_year:
                 canonical["schema_year_proxy_for"] = resolution.canonical_year
+        attach_source_metadata(canonical, source_artifact)
     except Exception as e:
         if not dry_run:
             mark_extraction_status(client, document_id, "failed", source_format)
@@ -895,7 +940,8 @@ def _run_tier4(
 
     if not dry_run:
         if artifact_already_extracted(
-            client, document_id, producer, producer_version, resolution.schema_version,
+            client, document_id, producer, producer_version,
+            resolution.schema_version, canonical.get("source_sha256"),
         ):
             mark_extraction_status(client, document_id, "extracted", source_format)
             if quality_flag:
@@ -1050,11 +1096,12 @@ def extract_one(
     document_id = doc["id"]
     school_id = doc["school_id"]
 
-    storage_path = fetch_latest_source_path(client, document_id)
-    if not storage_path:
+    source_artifact = fetch_latest_source_artifact(client, document_id)
+    if not source_artifact:
         if not dry_run:
             mark_extraction_status(client, document_id, "failed")
         return extraction_no_project("no_source_artifact")
+    storage_path = source_artifact["storage_path"]
 
     try:
         pdf_bytes = download_source(client, storage_path)
@@ -1121,7 +1168,7 @@ def extract_one(
     if source_format == "xlsx" and cell_map:
         return _run_tier1(
             client, document_id, school_id, pdf_bytes,
-            source_format, resolution, cell_map, dry_run,
+            source_format, resolution, cell_map, source_artifact, dry_run,
         )
     if source_format == "xlsx" and not cell_map:
         if not dry_run:
@@ -1138,7 +1185,7 @@ def extract_one(
         schema_index = SchemaIndex(resolution.schema_path)
         return _run_tier6(
             client, document_id, school_id, pdf_bytes,
-            source_format, resolution, schema_index, dry_run,
+            source_format, resolution, schema_index, source_artifact, dry_run,
         )
 
     # pdf_scanned routes to Tier 4 too — Docling's do_ocr=True lazily runs
@@ -1150,7 +1197,7 @@ def extract_one(
         schema_index = SchemaIndex(resolution.schema_path)
         return _run_tier4(
             client, document_id, school_id, pdf_bytes,
-            source_format, resolution, schema_index, dry_run,
+            source_format, resolution, schema_index, source_artifact, dry_run,
         )
 
     if source_format != "pdf_fillable":
@@ -1162,6 +1209,7 @@ def extract_one(
     try:
         canonical = run_tier2(pdf_bytes, resolution.schema)
         attach_schema_metadata(canonical, resolution)
+        attach_source_metadata(canonical, source_artifact)
         unmapped_count = annotate_tier2_unmapped_fields(canonical)
         if unmapped_count:
             sample_tags = [
@@ -1186,7 +1234,8 @@ def extract_one(
 
     if not dry_run:
         if artifact_already_extracted(
-            client, document_id, producer, producer_version, resolution.schema_version,
+            client, document_id, producer, producer_version,
+            resolution.schema_version, canonical.get("source_sha256"),
         ):
             # Idempotent re-run: the row was already extracted with this
             # producer version at some earlier point. Mark extracted and

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -201,16 +201,18 @@ def extract_values_from_cell_map(
     qnum_to_field: dict[str, dict],
 ) -> tuple[dict, set[str], int]:
     available_sheets = set(wb.sheetnames)
+    sheet_aliases = build_sheet_aliases(available_sheets)
     values = {}
     missing_sheets = set()
     empty_count = 0
 
     for qnum, (sheet_name, cell_ref) in cell_map.items():
-        if sheet_name not in available_sheets:
+        resolved_sheet_name = sheet_name if sheet_name in available_sheets else sheet_aliases.get(sheet_name)
+        if not resolved_sheet_name:
             missing_sheets.add(sheet_name)
             continue
 
-        ws = wb[sheet_name]
+        ws = wb[resolved_sheet_name]
         try:
             val = ws[cell_ref].value
         except Exception:
@@ -238,6 +240,35 @@ def extract_values_from_cell_map(
     return values, missing_sheets, empty_count
 
 
+def build_sheet_aliases(available_sheets: set[str]) -> dict[str, str]:
+    """Map official template tab names to common school-published variants."""
+    aliases: dict[str, str] = {}
+    for section in "ABCDEFGHIJ":
+        official = f"CDS-{section}"
+        if official not in available_sheets and section in available_sheets:
+            aliases[official] = section
+    descriptive_aliases = {
+        "CDS-A": ("Information",),
+        "CDS-B": ("Enrollment",),
+        "CDS-C": ("Admission", "Admissions"),
+        "CDS-D": ("Transfer",),
+        "CDS-E": ("Academic",),
+        "CDS-F": ("Student Life",),
+        "CDS-G": ("Expenses",),
+        "CDS-H": ("Financial Aid",),
+        "CDS-I": ("Faculty",),
+        "CDS-J": ("Degrees",),
+    }
+    for official, candidates in descriptive_aliases.items():
+        if official in available_sheets or official in aliases:
+            continue
+        for candidate in candidates:
+            if candidate in available_sheets:
+                aliases[official] = candidate
+                break
+    return aliases
+
+
 def recover_c9_academic_profile_values(
     wb,
     qnum_to_field: dict[str, dict],
@@ -251,9 +282,11 @@ def recover_c9_academic_profile_values(
     deterministic source of truth, and this avoids publishing application-date
     cells as SAT Math percentiles when a workbook removed earlier template rows.
     """
-    if "CDS-C" not in wb.sheetnames:
+    available_sheets = set(wb.sheetnames)
+    sheet_name = "CDS-C" if "CDS-C" in available_sheets else build_sheet_aliases(available_sheets).get("CDS-C")
+    if not sheet_name:
         return 0
-    ws = wb["CDS-C"]
+    ws = wb[sheet_name]
     recovered: dict[str, object] = {}
 
     submit_rows = {
@@ -268,11 +301,8 @@ def recover_c9_academic_profile_values(
     }
 
     in_c9 = False
-    for row_idx in range(1, ws.max_row + 1):
-        row_values = [
-            ws.cell(row=row_idx, column=col_idx).value
-            for col_idx in range(1, min(ws.max_column, 12) + 1)
-        ]
+    for row in ws.iter_rows(max_col=12):
+        row_values = [cell.value for cell in row]
         row_text = " ".join(_norm_label(v) for v in row_values if v is not None)
         if _is_c9_header(row_text):
             in_c9 = True
@@ -297,13 +327,13 @@ def recover_c9_academic_profile_values(
 
         if label in submit_rows:
             percent_q, count_q = submit_rows[label]
-            percent_value = ws.cell(row=row_idx, column=label_col + 1).value
-            count_value = ws.cell(row=row_idx, column=label_col + 2).value
+            percent_value = _row_value(row_values, label_col)
+            count_value = _row_value(row_values, label_col + 1)
             recovered[percent_q] = percent_value if _is_c9_value(percent_value) else None
             recovered[count_q] = count_value if _is_c9_value(count_value) else None
         elif label in score_rows:
             for offset, qnum in enumerate(score_rows[label], start=1):
-                raw_value = ws.cell(row=row_idx, column=label_col + offset).value
+                raw_value = _row_value(row_values, label_col - 1 + offset)
                 recovered[qnum] = raw_value if _is_c9_value(raw_value) else None
 
     count = 0
@@ -323,6 +353,12 @@ def recover_c9_academic_profile_values(
         values[qnum] = _field_record(qnum, value, qnum_to_field)
         count += 1
     return count
+
+
+def _row_value(row_values: list, zero_based_index: int):
+    if zero_based_index < 0 or zero_based_index >= len(row_values):
+        return None
+    return row_values[zero_based_index]
 
 
 def _is_c9_header(row_text: str) -> bool:

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -12,6 +12,77 @@ from extract import extract
 
 
 class Tier1ExtractTests(unittest.TestCase):
+    def test_uses_short_section_tab_aliases_for_template_cell_map(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "A"
+        ws["D4"] = "Alias University"
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            schema = {
+                "schema_version": "2025-26",
+                "fields": [{
+                    "question_number": "A.101",
+                    "word_tag": "institution_name",
+                    "question": "Name of College/University:",
+                    "section": "General Information",
+                    "subsection": "Institutional Contact Information",
+                    "value_type": "Text",
+                }],
+            }
+            result = extract(
+                Path(tmp.name),
+                schema,
+                {"A.101": ("CDS-A", "D4")},
+            )
+
+        self.assertEqual(result["stats"]["extraction_layout"], "template_cell_map")
+        self.assertEqual(result["stats"]["schema_fields_populated"], 1)
+        self.assertEqual(result["values"]["A.101"]["value"], "Alias University")
+        self.assertEqual(result["stats"]["missing_sheets"], [])
+
+    def test_uses_descriptive_section_tab_aliases_for_c9_recovery(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Admissions"
+        ws["B10"] = "Percent and number of first-time, first-year students enrolled in Fall 2025 who submitted national standardized (SAT/ACT) test scores."
+        ws["B13"] = "Submitting SAT Scores"
+        ws["C13"] = 0.55
+        ws["D13"] = 2833
+        ws["B18"] = "SAT Composite"
+        ws["C18"] = 1140
+        ws["D18"] = 1250
+        ws["E18"] = 1350
+
+        schema = {
+            "schema_version": "2025-26",
+            "fields": [
+                {
+                    "question_number": qnum,
+                    "word_tag": None,
+                    "question": qnum,
+                    "section": "First-Time, First-Year Admission",
+                    "subsection": "First-time, first-year Profile",
+                    "value_type": "Number",
+                }
+                for qnum in ("C.901", "C.903", "C.905", "C.906", "C.907")
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(
+                Path(tmp.name),
+                schema,
+                {"C.901": ("CDS-C", "C99")},
+            )
+
+        self.assertEqual(result["values"]["C.901"]["value"], "0.55")
+        self.assertEqual(result["values"]["C.903"]["value"], "2833")
+        self.assertEqual(result["values"]["C.905"]["value"], "1140")
+        self.assertEqual(result["values"]["C.907"]["value"], "1350")
+
     def test_falls_back_to_embedded_answer_columns(self):
         wb = openpyxl.Workbook()
         ws = wb.active


### PR DESCRIPTION
## Summary
- Add PRD 019 change-intelligence plan and admissions reporting spike script
- Fix XLSX sheet alias handling and low-field quality flags
- Recover compact/question-number-led Tier 4 rows such as Pitt-style A101/C101 exports
- Make extraction idempotency source-aware so refreshed source PDFs force fresh canonical artifacts

## Verification
- PYTHONPATH=tools/extraction_worker:tools python3 -m unittest tools/extraction_worker/test_worker_projection_refresh.py tools/tier1_extractor/test_extract.py tools/extraction_worker/test_tier4_cleaner_a_general.py
- Local managed Docling redrain for Pitt all files
- Local managed Docling redrain for 20 compact-question-number current-year docs