### PR TITLE
Fix Stanford C9 extraction and preserve change reviews

### DIFF
--- a/tools/change_intelligence/project_change_events.py
+++ b/tools/change_intelligence/project_change_events.py
@@ -35,6 +35,7 @@ DEFAULT_WATCHLIST = REPO_ROOT / "data" / "watchlists" / "change_intelligence_cal
 DEFAULT_REPORT_DIR = REPO_ROOT / ".context" / "reports"
 
 BAD_FLAGS = {"wrong_file", "blank_template", "low_coverage"}
+REVIEWED_STATUSES = {"confirmed", "extractor_noise", "ambiguous", "not_reportable"}
 PRODUCER_FAMILY = {
     "tier1_xlsx": "tier1",
     "tier2_acroform": "tier2",
@@ -638,36 +639,80 @@ def write_report(
     path.write_text("\n".join(lines) + "\n")
 
 
-def persist_events(client: Any, events: list[dict[str, Any]], to_year: int, watchlist: set[str] | None) -> None:
-    existing_status: dict[str, str] = {}
-    event_ids = [event["id"] for event in events]
-    for i in range(0, len(event_ids), 100):
-        rows = (
-            client.table("cds_field_change_events")
-            .select("id,verification_status")
-            .in_("id", event_ids[i:i + 100])
-            .execute()
-            .data
-            or []
-        )
-        existing_status.update({row["id"]: row.get("verification_status") for row in rows})
+def apply_existing_review_state(
+    events: list[dict[str, Any]],
+    existing_rows: list[dict[str, Any]],
+) -> None:
+    existing_by_id = {row["id"]: row for row in existing_rows}
     for event in events:
-        status = existing_status.get(event["id"])
-        if status in {"confirmed", "extractor_noise", "ambiguous", "not_reportable"}:
+        existing = existing_by_id.get(event["id"])
+        if not existing:
+            continue
+        status = existing.get("verification_status")
+        if status in REVIEWED_STATUSES:
             event["verification_status"] = status
+            event["public_visible"] = bool(existing.get("public_visible"))
 
+
+def stale_unreviewed_event_ids(
+    existing_rows: list[dict[str, Any]],
+    current_event_ids: set[str],
+) -> list[str]:
+    stale: list[str] = []
+    for row in existing_rows:
+        if row.get("id") in current_event_ids:
+            continue
+        if row.get("verification_status") in REVIEWED_STATUSES:
+            continue
+        if row.get("public_visible"):
+            continue
+        stale.append(row["id"])
+    return stale
+
+
+def fetch_existing_events_in_scope(
+    client: Any,
+    to_year: int,
+    watchlist: set[str] | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if watchlist:
         schools = sorted(watchlist)
-        for i in range(0, len(watchlist), 100):
-            (
+        for i in range(0, len(schools), 100):
+            chunk = schools[i:i + 100]
+            rows.extend(
                 client.table("cds_field_change_events")
-                .delete()
+                .select("id,verification_status,public_visible")
                 .eq("to_year_start", to_year)
-                .in_("school_id", schools[i:i + 100])
+                .in_("school_id", chunk)
                 .execute()
+                .data
+                or []
             )
-    else:
-        client.table("cds_field_change_events").delete().eq("to_year_start", to_year).execute()
+        return rows
+    return (
+        client.table("cds_field_change_events")
+        .select("id,verification_status,public_visible")
+        .eq("to_year_start", to_year)
+        .execute()
+        .data
+        or []
+    )
+
+
+def persist_events(client: Any, events: list[dict[str, Any]], to_year: int, watchlist: set[str] | None) -> None:
+    existing_rows = fetch_existing_events_in_scope(client, to_year, watchlist)
+    event_ids = {event["id"] for event in events}
+    apply_existing_review_state(events, existing_rows)
+
+    stale_ids = stale_unreviewed_event_ids(existing_rows, event_ids)
+    for i in range(0, len(stale_ids), 100):
+        (
+            client.table("cds_field_change_events")
+            .delete()
+            .in_("id", stale_ids[i:i + 100])
+            .execute()
+        )
     for i in range(0, len(events), 100):
         client.table("cds_field_change_events").upsert(events[i:i + 100]).execute()
 

--- a/tools/change_intelligence/test_project_change_events.py
+++ b/tools/change_intelligence/test_project_change_events.py
@@ -6,10 +6,12 @@ from tempfile import TemporaryDirectory
 
 from project_change_events import (
     FieldRule,
+    apply_existing_review_state,
     build_events,
     classify_field_change,
     selectivity_band,
     school_year_coverage,
+    stale_unreviewed_event_ids,
     write_report,
 )
 
@@ -196,6 +198,51 @@ class ChangeEventClassificationTests(unittest.TestCase):
         self.assertIn("## Reporting gaps and silences worth reviewing", text)
         self.assertIn("CDS events describe what changed", text)
         self.assertIn("Test College", text)
+
+    def test_existing_review_state_preserves_public_visibility(self):
+        events = [
+            {
+                "id": "reviewed",
+                "verification_status": "candidate",
+                "public_visible": False,
+            },
+            {
+                "id": "fresh",
+                "verification_status": "not_required",
+                "public_visible": False,
+            },
+        ]
+        existing = [
+            {
+                "id": "reviewed",
+                "verification_status": "confirmed",
+                "public_visible": True,
+            },
+            {
+                "id": "fresh",
+                "verification_status": "not_required",
+                "public_visible": False,
+            },
+        ]
+
+        apply_existing_review_state(events, existing)
+
+        self.assertEqual(events[0]["verification_status"], "confirmed")
+        self.assertTrue(events[0]["public_visible"])
+        self.assertEqual(events[1]["verification_status"], "not_required")
+        self.assertFalse(events[1]["public_visible"])
+
+    def test_stale_delete_keeps_reviewed_events(self):
+        existing = [
+            {"id": "regenerated", "verification_status": "not_required", "public_visible": False},
+            {"id": "stale-candidate", "verification_status": "candidate", "public_visible": False},
+            {"id": "stale-rejected", "verification_status": "extractor_noise", "public_visible": False},
+            {"id": "stale-public", "verification_status": "confirmed", "public_visible": True},
+        ]
+
+        stale = stale_unreviewed_event_ids(existing, {"regenerated"})
+
+        self.assertEqual(stale, ["stale-candidate"])
 
 
 if __name__ == "__main__":

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -6,6 +6,45 @@ from tier4_cleaner import clean
 
 
 class Tier4CleanerC9Test(unittest.TestCase):
+    def test_c9_submission_rates_decimal_table_without_headers(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+Submitting SAT Scores Submitting ACT Scores
+
+| 50.3%   |   857 |
+|---------|-------|
+| 19.0%   |   324 |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "50.3")
+        self.assertEqual(values["C.902"]["value"], "19.0")
+        self.assertEqual(values["C.903"]["value"], "857")
+        self.assertEqual(values["C.904"]["value"], "324")
+
+    def test_c9_submission_rates_labels_separated_from_percent_table(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2025 who submitted national standardized (SAT/ACT) test scores.
+
+Submitting SAT Scores Submitting ACT Scores
+
+For each assessment listed below, report the score that represents the 25th percentile.
+
+| Percent   | Number   |
+|-----------|----------|
+| 56%       | 1,022    |
+| 21%       | 385      |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "56")
+        self.assertEqual(values["C.902"]["value"], "21")
+        self.assertEqual(values["C.903"]["value"], "1022")
+        self.assertEqual(values["C.904"]["value"], "385")
+
     def test_c9_split_submission_labels_and_blank_sat_composite(self):
         markdown = """
 ## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -445,7 +445,7 @@ _INLINE_PATTERNS: list[tuple[str, str, str]] = [
     # as free text rather than in the first table column, so the row-based
     # extractor can't find them. The anchor is the SAT label text, the
     # window captures the first N% that follows.
-    (r"submitting sat scores", r"(\d+)\s*%", "C.901"),
+    (r"submitting sat scores", r"(\d+(?:\.\d+)?)\s*%", "C.901"),
 ]
 
 
@@ -2857,19 +2857,61 @@ def resolve_c9_submission_rates(
     if "Submitting SAT Scores" not in markdown or "Submitting ACT Scores" not in markdown:
         return out
 
-    pattern = re.compile(
-        r"Submitting SAT Scores\s+Submitting ACT Scores\s+"
-        r"\|\s*Percent\s*\|\s*Number\s*\|\s*\n"
-        r"\|[\s\-:|]+\|\s*\n"
-        r"\|\s*([0-9.]+)\s*%?\s*\|\s*([0-9,]+)\s*\|\s*\n"
-        r"\|\s*([0-9.]+)\s*%?\s*\|\s*([0-9,]+)\s*\|",
+    labels = re.search(
+        r"Submitting SAT Scores\s+Submitting ACT Scores",
+        markdown,
         re.IGNORECASE,
     )
-    match = pattern.search(markdown)
-    if not match:
+    if not labels:
         return out
 
-    sat_pct, sat_num, act_pct, act_num = match.groups()
+    window = markdown[labels.end(): labels.end() + 1200]
+    table_match = re.search(
+        r"(\|\s*Percent\s*\|\s*Number\s*\|\s*\n"
+        r"\|[\s\-:|]+\|\s*\n"
+        r"\|\s*[0-9.]+\s*%?\s*\|\s*[0-9,]+\s*\|\s*\n"
+        r"\|\s*[0-9.]+\s*%?\s*\|\s*[0-9,]+\s*\|)",
+        window,
+        re.IGNORECASE,
+    )
+    if not table_match:
+        table_match = re.search(
+            r"(\|\s*[0-9.]+\s*%?\s*\|\s*[0-9,]+\s*\|\s*\n"
+            r"\|[\s\-:|]+\|\s*\n"
+            r"\|\s*[0-9.]+\s*%?\s*\|\s*[0-9,]+\s*\|)",
+            window,
+            re.IGNORECASE,
+        )
+    if not table_match:
+        return out
+
+    rows = [
+        line.strip()
+        for line in table_match.group(1).splitlines()
+        if line.strip().startswith("|")
+        and not re.match(r"^\|[\s\-:|]+\|$", line.strip())
+        and "percent" not in line.lower()
+    ]
+    if len(rows) < 2:
+        return out
+
+    def row_values(row: str) -> tuple[str, str] | None:
+        cells = [cell.strip() for cell in row.split("|")[1:-1]]
+        if len(cells) < 2:
+            return None
+        pct = _extract_number(cells[0])
+        num = _extract_number(cells[1])
+        if pct is None or num is None:
+            return None
+        return pct, num
+
+    sat = row_values(rows[0])
+    act = row_values(rows[1])
+    if not sat or not act:
+        return out
+
+    sat_pct, sat_num = sat
+    act_pct, act_num = act
     out["C.901"] = {"value": sat_pct.replace(",", ""), "source": "tier4_cleaner"}
     out["C.903"] = {"value": sat_num.replace(",", ""), "source": "tier4_cleaner"}
     out["C.902"] = {"value": act_pct.replace(",", ""), "source": "tier4_cleaner"}


### PR DESCRIPTION
## Summary
- Fix Tier 4 C9 submission-rate extraction for Stanford-style layouts where SAT/ACT labels are separated from the Percent/Number table or decimal percentages are emitted without headers.
- Preserve reviewed/public PRD 019 change events across projector reruns instead of deleting review state before upsert.
- Add regression coverage for both extraction and review-preservation behavior.

## Production follow-up already run
- Re-drained Stanford 2024-25 and 2025-26 locally on the MacBook via managed Docling.
- Refreshed browser projections for both documents.
- Re-ran the PRD 019 calibration projector.
- Published the confirmed Stanford SAT submit-rate event: 50.3% -> 56.0%.

## Verification
- python3 -m unittest discover -s tools/change_intelligence -p 'test_*.py'
- python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'
- git diff --check