### PR TITLE
PRD 019 Top 200 freshness drain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,19 @@ Open-source archive of U.S. college Common Data Set (CDS) documents.
   into `tools/` or the repo root, so working trees stay clean and
   nothing important hides among the dumps.
 
+## Data quality loop
+
+When doing whack-a-mole CDS data improvements, treat each fix as a signal about the
+whole corpus, not a one-off.
+
+- For canary-style extraction issues, search the corpus for other documents with the
+  same failure shape and redrain the similar files after the parser/cleaner fix.
+- For finding/discovery issues, find and archive the most recent two CDS years when
+  available, then add a durable finder or archiver hint so the next year's document
+  can be found automatically.
+- Close the loop across current state, prior-year baseline, future discovery, and
+  similar files before calling the issue handled.
+
 ## Migrations
 
 Migrations are applied to production **only from `main`**, never from a

--- a/data/watchlists/top_200_change_intelligence.yaml
+++ b/data/watchlists/top_200_change_intelligence.yaml
@@ -1,72 +1,406 @@
-version: 0.1.0
-status: operator_seed_v0
-description: >
-  Operator-only PRD 019 watchlist seed. This is intentionally not a public
-  ranking. v0 starts with the calibration subset plus high-recognition schools
-  already important to the product; later passes should expand this toward the
-  full Top 200 recipe from the PRD using application volume, flagship publics,
-  and public/operator-reviewed LAC recognition.
+version: 0.2.0
+status: operator_top200_v1
+description: 'Operator-only PRD 019 Top 200 watchlist. Expanded from the v0 seed using the PRD recipe: latest available CDS
+  C1 application volume, curated flagship publics, curated high-recognition LACs, then application-volume supplements to reach
+  200 after overlap. Not a public ranking.'
 schools:
-  - { school_id: harvard, segment: high_selectivity_private }
-  - { school_id: yale, segment: high_selectivity_private }
-  - { school_id: princeton, segment: high_selectivity_private }
-  - { school_id: mit, segment: high_selectivity_private }
-  - { school_id: stanford, segment: high_selectivity_private }
-  - { school_id: duke, segment: high_selectivity_private }
-  - { school_id: northwestern, segment: high_selectivity_private }
-  - { school_id: vanderbilt, segment: high_selectivity_private }
-  - { school_id: amherst-college, segment: high_selectivity_private }
-  - { school_id: bowdoin-college, segment: high_selectivity_private }
-  - { school_id: brown, segment: high_selectivity_private }
-  - { school_id: dartmouth, segment: high_selectivity_private }
-  - { school_id: cornell, segment: high_selectivity_private }
-  - { school_id: university-of-pennsylvania, segment: high_selectivity_private }
-  - { school_id: caltech, segment: high_selectivity_private }
-  - { school_id: rice, segment: high_selectivity_private }
-  - { school_id: notre-dame, segment: high_selectivity_private }
-  - { school_id: washington-university-in-st-louis, segment: high_selectivity_private }
-  - { school_id: emory, segment: high_selectivity_private }
-  - { school_id: georgetown, segment: high_selectivity_private }
-  - { school_id: williams-college, segment: high_selectivity_lac }
-  - { school_id: pomona-college, segment: high_selectivity_lac }
-  - { school_id: swarthmore-college, segment: high_selectivity_lac }
-  - { school_id: wellesley-college, segment: high_selectivity_lac }
-  - { school_id: carleton-college, segment: high_selectivity_lac }
-  - { school_id: middlebury-college, segment: high_selectivity_lac }
-  - { school_id: grinnell-college, segment: high_selectivity_lac }
-  - { school_id: haverford-college, segment: high_selectivity_lac }
-  - { school_id: smith-college, segment: high_selectivity_lac }
-  - { school_id: barnard, segment: high_selectivity_lac }
-  - { school_id: uc-berkeley, segment: flagship_public }
-  - { school_id: ucla, segment: flagship_public }
-  - { school_id: university-of-michigan, segment: flagship_public }
-  - { school_id: university-of-virginia, segment: flagship_public }
-  - { school_id: university-of-north-carolina-at-chapel-hill, segment: flagship_public }
-  - { school_id: georgia-tech, segment: flagship_public }
-  - { school_id: texas-am, segment: flagship_public }
-  - { school_id: ohio-state, segment: flagship_public }
-  - { school_id: university-of-wisconsin-madison, segment: flagship_public }
-  - { school_id: university-of-florida, segment: flagship_public }
-  - { school_id: university-of-washington, segment: flagship_public }
-  - { school_id: university-of-illinois-urbana-champaign, segment: flagship_public }
-  - { school_id: penn-state, segment: flagship_public }
-  - { school_id: university-of-texas-at-austin, segment: flagship_public }
-  - { school_id: university-of-georgia, segment: flagship_public }
-  - { school_id: university-of-maryland-college-park, segment: flagship_public }
-  - { school_id: university-of-minnesota-twin-cities, segment: flagship_public }
-  - { school_id: university-of-pittsburgh, segment: flagship_public }
-  - { school_id: university-of-arizona, segment: flagship_public }
-  - { school_id: university-of-oregon, segment: flagship_public }
-  - { school_id: columbia, segment: international_heavy }
-  - { school_id: nyu, segment: international_heavy }
-  - { school_id: northeastern, segment: international_heavy }
-  - { school_id: usc, segment: international_heavy }
-  - { school_id: boston-university, segment: international_heavy }
-  - { school_id: carnegie-mellon, segment: international_heavy }
-  - { school_id: university-of-rochester, segment: international_heavy }
-  - { school_id: case-western-reserve-university, segment: international_heavy }
-  - { school_id: arizona-state, segment: broad_access_or_edge }
-  - { school_id: university-of-cincinnati, segment: broad_access_or_edge }
-  - { school_id: george-mason-university, segment: broad_access_or_edge }
-  - { school_id: kent-state, segment: broad_access_or_edge }
-  - { school_id: university-of-texas-at-dallas, segment: broad_access_or_edge }
+- school_id: harvard
+  segment: high_selectivity_private
+- school_id: yale
+  segment: high_selectivity_private
+- school_id: princeton
+  segment: high_selectivity_private
+- school_id: mit
+  segment: high_selectivity_private
+- school_id: stanford
+  segment: high_selectivity_private
+- school_id: duke
+  segment: high_selectivity_private
+- school_id: northwestern
+  segment: high_selectivity_private
+- school_id: vanderbilt
+  segment: high_selectivity_private
+- school_id: amherst
+  segment: high_selectivity_private
+- school_id: bowdoin
+  segment: high_selectivity_private
+- school_id: brown
+  segment: high_selectivity_private
+- school_id: dartmouth
+  segment: high_selectivity_private
+- school_id: cornell
+  segment: high_selectivity_private
+- school_id: upenn
+  segment: high_selectivity_private
+- school_id: california-institute-of-technology
+  segment: high_selectivity_private
+- school_id: rice
+  segment: high_selectivity_private
+- school_id: university-of-notre-dame
+  segment: high_selectivity_private
+- school_id: washington-university-in-st-louis
+  segment: high_selectivity_private
+- school_id: emory
+  segment: high_selectivity_private
+- school_id: georgetown
+  segment: high_selectivity_private
+- school_id: williams-college
+  segment: high_selectivity_lac
+- school_id: pomona-college
+  segment: high_selectivity_lac
+- school_id: swarthmore
+  segment: high_selectivity_lac
+- school_id: wellesley-college
+  segment: high_selectivity_lac
+- school_id: carleton-college
+  segment: high_selectivity_lac
+- school_id: middlebury-college
+  segment: high_selectivity_lac
+- school_id: grinnell-college
+  segment: high_selectivity_lac
+- school_id: haverford-college
+  segment: high_selectivity_lac
+- school_id: smith-college
+  segment: high_selectivity_lac
+- school_id: barnard
+  segment: high_selectivity_lac
+- school_id: uc-berkeley
+  segment: flagship_public
+- school_id: ucla
+  segment: flagship_public
+- school_id: umich
+  segment: flagship_public
+- school_id: uva
+  segment: flagship_public
+- school_id: unc
+  segment: flagship_public
+- school_id: georgia-tech
+  segment: flagship_public
+- school_id: texas-am
+  segment: flagship_public
+- school_id: osu
+  segment: flagship_public
+- school_id: uw-madison
+  segment: flagship_public
+- school_id: uf
+  segment: flagship_public
+- school_id: uw
+  segment: flagship_public
+- school_id: university-of-illinois-urbana-champaign
+  segment: flagship_public
+- school_id: penn-state
+  segment: flagship_public
+- school_id: ut-austin
+  segment: flagship_public
+- school_id: uga
+  segment: flagship_public
+- school_id: umd
+  segment: flagship_public
+- school_id: university-of-minnesota-twin-cities
+  segment: flagship_public
+- school_id: upitt
+  segment: flagship_public
+- school_id: university-of-arizona
+  segment: flagship_public
+- school_id: university-of-oregon
+  segment: flagship_public
+- school_id: columbia
+  segment: international_heavy
+- school_id: nyu
+  segment: international_heavy
+- school_id: northeastern
+  segment: international_heavy
+- school_id: usc
+  segment: international_heavy
+- school_id: boston-university
+  segment: international_heavy
+- school_id: carnegie-mellon
+  segment: international_heavy
+- school_id: university-of-rochester
+  segment: international_heavy
+- school_id: case-western-reserve-university
+  segment: international_heavy
+- school_id: arizona-state-university-campus-immersion
+  segment: broad_access_or_edge
+- school_id: university-of-cincinnati-main-campus
+  segment: broad_access_or_edge
+- school_id: george-mason-university
+  segment: broad_access_or_edge
+- school_id: kent-state-university-at-kent
+  segment: broad_access_or_edge
+- school_id: the-university-of-texas-at-dallas
+  segment: broad_access_or_edge
+- school_id: uc-san-diego
+  segment: application_volume
+- school_id: uc-irvine
+  segment: application_volume
+- school_id: uc-santa-barbara
+  segment: application_volume
+- school_id: uc-davis
+  segment: application_volume
+- school_id: california-state-university-long-beach
+  segment: application_volume
+- school_id: california-polytechnic-state-university-san-luis-obispo
+  segment: application_volume
+- school_id: university-of-california-santa-cruz
+  segment: application_volume
+- school_id: colorado
+  segment: flagship_public
+- school_id: university-of-south-florida
+  segment: application_volume
+- school_id: stony-brook-university
+  segment: application_volume
+- school_id: clemson
+  segment: application_volume
+- school_id: university-of-miami
+  segment: application_volume
+- school_id: virginia-polytechnic-institute-and-state-university
+  segment: application_volume
+- school_id: university-of-california-riverside
+  segment: application_volume
+- school_id: the-university-of-alabama
+  segment: flagship_public
+- school_id: university-of-connecticut
+  segment: flagship_public
+- school_id: university-of-central-florida
+  segment: application_volume
+- school_id: the-university-of-tennessee-knoxville
+  segment: flagship_public
+- school_id: binghamton-university
+  segment: application_volume
+- school_id: university-of-south-carolina-columbia
+  segment: flagship_public
+- school_id: university-of-south-carolina-aiken
+  segment: application_volume
+- school_id: california-state-polytechnic-university-pomona
+  segment: application_volume
+- school_id: university-of-massachusetts-amherst
+  segment: flagship_public
+- school_id: baylor-university
+  segment: application_volume
+- school_id: johns-hopkins
+  segment: application_volume
+- school_id: loyola-university-chicago
+  segment: application_volume
+- school_id: uchicago
+  segment: application_volume
+- school_id: university-of-north-texas
+  segment: application_volume
+- school_id: university-at-buffalo
+  segment: flagship_public
+- school_id: northern-arizona-university
+  segment: application_volume
+- school_id: colorado-mesa-university
+  segment: application_volume
+- school_id: san-jose-state-university
+  segment: application_volume
+- school_id: boston-college
+  segment: application_volume
+- school_id: university-of-houston
+  segment: application_volume
+- school_id: kennesaw-state-university
+  segment: application_volume
+- school_id: tufts
+  segment: application_volume
+- school_id: cuny-city-college
+  segment: application_volume
+- school_id: texas-tech-university
+  segment: application_volume
+- school_id: howard-university
+  segment: application_volume
+- school_id: georgia-state-university
+  segment: application_volume
+- school_id: university-of-mississippi
+  segment: flagship_public
+- school_id: tulane-university-of-louisiana
+  segment: application_volume
+- school_id: university-of-arkansas
+  segment: flagship_public
+- school_id: california-state-university-los-angeles
+  segment: application_volume
+- school_id: college-of-charleston
+  segment: application_volume
+- school_id: university-of-california-merced
+  segment: application_volume
+- school_id: university-of-kentucky
+  segment: flagship_public
+- school_id: oregon-state-university
+  segment: application_volume
+- school_id: university-of-illinois-chicago
+  segment: application_volume
+- school_id: rochester-institute-of-technology
+  segment: application_volume
+- school_id: california-state-university-sacramento
+  segment: application_volume
+- school_id: grand-valley-state-university
+  segment: application_volume
+- school_id: gwu
+  segment: application_volume
+- school_id: university-of-rhode-island
+  segment: flagship_public
+- school_id: east-carolina-university
+  segment: application_volume
+- school_id: university-of-vermont
+  segment: flagship_public
+- school_id: hofstra-university
+  segment: application_volume
+- school_id: university-of-san-francisco
+  segment: application_volume
+- school_id: appalachian-state-university
+  segment: application_volume
+- school_id: southern-methodist-university
+  segment: application_volume
+- school_id: university-of-north-carolina-at-charlotte
+  segment: application_volume
+- school_id: villanova-university
+  segment: application_volume
+- school_id: university-of-alaska-fairbanks
+  segment: flagship_public
+- school_id: udel
+  segment: flagship_public
+- school_id: university-of-hawaii-at-manoa
+  segment: flagship_public
+- school_id: university-of-idaho
+  segment: flagship_public
+- school_id: indiana-bloomington
+  segment: flagship_public
+- school_id: university-of-iowa
+  segment: flagship_public
+- school_id: university-of-kansas
+  segment: flagship_public
+- school_id: louisiana-state-university-and-agricultural-and-mechanical
+  segment: flagship_public
+- school_id: university-of-maine
+  segment: flagship_public
+- school_id: university-of-missouri-columbia
+  segment: flagship_public
+- school_id: montana-state-university
+  segment: flagship_public
+- school_id: university-of-nebraska-lincoln
+  segment: flagship_public
+- school_id: university-of-nevada-reno
+  segment: flagship_public
+- school_id: university-of-new-hampshire-main-campus
+  segment: flagship_public
+- school_id: rutgers
+  segment: flagship_public
+- school_id: university-of-new-mexico-main-campus
+  segment: flagship_public
+- school_id: university-of-north-dakota
+  segment: flagship_public
+- school_id: university-of-oklahoma-norman-campus
+  segment: flagship_public
+- school_id: claremont-mckenna
+  segment: high_recognition_lac
+- school_id: davidson-college
+  segment: high_recognition_lac
+- school_id: vassar-college
+  segment: high_recognition_lac
+- school_id: washington-and-lee
+  segment: high_recognition_lac
+- school_id: colby
+  segment: high_recognition_lac
+- school_id: hamilton
+  segment: high_recognition_lac
+- school_id: wesleyan-university
+  segment: high_recognition_lac
+- school_id: colgate-university
+  segment: high_recognition_lac
+- school_id: bates
+  segment: high_recognition_lac
+- school_id: macalester-college
+  segment: high_recognition_lac
+- school_id: harvey-mudd
+  segment: high_recognition_lac
+- school_id: university-of-richmond
+  segment: high_recognition_lac
+- school_id: colorado-college
+  segment: high_recognition_lac
+- school_id: kenyon
+  segment: high_recognition_lac
+- school_id: scripps-college
+  segment: high_recognition_lac
+- school_id: bryn-mawr-college
+  segment: high_recognition_lac
+- school_id: bucknell
+  segment: high_recognition_lac
+- school_id: lafayette-college
+  segment: high_recognition_lac
+- school_id: college-of-the-holy-cross
+  segment: high_recognition_lac
+- school_id: oberlin
+  segment: high_recognition_lac
+- school_id: reed-college
+  segment: high_recognition_lac
+- school_id: franklin-and-marshall-college
+  segment: high_recognition_lac
+- school_id: denison-university
+  segment: high_recognition_lac
+- school_id: trinity-college
+  segment: high_recognition_lac
+- school_id: union-college
+  segment: high_recognition_lac
+- school_id: rhodes-college
+  segment: high_recognition_lac
+- school_id: skidmore-college
+  segment: high_recognition_lac
+- school_id: dickinson-college
+  segment: high_recognition_lac
+- school_id: furman-university
+  segment: high_recognition_lac
+- school_id: centre-college
+  segment: high_recognition_lac
+- school_id: occidental-college
+  segment: high_recognition_lac
+- school_id: whitman-college
+  segment: high_recognition_lac
+- school_id: gettysburg-college
+  segment: high_recognition_lac
+- school_id: depauw-university
+  segment: high_recognition_lac
+- school_id: st-olaf-college
+  segment: high_recognition_lac
+- school_id: the-college-of-wooster
+  segment: high_recognition_lac
+- school_id: mount-holyoke-college
+  segment: high_recognition_lac
+- school_id: connecticut-college
+  segment: high_recognition_lac
+- school_id: winona-state-university
+  segment: application_volume_supplement
+- school_id: loyola-marymount-university
+  segment: application_volume_supplement
+- school_id: texas-christian-university
+  segment: application_volume_supplement
+- school_id: illinois-state-university
+  segment: application_volume_supplement
+- school_id: coastal-carolina-university
+  segment: application_volume_supplement
+- school_id: california-state-university-san-marcos
+  segment: application_volume_supplement
+- school_id: florida-gulf-coast-university
+  segment: application_volume_supplement
+- school_id: university-of-north-carolina-wilmington
+  segment: application_volume_supplement
+- school_id: marquette-university
+  segment: application_volume_supplement
+- school_id: lehigh
+  segment: application_volume_supplement
+- school_id: santa-clara-university
+  segment: application_volume_supplement
+- school_id: stephen-f-austin-state-university
+  segment: application_volume_supplement
+- school_id: university-of-denver
+  segment: application_volume_supplement
+- school_id: fairfield-university
+  segment: application_volume_supplement
+- school_id: north-carolina-central-university
+  segment: application_volume_supplement
+- school_id: florida-institute-of-technology
+  segment: application_volume_supplement
+- school_id: wayne-state-university
+  segment: application_volume_supplement
+- school_id: rpi
+  segment: application_volume_supplement
+- school_id: american-university
+  segment: application_volume_supplement

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -121,6 +121,27 @@ Sections are ordered **Open → Resolved → Strategic context**. Every open ite
 
 - **Tier 4 cleaner — continue resolver coverage beyond the core product surfaces.** [PRD 005](prd/005-full-schema-extraction.md)'s Phase 6 architecture shipped 2026-04-20 (commit `aecca9b`): the section-family resolver framework backed by a shared `SchemaIndex` took the cleaner from 72 -> ~380 fields (Harvard 382, Yale 390, Dartmouth 343). PRD 016B and PRD 018 added targeted C21/C22 and H1/H2/H2A coverage. Remaining work is continuing to add resolvers for thinner sections as specific schools surface gaps; the ceiling is 1,105 fields, but full-schema parity is not urgent.
 
+- **Logical CDS assembly for schools that publish by section.** Some schools
+  publish one CDS year as multiple section PDFs instead of a single A-J file
+  (recent examples: KU, CMU, Oxy, UTK current-year section pages). The current
+  resolver can choose Section C for admissions change intelligence, but that is
+  only a tactical repair: it still loses the rest of the CDS for browser fields,
+  merit profile data, and future sections. Future shape: archive each original
+  section file as its own source/component with URL + hash provenance, then
+  create a derived logical "assembled CDS" artifact ordered A through J. Run
+  extraction/projection against the assembled artifact while preserving links
+  back to the original component sources. Track `partial_sections` metadata so
+  a year with only A-C published is visibly partial rather than silently
+  complete. Prefer a real full CDS when present; assemble only when the school
+  clearly publishes section fragments for one year. **Why it matters:** avoids
+  one-off Section C repairs, gives sectionized publishers normal year-over-year
+  comparability, and keeps provenance clean. **Risks / design questions:**
+  section/year mismatch on sloppy pages, handling later section additions,
+  uniqueness/modeling for one logical school-year built from multiple URLs, and
+  whether the derived artifact should be a physical merged PDF or a logical
+  extraction bundle. **Effort:** probably a small PRD / 1-2 day implementation
+  after the current PRD 019 freshness drain, with KU/CMU/Oxy as fixtures.
+
 - **Tier 4 cleaner — Docling flat-text table recovery.** Dartmouth's C10 and Harvard's Submitting SAT/ACT block are cases where Docling emitted a two-column table as two sequential paragraphs (all labels first, then all values in the same order) instead of interleaved table rows. Current cleaner has no recovery path for this shape — the `_INLINE_PATTERNS` fallback handles single-field cases but not these multi-row column-flattened ones. **Fix shape:** detect consecutive N-line blocks of label-like paragraphs (each starting with "Percent..." or matching the row-label pattern of a known table) followed by N value-like paragraphs (e.g. `\d+%`), and pair them positionally. Only worth building if corpus survey shows many schools hitting this pattern — currently it's a known miss for ~2 fields per affected school.
 
 - **Retire `cds_year` as discovery output (ADR 0007 follow-up / "Stage D").** ADR 0007 Stage C landed as docs-only because `normalizeYear` turned out to be load-bearing inside `pickCandidates` — it's the partitioning signal that lets a multi-year landing page like Lafayette's 19-year archive fan out into 19 distinct `cds_documents` rows without colliding on `UNIQUE (school_id, sub_institutional, cds_year)`. Deleting `_shared/year.ts` cleanly requires first dropping `cds_year` from that unique constraint and rekeying on something URL-derived. **What to build:** (1) migration replacing `UNIQUE (school_id, sub_institutional, cds_year)` with `UNIQUE (school_id, sub_institutional, source_url_hash)` (or `source_sha256` if we're willing to couple uniqueness to the file contents rather than the source URL — tradeoff is whether a republished identical PDF at a new URL should be a new row); (2) rework `pickCandidates` in `supabase/functions/_shared/resolve.ts` to partition on URL uniqueness instead of `year`, with `chosen = dedupe-by-url(clean-set)` and no year-based branching; (3) delete `supabase/functions/_shared/year.ts` and `_shared/year.test.ts`; (4) remove the `cds_year` NOT NULL constraint or drop the column entirely depending on whether `cds_manifest` consumers still read it; (5) update `cds_manifest.canonical_year` expression to draw only from `detected_year` (falling back to NULL/"unknown" for undetected rows); (6) re-run the full-corpus drain and compare fan-out vs the pre-Stage-D baseline. **Why it matters:** closes the loop on ADR 0007. Today `cds_year` is a best-effort URL guess that Stage B already overrides via `detected_year`; keeping it as a NOT NULL unique-constraint participant means the resolver still has to produce plausible-looking year strings (or `UNKNOWN_YEAR_SENTINEL`) and the year module cannot be deleted. This is dead weight with an active footgun — any future resolver work has to reason about URL year parsing even though the result is purely decorative. **Effort:** ~3-4 hours including the migration, test updates, and a re-drain. Not urgent — `detected_year` already gives consumers the right answer via `cds_manifest.canonical_year`. Defer until the schema is otherwise due for a migration. **Cross-references:** [ADR 0007](decisions/0007-year-authority-moves-to-extraction.md) Shipped section; `supabase/functions/_shared/year.ts` header comment.

--- a/supabase/functions/_shared/resolve.test.ts
+++ b/supabase/functions/_shared/resolve.test.ts
@@ -69,10 +69,14 @@ Deno.test("extractCdsAnchors: commondataset.org documents are excluded even when
 });
 
 Deno.test("extractCdsAnchors: section marker detected", () => {
-  const html = `<a href="/files/cds-section-d-2024-25.pdf">Common Data Set Section D 2024-25</a>`;
+  const html = `
+    <a href="/files/cds-section-d-2024-25.pdf">Common Data Set Section D 2024-25</a>
+    <a href="/files/CDS_C_2526_0.pdf">Admissions</a>
+    <a href="/CDS/2025-2026/J.pdf">Degrees Conferred</a>
+  `;
   const anchors = extractCdsAnchors(html, BASE);
-  assertEquals(anchors.length, 1);
-  assertEquals(anchors[0].is_section_file, true);
+  assertEquals(anchors.length, 3);
+  assertEquals(anchors.every((a) => a.is_section_file), true);
 });
 
 Deno.test("extractCdsAnchors: HTML subpage categorized", () => {
@@ -483,8 +487,8 @@ Deno.test("pickCandidates: clean beats demoted when a clean sibling exists", () 
     {
       url: "https://ex.edu/cds2024-25_test.pdf",
       filename: "cds2024-25_test.pdf",
-      link_text: "CDS 2024-25 (Test)",
-      year: "2024-25",
+      link_text: "CDS 2023-24 (Test)",
+      year: "2023-24",
       year_source: "filename" as const,
       kind: "document" as const,
       is_section_file: false,
@@ -506,6 +510,90 @@ Deno.test("pickCandidates: clean beats demoted when a clean sibling exists", () 
   assertEquals(result.length, 1);
   assertEquals(result[0].filename, "cds2023-24.pdf");
   assertEquals(result[0].is_test_artifact, false);
+});
+
+Deno.test("pickCandidates: section-only years select Section C instead of Section J", () => {
+  const anchors = [
+    {
+      url: "https://aire.ku.edu/sites/aire/files/files/CDS/2025-2026/C.pdf",
+      filename: "C.pdf",
+      link_text: "C. First-Time, First-Year Admission",
+      year: "2025-26",
+      year_source: "url_path" as const,
+      kind: "document" as const,
+      is_section_file: true,
+      is_test_artifact: false,
+    },
+    {
+      url: "https://aire.ku.edu/sites/aire/files/files/CDS/2025-2026/J.pdf",
+      filename: "J.pdf",
+      link_text: "J. Degrees Conferred",
+      year: "2025-26",
+      year_source: "url_path" as const,
+      kind: "document" as const,
+      is_section_file: true,
+      is_test_artifact: false,
+    },
+  ];
+  const result = pickCandidates(anchors, "landing");
+  assertExists(result);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].filename, "C.pdf");
+});
+
+Deno.test("pickCandidates: older full CDS and current sectionized CDS can coexist", () => {
+  const anchors = [
+    {
+      url: "https://www.oxy.edu/sites/default/files/assets/Institutional_Research/CDS_C_2526_0.pdf",
+      filename: "CDS_C_2526_0.pdf",
+      link_text: "Admissions",
+      year: "2025-26",
+      year_source: "filename" as const,
+      kind: "document" as const,
+      is_section_file: true,
+      is_test_artifact: false,
+    },
+    {
+      url: "https://www.oxy.edu/sites/default/files/assets/Institutional_Research/CDS_J_2526.pdf",
+      filename: "CDS_J_2526.pdf",
+      link_text: "Degrees Conferred",
+      year: "2025-26",
+      year_source: "filename" as const,
+      kind: "document" as const,
+      is_section_file: true,
+      is_test_artifact: false,
+    },
+    {
+      url: "https://www.oxy.edu/sites/default/files/assets/Institutional_Research/CDS%202023-24.pdf",
+      filename: "CDS 2023-24.pdf",
+      link_text: "CDS 2023-24",
+      year: "2023-24",
+      year_source: "filename" as const,
+      kind: "document" as const,
+      is_section_file: false,
+      is_test_artifact: false,
+    },
+  ];
+  const result = pickCandidates(anchors, "landing");
+  assertExists(result);
+  assertEquals(result.map((r) => r.filename).sort(), [
+    "CDS 2023-24.pdf",
+    "CDS_C_2526_0.pdf",
+  ]);
+});
+
+Deno.test("pickCandidates: reference-only documents are skipped", () => {
+  const anchors = [{
+    url: "https://ex.edu/CDS_2024-2025_Definitions_.pdf",
+    filename: "CDS_2024-2025_Definitions_.pdf",
+    link_text: "Common Data Set Definitions",
+    year: "2024-25",
+    year_source: "filename" as const,
+    kind: "document" as const,
+    is_section_file: false,
+    is_test_artifact: false,
+  }];
+  assertEquals(pickCandidates(anchors, "landing"), []);
 });
 
 Deno.test("pickCandidates: falls back to demoted set when no clean siblings exist (CSULB)", () => {

--- a/supabase/functions/_shared/resolve.ts
+++ b/supabase/functions/_shared/resolve.ts
@@ -40,9 +40,39 @@ const DOCUMENT_EXT_RE = /\.(pdf|xlsx|docx)(\?|#|$)/i;
 // The earlier broader regex produced false positives when legit full-CDS
 // anchors had link text like "Enrollment and First-Time Information" in
 // the school's IR page hierarchy. Filenames are the only reliable signal.
-// "section [a-j]" suffix or explicit "section-d" prefix is the canonical
-// marker across the corpus.
-const SECTION_MARKER_RE = /\bsection[-_ ]?[a-j]\b/i;
+// Cover both explicit `section_C` filenames and section-only publisher
+// layouts such as KU's `/CDS/2025-2026/C.pdf` and Oxy's
+// `CDS_C_2526_0.pdf`.
+const EXPLICIT_SECTION_MARKER_RE = /(?:^|[-_ .])section[-_ ]?([a-j])(?:[-_ .]|$)/i;
+const CDS_SECTION_FILENAME_RE = /\bcds[-_ ]?([a-j])(?:[-_ .]|\d|$)/i;
+const SINGLE_SECTION_FILENAME_RE = /^([a-j])\d*\.pdf$/i;
+
+// Reference/supporting artifacts from school CDS pages. These often carry
+// "CDS" and a year in the URL but are not institutional responses.
+const REFERENCE_ARTIFACT_RE =
+  /(?:^|[-_ .])(?:appendix|definition|definitions|instructions|template|blank|glossary|summary[-_ ]?of[-_ ]?changes)(?:[-_ .]|$)/i;
+
+function sectionLetterFromFilename(filename: string): string | null {
+  const explicit = filename.match(EXPLICIT_SECTION_MARKER_RE);
+  if (explicit) return explicit[1].toUpperCase();
+
+  const cdsSection = filename.match(CDS_SECTION_FILENAME_RE);
+  if (cdsSection) return cdsSection[1].toUpperCase();
+
+  const single = filename.match(SINGLE_SECTION_FILENAME_RE);
+  if (single) return single[1].toUpperCase();
+
+  return null;
+}
+
+function isSectionFile(filename: string): boolean {
+  return sectionLetterFromFilename(filename) !== null ||
+    /(?:^|[-_ .])section[-_ ]?(?:appendix|definitions?)(?:[-_ .]|$)/i.test(filename);
+}
+
+function isReferenceArtifact(filename: string): boolean {
+  return REFERENCE_ARTIFACT_RE.test(filename);
+}
 
 // Staging artifacts schools leave behind on their CMS. CSULB's
 // cds_url_hint landing page exposes `cds_2015-2016_test.pdf` twice
@@ -471,7 +501,7 @@ export function extractCdsAnchors(html: string, baseUrl: string): CdsAnchor[] {
       // Section marker checked only against filename. Link text like
       // "Enrollment and General Information" on a CDS overview page would
       // otherwise flag a full CDS as a section file and demote it.
-      is_section_file: SECTION_MARKER_RE.test(filename),
+      is_section_file: isSectionFile(filename),
       is_test_artifact: TEST_ARTIFACT_RE.test(filename),
     });
   }
@@ -589,10 +619,11 @@ export function findDownloadLinks(html: string, baseUrl: string): CdsAnchor[] {
 // Stage B).
 //
 //   1. Full CDS beats section files
-//   2. Non-test files beat test/draft/backup staging artifacts
-//   3. Anchors with a year beat anchors without
-//   4. More recent year beats older
-//   5. Within ties, document order wins (earlier in HTML = more prominent)
+//   2. Non-reference files beat definitions/appendices/templates
+//   3. Non-test files beat test/draft/backup staging artifacts
+//   4. Anchors with a year beat anchors without
+//   5. More recent year beats older
+//   6. Within ties, document order wins (earlier in HTML = more prominent)
 export function findBestSourceAnchor(
   anchors: CdsAnchor[],
 ): CdsAnchor | null {
@@ -603,6 +634,9 @@ export function findBestSourceAnchor(
     if (a.is_section_file !== b.is_section_file) {
       return a.is_section_file ? 1 : -1;
     }
+    const aReference = isReferenceArtifact(a.filename);
+    const bReference = isReferenceArtifact(b.filename);
+    if (aReference !== bReference) return aReference ? 1 : -1;
     if (a.is_test_artifact !== b.is_test_artifact) {
       return a.is_test_artifact ? 1 : -1;
     }
@@ -628,28 +662,14 @@ export function findBestSourceAnchor(
 //
 //   1. Deduplicate by URL. extractCdsAnchors already does intra-HTML
 //      dedup; this also catches duplicates across subpage walk results.
-//   2. Partition into clean vs demoted (section files + test
-//      artifacts). If the clean set is non-empty, use it; otherwise
-//      fall back to the demoted set so schools whose only archivable
-//      file is a `_test` upload (CSULB) still ship.
-//   3. Within the chosen set:
-//      - **All have URL years** → return every candidate as its own
-//        ResolvedDocument. This is the Lafayette / NMU multi-year
-//        historical archive case.
-//      - **Exactly one candidate, no URL year** → return it with
-//        cds_year = UNKNOWN_YEAR_SENTINEL. This is the direct-doc
-//        no-year-in-filename case. Single row per school, no
-//        collision.
-//      - **Mixed: some have years, some don't** → keep only the
-//        year-known candidates. Year-less ones are dropped. They
-//        would otherwise collide in the unique key with each other
-//        or with each others' sentinels.
-//      - **Multiple candidates, none have years** → return null.
-//        Caller emits no_cds_found with a "Stage B limitation"
-//        reason. Out of scope for this PR; tracked as a follow-up
-//        because the real fix needs either a per-candidate
-//        disambiguator in cds_year (ugly) or the unique constraint
-//        to drop cds_year entirely (riskier).
+//   2. Drop reference artifacts (definitions, appendices, templates).
+//   3. For each year, choose one candidate:
+//      - full clean CDS
+//      - full test/draft artifact if that is the only full response
+//      - Section C when the school publishes the current year by section
+//   4. Year-less candidates keep the older collision-avoidance behavior:
+//      one year-less candidate is allowed only when no year-known
+//      candidate exists; multiple year-less candidates return null.
 //
 // Return value of null means "fail this school with no_cds_found."
 // Empty array means "no document-kind anchors at all" — caller's
@@ -668,29 +688,40 @@ export function pickCandidates(
     const key = d.url.split("#")[0];
     if (!byUrl.has(key)) byUrl.set(key, d);
   }
-  const unique = Array.from(byUrl.values());
+  const unique = Array.from(byUrl.values())
+    .filter((d) => !isReferenceArtifact(d.filename));
 
-  const clean = unique.filter(
-    (d) => !d.is_section_file && !d.is_test_artifact,
-  );
-  const set = clean.length > 0 ? clean : unique;
+  const withYear = unique.filter((a) => a.year !== null);
+  const withoutYear = unique.filter((a) => a.year === null);
 
-  const withYear = set.filter((a) => a.year !== null);
-  const withoutYear = set.filter((a) => a.year === null);
+  let chosen: CdsAnchor[] = [];
+  if (withYear.length > 0) {
+    const byYear = new Map<string, CdsAnchor[]>();
+    for (const d of withYear) {
+      const year = d.year!;
+      byYear.set(year, [...(byYear.get(year) ?? []), d]);
+    }
 
-  let chosen: CdsAnchor[];
-  if (withoutYear.length === 0) {
-    chosen = withYear;
-  } else if (set.length === 1) {
+    for (const [, group] of byYear) {
+      const fullClean = group.filter((d) => !d.is_section_file && !d.is_test_artifact);
+      const fullTest = group.filter((d) => !d.is_section_file && d.is_test_artifact);
+      const sectionC = group.filter((d) => sectionLetterFromFilename(d.filename) === "C");
+      const pool = fullClean.length > 0
+        ? fullClean
+        : fullTest.length > 0
+        ? fullTest
+        : sectionC;
+      if (pool.length > 0) chosen.push(pool[0]);
+    }
+  } else if (unique.length === 1) {
     // Single year-less candidate — sentinel is safe, no collision.
-    chosen = set;
-  } else if (withYear.length > 0) {
-    // Mixed set. Drop year-less to avoid collisions; keep year-known.
-    chosen = withYear;
-  } else {
+    chosen = unique;
+  } else if (withoutYear.length > 1) {
     // Multiple year-less candidates. Out of Stage B scope.
     return null;
   }
+
+  if (chosen.length === 0) return [];
 
   return chosen.map((d) => ({
     url: d.url,
@@ -911,7 +942,7 @@ export async function resolveCdsForSchool(
       url: hint,
       cds_year: year ?? UNKNOWN_YEAR_SENTINEL,
       filename,
-      is_section_file: SECTION_MARKER_RE.test(filename),
+      is_section_file: isSectionFile(filename),
       is_test_artifact: TEST_ARTIFACT_RE.test(filename),
       discovered_via: "direct",
     };
@@ -991,7 +1022,7 @@ export async function resolveCdsForSchool(
         url: landing.finalUrl,
         cds_year: year ?? UNKNOWN_YEAR_SENTINEL,
         filename,
-        is_section_file: SECTION_MARKER_RE.test(filename),
+        is_section_file: isSectionFile(filename),
         is_test_artifact: TEST_ARTIFACT_RE.test(filename),
         discovered_via: "direct",
       }],
@@ -1064,7 +1095,7 @@ export async function resolveCdsForSchool(
           year,
           year_source: (year ? "filename" : "unknown") as YearSource,
           kind: "document" as AnchorKind,
-          is_section_file: SECTION_MARKER_RE.test(filename),
+          is_section_file: isSectionFile(filename),
           is_test_artifact: TEST_ARTIFACT_RE.test(filename),
         }];
       }
@@ -1086,7 +1117,7 @@ export async function resolveCdsForSchool(
           year: sub.year,
           year_source: sub.year_source,
           kind: "document" as AnchorKind,
-          is_section_file: SECTION_MARKER_RE.test(filename),
+          is_section_file: isSectionFile(filename),
           is_test_artifact: TEST_ARTIFACT_RE.test(filename),
         }];
       }

--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -437,6 +437,32 @@ def artifact_schema_fallback_used(row: dict[str, Any]) -> bool:
     return bool(notes.get("schema_fallback_used"))
 
 
+def artifact_is_unusable_label_acroform(row: dict[str, Any]) -> bool:
+    """Tier 2 can be worse than Tier 4 when AcroForm tags are prompt labels.
+
+    These artifacts have many populated AcroForm fields, but almost none match
+    the selected schema. Keep the artifact for audit, but do not let producer
+    precedence make it the browser projection source when a usable layout
+    extraction exists for the same document.
+    """
+    if row.get("producer") != "tier2_acroform":
+        return False
+    notes = row.get("notes") or {}
+    if not isinstance(notes, dict):
+        return False
+    stats = notes.get("stats") or {}
+    if not isinstance(stats, dict):
+        return False
+    acroform_fields = int(stats.get("acroform_fields_total") or 0)
+    mapped_fields = int(stats.get("schema_fields_populated") or 0)
+    unmapped_fields = int(stats.get("unmapped_acroform_fields") or 0)
+    if acroform_fields < 50:
+        return False
+    if mapped_fields >= 5:
+        return False
+    return unmapped_fields >= int(acroform_fields * 0.8)
+
+
 def sort_base_candidates(
     candidates: list[dict[str, Any]],
     expected_schema_version: Optional[str] = None,
@@ -449,6 +475,10 @@ def sort_base_candidates(
     sorted_candidates = sorted(
         sorted_candidates,
         key=lambda row: BASE_PRODUCER_RANK.get(str(row.get("producer")), 99),
+    )
+    sorted_candidates = sorted(
+        sorted_candidates,
+        key=lambda row: 1 if artifact_is_unusable_label_acroform(row) else 0,
     )
     sorted_candidates = sorted(
         sorted_candidates,

--- a/tools/browser_backend/project_browser_data_test.py
+++ b/tools/browser_backend/project_browser_data_test.py
@@ -723,6 +723,68 @@ class BrowserProjectionTests(unittest.TestCase):
         self.assertIn("C.101", selected.values)
         self.assertNotIn("C.116", selected.values)
 
+    def test_selected_result_skips_unusable_label_acroform_tier2(self):
+        selected = select_extraction_result(
+            "00000000-0000-0000-0000-000000000001",
+            [
+                artifact(
+                    producer="tier2_acroform",
+                    values={},
+                    schema_version="2024-25",
+                    notes_extra={
+                        "stats": {
+                            "acroform_fields_total": 581,
+                            "schema_fields_populated": 0,
+                            "unmapped_acroform_fields": 581,
+                        },
+                    },
+                ),
+                artifact(
+                    producer="tier4_docling",
+                    values={"C.101": {"value": "5746"}},
+                    schema_version="2024-25",
+                    created_at="2026-01-02T00:00:00Z",
+                ),
+            ],
+            expected_schema_version="2024-25",
+        )
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected.base_producer, "tier4_docling")
+        self.assertEqual(selected.values["C.101"]["value"], "5746")
+
+    def test_selected_result_keeps_usable_tier2_over_tier4(self):
+        selected = select_extraction_result(
+            "00000000-0000-0000-0000-000000000001",
+            [
+                artifact(
+                    producer="tier2_acroform",
+                    values={"C.101": {"value": "576"}},
+                    schema_version="2024-25",
+                    notes_extra={
+                        "stats": {
+                            "acroform_fields_total": 732,
+                            "schema_fields_populated": 576,
+                            "unmapped_acroform_fields": 156,
+                        },
+                    },
+                ),
+                artifact(
+                    producer="tier4_docling",
+                    values={"C.101": {"value": "999"}},
+                    schema_version="2024-25",
+                    created_at="2026-01-02T00:00:00Z",
+                ),
+            ],
+            expected_schema_version="2024-25",
+        )
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected.base_producer, "tier2_acroform")
+        self.assertEqual(selected.values["C.101"]["value"], "576")
+
     def test_tier4_fallback_overlay_ignores_stale_base(self):
         selected = select_extraction_result(
             "00000000-0000-0000-0000-000000000001",

--- a/tools/change_intelligence/README.md
+++ b/tools/change_intelligence/README.md
@@ -7,6 +7,21 @@ For the spike/QA results that justified this pipeline, see
 
 ## Operator flow
 
+Audit watchlist freshness and produce a targeted local redrain queue:
+
+```bash
+python tools/change_intelligence/audit_watchlist_freshness.py \
+  --env /path/to/.env \
+  --watchlist data/watchlists/top_200_change_intelligence.yaml \
+  --out-dir .context/reports/prd019-top200-freshness \
+  --redrain-limit 25
+```
+
+The audit writes `freshness-audit.md`, `freshness-detail.csv`,
+`redrain-targets.csv`, `redrain-document-ids.txt`, and `summary.json`.
+Use the generated document-id list with the local extraction worker for managed
+Docling re-drains.
+
 Dry-run the calibration subset:
 
 ```bash

--- a/tools/change_intelligence/audit_watchlist_freshness.py
+++ b/tools/change_intelligence/audit_watchlist_freshness.py
@@ -8,6 +8,7 @@ This operator script answers three questions:
 1. Which watchlist schools have prior/latest browser rows?
 2. Which missing rows already have archived documents that can be re-drained?
 3. Which selected Tier 4 rows were produced by an older cleaner version?
+4. Which selected rows are section-only source fragments?
 """
 
 from __future__ import annotations
@@ -36,6 +37,18 @@ DEFAULT_OUT_DIR = REPO_ROOT / ".context" / "reports" / "prd019-top200-freshness"
 CURRENT_TIER4_VERSION = "0.3.4"
 REDRAIN_FORMATS = {"pdf_flat", "pdf_scanned"}
 BAD_FLAGS = {"wrong_file", "blank_template", "low_coverage"}
+SECTION_HINTS = {
+    "section_a": ("-a-", "general-information"),
+    "section_b": ("-b-", "enrollment-and-persistence"),
+    "section_c": ("-c-", "first-time-first-year"),
+    "section_d": ("-d-", "transfer-admission"),
+    "section_e": ("-e-", "academic-offerings"),
+    "section_f": ("-f-", "student-life"),
+    "section_g": ("-g-", "annual-expenses"),
+    "section_h": ("-h-", "financial-aid"),
+    "section_i": ("-i-", "instructional-faculty"),
+    "section_j": ("-j-", "degrees"),
+}
 
 
 @dataclass(frozen=True)
@@ -273,6 +286,27 @@ def needs_tier4_redrain(row: dict[str, Any] | None) -> bool:
     )
 
 
+def section_scope(source_url: str | None) -> str:
+    url = (source_url or "").lower()
+    if not url:
+        return ""
+    for label, needles in SECTION_HINTS.items():
+        if all(needle in url for needle in needles):
+            return label
+    return ""
+
+
+def row_source_url(row: dict[str, Any] | None, docs_by_id: dict[str, dict[str, Any]]) -> str:
+    if not row:
+        return ""
+    doc = docs_by_id.get(str(row.get("document_id") or "")) or {}
+    return str(doc.get("source_url") or "")
+
+
+def row_section_scope(row: dict[str, Any] | None, docs_by_id: dict[str, dict[str, Any]]) -> str:
+    return section_scope(row_source_url(row, docs_by_id))
+
+
 def target_doc_ids_for_school(
     school_id: str,
     docs: list[dict[str, Any]],
@@ -350,6 +384,7 @@ def write_markdown(summary: dict[str, Any], rows: list[dict[str, Any]], targets:
         f"- Latest-year rows: {summary['with_latest']}",
         f"- Pairable rows: {summary['pairable']} ({summary['pairable_pct']:.1%})",
         f"- Pairable with >=3 useful launch fields in both years: {summary['pairable_useful']} ({summary['pairable_useful_pct']:.1%})",
+        f"- Selected section-fragment rows: {summary['section_fragment_rows']}",
         f"- Targeted redrain documents: {summary['target_document_count']}",
         "",
         "## Redrain Targets",
@@ -373,14 +408,15 @@ def write_markdown(summary: dict[str, Any], rows: list[dict[str, Any]], targets:
         "",
         "## Watchlist Detail",
         "",
-        "| # | School | Segment | Prior | Latest | Useful Prior | Useful Latest | Status |",
-        "|---:|---|---|---|---|---:|---:|---|",
+        "| # | School | Segment | Prior | Latest | Useful Prior | Useful Latest | Section Scope | Status |",
+        "|---:|---|---|---|---|---:|---:|---|---|",
     ])
     for row in rows:
         lines.append(
             f"| {row['ordinal']} | {row['school_id']} | {row['segment']} | "
             f"{row['prior_status']} | {row['latest_status']} | "
-            f"{row['prior_useful_fields']} | {row['latest_useful_fields']} | {row['status']} |"
+            f"{row['prior_useful_fields']} | {row['latest_useful_fields']} | "
+            f"{row['section_scope']} | {row['status']} |"
         )
     path.write_text("\n".join(lines) + "\n")
 
@@ -403,8 +439,10 @@ def main() -> int:
     documents = fetch_documents(client, school_ids)
     selected = select_browser_rows(browser_rows)
     docs_by_school: dict[str, list[dict[str, Any]]] = {}
+    docs_by_id: dict[str, dict[str, Any]] = {}
     for doc in documents:
         docs_by_school.setdefault(str(doc["school_id"]), []).append(doc)
+        docs_by_id[str(doc["id"])] = doc
 
     detail_rows: list[dict[str, Any]] = []
     redrain_targets: list[dict[str, Any]] = []
@@ -413,6 +451,10 @@ def main() -> int:
         latest = selected.get((school.school_id, args.to_year))
         prior_useful = useful_field_count(prior)
         latest_useful = useful_field_count(latest)
+        prior_scope = row_section_scope(prior, docs_by_id)
+        latest_scope = row_section_scope(latest, docs_by_id)
+        selected_scopes = [scope for scope in (prior_scope, latest_scope) if scope]
+        scope_status = "/".join(selected_scopes)
         school_docs = docs_by_school.get(school.school_id, [])
         target_docs = target_doc_ids_for_school(
             school.school_id,
@@ -443,6 +485,11 @@ def main() -> int:
             "latest_status": f"{latest.get('producer')}@{latest.get('producer_version')}" if latest else "missing",
             "prior_useful_fields": prior_useful,
             "latest_useful_fields": latest_useful,
+            "prior_section_scope": prior_scope,
+            "latest_section_scope": latest_scope,
+            "section_scope": scope_status,
+            "prior_source_url": row_source_url(prior, docs_by_id),
+            "latest_source_url": row_source_url(latest, docs_by_id),
             "prior_doc_candidates": sum(1 for doc in school_docs if doc_year(doc) == args.from_year),
             "latest_doc_candidates": sum(1 for doc in school_docs if doc_year(doc) == args.to_year),
             "status": status,
@@ -471,6 +518,10 @@ def main() -> int:
         "with_latest": sum(1 for row in detail_rows if row["latest_document_id"]),
         "pairable": sum(1 for row in detail_rows if row["prior_document_id"] and row["latest_document_id"]),
         "pairable_useful": sum(1 for row in detail_rows if row["status"] == "pairable_useful"),
+        "section_fragment_rows": sum(
+            int(bool(row["prior_section_scope"])) + int(bool(row["latest_section_scope"]))
+            for row in detail_rows
+        ),
         "target_document_count": len(limited_targets),
         "all_target_document_count": len(redrain_targets),
         "target_document_ids": [row["document_id"] for row in limited_targets],

--- a/tools/change_intelligence/audit_watchlist_freshness.py
+++ b/tools/change_intelligence/audit_watchlist_freshness.py
@@ -34,7 +34,7 @@ from supabase import Client, create_client
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WATCHLIST = REPO_ROOT / "data" / "watchlists" / "top_200_change_intelligence.yaml"
 DEFAULT_OUT_DIR = REPO_ROOT / ".context" / "reports" / "prd019-top200-freshness"
-CURRENT_TIER4_VERSION = "0.3.4"
+CURRENT_TIER4_VERSION = "0.3.8"
 REDRAIN_FORMATS = {"pdf_flat", "pdf_scanned"}
 BAD_FLAGS = {"wrong_file", "blank_template", "low_coverage"}
 SECTION_HINTS = {

--- a/tools/change_intelligence/audit_watchlist_freshness.py
+++ b/tools/change_intelligence/audit_watchlist_freshness.py
@@ -34,7 +34,7 @@ from supabase import Client, create_client
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WATCHLIST = REPO_ROOT / "data" / "watchlists" / "top_200_change_intelligence.yaml"
 DEFAULT_OUT_DIR = REPO_ROOT / ".context" / "reports" / "prd019-top200-freshness"
-CURRENT_TIER4_VERSION = "0.3.8"
+CURRENT_TIER4_VERSION = "0.3.9"
 REDRAIN_FORMATS = {"pdf_flat", "pdf_scanned"}
 BAD_FLAGS = {"wrong_file", "blank_template", "low_coverage"}
 SECTION_HINTS = {

--- a/tools/change_intelligence/audit_watchlist_freshness.py
+++ b/tools/change_intelligence/audit_watchlist_freshness.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Audit PRD 019 watchlist freshness and propose targeted re-drains.
+
+The change-intelligence projector can only tell a useful story when each
+watchlist school has pairable selected-primary rows for the comparison years.
+This operator script answers three questions:
+
+1. Which watchlist schools have prior/latest browser rows?
+2. Which missing rows already have archived documents that can be re-drained?
+3. Which selected Tier 4 rows were produced by an older cleaner version?
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - operator venvs include PyYAML.
+    yaml = None
+
+from supabase import Client, create_client
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WATCHLIST = REPO_ROOT / "data" / "watchlists" / "top_200_change_intelligence.yaml"
+DEFAULT_OUT_DIR = REPO_ROOT / ".context" / "reports" / "prd019-top200-freshness"
+CURRENT_TIER4_VERSION = "0.3.4"
+REDRAIN_FORMATS = {"pdf_flat", "pdf_scanned"}
+BAD_FLAGS = {"wrong_file", "blank_template", "low_coverage"}
+
+
+@dataclass(frozen=True)
+class WatchSchool:
+    school_id: str
+    segment: str
+    ordinal: int
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    env: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def load_env(path: Path | None) -> dict[str, str]:
+    env = dict(os.environ)
+    for candidate in (
+        path,
+        REPO_ROOT / ".env",
+        Path("/Users/santhonys/Projects/Owen/colleges/collegedata-fyi/.env"),
+    ):
+        if candidate:
+            for key, value in read_env_file(candidate).items():
+                env.setdefault(key, value)
+    return env
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to read watchlist files")
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def load_watchlist(path: Path) -> list[WatchSchool]:
+    raw = load_yaml(path)
+    schools: list[WatchSchool] = []
+    for ordinal, item in enumerate(raw.get("schools") or [], start=1):
+        if isinstance(item, str):
+            schools.append(WatchSchool(item, "", ordinal))
+        elif isinstance(item, dict) and item.get("school_id"):
+            schools.append(
+                WatchSchool(
+                    school_id=str(item["school_id"]),
+                    segment=str(item.get("segment") or ""),
+                    ordinal=ordinal,
+                ),
+            )
+    return schools
+
+
+def create_supabase_client(env: dict[str, str]) -> Client:
+    url = env.get("SUPABASE_URL") or env.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = env.get("SUPABASE_SERVICE_ROLE_KEY") or env.get("SUPABASE_ANON_KEY")
+    if not url or not key:
+        raise SystemExit("Missing SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/ANON key")
+    return create_client(url, key)
+
+
+def chunks(values: list[str], size: int = 80) -> list[list[str]]:
+    return [values[i:i + size] for i in range(0, len(values), size)]
+
+
+def fetch_browser_rows(
+    client: Client,
+    school_ids: list[str],
+    from_year: int,
+    to_year: int,
+) -> list[dict[str, Any]]:
+    columns = [
+        "document_id",
+        "school_id",
+        "school_name",
+        "sub_institutional",
+        "canonical_year",
+        "year_start",
+        "source_format",
+        "producer",
+        "producer_version",
+        "data_quality_flag",
+        "archive_url",
+        "applied",
+        "admitted",
+        "enrolled_first_year",
+        "acceptance_rate",
+        "yield_rate",
+        "sat_submit_rate",
+        "act_submit_rate",
+        "sat_composite_p25",
+        "sat_composite_p75",
+        "act_composite_p25",
+        "act_composite_p75",
+    ]
+    rows: list[dict[str, Any]] = []
+    for page_ids in chunks(school_ids):
+        page = (
+            client.table("school_browser_rows")
+            .select(",".join(columns))
+            .in_("school_id", page_ids)
+            .gte("year_start", from_year)
+            .lte("year_start", to_year)
+            .is_("sub_institutional", "null")
+            .execute()
+            .data
+            or []
+        )
+        rows.extend(page)
+    return rows
+
+
+def fetch_documents(client: Client, school_ids: list[str]) -> list[dict[str, Any]]:
+    columns = [
+        "id",
+        "school_id",
+        "school_name",
+        "sub_institutional",
+        "cds_year",
+        "detected_year",
+        "source_format",
+        "extraction_status",
+        "participation_status",
+        "data_quality_flag",
+        "source_provenance",
+        "discovered_at",
+        "updated_at",
+        "source_url",
+    ]
+    rows: list[dict[str, Any]] = []
+    for page_ids in chunks(school_ids):
+        page = (
+            client.table("cds_documents")
+            .select(",".join(columns))
+            .in_("school_id", page_ids)
+            .is_("sub_institutional", "null")
+            .execute()
+            .data
+            or []
+        )
+        rows.extend(page)
+    return rows
+
+
+def year_start(value: Any) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(str(value)[:4])
+    except ValueError:
+        return None
+
+
+def doc_year(doc: dict[str, Any]) -> int | None:
+    return year_start(doc.get("detected_year") or doc.get("cds_year"))
+
+
+def row_rank(row: dict[str, Any]) -> tuple[int, int, str]:
+    bad = 1 if row.get("data_quality_flag") in BAD_FLAGS else 0
+    provenance = 0 if row.get("source_provenance") in ("school_direct", "operator_manual") else 1
+    return bad, provenance, str(row.get("document_id") or "")
+
+
+def select_browser_rows(rows: list[dict[str, Any]]) -> dict[tuple[str, int], dict[str, Any]]:
+    grouped: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    for row in rows:
+        if row.get("sub_institutional") is not None:
+            continue
+        if row.get("year_start") is None:
+            continue
+        grouped.setdefault((str(row["school_id"]), int(row["year_start"])), []).append(row)
+    return {key: sorted(values, key=row_rank)[0] for key, values in grouped.items()}
+
+
+def useful_field_count(row: dict[str, Any] | None) -> int:
+    if not row:
+        return 0
+    keys = [
+        "applied",
+        "admitted",
+        "enrolled_first_year",
+        "acceptance_rate",
+        "yield_rate",
+        "sat_submit_rate",
+        "act_submit_rate",
+        "sat_composite_p25",
+        "sat_composite_p75",
+        "act_composite_p25",
+        "act_composite_p75",
+    ]
+    return sum(1 for key in keys if row.get(key) is not None)
+
+
+def version_tuple(value: Any) -> tuple[int, ...]:
+    parts = []
+    for part in str(value or "").split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def best_doc_for_year(docs: list[dict[str, Any]], target_year: int) -> dict[str, Any] | None:
+    candidates = [doc for doc in docs if doc_year(doc) == target_year]
+    if not candidates:
+        return None
+
+    def rank(doc: dict[str, Any]) -> tuple[int, int, int, str]:
+        status_priority = {
+            "extraction_pending": 0,
+            "failed": 1,
+            "extracted": 2,
+            "not_applicable": 3,
+        }.get(str(doc.get("extraction_status") or ""), 4)
+        format_priority = 0 if doc.get("source_format") in REDRAIN_FORMATS else 1
+        bad = 1 if doc.get("data_quality_flag") in BAD_FLAGS else 0
+        discovered = str(doc.get("discovered_at") or "")
+        return status_priority, format_priority, bad, discovered
+
+    return sorted(candidates, key=rank)[0]
+
+
+def needs_tier4_redrain(row: dict[str, Any] | None) -> bool:
+    if not row:
+        return False
+    return (
+        row.get("producer") == "tier4_docling"
+        and version_tuple(row.get("producer_version")) < version_tuple(CURRENT_TIER4_VERSION)
+    )
+
+
+def target_doc_ids_for_school(
+    school_id: str,
+    docs: list[dict[str, Any]],
+    prior: dict[str, Any] | None,
+    latest: dict[str, Any] | None,
+    from_year: int,
+    to_year: int,
+) -> list[dict[str, Any]]:
+    targets: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    pairable = bool(prior and latest)
+
+    for year, row in ((from_year, prior), (to_year, latest)):
+        if needs_tier4_redrain(row):
+            doc_id = str(row.get("document_id") or "")
+            if doc_id and doc_id not in seen:
+                targets.append({
+                    "document_id": doc_id,
+                    "school_id": school_id,
+                    "year_start": year,
+                    "priority_class": "pairable_stale" if pairable else "stale_unpairable",
+                    "reason": "selected_tier4_stale",
+                    "source_format": row.get("source_format") or "",
+                    "producer_version": row.get("producer_version") or "",
+                })
+                seen.add(doc_id)
+            continue
+
+        if row:
+            continue
+
+        doc = best_doc_for_year(docs, year)
+        if not doc:
+            continue
+        if doc.get("source_format") not in REDRAIN_FORMATS:
+            continue
+        doc_id = str(doc.get("id") or "")
+        if doc_id and doc_id not in seen:
+            targets.append({
+                "document_id": doc_id,
+                "school_id": school_id,
+                "year_start": year,
+                "priority_class": "latest_gap" if year == to_year else "prior_gap",
+                "reason": f"missing_browser_row_{doc.get('extraction_status') or 'unknown'}",
+                "source_format": doc.get("source_format") or "",
+                "producer_version": "",
+            })
+            seen.add(doc_id)
+
+    return targets
+
+
+def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("")
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown(summary: dict[str, Any], rows: list[dict[str, Any]], targets: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# PRD 019 watchlist freshness audit",
+        "",
+        f"Generated: {summary['generated_at']}",
+        "",
+        "## Summary",
+        "",
+        f"- Watchlist schools: {summary['watchlist_size']}",
+        f"- Prior-year rows: {summary['with_prior']}",
+        f"- Latest-year rows: {summary['with_latest']}",
+        f"- Pairable rows: {summary['pairable']} ({summary['pairable_pct']:.1%})",
+        f"- Pairable with >=3 useful launch fields in both years: {summary['pairable_useful']} ({summary['pairable_useful_pct']:.1%})",
+        f"- Targeted redrain documents: {summary['target_document_count']}",
+        "",
+        "## Redrain Targets",
+        "",
+    ]
+    if targets:
+        lines.extend([
+            "| Priority | School | Year | Reason | Format | Document ID |",
+            "|---:|---|---:|---|---|---|",
+        ])
+        for index, target in enumerate(targets[:100], start=1):
+            lines.append(
+                f"| {index} | {target['school_id']} | {target['year_start']} | "
+                f"{target['priority_class']} / {target['reason']} | "
+                f"{target['source_format']} | `{target['document_id']}` |"
+            )
+    else:
+        lines.append("No targetable Tier 4 documents found.")
+
+    lines.extend([
+        "",
+        "## Watchlist Detail",
+        "",
+        "| # | School | Segment | Prior | Latest | Useful Prior | Useful Latest | Status |",
+        "|---:|---|---|---|---|---:|---:|---|",
+    ])
+    for row in rows:
+        lines.append(
+            f"| {row['ordinal']} | {row['school_id']} | {row['segment']} | "
+            f"{row['prior_status']} | {row['latest_status']} | "
+            f"{row['prior_useful_fields']} | {row['latest_useful_fields']} | {row['status']} |"
+        )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", type=Path, default=None)
+    parser.add_argument("--watchlist", type=Path, default=DEFAULT_WATCHLIST)
+    parser.add_argument("--from-year", type=int, default=2024)
+    parser.add_argument("--to-year", type=int, default=2025)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--redrain-limit", type=int, default=25)
+    args = parser.parse_args()
+
+    watchlist = load_watchlist(args.watchlist)
+    school_ids = [school.school_id for school in watchlist]
+    client = create_supabase_client(load_env(args.env))
+
+    browser_rows = fetch_browser_rows(client, school_ids, args.from_year, args.to_year)
+    documents = fetch_documents(client, school_ids)
+    selected = select_browser_rows(browser_rows)
+    docs_by_school: dict[str, list[dict[str, Any]]] = {}
+    for doc in documents:
+        docs_by_school.setdefault(str(doc["school_id"]), []).append(doc)
+
+    detail_rows: list[dict[str, Any]] = []
+    redrain_targets: list[dict[str, Any]] = []
+    for school in watchlist:
+        prior = selected.get((school.school_id, args.from_year))
+        latest = selected.get((school.school_id, args.to_year))
+        prior_useful = useful_field_count(prior)
+        latest_useful = useful_field_count(latest)
+        school_docs = docs_by_school.get(school.school_id, [])
+        target_docs = target_doc_ids_for_school(
+            school.school_id,
+            school_docs,
+            prior,
+            latest,
+            args.from_year,
+            args.to_year,
+        )
+        redrain_targets.extend({**target, "ordinal": school.ordinal} for target in target_docs)
+
+        if prior and latest and prior_useful >= 3 and latest_useful >= 3:
+            status = "pairable_useful"
+        elif prior and latest:
+            status = "pairable_sparse"
+        elif target_docs:
+            status = "targetable_gap"
+        else:
+            status = "archive_gap"
+
+        detail_rows.append({
+            "ordinal": school.ordinal,
+            "school_id": school.school_id,
+            "segment": school.segment,
+            "prior_document_id": prior.get("document_id") if prior else "",
+            "latest_document_id": latest.get("document_id") if latest else "",
+            "prior_status": f"{prior.get('producer')}@{prior.get('producer_version')}" if prior else "missing",
+            "latest_status": f"{latest.get('producer')}@{latest.get('producer_version')}" if latest else "missing",
+            "prior_useful_fields": prior_useful,
+            "latest_useful_fields": latest_useful,
+            "prior_doc_candidates": sum(1 for doc in school_docs if doc_year(doc) == args.from_year),
+            "latest_doc_candidates": sum(1 for doc in school_docs if doc_year(doc) == args.to_year),
+            "status": status,
+        })
+
+    priority_order = {
+        "latest_gap": 0,
+        "prior_gap": 1,
+        "pairable_stale": 2,
+        "stale_unpairable": 3,
+    }
+    redrain_targets.sort(key=lambda row: (
+        priority_order.get(str(row["priority_class"]), 9),
+        int(row["ordinal"]),
+        0 if row["year_start"] == args.to_year else 1,
+        row["reason"],
+    ))
+    limited_targets = redrain_targets[:args.redrain_limit]
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "watchlist": str(args.watchlist),
+        "from_year": args.from_year,
+        "to_year": args.to_year,
+        "watchlist_size": len(watchlist),
+        "with_prior": sum(1 for row in detail_rows if row["prior_document_id"]),
+        "with_latest": sum(1 for row in detail_rows if row["latest_document_id"]),
+        "pairable": sum(1 for row in detail_rows if row["prior_document_id"] and row["latest_document_id"]),
+        "pairable_useful": sum(1 for row in detail_rows if row["status"] == "pairable_useful"),
+        "target_document_count": len(limited_targets),
+        "all_target_document_count": len(redrain_targets),
+        "target_document_ids": [row["document_id"] for row in limited_targets],
+    }
+    summary["pairable_pct"] = summary["pairable"] / summary["watchlist_size"] if summary["watchlist_size"] else 0
+    summary["pairable_useful_pct"] = summary["pairable_useful"] / summary["watchlist_size"] if summary["watchlist_size"] else 0
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    write_csv(detail_rows, args.out_dir / "freshness-detail.csv")
+    write_csv(limited_targets, args.out_dir / "redrain-targets.csv")
+    (args.out_dir / "redrain-document-ids.txt").write_text(
+        ",".join(summary["target_document_ids"]) + "\n",
+    )
+    (args.out_dir / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    write_markdown(summary, detail_rows, limited_targets, args.out_dir / "freshness-audit.md")
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/data_quality/README.md
+++ b/tools/data_quality/README.md
@@ -9,6 +9,7 @@ Some tools also produce CSV batches for human contributors (the kids worklist pi
 | File | Purpose |
 |---|---|
 | `audit_manifest.py` | Post-ingest data-quality audit. Reads canonical artifacts, flags documents with <5 populated fields as `blank_template` or `low_coverage`, optionally writes `data_quality_flag` back to `cds_documents`. Frontend surfaces this as an amber badge. |
+| `audit_visual_ocr_candidates.py` | Finds Tier 4 PDFs with C1/C9 labels present but key admissions/test-score values absent. Use it to queue managed local re-drains through the visual-OCR supplement and to confirm which documents were repaired by `tier4_docling` 0.3.5+. |
 | `completeness_report.py` | Top-to-bottom funnel pivot per `cds_year`: corpus → discovered → archived → extracted → high_quality. Default window = past 5 CDS years. Output: terminal table + optional JSON. Use this to size the coverage picture before scoping any discovery work. |
 | `active_schools_missing_recent.py` | Per-school CSV of which active schools lack docs for which recent years. Feeds the kids worklist; also useful standalone for operator spot-checks. |
 | `kids_worklist.py` | Generates batched Google-Sheets-ready CSVs (50 schools per batch, sorted highest-yield first) of active schools missing recent years. Queries `latest_school_hosting` to skip auth-walled schools, prefers `browse_url` over `discovery_seed_url`, and surfaces a `hosting_note` so contributors know what to expect (Box folder, JS-rendered, "needs landing page", etc.). Applies `tools/finder/school_overrides.yaml` on top of DB observations. Output: `tools/data_quality/kids-worklist/batch-NNN.csv`. |
@@ -24,6 +25,10 @@ tools/extraction_worker/.venv/bin/python tools/data_quality/completeness_report.
 
 # "Which CDS files look broken?" — audit canonical artifacts
 tools/extraction_worker/.venv/bin/python tools/data_quality/audit_manifest.py --write
+
+# "Which extracted PDFs likely need visual OCR?" — emit a re-drain review CSV
+tools/extraction_worker/.venv/bin/python tools/data_quality/audit_visual_ocr_candidates.py \
+    --csv-output .context/reports/visual-ocr-candidates.csv
 
 # "Generate a kids worklist" — regenerates 16 batch CSVs
 tools/extraction_worker/.venv/bin/python tools/data_quality/kids_worklist.py
@@ -41,6 +46,7 @@ All tools read `.env` at the repo root for `SUPABASE_URL` and `SUPABASE_SERVICE_
 `tools/data_quality/` accumulates JSON/JSONL/CSV output files from the above tools. These are deliberately left out of git — they're point-in-time snapshots and would churn noisily. Examples:
 
 - `audit-report-YYYYMMDD.json` — output of `audit_manifest.py`
+- `visual-ocr-candidates.csv` — output of `audit_visual_ocr_candidates.py`
 - `completeness-YYYYMMDD.json` — output of `completeness_report.py`
 - `full-drain-YYYYMMDD.jsonl` — output of `force_resolve_missing.py --all`
 - `active-schools-missing-recent.csv` — output of `active_schools_missing_recent.py`

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -29,7 +29,7 @@ from supabase import create_client
 
 C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
 C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
-OCR_PRODUCER_VERSION = "0.3.7"
+OCR_PRODUCER_VERSION = "0.3.8"
 
 
 def parse_year_start(year: str | None) -> int | None:

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Find CDS artifacts likely to benefit from the visual OCR supplement.
+
+This audits canonical Tier 4 artifacts for the Arizona failure mode:
+section labels are present in the extracted text, but high-value admissions
+numbers are absent because the PDF rendered filled-in cells visually rather
+than in the embedded text layer.
+
+Usage:
+    python tools/data_quality/audit_visual_ocr_candidates.py \
+      --env /path/to/.env \
+      --csv-output .context/reports/visual-ocr-candidates.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from supabase import create_client
+
+
+C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
+C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
+OCR_PRODUCER_VERSION = "0.3.5"
+
+
+def parse_year_start(year: str | None) -> int | None:
+    if not year:
+        return None
+    match = re.match(r"^((?:19|20)\d{2})-\d{2}$", year)
+    return int(match.group(1)) if match else None
+
+
+def version_tuple(version: str | None) -> tuple[int, ...]:
+    if not version:
+        return ()
+    parts: list[int] = []
+    for part in str(version).split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def fetch_all(client: Any, table: str, select: str, page_size: int = 100) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        batch: list[dict[str, Any]] = []
+        for attempt in range(4):
+            try:
+                batch = (
+                    client.table(table)
+                    .select(select)
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                    .data
+                    or []
+                )
+                break
+            except Exception:
+                if attempt == 3:
+                    raise
+                time.sleep(2 ** attempt)
+        rows.extend(batch)
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return rows
+
+
+def latest_canonical_artifacts(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for row in sorted(rows, key=lambda r: str(r.get("created_at") or ""), reverse=True):
+        if row.get("kind") != "canonical":
+            continue
+        doc_id = str(row.get("document_id") or "")
+        if doc_id and doc_id not in latest:
+            latest[doc_id] = row
+    return latest
+
+
+def fetch_artifacts_for_documents(client: Any, document_ids: list[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    chunk_size = 40
+    select = "id,document_id,kind,producer,producer_version,schema_version,created_at,notes"
+    for start in range(0, len(document_ids), chunk_size):
+        chunk = document_ids[start:start + chunk_size]
+        for attempt in range(4):
+            try:
+                batch = (
+                    client.table("cds_artifacts")
+                    .select(select)
+                    .eq("kind", "canonical")
+                    .in_("document_id", chunk)
+                    .execute()
+                    .data
+                    or []
+                )
+                rows.extend(batch)
+                break
+            except Exception:
+                if attempt == 3:
+                    raise
+                time.sleep(2 ** attempt)
+    return rows
+
+
+def has_c1_anchor(markdown: str) -> bool:
+    lowered = markdown.lower()
+    return (
+        "c1. first-time" in lowered
+        or "first-time, first-year student applicants" in lowered
+        or "first-time, first-year admission" in lowered
+    )
+
+
+def has_c9_anchor(markdown: str) -> bool:
+    lowered = markdown.lower()
+    return "submitting sat scores" in lowered or "c9. percent and number" in lowered
+
+
+def classify(doc: dict[str, Any], artifact: dict[str, Any]) -> dict[str, Any] | None:
+    notes = artifact.get("notes") or {}
+    if not isinstance(notes, dict):
+        return None
+    markdown = str(notes.get("markdown") or "")
+    values = notes.get("values") or {}
+    if not isinstance(values, dict):
+        values = {}
+    stats = notes.get("stats") or {}
+    if not isinstance(stats, dict):
+        stats = {}
+
+    visual_pages = stats.get("visual_ocr_pages") or []
+    if not isinstance(visual_pages, list):
+        visual_pages = []
+    field_count = int(stats.get("schema_fields_populated") or len(values) or 0)
+    producer_version = str(artifact.get("producer_version") or "")
+
+    c1_anchor = has_c1_anchor(markdown)
+    c9_anchor = has_c9_anchor(markdown)
+    missing_c1 = c1_anchor and not C1_KEYS.intersection(values)
+    missing_c9 = c9_anchor and not C9_KEYS.intersection(values)
+    recovered_c1 = c1_anchor and bool(C1_KEYS.intersection(values))
+    recovered_c9 = c9_anchor and bool(C9_KEYS.intersection(values))
+
+    if visual_pages:
+        if missing_c1 or missing_c9:
+            status = "ocr_attempt_still_missing"
+        else:
+            status = "visual_ocr_recovered"
+    elif (missing_c1 or missing_c9) and field_count < 150:
+        status = (
+            "needs_redrain_visual_ocr"
+            if version_tuple(producer_version) < version_tuple(OCR_PRODUCER_VERSION)
+            else "candidate_without_ocr_pages"
+        )
+    else:
+        return None
+
+    return {
+        "status": status,
+        "document_id": doc["id"],
+        "school_id": doc["school_id"],
+        "school_name": doc.get("school_name") or "",
+        "cds_year": doc.get("detected_year") or doc.get("cds_year") or "",
+        "source_format": doc.get("source_format") or "",
+        "producer": artifact.get("producer") or "",
+        "producer_version": producer_version,
+        "schema_version": artifact.get("schema_version") or "",
+        "schema_fallback_used": bool(notes.get("schema_fallback_used")),
+        "field_count": field_count,
+        "visual_ocr_pages": ",".join(str(p) for p in visual_pages),
+        "missing_c1": int(missing_c1),
+        "missing_c9": int(missing_c9),
+        "recovered_c1": int(recovered_c1),
+        "recovered_c9": int(recovered_c9),
+        "source_url": doc.get("source_url") or "",
+        "created_at": artifact.get("created_at") or "",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit visual-OCR extraction candidates")
+    parser.add_argument("--env", default=".env", help="Path to .env file")
+    parser.add_argument("--school", help="Restrict to one school_id")
+    parser.add_argument("--min-year-start", type=int, default=2024)
+    parser.add_argument("--include-all-years", action="store_true")
+    parser.add_argument("--csv-output", type=Path)
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+
+    load_dotenv(args.env)
+    client = create_client(
+        os.environ["SUPABASE_URL"],
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ["SUPABASE_ANON_KEY"],
+    )
+
+    docs = fetch_all(
+        client,
+        "cds_documents",
+        "id,school_id,school_name,cds_year,detected_year,source_format,source_url",
+        page_size=1000,
+    )
+    docs = [
+        doc
+        for doc in docs
+        if (not args.school or doc.get("school_id") == args.school)
+        and doc.get("source_format") in {"pdf_flat", "pdf_scanned"}
+        and (
+            args.include_all_years
+            or (
+                (parse_year_start(doc.get("detected_year") or doc.get("cds_year")) or 0)
+                >= args.min_year_start
+            )
+        )
+    ]
+    artifacts = latest_canonical_artifacts(
+        fetch_artifacts_for_documents(client, [str(doc["id"]) for doc in docs])
+    )
+
+    rows: list[dict[str, Any]] = []
+    for doc in docs:
+        artifact = artifacts.get(str(doc["id"]))
+        if not artifact or artifact.get("producer") != "tier4_docling":
+            continue
+        row = classify(doc, artifact)
+        if row:
+            rows.append(row)
+
+    status_order = {
+        "needs_redrain_visual_ocr": 0,
+        "candidate_without_ocr_pages": 1,
+        "ocr_attempt_still_missing": 2,
+        "visual_ocr_recovered": 3,
+    }
+    rows.sort(key=lambda r: (status_order.get(r["status"], 9), r["school_id"], r["cds_year"]))
+
+    fieldnames = [
+        "status",
+        "document_id",
+        "school_id",
+        "school_name",
+        "cds_year",
+        "source_format",
+        "producer",
+        "producer_version",
+        "schema_version",
+        "schema_fallback_used",
+        "field_count",
+        "visual_ocr_pages",
+        "missing_c1",
+        "missing_c9",
+        "recovered_c1",
+        "recovered_c9",
+        "source_url",
+        "created_at",
+    ]
+    if args.csv_output:
+        args.csv_output.parent.mkdir(parents=True, exist_ok=True)
+        with args.csv_output.open("w", newline="") as fp:
+            writer = csv.DictWriter(fp, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n")
+
+    summary: dict[str, int] = {"total": len(rows)}
+    for row in rows:
+        summary[row["status"]] = summary.get(row["status"], 0) + 1
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    for row in rows[:25]:
+        print(
+            f"{row['status']:27s} {row['school_id']:45s} "
+            f"{row['cds_year']:7s} fields={row['field_count']:3d} "
+            f"pages={row['visual_ocr_pages'] or '-'}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -29,7 +29,7 @@ from supabase import create_client
 
 C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
 C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
-OCR_PRODUCER_VERSION = "0.3.6"
+OCR_PRODUCER_VERSION = "0.3.7"
 
 
 def parse_year_start(year: str | None) -> int | None:

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -29,7 +29,7 @@ from supabase import create_client
 
 C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
 C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
-OCR_PRODUCER_VERSION = "0.3.5"
+OCR_PRODUCER_VERSION = "0.3.6"
 
 
 def parse_year_start(year: str | None) -> int | None:

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -42,6 +42,57 @@ class Tier4CleanerC1C2Test(unittest.TestCase):
         self.assertEqual(values["C.118"]["value"], "8749")
         self.assertEqual(values["C.119"]["value"], "3268")
 
+    def test_c1_visual_ocr_layout_lines(self):
+        markdown = """
+FIRST-TIME, FIRST-YEAR STUDENT APPLICANTS TOTAL
+Total first-time, first-year men who applied 25635
+Total first-time, first-year women who applied 32704
+Total first-time, first-year of another gender who applied
+Total first-time, first-year of unknown gender who applied
+
+FIRST-TIME, FIRST-YEAR STUDENT ADMITS TOTAL
+Total first-time, first-year men who were admitted 21436
+Total first-time, first-year women who were admitted 28816
+
+FIRST-TIME, FIRST-YEAR STUDENT ENROLLEES TOTAL
+Total first-time, first-year men who enrolled 3714
+Total first-time, first-year women who enrolled 5526
+
+FIRST-TIME, FIRST-YEAR STUDENT ENROLLEES BY STATUS TOTAL
+Total full-time, first-time, first-year men who enrolled 3528
+Total part-time, first-time, first-year men who enrolled 186
+Total full-time, first-time, first-year women who enrolled 5280
+Total part-time, first-time, first-year women who enrolled 246
+
+FIRST-TIME, FIRST-YEAR STUDENT APPLICANTS IN-STATE OUT.OF- INTERNATIONAL] UNKNOWN | TOTAL
+Total first-time, first-year (degree-seeking) who applied 15064 34044 9231 58339
+Total first-time, first-year (degree-seeking) who were admitted} 13619 31303 5330 50252
+Total first-time, first-year (degree-seeking) enrolled 4983 3914 343 9240
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2024_25.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "25635")
+        self.assertEqual(values["C.102"]["value"], "32704")
+        self.assertEqual(values["C.105"]["value"], "21436")
+        self.assertEqual(values["C.106"]["value"], "28816")
+        self.assertEqual(values["C.109"]["value"], "3528")
+        self.assertEqual(values["C.110"]["value"], "186")
+        self.assertEqual(values["C.111"]["value"], "5280")
+        self.assertEqual(values["C.112"]["value"], "246")
+        self.assertEqual(values["C.117"]["value"], "58339")
+        self.assertEqual(values["C.118"]["value"], "50252")
+        self.assertEqual(values["C.119"]["value"], "9240")
+        self.assertEqual(values["C.120"]["value"], "15064")
+        self.assertEqual(values["C.123"]["value"], "34044")
+        self.assertEqual(values["C.126"]["value"], "9231")
+        self.assertEqual(values["C.122"]["value"], "4983")
+        self.assertEqual(values["C.125"]["value"], "3914")
+        self.assertEqual(values["C.128"]["value"], "343")
+
     def test_c2_waitlist_policy_and_counts_from_layout(self):
         supplemental = """
 C2   First-time, first-year wait-listed students

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -124,6 +124,35 @@ Total part-time, first-time first-year (freshman) who enrolled: 0 0 0 0 0
         self.assertEqual(values["C.117"]["value"], "3859")
         self.assertEqual(values["C.118"]["value"], "1804")
 
+    def test_c1_compact_gender_columns_without_another_or_unknown(self):
+        markdown = """
+C1 First-time, first-year students
+
+Men Women Total
+Total first-time, first-year students who applied 48,101 50,209 98,310
+Total first-time, first-year students admitted 6,684 8,689 15,373
+Total first-time, first-year students enrolled 3,199 4,079 7,278
+Full-time, first-time, first-year students enrolled 3,188 4,064 7,252
+Part-time, first-time, first-year students enrolled 11 15 26
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2024_25.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "48101")
+        self.assertEqual(values["C.102"]["value"], "50209")
+        self.assertEqual(values["C.105"]["value"], "6684")
+        self.assertEqual(values["C.106"]["value"], "8689")
+        self.assertEqual(values["C.109"]["value"], "3188")
+        self.assertEqual(values["C.110"]["value"], "11")
+        self.assertEqual(values["C.111"]["value"], "4064")
+        self.assertEqual(values["C.112"]["value"], "15")
+        self.assertEqual(values["C.117"]["value"], "98310")
+        self.assertEqual(values["C.118"]["value"], "15373")
+        self.assertEqual(values["C.119"]["value"], "7278")
+
     def test_c1_application_data_line_stacks(self):
         markdown = """
 Common Data Set

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -1,11 +1,47 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
-from tier4_cleaner import clean
+from tier4_cleaner import SchemaIndex, clean
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class Tier4CleanerC1C2Test(unittest.TestCase):
+    def test_c1_compact_gender_columns(self):
+        markdown = """
+## C1. First-time, first-year students admissions statistics
+
+|                    |    Men |   Women |   Another Gender |   Unknown |   Total |
+|--------------------|--------|---------|------------------|-----------|---------|
+| Applied            | 30,456 |  44,822 |            3,479 |        12 |  78,769 |
+| Admitted           |  3,492 |   4,975 |              278 |         4 |   8,749 |
+| Full-time enrolled |  1,267 |   1,887 |              113 |         1 |   3,268 |
+| Part-time enrolled |      0 |       0 |                0 |         0 |       0 |
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2024_25.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "30456")
+        self.assertEqual(values["C.102"]["value"], "44822")
+        self.assertEqual(values["C.103"]["value"], "3479")
+        self.assertEqual(values["C.104"]["value"], "12")
+        self.assertEqual(values["C.105"]["value"], "3492")
+        self.assertEqual(values["C.106"]["value"], "4975")
+        self.assertEqual(values["C.107"]["value"], "278")
+        self.assertEqual(values["C.108"]["value"], "4")
+        self.assertEqual(values["C.109"]["value"], "1267")
+        self.assertEqual(values["C.111"]["value"], "1887")
+        self.assertEqual(values["C.113"]["value"], "113")
+        self.assertEqual(values["C.115"]["value"], "1")
+        self.assertEqual(values["C.117"]["value"], "78769")
+        self.assertEqual(values["C.118"]["value"], "8749")
+        self.assertEqual(values["C.119"]["value"], "3268")
+
     def test_c2_waitlist_policy_and_counts_from_layout(self):
         supplemental = """
 C2   First-time, first-year wait-listed students

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -201,6 +201,81 @@ Enrolled
         self.assertEqual(values["C.125"]["value"], "2300")
         self.assertEqual(values["C.128"]["value"], "95")
 
+    def test_c1_tableau_layout_block_2025_schema(self):
+        markdown = """
+Common Data Set
+
+C. FIRST-TIME, FIRST-YEAR ADMISSION
+
+C1. Applications
+
+Category                                   Unit load                               Males                                Females                                Unknown
+Applied                                    All                                     5365                                   7096                                     9
+Admitted                                   All                                      418                                    471                                     1
+Enrolled                                   Full-Time                                199                                    221                                     1
+                                           Part-Time
+                                           All                                      199                                    221                                     1
+
+C2. First-time, first-year wait-listed students
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2025_26.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "5365")
+        self.assertEqual(values["C.102"]["value"], "7096")
+        self.assertEqual(values["C.103"]["value"], "9")
+        self.assertEqual(values["C.104"]["value"], "418")
+        self.assertEqual(values["C.105"]["value"], "471")
+        self.assertEqual(values["C.106"]["value"], "1")
+        self.assertEqual(values["C.107"]["value"], "199")
+        self.assertEqual(values["C.108"]["value"], "221")
+        self.assertEqual(values["C.109"]["value"], "1")
+        self.assertEqual(values["C.110"]["value"], "199")
+        self.assertEqual(values["C.112"]["value"], "221")
+        self.assertEqual(values["C.114"]["value"], "1")
+        self.assertEqual(values["C.116"]["value"], "12470")
+        self.assertEqual(values["C.117"]["value"], "890")
+        self.assertEqual(values["C.118"]["value"], "421")
+
+    def test_c1_tableau_layout_block_2024_schema(self):
+        markdown = """
+Common Data Set
+
+C. FIRST-TIME, FIRST-YEAR ADMISSION
+
+C1. First-time, first-year students
+
+Category              Unit load                          Men                              Women                          Another Gender                         Unknown
+Applied               All                               5283                                6956                                10                                  0
+Admitted              All                                401                                466                                  1                                  0
+Enrolled              Full-Time                          194                                242                                  0                                  0
+                      Part-Time                            0                                  0                                  0                                  0
+
+C2. First-time, first-year wait-listed students
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2024_25.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "5283")
+        self.assertEqual(values["C.102"]["value"], "6956")
+        self.assertEqual(values["C.103"]["value"], "10")
+        self.assertEqual(values["C.104"]["value"], "0")
+        self.assertEqual(values["C.105"]["value"], "401")
+        self.assertEqual(values["C.106"]["value"], "466")
+        self.assertEqual(values["C.107"]["value"], "1")
+        self.assertEqual(values["C.108"]["value"], "0")
+        self.assertEqual(values["C.109"]["value"], "194")
+        self.assertEqual(values["C.111"]["value"], "242")
+        self.assertEqual(values["C.117"]["value"], "12249")
+        self.assertEqual(values["C.118"]["value"], "868")
+        self.assertEqual(values["C.119"]["value"], "436")
+
     def test_c1_compact_question_lines(self):
         markdown = """
 ## C. First-time, First-year Admission

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -201,6 +201,46 @@ Enrolled
         self.assertEqual(values["C.125"]["value"], "2300")
         self.assertEqual(values["C.128"]["value"], "95")
 
+    def test_c1_compact_question_lines(self):
+        markdown = """
+## C. First-time, First-year Admission
+
+C101 Total first-time, first-year men who applied 7,224
+C102 Total first-time, first-year women who applied 8,044
+C104 Total first-time, first-year men who were admitted 621
+C105 Total first-time, first-year women who were admitted 654
+C107 Total first-time, first-year men who enrolled 238
+C108 Total first-time, first-year women who enrolled 306
+C116 Total first-time, first-year students who applied 15,411
+C117 Total first-time, first-year students who were admitted 1,272
+C118 Total first-time, first-year students who enrolled 547
+C201 Do you have a policy of placing students on a waiting list? Y
+C202 Number of qualified applicants offered a place on waiting list: 2,303
+C203 Number accepting a place on the waiting list: 858
+C204 Number of wait-listed students admitted: 113
+C802 SAT or ACT Not required for admission, but considered if submitted
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2025_26.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "7224")
+        self.assertEqual(values["C.102"]["value"], "8044")
+        self.assertEqual(values["C.104"]["value"], "621")
+        self.assertEqual(values["C.105"]["value"], "654")
+        self.assertEqual(values["C.107"]["value"], "238")
+        self.assertEqual(values["C.108"]["value"], "306")
+        self.assertEqual(values["C.116"]["value"], "15411")
+        self.assertEqual(values["C.117"]["value"], "1272")
+        self.assertEqual(values["C.118"]["value"], "547")
+        self.assertEqual(values["C.201"]["value"], "Y")
+        self.assertEqual(values["C.202"]["value"], "2303")
+        self.assertEqual(values["C.203"]["value"], "858")
+        self.assertEqual(values["C.204"]["value"], "113")
+        self.assertNotIn("C.802", values)
+
     def test_c2_waitlist_policy_and_counts_from_layout(self):
         supplemental = """
 C2   First-time, first-year wait-listed students

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -93,6 +93,114 @@ Total first-time, first-year (degree-seeking) enrolled 4983 3914 343 9240
         self.assertEqual(values["C.125"]["value"], "3914")
         self.assertEqual(values["C.128"]["value"], "343")
 
+    def test_c1_visual_ocr_compact_gender_columns(self):
+        markdown = """
+Applications
+C1. First-time, first-year (freshman) students:
+
+Men Women _| Another Un- Total
+Gender reported
+Total first-time, first-year (freshman) who applied: 21,054 12,942 871 0 34,867
+Total first-time, first-year (freshman) who were admitted: 2,140 1,628 91 0 3,859
+Total full-time, first-time first-year (freshman) who enrolled: 1,060 700 44 0 1804
+Total part-time, first-time first-year (freshman) who enrolled: 0 0 0 0 0
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2025_26.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "21054")
+        self.assertEqual(values["C.102"]["value"], "12942")
+        self.assertEqual(values["C.103"]["value"], "0")
+        self.assertEqual(values["C.104"]["value"], "2140")
+        self.assertEqual(values["C.105"]["value"], "1628")
+        self.assertEqual(values["C.106"]["value"], "0")
+        self.assertEqual(values["C.110"]["value"], "1060")
+        self.assertEqual(values["C.112"]["value"], "700")
+        self.assertEqual(values["C.114"]["value"], "0")
+        self.assertEqual(values["C.116"]["value"], "34867")
+        self.assertEqual(values["C.117"]["value"], "3859")
+        self.assertEqual(values["C.118"]["value"], "1804")
+
+    def test_c1_application_data_line_stacks(self):
+        markdown = """
+Common Data Set
+Section C. First-time Freshman Admissions
+2024-2025
+University of Kansas
+
+Application Data by Sex
+Men
+Women
+Total
+Applications
+9,927
+12,436
+22,363
+Admits
+9,166
+11,739
+20,905
+Enrolled
+2,336
+2,987
+5,323
+Full-time
+2,309
+2,960
+5,269
+Part-time
+27
+27
+54
+
+Application Data by Residency
+In-State
+Out-of-State
+International
+Total
+Applications
+7,334
+14,503
+526
+22,363
+Admits
+6,919
+13,495
+491
+20,905
+Enrolled
+2,928
+2,300
+95
+5,323
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2024_25.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "9927")
+        self.assertEqual(values["C.102"]["value"], "12436")
+        self.assertEqual(values["C.105"]["value"], "9166")
+        self.assertEqual(values["C.106"]["value"], "11739")
+        self.assertEqual(values["C.109"]["value"], "2336")
+        self.assertEqual(values["C.110"]["value"], "27")
+        self.assertEqual(values["C.111"]["value"], "2987")
+        self.assertEqual(values["C.112"]["value"], "27")
+        self.assertEqual(values["C.117"]["value"], "22363")
+        self.assertEqual(values["C.118"]["value"], "20905")
+        self.assertEqual(values["C.119"]["value"], "5323")
+        self.assertEqual(values["C.120"]["value"], "7334")
+        self.assertEqual(values["C.123"]["value"], "14503")
+        self.assertEqual(values["C.126"]["value"], "526")
+        self.assertEqual(values["C.122"]["value"], "2928")
+        self.assertEqual(values["C.125"]["value"], "2300")
+        self.assertEqual(values["C.128"]["value"], "95")
+
     def test_c2_waitlist_policy_and_counts_from_layout(self):
         supplemental = """
 C2   First-time, first-year wait-listed students

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -45,6 +45,39 @@ For each assessment listed below, report the score that represents the 25th perc
         self.assertEqual(values["C.903"]["value"], "1022")
         self.assertEqual(values["C.904"]["value"], "385")
 
+    def test_c9_combined_submission_and_percentile_table(self):
+        markdown = """
+C9. Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+|       | %Submitting   |   Number |                                        | Percentiles 25th   | 50th   | 75th   |
+|-------|---------------|----------|----------------------------------------|--------------------|--------|--------|
+| SAT I | 33%           |     1083 | SAT Evidence-Based Reading and Writing | 690                | 720    | 750    |
+|       |               |          | SAT Math                               | 730                | 760    | 780    |
+| ACT   | 10%           |      330 | SAT Composite                          | 1430               | 1470   | 1510   |
+|       |               |          | ACT Composite                          | 32                 | 33     | 34     |
+|       |               |          | ACT English                            | 33                 | 35     | 35     |
+|       |               |          | ACT Math                               | 29                 | 32     | 35     |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "33")
+        self.assertEqual(values["C.902"]["value"], "10")
+        self.assertEqual(values["C.903"]["value"], "1083")
+        self.assertEqual(values["C.904"]["value"], "330")
+        self.assertEqual(values["C.905"]["value"], "1430")
+        self.assertEqual(values["C.906"]["value"], "1470")
+        self.assertEqual(values["C.907"]["value"], "1510")
+        self.assertEqual(values["C.908"]["value"], "690")
+        self.assertEqual(values["C.909"]["value"], "720")
+        self.assertEqual(values["C.910"]["value"], "750")
+        self.assertEqual(values["C.911"]["value"], "730")
+        self.assertEqual(values["C.912"]["value"], "760")
+        self.assertEqual(values["C.913"]["value"], "780")
+        self.assertEqual(values["C.914"]["value"], "32")
+        self.assertEqual(values["C.915"]["value"], "33")
+        self.assertEqual(values["C.916"]["value"], "34")
+
     def test_c9_split_submission_labels_and_blank_sat_composite(self):
         markdown = """
 ## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -78,6 +78,46 @@ C9. Percent and number of first-time, first-year students enrolled in Fall 2024 
         self.assertEqual(values["C.915"]["value"], "33")
         self.assertEqual(values["C.916"]["value"], "34")
 
+    def test_c9_visual_ocr_layout_lines(self):
+        markdown = """
+C9. Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+Percent Number
+Submitting SAT Scores 11 1031
+Submitting ACT Scores 18 1692
+
+Assessment 25th Percentile 50th Percentile 75th Percentile
+Score Score Score
+
+SAT Composite 1130 1240 1340
+Reading and Writing 560 620 670
+SAT Math 560 620 680
+ACT Composite 21 24 28
+ACT Math 21 24 28
+ACT English 20 24 29
+ACT Science 21 24 27
+ACT Reading 21 25 30
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "11")
+        self.assertEqual(values["C.902"]["value"], "18")
+        self.assertEqual(values["C.903"]["value"], "1031")
+        self.assertEqual(values["C.904"]["value"], "1692")
+        self.assertEqual(values["C.905"]["value"], "1130")
+        self.assertEqual(values["C.906"]["value"], "1240")
+        self.assertEqual(values["C.907"]["value"], "1340")
+        self.assertEqual(values["C.908"]["value"], "560")
+        self.assertEqual(values["C.909"]["value"], "620")
+        self.assertEqual(values["C.910"]["value"], "670")
+        self.assertEqual(values["C.911"]["value"], "560")
+        self.assertEqual(values["C.912"]["value"], "620")
+        self.assertEqual(values["C.913"]["value"], "680")
+        self.assertEqual(values["C.914"]["value"], "21")
+        self.assertEqual(values["C.915"]["value"], "24")
+        self.assertEqual(values["C.916"]["value"], "28")
+
     def test_c9_split_submission_labels_and_blank_sat_composite(self):
         markdown = """
 ## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -118,6 +118,30 @@ ACT Reading 21 25 30
         self.assertEqual(values["C.915"]["value"], "24")
         self.assertEqual(values["C.916"]["value"], "28")
 
+    def test_c9_form_style_submission_values_on_following_lines(self):
+        markdown = """
+Score that represents the 25th and 75th percentile score for students who enrolled in Fall 2024 (CDS C9)
+
+(2 Percent submitting SAT scores RQ
+| 13 |
+
+(2 Number submitting SAT scores ro
+| 365 |
+
+(2 Percent submitting ACT scores RQ
+L2 |
+
+(2 Number submitting ACT scores ro
+[ 47 |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "13")
+        self.assertEqual(values["C.902"]["value"], "2")
+        self.assertEqual(values["C.903"]["value"], "365")
+        self.assertEqual(values["C.904"]["value"], "47")
+
     def test_c9_split_submission_labels_and_blank_sat_composite(self):
         markdown = """
 ## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -312,6 +312,78 @@ ACT Composite 28 33 32 31
         self.assertEqual(values["C.915"]["value"], "32")
         self.assertEqual(values["C.916"]["value"], "33")
 
+    def test_c9_percentile_single_label_lines_ignore_distribution_ranges(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+SAT Composite: 25th Percentile 1330
+SAT Composite: 50th Percentile 1410
+SAT Composite: 75th Percentile 1480
+SAT Evidence-Based Reading and Writing: 25th Percentile 650
+SAT Evidence-Based Reading and Writing: 50th Percentile 700
+SAT Evidence-Based Reading and Writing: 75th Percentile 730
+SAT Math: 25th Percentile 660
+SAT Math: 50th Percentile 720
+SAT Math: 75th Percentile 770
+ACT Composite: 25th Percentile 30
+ACT Composite: 50th Percentile 32
+ACT Composite: 75th Percentile 33
+
+| Score Range  | SAT Composite |
+|--------------|---------------|
+| 1400-1600    | 55%           |
+| 1200-1399    | 35%           |
+
+| Score Range  | ACT Composite |
+|--------------|---------------|
+| 18-23        | 2%            |
+| 12-17        | 0%            |
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.905"]["value"], "1330")
+        self.assertEqual(values["C.906"]["value"], "1410")
+        self.assertEqual(values["C.907"]["value"], "1480")
+        self.assertEqual(values["C.908"]["value"], "650")
+        self.assertEqual(values["C.910"]["value"], "730")
+        self.assertEqual(values["C.911"]["value"], "660")
+        self.assertEqual(values["C.913"]["value"], "770")
+        self.assertEqual(values["C.914"]["value"], "30")
+        self.assertEqual(values["C.915"]["value"], "32")
+        self.assertEqual(values["C.916"]["value"], "33")
+
+    def test_c9_does_not_infer_missing_sat_composite_from_score_ranges(self):
+        markdown = """
+## C9 Percent and number of first-time, first-year students enrolled in Fall 2024 who submitted national standardized (SAT/ACT) test scores.
+
+| Assessment                             | 25th Percentile | 50th Percentile | 75th Percentile |
+|----------------------------------------|-----------------|-----------------|-----------------|
+| SAT Evidence-Based Reading and Writing | 640             | 680             | 720             |
+| SAT Math                               | 640             | 680             | 740             |
+| ACT Composite                          | 29              | 31              | 33              |
+
+| Score Range | SAT Composite |
+|-------------|---------------|
+| 1400-1600   | 42%           |
+| 1200-1399   | 44%           |
+
+C946   SAT Composite: 1400-1600 39%
+C947   SAT Composite: 1200-1399 55%
+"""
+
+        values = clean(markdown)
+
+        self.assertNotIn("C.905", values)
+        self.assertNotIn("C.906", values)
+        self.assertNotIn("C.907", values)
+        self.assertEqual(values["C.908"]["value"], "640")
+        self.assertEqual(values["C.910"]["value"], "720")
+        self.assertEqual(values["C.911"]["value"], "640")
+        self.assertEqual(values["C.913"]["value"], "740")
+        self.assertEqual(values["C.914"]["value"], "29")
+        self.assertEqual(values["C.916"]["value"], "33")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
+++ b/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
@@ -9,6 +9,11 @@ import tier4_extractor
 
 
 class Tier4ExtractorVisualOcrTest(unittest.TestCase):
+    def test_visual_ocr_trigger_normalizes_whitespace(self):
+        text = "Percent  Number\nSubmitting SAT  Scores\nSubmitting ACT Scores"
+
+        self.assertTrue(tier4_extractor._matches_visual_ocr_trigger(text))
+
     def test_scanned_fallback_pages_when_text_layer_has_no_candidates(self):
         calls: list[list[str]] = []
 

--- a/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
+++ b/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import tier4_extractor
+
+
+class Tier4ExtractorVisualOcrTest(unittest.TestCase):
+    def test_scanned_fallback_pages_when_text_layer_has_no_candidates(self):
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(list(args))
+            if args[0] == "pdftoppm":
+                Path(f"{args[-1]}-1.png").write_text("")
+                return subprocess.CompletedProcess(args, 0)
+            return subprocess.CompletedProcess(args, 0, stdout="Submitting SAT Scores 11 1031")
+
+        with (
+            patch("tier4_extractor.shutil.which", return_value="/usr/bin/tool"),
+            patch("tier4_extractor._visual_ocr_candidate_pages", return_value=[]),
+            patch("tier4_extractor.subprocess.run", side_effect=fake_run),
+        ):
+            text, pages = tier4_extractor._extract_visual_ocr_text(
+                Path("fake.pdf"),
+                fallback_page_count=3,
+            )
+
+        self.assertEqual(pages, [1, 2, 3])
+        self.assertEqual(text.count("Submitting SAT Scores"), 3)
+        self.assertEqual(sum(1 for call in calls if call[0] == "pdftoppm"), 3)
+        self.assertEqual(sum(1 for call in calls if call[0] == "tesseract"), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -14,6 +14,7 @@ from worker import (
     mean_or_none,
     parsed_field_count,
     pending_doc_priority_key,
+    should_fallback_tier2_to_tier4,
 )
 
 
@@ -161,6 +162,39 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
 
         self.assertEqual(count, 0)
         self.assertNotIn("quality_warnings", canonical)
+
+    def test_tier2_label_acroform_falls_back_to_tier4(self):
+        canonical = {
+            "stats": {
+                "acroform_fields_total": 581,
+                "schema_fields_populated": 0,
+                "unmapped_acroform_fields": 581,
+            },
+        }
+
+        self.assertTrue(should_fallback_tier2_to_tier4(canonical))
+
+    def test_tier2_partial_schema_match_does_not_fallback_to_tier4(self):
+        canonical = {
+            "stats": {
+                "acroform_fields_total": 732,
+                "schema_fields_populated": 576,
+                "unmapped_acroform_fields": 156,
+            },
+        }
+
+        self.assertFalse(should_fallback_tier2_to_tier4(canonical))
+
+    def test_tier2_tiny_acroform_does_not_fallback_to_tier4(self):
+        canonical = {
+            "stats": {
+                "acroform_fields_total": 1,
+                "schema_fields_populated": 0,
+                "unmapped_acroform_fields": 1,
+            },
+        }
+
+        self.assertFalse(should_fallback_tier2_to_tier4(canonical))
 
 
 if __name__ == "__main__":

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -2072,29 +2072,38 @@ def resolve_c1_applications(
                 continue
 
             compact_match = re.search(
-                r"total\s+"
+                r"(?:total\s+)?"
                 r"(?:(full|part)[-\s]?time,\s*)?"
                 r"first[-\s]time,?\s*first[-\s]year"
-                r"(?:\s+\([^)]*\))?\s+who\s+"
-                r"(applied|were admitted|enrolled):?\s+"
+                r"(?:\s+\([^)]*\))?(?:\s+students)?\s+(?:who\s+)?"
+                r"(applied|were admitted|admitted|enrolled):?\s+"
                 r"([0-9][0-9,\s]+[0-9])\s*$",
                 line,
                 re.IGNORECASE,
             )
-            if compact_match:
+            if compact_match and "degree seeking" not in _normalize_label(line):
                 load_raw, action_raw, raw_numbers = compact_match.groups()
                 numbers = re.findall(r"\d[\d,]*", raw_numbers)
-                if len(numbers) >= 5:
+                if len(numbers) >= 3:
                     action = "admitted" if "admitted" in action_raw.lower() else (
                         "applied" if "applied" in action_raw.lower() else "enrolled"
                     )
                     unit_load = "All"
                     if action == "enrolled" and load_raw:
                         unit_load = "FT" if load_raw.lower().startswith("full") else "PT"
-                    for gender, value in zip(
-                        ("Males", "Females", "Another Gender", "Unknown", "All"),
-                        numbers[-5:],
-                    ):
+                    if len(numbers) >= 5:
+                        ordered = list(zip(
+                            ("Males", "Females", "Another Gender", "Unknown", "All"),
+                            numbers[-5:],
+                        ))
+                    elif len(numbers) == 4:
+                        ordered = list(zip(
+                            ("Males", "Females", "Another Gender", "All"),
+                            numbers[-4:],
+                        ))
+                    else:
+                        ordered = list(zip(("Males", "Females", "All"), numbers[-3:]))
+                    for gender, value in ordered:
                         num = _extract_number(value)
                         if num is None:
                             continue
@@ -2102,6 +2111,8 @@ def resolve_c1_applications(
                             gender_sums[("enrolled", "FTPT")] = (
                                 gender_sums.get(("enrolled", "FTPT"), 0) + int(float(num))
                             )
+                            continue
+                        if gender != "All" and action == "enrolled" and unit_load == "All":
                             continue
                         qn = _lookup_compact_gender_column(gender, action, unit_load)
                         if qn:
@@ -3515,6 +3526,10 @@ def resolve_c9_percentile_anchors(
         line = line_match.group(0)
         if re.search(r"\bC\.?\s*(?:90[5-9]|91[0-9]|92[0-2])\b", line, re.IGNORECASE):
             continue
+        if re.search(r"\bC\.?\s*9(?:2[3-9]|[3-5]\d)\b", line, re.IGNORECASE):
+            continue
+        if re.search(r"\b\d+\s*[-–—]\s*\d+\b", line):
+            continue
         label_norm = _normalize_label(line)
         if not label_norm or "submitting" in label_norm or "score range" in label_norm:
             continue
@@ -3530,6 +3545,23 @@ def resolve_c9_percentile_anchors(
             continue
 
         numbers = re.findall(r"\b\d+(?:\.\d+)?\b", line.replace(",", ""))
+        single_role_match = re.search(
+            r"\b(25(?:th)?|50(?:th)?|75(?:th)?)\s+percentile\b",
+            line,
+            re.IGNORECASE,
+        )
+        if single_role_match and numbers:
+            role_token = single_role_match.group(1)
+            role = (
+                "p25" if role_token.startswith("25")
+                else "p50" if role_token.startswith("50")
+                else "p75"
+            )
+            qn = qns_by_role.get(role)
+            value = numbers[-1]
+            if qn and _is_plausible_c9_percentile_value(qn, value):
+                out.setdefault(qn, {"value": value, "source": "tier4_cleaner"})
+            continue
         if len(numbers) < 3:
             continue
         context = section_no_ranges[max(0, line_match.start() - 600):line_match.start()]
@@ -5894,8 +5926,14 @@ def clean(
                     values[qnum] = {"value": num, "source": "tier4_cleaner"}
 
             # --- Percentile table ---
+            row_label_norm = _normalize_label(row["label"])
+            row_text = " ".join([str(row.get("label") or ""), *[str(v) for v in row.get("values") or []]])
+            if re.search(r"\b\d+\s*[-–—]\s*\d+\b", row_text):
+                continue
+            if re.search(r"\bC\.?\s*9(?:2[3-9]|[3-5]\d)\b", row_text, re.IGNORECASE):
+                continue
             for col_idx, value in enumerate(row["values"]):
-                qnum = _c9_percentile_qn(label_norm, col_idx, headers_norm)
+                qnum = _c9_percentile_qn(row_label_norm, col_idx, headers_norm)
                 if not qnum:
                     continue
                 num = _extract_number(value)

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -1997,12 +1997,62 @@ def resolve_c1_applications(
                     return f["question_number"]
         return None
 
+    def _lookup_compact_gender_column(gender: str, action: str, unit_load: str) -> str | None:
+        if action == "enrolled" and unit_load in {"FT", "PT"}:
+            load_phrase = "full time" if unit_load == "FT" else "part time"
+            for f in c1_fields:
+                if not _gender_matches(str(f["gender"]), gender):
+                    continue
+                if f["residency"] != "All":
+                    continue
+                q_norm = str(f["_q_norm"])
+                if action in q_norm and load_phrase in q_norm:
+                    return f["question_number"]
+        return _lookup(gender, "All", action, unit_load=unit_load)
+
     def _apply_layout_lines(text: str) -> None:
         gender_sums: dict[tuple[str, str], int] = {}
         for raw_line in text.splitlines():
             line = raw_line.strip()
             if not line:
                 continue
+
+            compact_match = re.search(
+                r"total\s+"
+                r"(?:(full|part)[-\s]?time,\s*)?"
+                r"first[-\s]time,?\s*first[-\s]year"
+                r"(?:\s+\([^)]*\))?\s+who\s+"
+                r"(applied|were admitted|enrolled):?\s+"
+                r"([0-9][0-9,\s]+[0-9])\s*$",
+                line,
+                re.IGNORECASE,
+            )
+            if compact_match:
+                load_raw, action_raw, raw_numbers = compact_match.groups()
+                numbers = re.findall(r"\d[\d,]*", raw_numbers)
+                if len(numbers) >= 5:
+                    action = "admitted" if "admitted" in action_raw.lower() else (
+                        "applied" if "applied" in action_raw.lower() else "enrolled"
+                    )
+                    unit_load = "All"
+                    if action == "enrolled" and load_raw:
+                        unit_load = "FT" if load_raw.lower().startswith("full") else "PT"
+                    for gender, value in zip(
+                        ("Males", "Females", "Another Gender", "Unknown", "All"),
+                        numbers[-5:],
+                    ):
+                        num = _extract_number(value)
+                        if num is None:
+                            continue
+                        if gender == "All" and action == "enrolled" and unit_load in {"FT", "PT"}:
+                            gender_sums[("enrolled", "FTPT")] = (
+                                gender_sums.get(("enrolled", "FTPT"), 0) + int(float(num))
+                            )
+                            continue
+                        qn = _lookup_compact_gender_column(gender, action, unit_load)
+                        if qn:
+                            out.setdefault(qn, {"value": num, "source": "tier4_cleaner"})
+                    continue
 
             gender_match = re.search(
                 r"total\s+"
@@ -2035,7 +2085,7 @@ def resolve_c1_applications(
                 num = _extract_number(value)
                 qn = None
                 if not (action == "enrolled" and not load_raw):
-                    qn = _lookup(gender, "All", action, unit_load=unit_load)
+                    qn = _lookup_compact_gender_column(gender, action, unit_load)
                 if qn and num is not None:
                     out.setdefault(qn, {"value": num, "source": "tier4_cleaner"})
                 if num is not None:
@@ -2096,7 +2146,75 @@ def resolve_c1_applications(
             if total is not None:
                 out[qn] = {"value": str(total), "source": "tier4_cleaner"}
 
+    def _apply_ku_application_data_blocks(text: str) -> None:
+        """Parse section PDFs that render C1 as label/value line stacks.
+
+        KU's current Section C PDFs use headings like "Application Data by
+        Sex", then separate non-table lines for headers, labels, and values:
+        `Applications`, `9,704`, `12,483`, `22,187`. Docling often preserves
+        that as plain lines rather than a structured table.
+        """
+        lines = _nonempty_lines(text)
+
+        def _numbers_after_label(start: int, label: str, count: int) -> list[str] | None:
+            label_norm = _normalize_label(label)
+            for pos in range(start, min(len(lines), start + 60)):
+                line_norm = _normalize_label(lines[pos])
+                if line_norm != label_norm and not line_norm.startswith(f"{label_norm} "):
+                    continue
+                same_line_numbers = re.findall(r"\b\d[\d,]*\b", lines[pos])
+                if len(same_line_numbers) >= count:
+                    return same_line_numbers[-count:]
+                values: list[str] = []
+                cursor = pos + 1
+                while cursor < len(lines) and len(values) < count:
+                    num = _extract_number(lines[cursor])
+                    if num is not None:
+                        values.append(str(num))
+                    elif values:
+                        break
+                    cursor += 1
+                return values if len(values) == count else None
+            return None
+
+        for idx, line in enumerate(lines):
+            if _normalize_label(line) == "application data by sex":
+                row_specs = [
+                    ("Applications", "applied", "All"),
+                    ("Admits", "admitted", "All"),
+                    ("Enrolled", "enrolled", "All"),
+                    ("Full-time", "enrolled", "FT"),
+                    ("Part-time", "enrolled", "PT"),
+                ]
+                for label, action, unit_load in row_specs:
+                    values = _numbers_after_label(idx, label, 3)
+                    if not values:
+                        continue
+                    for gender, value in zip(("Males", "Females", "All"), values):
+                        qn = _lookup_compact_gender_column(gender, action, unit_load)
+                        if qn and qn not in out:
+                            out[qn] = {"value": value, "source": "tier4_cleaner"}
+
+            if _normalize_label(line) == "application data by residency":
+                row_specs = [
+                    ("Applications", "applied"),
+                    ("Admits", "admitted"),
+                    ("Enrolled", "enrolled"),
+                ]
+                for label, action in row_specs:
+                    values = _numbers_after_label(idx, label, 4)
+                    if not values:
+                        continue
+                    for residency, value in zip(
+                        ("In-State", "Out-of-State", "Nonresidents", "All"),
+                        values,
+                    ):
+                        qn = _lookup("All", residency, action)
+                        if qn and qn not in out:
+                            out[qn] = {"value": value, "source": "tier4_cleaner"}
+
     _apply_layout_lines(markdown)
+    _apply_ku_application_data_blocks(markdown)
 
     for table in tables:
         headers_norm = [_normalize_label(h) for h in table.get("headers", [])]
@@ -2174,7 +2292,7 @@ def resolve_c1_applications(
                         total_enrolled += int(float(num))
                         saw_total_enrolled = True
                         continue
-                    qn = _lookup(gender, "All", action, unit_load=unit_load)
+                    qn = _lookup_compact_gender_column(gender, action, unit_load)
                     if qn and qn not in out:
                         out[qn] = {"value": num, "source": "tier4_cleaner"}
 
@@ -3022,7 +3140,8 @@ def resolve_c9_submission_rates(
     tables: list[dict], markdown: str, schema: SchemaIndex
 ) -> dict[str, dict]:
     out: dict[str, dict] = {}
-    if "Submitting SAT Scores" not in markdown or "Submitting ACT Scores" not in markdown:
+    lowered = markdown.lower()
+    if "submitting sat scores" not in lowered or "submitting act scores" not in lowered:
         return out
 
     for test_name, pct_qn, num_qn in (
@@ -3038,6 +3157,26 @@ def resolve_c9_submission_rates(
             pct, num = line_match.groups()
             out.setdefault(pct_qn, {"value": pct.replace(",", ""), "source": "tier4_cleaner"})
             out.setdefault(num_qn, {"value": num.replace(",", ""), "source": "tier4_cleaner"})
+
+    def form_value_after(label: str) -> str | None:
+        match = re.search(label, markdown, re.IGNORECASE)
+        if not match:
+            return None
+        window = markdown[match.end(): match.end() + 120]
+        value_match = re.search(r"(?<!\d)(\d[\d,]*(?:\.\d+)?)", window)
+        if not value_match:
+            return None
+        return value_match.group(1).replace(",", "")
+
+    for label, qn in (
+        (r"percent[ \t]+submitting[ \t]+sat[ \t]+scores", "C.901"),
+        (r"percent[ \t]+submitting[ \t]+act[ \t]+scores", "C.902"),
+        (r"number[ \t]+submitting[ \t]+sat[ \t]+scores", "C.903"),
+        (r"number[ \t]+submitting[ \t]+act[ \t]+scores", "C.904"),
+    ):
+        value = form_value_after(label)
+        if value is not None:
+            out.setdefault(qn, {"value": value, "source": "tier4_cleaner"})
 
     labels = re.search(
         r"Submitting SAT Scores\s+Submitting ACT Scores",

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -1997,6 +1997,107 @@ def resolve_c1_applications(
                     return f["question_number"]
         return None
 
+    def _apply_layout_lines(text: str) -> None:
+        gender_sums: dict[tuple[str, str], int] = {}
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            gender_match = re.search(
+                r"total\s+"
+                r"(?:(full|part)[-\s]?time,\s*)?"
+                r"first[-\s]time,\s*first[-\s]year\s+"
+                r"(men|women|of another gender|of unknown gender|another gender|unknown gender)"
+                r"\s+who\s+(applied|were admitted|enrolled)\s+([0-9][0-9,]*)\b",
+                line,
+                re.IGNORECASE,
+            )
+            if gender_match:
+                load_raw, gender_raw, action_raw, value = gender_match.groups()
+                gender_norm = _normalize_label_without_gender_rewrite(gender_raw)
+                if gender_norm in {"men", "males"}:
+                    gender = "Males"
+                elif gender_norm in {"women", "females"}:
+                    gender = "Females"
+                elif "another gender" in gender_norm:
+                    gender = "Another Gender"
+                else:
+                    gender = "Unknown"
+
+                action = "admitted" if "admitted" in action_raw.lower() else (
+                    "applied" if "applied" in action_raw.lower() else "enrolled"
+                )
+                unit_load = "All"
+                if action == "enrolled" and load_raw:
+                    unit_load = "FT" if load_raw.lower().startswith("full") else "PT"
+
+                num = _extract_number(value)
+                qn = None
+                if not (action == "enrolled" and not load_raw):
+                    qn = _lookup(gender, "All", action, unit_load=unit_load)
+                if qn and num is not None:
+                    out.setdefault(qn, {"value": num, "source": "tier4_cleaner"})
+                if num is not None:
+                    if unit_load == "All" or action != "enrolled":
+                        gender_sums[(action, "All")] = (
+                            gender_sums.get((action, "All"), 0) + int(float(num))
+                        )
+                    elif action == "enrolled":
+                        gender_sums[(action, "FTPT")] = (
+                            gender_sums.get((action, "FTPT"), 0) + int(float(num))
+                        )
+                continue
+
+            residency_norm = _normalize_label(line)
+            if "degree seeking" not in residency_norm:
+                continue
+            action = None
+            if "who were admitted" in residency_norm:
+                action = "admitted"
+            elif "who applied" in residency_norm:
+                action = "applied"
+            elif "enrolled" in residency_norm:
+                action = "enrolled"
+            if not action:
+                continue
+
+            numbers = re.findall(r"\b\d[\d,]*\b", line)
+            if len(numbers) < 4:
+                continue
+            if len(numbers) >= 5:
+                ordered = [
+                    ("In-State", numbers[-5]),
+                    ("Out-of-State", numbers[-4]),
+                    ("Nonresidents", numbers[-3]),
+                    ("Unknown", numbers[-2]),
+                    ("All", numbers[-1]),
+                ]
+            else:
+                ordered = [
+                    ("In-State", numbers[-4]),
+                    ("Out-of-State", numbers[-3]),
+                    ("Nonresidents", numbers[-2]),
+                    ("All", numbers[-1]),
+                ]
+            for residency, value in ordered:
+                num = _extract_number(value)
+                qn = _lookup("All", residency, action)
+                if qn and num is not None:
+                    out.setdefault(qn, {"value": num, "source": "tier4_cleaner"})
+
+        for action in ("applied", "admitted", "enrolled"):
+            qn = _lookup("All", "All", action)
+            if not qn or qn in out:
+                continue
+            total = gender_sums.get((action, "All"))
+            if total is None and action == "enrolled":
+                total = gender_sums.get((action, "FTPT"))
+            if total is not None:
+                out[qn] = {"value": str(total), "source": "tier4_cleaner"}
+
+    _apply_layout_lines(markdown)
+
     for table in tables:
         headers_norm = [_normalize_label(h) for h in table.get("headers", [])]
         joined_hdr = " ".join(headers_norm)
@@ -2924,6 +3025,20 @@ def resolve_c9_submission_rates(
     if "Submitting SAT Scores" not in markdown or "Submitting ACT Scores" not in markdown:
         return out
 
+    for test_name, pct_qn, num_qn in (
+        ("SAT", "C.901", "C.903"),
+        ("ACT", "C.902", "C.904"),
+    ):
+        line_match = re.search(
+            rf"Submitting\s+{test_name}\s+Scores\s+([0-9.]+)%?\s+([0-9][0-9,]*)\b",
+            markdown,
+            re.IGNORECASE,
+        )
+        if line_match:
+            pct, num = line_match.groups()
+            out.setdefault(pct_qn, {"value": pct.replace(",", ""), "source": "tier4_cleaner"})
+            out.setdefault(num_qn, {"value": num.replace(",", ""), "source": "tier4_cleaner"})
+
     labels = re.search(
         r"Submitting SAT Scores\s+Submitting ACT Scores",
         markdown,
@@ -3117,6 +3232,8 @@ def resolve_c9_percentile_anchors(
             if _normalize_label(row_label) in label_norm:
                 qns_by_role = candidate
                 break
+        if not qns_by_role and "reading and writing" in label_norm:
+            qns_by_role = _PERCENTILE_QNS.get("sat evidence-based reading")
         if not qns_by_role:
             continue
 
@@ -5525,8 +5642,10 @@ def clean(
             resolve_b3_degrees,
             resolve_b_two_year_rates,
             resolve_b5_graduation,
+            resolve_c1_applications,
             resolve_c2_waitlist,
             resolve_c8_entrance_exams,
+            resolve_c9_submission_rates,
             resolve_c9_percentile_anchors,
             resolve_c12_gpa_summary,
             resolve_c13_application_fee,
@@ -5550,7 +5669,10 @@ def clean(
                     resolve_b3_degrees,
                     resolve_b_two_year_rates,
                     resolve_b5_graduation,
+                    resolve_c1_applications,
                     resolve_c2_waitlist,
+                    resolve_c9_submission_rates,
+                    resolve_c9_percentile_anchors,
                     resolve_c13_application_fee,
                     resolve_i_faculty,
                     resolve_d_transfer,

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -5634,6 +5634,7 @@ def clean(
     # This preserves the regression-safe ordering: hand-coded > resolvers.
     for resolver in _RESOLVERS:
         new = resolver(tables, markdown, idx)
+        supplemental_override_qns: set[str] = set()
         if resolver in (
             resolve_a_general,
             resolve_j_disciplines,
@@ -5680,10 +5681,18 @@ def clean(
                     resolve_h_financial_aid,
                 ):
                     new[qn] = rec
+                    if resolver in (
+                        resolve_c1_applications,
+                        resolve_c9_submission_rates,
+                        resolve_c9_percentile_anchors,
+                    ):
+                        supplemental_override_qns.add(qn)
                 else:
                     new.setdefault(qn, rec)
         for qn, rec in new.items():
-            if resolver is resolve_b5_graduation and re.match(r"^B\.[45]\d{2}$", qn):
+            if qn in supplemental_override_qns:
+                values[qn] = rec
+            elif resolver is resolve_b5_graduation and re.match(r"^B\.[45]\d{2}$", qn):
                 values[qn] = rec
             elif qn not in values:
                 values[qn] = rec

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -2267,8 +2267,107 @@ def resolve_c1_applications(
                         if qn and qn not in out:
                             out[qn] = {"value": value, "source": "tier4_cleaner"}
 
+    def _apply_tableau_c1_layout_block(text: str) -> None:
+        """Parse Tableau PDF exports that preserve C1 only in layout text.
+
+        Pomona's official CDS Tableau views export a PDF text layer where C1
+        appears as ordinary layout lines, not a Markdown table:
+
+            Category Unit load Males Females Unknown
+            Applied All 5365 7096 9
+            Admitted All 418 471 1
+            Enrolled Full-Time 199 221 1
+                     Part-Time
+                     All 199 221 1
+
+        Docling sees enough of the document for C9, but misses C1. The pypdf
+        layout supplement keeps these rows intact enough to recover counts.
+        """
+        c1 = _section_between(
+            text,
+            r"\bC1\.",
+            r"\bC2\.",
+        )
+        if not c1:
+            return
+
+        lines = [ln.strip() for ln in c1.splitlines() if ln.strip()]
+        header = " ".join(lines[:8])
+        header_norm = _normalize_label_without_gender_rewrite(header)
+        if "category" not in header_norm or "unit load" not in header_norm:
+            return
+        if not any(tok in header_norm for tok in ("men", "males")):
+            return
+        if not any(tok in header_norm for tok in ("women", "females")):
+            return
+
+        genders = ["Males", "Females"]
+        if "another gender" in header_norm:
+            genders.append("Another Gender")
+        if "unknown" in header_norm:
+            genders.append("Unknown")
+
+        enrolled_total_by_gender = {gender: 0 for gender in genders}
+        saw_enrolled_parts = False
+
+        def _record_gender_values(action: str, unit_load: str, values: list[str]) -> None:
+            nonlocal saw_enrolled_parts
+            for gender, value in zip(genders, values):
+                num = _extract_number(value)
+                if num is None:
+                    continue
+                if action == "enrolled" and unit_load in {"FT", "PT"}:
+                    enrolled_total_by_gender[gender] = (
+                        enrolled_total_by_gender.get(gender, 0) + int(float(num))
+                    )
+                    saw_enrolled_parts = True
+                qn = _lookup_compact_gender_column(gender, action, unit_load)
+                if qn and qn not in out:
+                    out[qn] = {"value": num, "source": "tier4_cleaner"}
+
+            total = sum(
+                int(float(_extract_number(value) or 0))
+                for value in values[:len(genders)]
+            )
+            total_qn = _lookup("All", "All", action)
+            if total_qn and total_qn not in out and action in {"applied", "admitted"}:
+                out[total_qn] = {"value": str(total), "source": "tier4_cleaner"}
+            elif total_qn and total_qn not in out and action == "enrolled" and unit_load == "All":
+                out[total_qn] = {"value": str(total), "source": "tier4_cleaner"}
+
+        for line in lines:
+            line_norm = _normalize_label(line)
+            numbers = re.findall(r"\b\d[\d,]*\b", line)
+            if len(numbers) < len(genders):
+                continue
+            values = numbers[-len(genders):]
+
+            if line_norm.startswith("applied all "):
+                _record_gender_values("applied", "All", values)
+            elif line_norm.startswith("admitted all "):
+                _record_gender_values("admitted", "All", values)
+            elif line_norm.startswith("enrolled full time "):
+                _record_gender_values("enrolled", "FT", values)
+            elif line_norm.startswith("part time "):
+                _record_gender_values("enrolled", "PT", values)
+            elif line_norm.startswith("all "):
+                _record_gender_values("enrolled", "All", values)
+
+        if saw_enrolled_parts:
+            for gender, total in enrolled_total_by_gender.items():
+                if total == 0:
+                    continue
+                qn = _lookup_compact_gender_column(gender, "enrolled", "All")
+                if qn and qn not in out:
+                    out[qn] = {"value": str(total), "source": "tier4_cleaner"}
+            total_qn = _lookup("All", "All", "enrolled")
+            total_all = sum(enrolled_total_by_gender.values())
+            if total_qn and total_qn not in out and total_all:
+                out[total_qn] = {"value": str(total_all), "source": "tier4_cleaner"}
+
     _apply_layout_lines(markdown)
     _apply_ku_application_data_blocks(markdown)
+    _apply_tableau_c1_layout_block(markdown)
 
     for table in tables:
         headers_norm = [_normalize_label(h) for h in table.get("headers", [])]

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -124,6 +124,60 @@ def _direct_qnum_value(row: dict) -> str | None:
     return None
 
 
+def _direct_qnum_line_value(line: str) -> tuple[str, str] | None:
+    """Extract values from line-oriented exports like ``C117 ... 15,411``.
+
+    Some PDF-to-text paths flatten a CDS row to a single line instead of a
+    markdown table. Keep this conservative: require a compact CDS row id at
+    line start and a response-looking value at the end of the line.
+    """
+    m = re.match(r"^\s*([A-J]\.?\d{1,3}[A-Z]?)\b\s+(.+?)\s*$", line, re.IGNORECASE)
+    if not m:
+        return None
+    qnum = _normalize_compact_question_number(m.group(1))
+    if not qnum:
+        return None
+
+    rest = m.group(2).strip()
+    if not rest:
+        return None
+
+    if ":" in rest:
+        tail = rest.rsplit(":", 1)[1].strip()
+        if _looks_like_direct_line_value(tail):
+            return qnum, _clean_direct_line_value(tail)
+
+    m_value = re.search(
+        r"(?i)(?:^|\s)([xyn]|-?\$?\d[\d,]*(?:\.\d+)?%?|\d{1,2}-[a-z]{3,9})\s*$",
+        rest,
+    )
+    if not m_value:
+        return None
+    return qnum, _clean_direct_line_value(m_value.group(1))
+
+
+def _looks_like_direct_line_value(value: str) -> bool:
+    value = value.strip()
+    if not value:
+        return False
+    if re.fullmatch(r"(?i)[xyn]", value):
+        return True
+    if re.fullmatch(r"-?\$?\d[\d,]*(?:\.\d+)?%?", value):
+        return True
+    if re.fullmatch(r"(?i)\d{1,2}-[a-z]{3,9}", value):
+        return True
+    if re.match(r"(?i)^https?://", value):
+        return True
+    return False
+
+
+def _clean_direct_line_value(value: str) -> str:
+    value = value.strip()
+    if re.fullmatch(r"-?\$?\d[\d,]*(?:\.\d+)?%?", value):
+        return value.replace(",", "").replace("$", "")
+    return value
+
+
 _NO_WRAP_EMPTY_LABELS = {
     "sat composite",
     "sat evidence based reading and writing",
@@ -5752,6 +5806,19 @@ def clean(
                     and qnum not in values
                 ):
                     values[qnum] = {"value": num, "source": "tier4_cleaner"}
+
+    for line in markdown.splitlines():
+        parsed_line = _direct_qnum_line_value(line)
+        if not parsed_line:
+            continue
+        qnum, direct_value = parsed_line
+        if (
+            re.match(r"^C\.9\d\d$", qnum)
+            and not _is_plausible_c9_percentile_value(qnum, direct_value)
+        ):
+            continue
+        if qnum in schema_qnums and qnum not in values:
+            values[qnum] = {"value": direct_value, "source": "tier4_cleaner"}
 
     # --- Inline patterns (non-table fields) ---
     # Runs after table extraction so table matches take precedence.

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -2014,8 +2014,75 @@ def resolve_c1_applications(
                                           "unknown gender who")):
                 gender_hits += 1
         is_gender_table = gender_hits >= 1
+        is_compact_gender_table = (
+            "men" in joined_hdr
+            and "women" in joined_hdr
+            and any(
+                _normalize_label(r["label"]) in {
+                    "applied",
+                    "admitted",
+                    "full time enrolled",
+                    "part time enrolled",
+                }
+                for r in table["rows"][:8]
+            )
+        )
 
-        if is_residency:
+        if is_compact_gender_table:
+            col_to_gender: list[tuple[int, str]] = []
+            raw_headers = [str(h).strip().lower() for h in table.get("headers", [])]
+            for ci, hdr in enumerate(raw_headers[1:]):
+                hdr_norm = _normalize_label_without_gender_rewrite(hdr)
+                if hdr_norm == "men" or hdr_norm == "males":
+                    col_to_gender.append((ci, "Males"))
+                elif hdr_norm == "women" or hdr_norm == "females":
+                    col_to_gender.append((ci, "Females"))
+                elif "another gender" in hdr_norm:
+                    col_to_gender.append((ci, "Another Gender"))
+                elif "unknown" in hdr_norm:
+                    col_to_gender.append((ci, "Unknown"))
+                elif hdr_norm == "total":
+                    col_to_gender.append((ci, "All"))
+
+            total_enrolled = 0
+            saw_total_enrolled = False
+            for row in table["rows"]:
+                label_norm = _normalize_label(row["label"])
+                if label_norm == "applied":
+                    action = "applied"
+                    unit_load = "All"
+                elif label_norm == "admitted":
+                    action = "admitted"
+                    unit_load = "All"
+                elif label_norm == "full time enrolled":
+                    action = "enrolled"
+                    unit_load = "FT"
+                elif label_norm == "part time enrolled":
+                    action = "enrolled"
+                    unit_load = "PT"
+                else:
+                    continue
+
+                for col_idx, gender in col_to_gender:
+                    if col_idx >= len(row["values"]):
+                        continue
+                    num = _extract_number(row["values"][col_idx])
+                    if num is None:
+                        continue
+                    if gender == "All" and action == "enrolled":
+                        total_enrolled += int(float(num))
+                        saw_total_enrolled = True
+                        continue
+                    qn = _lookup(gender, "All", action, unit_load=unit_load)
+                    if qn and qn not in out:
+                        out[qn] = {"value": num, "source": "tier4_cleaner"}
+
+            if saw_total_enrolled:
+                qn = _lookup("All", "All", "enrolled")
+                if qn and qn not in out:
+                    out[qn] = {"value": str(total_enrolled), "source": "tier4_cleaner"}
+
+        elif is_residency:
             # Map each value column index → residency key.
             col_to_res: list[tuple[int, str]] = []
             for ci, hdr in enumerate(headers_norm[1:]):
@@ -2916,6 +2983,49 @@ def resolve_c9_submission_rates(
     out["C.903"] = {"value": sat_num.replace(",", ""), "source": "tier4_cleaner"}
     out["C.902"] = {"value": act_pct.replace(",", ""), "source": "tier4_cleaner"}
     out["C.904"] = {"value": act_num.replace(",", ""), "source": "tier4_cleaner"}
+    return out
+
+
+def resolve_c9_combined_submission_percentile_table(
+    tables: list[dict], markdown: str, schema: SchemaIndex
+) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for table in tables:
+        for row in table["rows"]:
+            values = row.get("values") or []
+            if len(values) < 6:
+                continue
+            label_norm = _normalize_label(row.get("label") or "")
+
+            if label_norm.startswith("sat"):
+                pct = _extract_number(values[0])
+                num = _extract_number(values[1])
+                if pct is not None:
+                    out.setdefault("C.901", {"value": pct, "source": "tier4_cleaner"})
+                if num is not None:
+                    out.setdefault("C.903", {"value": num, "source": "tier4_cleaner"})
+            elif label_norm == "act":
+                pct = _extract_number(values[0])
+                num = _extract_number(values[1])
+                if pct is not None:
+                    out.setdefault("C.902", {"value": pct, "source": "tier4_cleaner"})
+                if num is not None:
+                    out.setdefault("C.904", {"value": num, "source": "tier4_cleaner"})
+
+            assessment_norm = _normalize_label(values[2])
+            qns_by_role = None
+            for row_label, candidate in _PERCENTILE_QNS.items():
+                if _normalize_label(row_label) in assessment_norm:
+                    qns_by_role = candidate
+                    break
+            if not qns_by_role:
+                continue
+
+            for value, role in zip(values[3:6], ("p25", "p50", "p75")):
+                qn = qns_by_role.get(role)
+                num = _extract_number(value)
+                if qn and num is not None and _is_plausible_c9_percentile_value(qn, num):
+                    out.setdefault(qn, {"value": num, "source": "tier4_cleaner"})
     return out
 
 
@@ -5264,6 +5374,7 @@ _RESOLVERS = [
     resolve_c7_basis_for_selection,
     resolve_c8_entrance_exams,
     resolve_c9_submission_rates,
+    resolve_c9_combined_submission_percentile_table,
     resolve_c9_percentile_anchors,
     resolve_c9_score_distributions,
     resolve_c11_gpa_profile,

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.8"
+PRODUCER_VERSION = "0.3.9"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -21,13 +21,15 @@ it increased full-cleaner field recovery without introducing conflicts.
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.4"
+PRODUCER_VERSION = "0.3.5"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 
@@ -47,6 +49,108 @@ def _extract_pdf_layout_text(pdf_path: Path) -> str:
         return "\n\n".join(chunks)
     except Exception:
         return ""
+
+
+def _visual_ocr_candidate_pages(pdf_path: Path) -> list[int]:
+    """Return 1-indexed pages where visual OCR can recover high-value fields.
+
+    Some PDFs have a normal text layer for labels but render filled-in values
+    as drawing commands. Docling and pypdf then see blank cells even though the
+    source PDF visibly contains the numbers. Keep this supplement focused on
+    admissions pages so low-field documents do not trigger a full-corpus OCR tax.
+    """
+    try:
+        import pypdf
+
+        reader = pypdf.PdfReader(str(pdf_path))
+        pages: set[int] = set()
+        triggers = (
+            "c1. first-time",
+            "first-time, first-year student applicants",
+            "residency breakdowns for total applicants",
+            "total first-time, first-year (degree-seeking) who applied",
+            "c2. first time",
+            "c2. first-time",
+            "waiting listtotal",
+            "c9. percent and number",
+            "submitting sat scores",
+        )
+        for idx, page in enumerate(reader.pages, start=1):
+            try:
+                text = page.extract_text() or ""
+            except Exception:
+                text = ""
+            lowered = text.lower()
+            if any(trigger in lowered for trigger in triggers):
+                pages.add(idx)
+        return sorted(pages)
+    except Exception:
+        return []
+
+
+def _extract_visual_ocr_text(pdf_path: Path) -> tuple[str, list[int]]:
+    """Best-effort Tesseract supplement for visually rendered table values."""
+    if not shutil.which("pdftoppm") or not shutil.which("tesseract"):
+        return "", []
+
+    pages = _visual_ocr_candidate_pages(pdf_path)
+    if not pages:
+        return "", []
+
+    chunks: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        for page_no in pages:
+            prefix = tmp / f"page_{page_no}"
+            try:
+                subprocess.run(
+                    [
+                        "pdftoppm",
+                        "-f",
+                        str(page_no),
+                        "-l",
+                        str(page_no),
+                        "-png",
+                        "-r",
+                        "160",
+                        str(pdf_path),
+                        str(prefix),
+                    ],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=30,
+                )
+                images = sorted(tmp.glob(f"page_{page_no}-*.png"))
+                if not images:
+                    continue
+                ocr = subprocess.run(
+                    ["tesseract", str(images[0]), "stdout", "--psm", "4"],
+                    check=True,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    timeout=30,
+                ).stdout
+            except Exception:
+                continue
+            if ocr.strip():
+                chunks.append(f"\n\n--- OCR PAGE {page_no} ---\n{ocr}")
+    return "\n".join(chunks), pages
+
+
+def _needs_visual_ocr_supplement(markdown: str, values: dict[str, dict]) -> bool:
+    if len(values) >= 100:
+        return False
+    c1_missing = (
+        "first-time, first-year student" in markdown.lower()
+        and not any(qn in values for qn in ("C.101", "C.117", "C.118", "C.119"))
+    )
+    c9_missing = (
+        "submitting sat scores" in markdown.lower()
+        and not any(qn in values for qn in ("C.901", "C.903", "C.905", "C.914"))
+    )
+    return c1_missing or c9_missing
 
 
 def extract(
@@ -97,7 +201,18 @@ def extract(
     from tier4_cleaner import clean
     from tier4_native_tables import compact_tables
     pdf_layout_text = _extract_pdf_layout_text(pdf_path)
-    values = clean(markdown, schema=schema, supplemental_text=pdf_layout_text)
+    supplemental_text = pdf_layout_text
+    values = clean(markdown, schema=schema, supplemental_text=supplemental_text)
+    visual_ocr_text = ""
+    visual_ocr_pages: list[int] = []
+    if _needs_visual_ocr_supplement(markdown, values):
+        visual_ocr_text, visual_ocr_pages = _extract_visual_ocr_text(pdf_path)
+        if visual_ocr_text:
+            # Put OCR first. Section slicers such as C9 stop at the first
+            # C10 boundary they see; if embedded layout text comes first and
+            # has blank cells, the later OCR repair block would be hidden.
+            supplemental_text = f"{visual_ocr_text}\n\n{pdf_layout_text}"
+            values = clean(markdown, schema=schema, supplemental_text=supplemental_text)
     native_tables = compact_tables(doc)
 
     artifact = {
@@ -124,6 +239,8 @@ def extract(
             "native_table_count": native_tables["table_count"],
             "native_table_cell_count": native_tables["cell_count"],
             "pdf_layout_text_length": len(pdf_layout_text),
+            "visual_ocr_text_length": len(visual_ocr_text),
+            "visual_ocr_pages": visual_ocr_pages,
         },
         "markdown": markdown,
         "native_tables": native_tables,

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.9"
+PRODUCER_VERSION = "0.3.10"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.5"
+PRODUCER_VERSION = "0.3.6"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -29,9 +29,10 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.6"
+PRODUCER_VERSION = "0.3.7"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
+SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35
 
 
 def _extract_pdf_layout_text(pdf_path: Path) -> str:
@@ -88,12 +89,18 @@ def _visual_ocr_candidate_pages(pdf_path: Path) -> list[int]:
         return []
 
 
-def _extract_visual_ocr_text(pdf_path: Path) -> tuple[str, list[int]]:
+def _extract_visual_ocr_text(
+    pdf_path: Path,
+    *,
+    fallback_page_count: int | None = None,
+) -> tuple[str, list[int]]:
     """Best-effort Tesseract supplement for visually rendered table values."""
     if not shutil.which("pdftoppm") or not shutil.which("tesseract"):
         return "", []
 
     pages = _visual_ocr_candidate_pages(pdf_path)
+    if not pages and fallback_page_count:
+        pages = list(range(1, min(fallback_page_count, SCANNED_ADMISSIONS_OCR_MAX_PAGE) + 1))
     if not pages:
         return "", []
 
@@ -206,7 +213,15 @@ def extract(
     visual_ocr_text = ""
     visual_ocr_pages: list[int] = []
     if _needs_visual_ocr_supplement(markdown, values):
-        visual_ocr_text, visual_ocr_pages = _extract_visual_ocr_text(pdf_path)
+        # Scanned PDFs have no embedded text layer for pypdf to select pages
+        # from. If Docling's full-page OCR still left admissions values blank,
+        # use a bounded Tesseract pass over the front CDS sections instead of
+        # silently skipping the visual supplement.
+        fallback_page_count = page_count if force_ocr else None
+        visual_ocr_text, visual_ocr_pages = _extract_visual_ocr_text(
+            pdf_path,
+            fallback_page_count=fallback_page_count,
+        )
         if visual_ocr_text:
             # Put OCR first. Section slicers such as C9 stop at the first
             # C10 boundary they see; if embedded layout text comes first and

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -21,6 +21,7 @@ it increased full-cleaner field recovery without introducing conflicts.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -29,10 +30,28 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.7"
+PRODUCER_VERSION = "0.3.8"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35
+
+
+def _matches_visual_ocr_trigger(text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", text.lower())
+    triggers = (
+        "c1. first-time",
+        "first-time, first-year student applicants",
+        "residency breakdowns for total applicants",
+        "total first-time, first-year (degree-seeking) who applied",
+        "c2. first time",
+        "c2. first-time",
+        "waiting listtotal",
+        "c9. percent",
+        "percent and number of first-time",
+        "submitting sat scores",
+        "percent of first-time, first-year students with scores in each range",
+    )
+    return any(trigger in normalized for trigger in triggers)
 
 
 def _extract_pdf_layout_text(pdf_path: Path) -> str:
@@ -65,24 +84,12 @@ def _visual_ocr_candidate_pages(pdf_path: Path) -> list[int]:
 
         reader = pypdf.PdfReader(str(pdf_path))
         pages: set[int] = set()
-        triggers = (
-            "c1. first-time",
-            "first-time, first-year student applicants",
-            "residency breakdowns for total applicants",
-            "total first-time, first-year (degree-seeking) who applied",
-            "c2. first time",
-            "c2. first-time",
-            "waiting listtotal",
-            "c9. percent and number",
-            "submitting sat scores",
-        )
         for idx, page in enumerate(reader.pages, start=1):
             try:
                 text = page.extract_text() or ""
             except Exception:
                 text = ""
-            lowered = text.lower()
-            if any(trigger in lowered for trigger in triggers):
+            if _matches_visual_ocr_trigger(text):
                 pages.add(idx)
         return sorted(pages)
     except Exception:

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -114,6 +114,7 @@ SCHEMA_DIR = _TOOLS_ROOT.parent / "schemas"
 TEMPLATE_DIR = SCHEMA_DIR / "templates"
 MIN_TIER1_FIELDS = 5
 MIN_TIER4_FIELDS = 25
+MIN_TIER2_LABEL_FALLBACK_ACROFORM_FIELDS = 50
 
 
 @dataclass(frozen=True)
@@ -744,6 +745,26 @@ def annotate_tier2_unmapped_fields(canonical: dict) -> int:
     return unmapped_count
 
 
+def should_fallback_tier2_to_tier4(canonical: dict) -> bool:
+    """Detect fillable PDFs whose AcroForm fields are populated but unusable.
+
+    Some schools publish fillable PDFs whose field names are visible prompt labels
+    ("Men_10", "Closing Date_5") instead of canonical CDS tags
+    ("AP_RECD_1ST_MEN_N"). Exact Tier 2 mapping will recover almost nothing even
+    though the PDF has real data. In that case, treat Tier 2 as a failed route and
+    let the Tier 4 layout cleaner parse the visible tables.
+    """
+    stats = canonical.get("stats") or {}
+    acroform_fields = int(stats.get("acroform_fields_total") or 0)
+    mapped_fields = int(stats.get("schema_fields_populated") or 0)
+    unmapped_fields = int(stats.get("unmapped_acroform_fields") or 0)
+    if acroform_fields < MIN_TIER2_LABEL_FALLBACK_ACROFORM_FIELDS:
+        return False
+    if mapped_fields >= MIN_TIER1_FIELDS:
+        return False
+    return unmapped_fields >= int(acroform_fields * 0.8)
+
+
 def _run_tier1(
     client: Client,
     document_id: str,
@@ -1285,6 +1306,26 @@ def extract_one(
                 f"sample_tags={sample_tags}",
                 file=sys.stderr,
                 flush=True,
+            )
+        if should_fallback_tier2_to_tier4(canonical):
+            print(
+                f"    tier2_label_acroform_fallback: school={school_id} "
+                f"document={document_id} "
+                f"mapped={canonical.get('stats', {}).get('schema_fields_populated', 0)} "
+                f"unmapped={unmapped_count}",
+                file=sys.stderr,
+                flush=True,
+            )
+            from tier4_cleaner import SchemaIndex
+            schema_index = SchemaIndex(resolution.schema_path)
+            outcome = _run_tier4(
+                client, document_id, school_id, pdf_bytes,
+                source_format, resolution, schema_index, source_artifact, dry_run,
+                force_reextract,
+            )
+            return ExtractionOutcome(
+                action=f"tier2_label_acroform_fallback_{outcome.action}",
+                refresh_projection=outcome.refresh_projection,
             )
     except Exception as e:
         if not dry_run:

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -754,6 +754,7 @@ def _run_tier1(
     cell_map: dict,
     source_artifact: dict,
     dry_run: bool,
+    force_reextract: bool = False,
 ) -> ExtractionOutcome:
     """Tier 1 path: read filled CDS XLSX via template cell-position map."""
     try:
@@ -775,7 +776,7 @@ def _run_tier1(
         return extraction_no_project(f"tier1_low_fields ({fields} fields)")
 
     if not dry_run:
-        if artifact_already_extracted(
+        if not force_reextract and artifact_already_extracted(
             client, document_id, producer, producer_version,
             resolution.schema_version, canonical.get("source_sha256"),
         ):
@@ -805,6 +806,7 @@ def _run_tier6(
     schema_index,
     source_artifact: dict,
     dry_run: bool,
+    force_reextract: bool = False,
 ) -> ExtractionOutcome:
     """Tier 6 path (PRD 008): HTML → markdown → tier4_cleaner.
 
@@ -869,7 +871,7 @@ def _run_tier6(
     quality_flag = low_field_quality_flag(fields)
 
     if not dry_run:
-        if artifact_already_extracted(
+        if not force_reextract and artifact_already_extracted(
             client, document_id, producer, producer_version,
             resolution.schema_version, canonical.get("source_sha256"),
         ):
@@ -905,6 +907,7 @@ def _run_tier4(
     schema_index,
     source_artifact: dict,
     dry_run: bool,
+    force_reextract: bool = False,
 ) -> ExtractionOutcome:
     """Tier 4 path: Docling baseline → markdown artifact.
 
@@ -939,7 +942,7 @@ def _run_tier4(
     quality_flag = low_field_quality_flag(fields)
 
     if not dry_run:
-        if artifact_already_extracted(
+        if not force_reextract and artifact_already_extracted(
             client, document_id, producer, producer_version,
             resolution.schema_version, canonical.get("source_sha256"),
         ):
@@ -1136,6 +1139,7 @@ def extract_one(
     schema_registry: dict[str, tuple[Path, dict[str, Any]]],
     dry_run: bool,
     cell_maps: dict[str, dict[str, tuple[str, str]]] | None = None,
+    force_reextract: bool = False,
 ) -> ExtractionOutcome:
     """Process a single cds_documents row. Returns a short action string
     for logging. Does NOT raise — every failure is caught and recorded
@@ -1224,6 +1228,7 @@ def extract_one(
         return _run_tier1(
             client, document_id, school_id, pdf_bytes,
             source_format, resolution, cell_map, source_artifact, dry_run,
+            force_reextract,
         )
     if source_format == "xlsx" and not cell_map:
         if not dry_run:
@@ -1241,6 +1246,7 @@ def extract_one(
         return _run_tier6(
             client, document_id, school_id, pdf_bytes,
             source_format, resolution, schema_index, source_artifact, dry_run,
+            force_reextract,
         )
 
     # pdf_scanned routes to Tier 4 too — Docling's do_ocr=True lazily runs
@@ -1253,6 +1259,7 @@ def extract_one(
         return _run_tier4(
             client, document_id, school_id, pdf_bytes,
             source_format, resolution, schema_index, source_artifact, dry_run,
+            force_reextract,
         )
 
     if source_format != "pdf_fillable":
@@ -1288,7 +1295,7 @@ def extract_one(
     producer_version = canonical["producer_version"]
 
     if not dry_run:
-        if artifact_already_extracted(
+        if not force_reextract and artifact_already_extracted(
             client, document_id, producer, producer_version,
             resolution.schema_version, canonical.get("source_sha256"),
         ):
@@ -1540,6 +1547,15 @@ def main() -> int:
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
+        "--force-reextract",
+        action="store_true",
+        help=(
+            "Write a fresh canonical artifact even when the same document, "
+            "producer version, schema, and source hash were already extracted. "
+            "Use for managed local re-drains after cleaner-only code changes."
+        ),
+    )
+    parser.add_argument(
         "--skip-projection-refresh",
         action="store_true",
         help=(
@@ -1754,7 +1770,14 @@ def main() -> int:
     low_field_docs: list[dict[str, Any]] = []
     failure_count = 0
     for i, doc in enumerate(docs, 1):
-        outcome = extract_one(client, doc, schema_registry, args.dry_run, cell_maps)
+        outcome = extract_one(
+            client,
+            doc,
+            schema_registry,
+            args.dry_run,
+            cell_maps,
+            force_reextract=args.force_reextract,
+        )
         bucket = outcome.action.split(":")[0].split(" ")[0]
         counts[bucket] += 1
         fields = parsed_field_count(outcome.action)

--- a/tools/finder/playwright_collect.py
+++ b/tools/finder/playwright_collect.py
@@ -88,7 +88,7 @@ STARTING_URLS: dict[str, str] = {
     "stevens-institute-of-technology": "https://www.stevens.edu/institutional-research-and-analytics/common-data-set",
     "marquette-university": "https://www.marquette.edu/institutional-research-analysis/common-data-set.php",
     "boston-college": "https://www.bc.edu/bc-web/offices/institutional-research-planning.html",
-    "boston-university": "https://www.bu.edu/asir/bu-institutional-datasets/common-data-set/",
+    "boston-university": "https://www.bu.edu/asir/bu-facts/common-data-set/",
     "william-and-mary": "https://www.wm.edu/offices/ir/university_data/cds/",
     "pomona-college": "https://www.pomona.edu/administration/institutional-research/common-data-sets",
     "wellesley-college": "https://www.wellesley.edu/institutionalplanningandassessment/institutional-research/common-data-set",

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -149,7 +149,7 @@ overrides:
     browse_url: https://oira.jhu.edu/common-data-set/
     direct_archive_urls:
       - { url: https://oira.jhu.edu/wp-content/uploads/2025-2026-CDS-Johns-Hopkins-University.pdf, year: "2025-26" }
-      - { url: https://drive.usercontent.google.com/download?id=1493J-a9EGTyGekgy-NAohQ_LSEQ3jtDp&export=download, year: "2024-25" }
+      - { url: "https://drive.usercontent.google.com/download?id=1493J-a9EGTyGekgy-NAohQ_LSEQ3jtDp&export=download", year: "2024-25" }
     hosting_override:
       file_storage: mixed
       cms: wordpress
@@ -177,7 +177,7 @@ overrides:
   - school_id: kent-state-university-at-kent
     browse_url: https://www.kent.edu/ir/common-dataset-cds
     direct_archive_urls:
-      - { url: https://www-s3-live.kent.edu/s3fs-root/s3fs-public/file/TU%20CDS_2025-2026-Final_web_1.docx?VersionId=8b11OcfWwv3GOtnZg.urP8_ZlgTVDMTY, year: "2025-26" }
+      - { url: "https://www-s3-live.kent.edu/s3fs-root/s3fs-public/file/TU%20CDS_2025-2026-Final_web_1.docx?VersionId=8b11OcfWwv3GOtnZg.urP8_ZlgTVDMTY", year: "2025-26" }
     hosting_override:
       file_storage: same_origin
       cms: drupal
@@ -257,3 +257,158 @@ overrides:
         For admissions freshness, prefer Section C when no full current-year
         PDF is available; do not let Section J become the canonical 2025-26
         document.
+
+  # PRD 019 archive/finder backfill repairs, 2026-05-06.
+  - school_id: cornell
+    browse_url: https://irp.cornell.edu/common-data-set/
+    direct_archive_urls:
+      - { url: https://irp.cornell.edu/wp-content/uploads/2026/04/CDS-Cornell-2025-2026.xlsx, year: "2025-26" }
+      - { url: https://irp.dpb.cornell.edu/wp-content/uploads/2025/07/CDS-2024-2025-v6-print.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        Cornell posts recent CDS files on the IRP Common Data Set page.
+        Current 2025-26 is XLSX; 2024-25 was PDF. The old irp.dpb.cornell.edu
+        host redirects from historical links and should still be accepted.
+
+  - school_id: uc-berkeley
+    browse_url: https://opa.berkeley.edu/campus-data/common-data-set
+    direct_archive_urls:
+      - { url: "https://docs.google.com/spreadsheets/d/1INsGFH6MhaO-MFMBZ1Dngcn84FeN-hc0BLS0-v8TL_k/export?format=xlsx", year: "2025-26" }
+      - { url: "https://docs.google.com/spreadsheets/d/11BnFbit7JcrmFMi9iV_TMkzhUyCQ_dQHS0V8weuOHPM/export?format=xlsx", year: "2024-25" }
+    hosting_override:
+      file_storage: google_drive
+      cms: custom
+      notes: >-
+        Berkeley publishes CDS workbooks as Google Sheets from the OPA
+        landing page. Archive via explicit export?format=xlsx URLs; browser
+        share links are not stable source artifacts.
+
+  - school_id: umd
+    browse_url: https://irpa.umd.edu/InstitutionalData/cds.html
+    direct_archive_urls:
+      - { url: https://irpa.umd.edu/InstitutionalData/CommonDataSet/CDS_2025-2026.xlsx, year: "2025-26" }
+      - { url: https://irpa.umd.edu/InstitutionalData/CommonDataSet/CDS_2024-2025.xlsx, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        UMD's CDS landing page exposes workbook links from a CommonDataSet
+        subdirectory. Preserve the InstitutionalData/CommonDataSet prefix;
+        root-relative guesses such as /CDS_2025-2026.xlsx return 404.
+
+  - school_id: arizona-state-university-campus-immersion
+    browse_url: https://uoia.asu.edu/common-data-set
+    direct_archive_urls:
+      - { url: https://uoia.asu.edu/sites/g/files/litvpz1436/files/2026-04/CDS%202025-26%20-%20ASU%20Campus%20Immersion.pdf, year: "2025-26" }
+      - { url: https://uoia.asu.edu/sites/g/files/litvpz1436/files/2025-04/ASU%20Campus%20Immersion%20-%20Common%20Data%20Set%202024-25.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        ASU Campus Immersion CDS files moved to UOIA. Reject stale provost
+        blank-template artifacts and keep the Campus Immersion campus scope;
+        ASU Online and other ASU rows are separate source-mapping targets.
+
+  - school_id: university-of-cincinnati-main-campus
+    browse_url: https://www.uc.edu/about/provost/offices/ir/common-data-set.html
+    direct_archive_urls:
+      - { url: https://www.uc.edu/content/dam/refresh/provost-62/offices/ir/2025-2026ay/CDS-2024-2025-University%20of%20Cincinnati%20Clifton%20FINAL%20Update%20072125%20Tuition%20Information.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Cincinnati posts recent CDS PDFs under dated provost DAM folders.
+        The canonical slug is university-of-cincinnati-main-campus, but the
+        school name in the source is University of Cincinnati Clifton.
+        No official 2025-26 CDS found as of 2026-05-06.
+
+  - school_id: uchicago
+    browse_url: https://data.uchicago.edu/common-data-set/
+    direct_archive_urls:
+      - { url: https://data.uchicago.edu/files/2025/08/CDS_2024-2025_to_publish.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        UChicago now publishes CDS PDFs on data.uchicago.edu. The 2024-25
+        PDF is current on the page as of 2026-05-06; no official 2025-26
+        CDS found yet.
+
+  - school_id: centre-college
+    browse_url: https://www.centre.edu/about/college-policies-initiatives/common-data-set
+    direct_archive_urls:
+      - { url: https://www.centre.edu/documents/2025-2026-common-data, year: "2025-26" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Centre publishes the current CDS from its Common Data Set landing
+        page using an extensionless document URL. Accept by content type and
+        document content, not URL suffix. The page did not list 2024-25 as of
+        2026-05-06.
+
+  - school_id: mit
+    browse_url: https://ir.mit.edu/project-topic/common-data-set/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      waf: cloudflare
+      notes: >-
+        MIT publishes CDS as year-specific HTML project pages. The newest
+        visible page found as of 2026-05-06 was 2024-25; no 2025-26 source
+        was found. Existing 2024-25 browser projection needs extraction QA
+        before narrative use because admissions values appear transposed.
+
+  - school_id: vanderbilt
+    browse_url: https://www.vanderbilt.edu/dsa/common-data-set/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        Vanderbilt publishes CDS workbooks on its DSA page. The newest
+        official source found as of 2026-05-06 was 2024-25; no 2025-26
+        source was found. Existing 2024-25 extraction is sparse and should
+        be handled as extraction QA, not source discovery.
+
+  - school_id: uw-madison
+    browse_url: https://data.wisc.edu/common-data-set/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        UW-Madison's public page listed 2024-2025 as the current CDS as of
+        2026-05-06; no 2025-26 source was found. Existing 2024-25 extraction
+        has implausible zero admissions counts and should be extraction QA.
+
+  - school_id: rutgers
+    browse_url: https://oirap.rutgers.edu/cds/
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Rutgers-New Brunswick public OIRAP CDS page still appeared to top
+        out at 2023-24 as of 2026-05-06. No official 2024-25 or 2025-26
+        source was found during the PRD 019 archive-gap pass.
+
+  - school_id: colby
+    browse_url: https://www.colby.edu/people/offices-directory/institutional-research/common-data-set/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      waf: cloudflare
+      notes: >-
+        Colby's official page was Cloudflare-blocked to local fetches during
+        the 2026-05-06 PRD 019 pass, and search did not reveal public 2024-25
+        or 2025-26 CDS files. Treat as source discovery/WAF follow-up.
+
+  - school_id: college-of-the-holy-cross
+    browse_url: https://www.holycross.edu/institutional-research-and-assessment/common-data-set
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Holy Cross' public Common Data Set page appeared to top out at
+        2023-24 as of 2026-05-06. No official 2024-25 or 2025-26 source was
+        found during the PRD 019 archive-gap pass.

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -412,3 +412,172 @@ overrides:
         Holy Cross' public Common Data Set page appeared to top out at
         2023-24 as of 2026-05-06. No official 2024-25 or 2025-26 source was
         found during the PRD 019 archive-gap pass.
+
+  # PRD 019 current-year live checks, 2026-05-06.
+  - school_id: princeton
+    browse_url: https://ir.princeton.edu/other-university-data/common-data-set
+    direct_archive_urls:
+      - { url: https://ir.princeton.edu/sites/g/files/toruqf2041/files/documents/CDS_2526_Princeton_v1.3.pdf, year: "2025-26" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      waf: cloudflare
+      notes: >-
+        Princeton's IR Common Data Set page lists 2025-2026 as current, but
+        local page fetches can return 403. The direct official PDF URL works
+        and should be preferred for archive backfill.
+
+  - school_id: wellesley-college
+    browse_url: https://www.wellesley.edu/about-us/offices-departments/office-of-institutional-research/public-data
+    direct_archive_urls:
+      - { url: "https://wellesley-college.files.svdcdn.com/production/administrative-departments/OIR/CDS_2025-2026-FINAL.pdf?dm=1773253066", year: "2025-26" }
+      - { url: "https://wellesley-college.files.svdcdn.com/production/administrative-departments/OIR/CDS_2024-2025-FINAL-1.pdf?dm=1762194243", year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Wellesley's public data page lists current and historical CDS files.
+        The current source is hosted on wellesley-college.files.svdcdn.com
+        with cache-busting query parameters, so preserve the full URL.
+
+  - school_id: middlebury-college
+    browse_url: https://www.middlebury.edu/assessment-institutional-research/institutional-data/historical-data
+    direct_archive_urls:
+      - { url: "https://www.middlebury.edu/sites/default/files/2026-04/Fall%202025%20CDS%20FINAL.pdf?fv=WuqVl12_", year: "2024-25" }
+      - { url: "https://www.middlebury.edu/sites/default/files/2025-04/Middlebury%20CDS%202024_2025.pdf?fv=_3Gr6e2c", year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Middlebury's Historical Data page labels the 2026-04 Fall 2025 PDF as
+        2025-2026, but the file text says Common Data Set 2024-2025 and the
+        extractor correctly projects it as 2024-25. Treat this as current-year
+        not recovered until Middlebury posts a file whose content identifies
+        as 2025-26.
+
+  - school_id: haverford-college
+    browse_url: https://www.haverford.edu/president/institutional-research/common-data-set
+    direct_archive_urls:
+      - { url: https://www.haverford.edu/sites/default/files/Office/President/CDS-2025-26.pdf, year: "2025-26" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      waf: cloudflare
+      notes: >-
+        Haverford's public CDS page can return 403 to local fetches, but
+        search surfaced the official 2025-26 PDF. The PDF title still says
+        Common Data Set 2024-2025 while sections reference Fall 2025; keep
+        the explicit archive year hint.
+
+  - school_id: pomona-college
+    browse_url: https://www.pomona.edu/administration/institutional-research/information-center/common-data-set
+    direct_archive_urls:
+      - { url: https://tableau.campus.pomona.edu/views/CDS2025-26/A_GeneralInformation, year: "2025-26" }
+      - { url: https://tableau.campus.pomona.edu/views/CDS2024-25/A_GeneralInformation, year: "2024-25" }
+    hosting_override:
+      file_storage: mixed
+      cms: drupal
+      rendering: js_required
+      notes: >-
+        Pomona's official page lists 2025-2026 and 2024-2025 CDS as Tableau
+        views, not PDFs. Do not archive the bare Tableau shell as a useful
+        source row until a Tableau extraction/export path exists; older years
+        remain Box-hosted PDFs.
+
+  - school_id: harvard
+    browse_url: https://oira.harvard.edu/common-data-set/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        Harvard's OIRA page still listed 2024-2025 as the latest CDS on
+        2026-05-06. No official 2025-26 source was found during the current
+        live-check pass.
+
+  - school_id: duke
+    browse_url: https://provost.duke.edu/administrative-resources/institutional-research/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        Duke's Institutional Research page lists CDS files through 2024-2025
+        only as of 2026-05-06. The 2024-25 source is an XLSX; no official
+        2025-26 source was found.
+
+  - school_id: northwestern
+    browse_url: https://enrollment.northwestern.edu/data/common-data-set.html
+    hosting_override:
+      file_storage: same_origin
+      cms: static
+      notes: >-
+        Northwestern's Common Data Set page listed 2024-2025 as current on
+        2026-05-06. Tested likely 2025-2026 PDF patterns under
+        enrollment.northwestern.edu/data; no current source found.
+
+  - school_id: amherst
+    browse_url: https://www.amherst.edu/offices/institutional-research/common-data-sets
+    hosting_override:
+      file_storage: google_drive
+      cms: custom
+      waf: unknown
+      notes: >-
+        Amherst's CDS page returned 405 to local fetches during the
+        2026-05-06 live check, and search did not surface an official
+        2025-26 CDS. Existing 2024-25 source is archived from Google Drive.
+
+  - school_id: california-institute-of-technology
+    browse_url: https://finance.caltech.edu/Resources/cds
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Caltech's Financial Services CDS page listed FY2024-25 as current on
+        2026-05-06. No official 2025-26 CDS source was found.
+
+  - school_id: rice
+    browse_url: https://ideas.rice.edu/common-data-set
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      waf: cloudflare
+      notes: >-
+        Rice's IDEAS Common Data Set page listed 2024-25 as current on
+        2026-05-06. No official 2025-26 source was found.
+
+  - school_id: washington-university-in-st-louis
+    browse_url: https://washu.edu/about/compliance-policies/registrar/student-consumer-information/
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        WashU's Student Consumer Information page listed Current Year:
+        2024-25 CDS on 2026-05-06. No official 2025-26 source was found.
+
+  - school_id: emory
+    browse_url: https://provost.emory.edu/planning-administration/data/common-data-set.html
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        Emory's institutional reporting page listed 2024-2025 as current on
+        2026-05-06. No official 2025-26 source was found.
+
+  - school_id: grinnell-college
+    browse_url: https://www.grinnell.edu/about/leadership/offices-services/institutional-research/common-data-set
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Grinnell's public CDS page listed 2024-25 as current on 2026-05-06.
+        The page notes recent CDS requests may require contacting AIR staff;
+        no public 2025-26 source was found.
+
+  - school_id: barnard
+    browse_url: https://barnard.edu/institutional-effectiveness/common-data-set
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Barnard's Institutional Effectiveness page listed 2024-25 as current
+        on 2026-05-06. A guessed 2025-26 inline-file PDF returned 404; no
+        official current source was found.

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -579,3 +579,188 @@ overrides:
         Barnard's Institutional Effectiveness page listed 2024-25 as current
         on 2026-05-06. A guessed 2025-26 inline-file PDF returned 404; no
         official current source was found.
+
+  # PRD 019 public flagship current-year checks, 2026-05-06.
+  - school_id: ucla
+    browse_url: https://apb.ucla.edu/campus-statistics/common-data-set-undergraduate-profile
+    direct_archive_urls:
+      - { url: https://apb.ucla.edu/file/d1ab04b3-ee89-4cf2-9124-8dc0471b5e5a, year: "2025-26" }
+      - { url: https://apb.ucla.edu/file/cedc749a-fd65-4935-b9ee-8a551f6de2fc, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        UCLA publishes current CDS PDFs behind extensionless /file/<uuid>
+        URLs. Accept by response content type and source bytes, not URL
+        suffix; 2025-26 and 2024-25 were force-archived from these official
+        APB links during the PRD 019 group 4 pass.
+
+  - school_id: uva
+    browse_url: https://ira.virginia.edu/data-analytics/common-data-set-initiatve
+    direct_archive_urls:
+      - { url: https://ira.virginia.edu/sites/g/files/jsddwu1106/files/2025-03/CDS_2024-2025_508.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        UVA's official page path is misspelled "initiatve". As of
+        2026-05-06 it explicitly says 2025-26 CDS Report coming soon and
+        lists 2024-25 as the newest PDF.
+
+  - school_id: unc
+    browse_url: https://oira.unc.edu/reports/reports-archives/common-data-set/
+    direct_archive_urls:
+      - { url: https://oira.unc.edu/wp-content/uploads/sites/297/2025/08/CDS_UNCCH_2024-25_20250829.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        UNC-Chapel Hill's OIRA archive listed 2024-25 as the newest public
+        CDS on 2026-05-06. No official 2025-26 source was found.
+
+  - school_id: uf
+    browse_url: https://ir.aa.ufl.edu/reports/cds-reports/
+    direct_archive_urls:
+      - { url: https://data-apps.ir.aa.ufl.edu/public/cds/CDS_2024-2025_UFMAIN_Post_v4_ADA5.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        UF's CDS Reports page listed 2024-25 and 2023-24 only on
+        2026-05-06. No official 2025-26 source was found.
+
+  - school_id: penn-state
+    browse_url: https://opair.psu.edu/project/common-data-set/
+    hosting_override:
+      file_storage: sharepoint
+      cms: wordpress
+      auth_required: none
+      notes: >-
+        Penn State's OPAIR page links to a SharePoint folder labeled Access
+        Files Here. The current canonical archive rows are Penn State York
+        campus PDFs, not University Park/main-campus CDS files; reject York
+        sources for the penn-state slug and handle the SharePoint folder as
+        source-mapping follow-up.
+
+  - school_id: ut-austin
+    browse_url: https://reports.utexas.edu/common-data-set/pdf
+    direct_archive_urls:
+      - { url: https://utexas.app.box.com/s/d9izqb6s8dw2xxg5h5sunxyhrnef2ay6, year: "2024-25" }
+    hosting_override:
+      file_storage: box
+      cms: drupal
+      notes: >-
+        UT Austin's PDF Common Data Set Reports page listed historical Box
+        links through 2024-25 on 2026-05-06; no 2025-26 source was listed.
+
+  - school_id: university-of-minnesota-twin-cities
+    browse_url: https://idr.umn.edu/institutional-metrics-compliance-reporting/common-data-set
+    direct_archive_urls:
+      - { url: https://idr.umn.edu/sites/idr.umn.edu/files/cds_2024_2025_tc_2.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        UMN's page separates Rochester and Twin Cities files. For this slug,
+        use only Twin Cities Campus CDS links; the newest Twin Cities link
+        visible on 2026-05-06 was 2024-2025.
+
+  - school_id: university-of-arizona
+    browse_url: https://uair.arizona.edu/content/common-data-set
+    direct_archive_urls:
+      - { url: https://uair.arizona.edu/sites/default/files/2025-03/CDS-2024-2025-FINAL.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Arizona's UAIR page listed 2024-2025 as the newest report on
+        2026-05-06. No official 2025-26 source was found.
+
+  - school_id: university-of-oregon
+    browse_url: https://ir.uoregon.edu/uo-overview/common-data-set
+    direct_archive_urls:
+      - { url: "https://uoregon.sharepoint.com/:b:/s/UOInstitutionalResearchPublicMaterials/IQCLb9PtNAxlQJCsPE6Rb8vcAVNYDIH7gnTYVb6ekL74NGU?e=QOIWky", year: "2025-26" }
+      - { url: "https://uoregon.sharepoint.com/:b:/s/UOInstitutionalResearchPublicMaterials/EW5k4dUJKOROg-jLajeQUE4B9IdCoV7T8DoI8Fys7Eghkw?e=9y4y4S", year: "2024-25" }
+    hosting_override:
+      file_storage: sharepoint
+      cms: drupal
+      auth_required: none
+      notes: >-
+        Oregon publishes current CDS files as public SharePoint file links.
+        archive-process cannot reliably fetch the viewer URL directly; use
+        the WAF/headless downloader to capture the SharePoint download.aspx
+        bytes before extraction.
+
+  - school_id: colorado
+    browse_url: https://data.colorado.edu/reports/common-data-set
+    hosting_override:
+      file_storage: sharepoint
+      cms: drupal
+      waf: cloudflare
+      notes: >-
+        CU Boulder's Data & Analytics Common Data Set report points to a
+        SharePoint folder and labels the covered academic term as 2025.
+        The page is public, but the folder needs manual or headless source
+        discovery to identify the specific CDS file before archive.
+
+  - school_id: the-university-of-alabama
+    browse_url: https://oira.ua.edu/reports/commonDataSet/
+    direct_archive_urls:
+      - { url: https://oira.ua.edu/d/sites/all/files/reports26/CDS%202025-26%20FINAL%209Dec2025.pdf, year: "2025-26" }
+      - { url: https://oira.ua.edu/d/sites/all/files/reports25/UA%20CDS%202024-25%20FINAL%2022aJan2025.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Alabama publishes direct annual CDS PDFs under reportsYY folders.
+        The 2025-26 and 2024-25 files were force-archived and redrained in
+        the PRD 019 group 4 pass.
+
+  - school_id: university-of-connecticut
+    browse_url: https://bpir.uconn.edu/home/institutional-research/data-resources/common-data-set/
+    direct_archive_urls:
+      - { url: https://bpir.media.uconn.edu/wp-content/uploads/sites/3452/2025/07/UConn_CDS_2024_2025.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        UConn BPIR listed 2024-25 as the newest public CDS on 2026-05-06.
+        No official 2025-26 source was found.
+
+  - school_id: university-of-south-carolina-columbia
+    browse_url: https://sc.edu/about/offices_and_divisions/institutional_research_assessment_and_analytics/institutional_effectiveness/common_data_set/
+    direct_archive_urls:
+      - { url: http://oiraa.dw.sc.edu/cds/cds2024/cds_2024-2025.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: custom
+      notes: >-
+        South Carolina's Institutional Research page listed 2024-25 as the
+        newest CDS on 2026-05-06. No official 2025-26 source was found.
+
+  - school_id: university-of-massachusetts-amherst
+    browse_url: https://www.umass.edu/uair/data/common-data-set
+    direct_archive_urls:
+      - { url: https://www.umass.edu/uair/media/1062/download, year: "2025-26" }
+      - { url: https://www.umass.edu/uair/media/1059/download, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        UMass Amherst publishes recent CDS files via extensionless media
+        download URLs. Accept by source bytes; 2025-26 and 2024-25 were
+        force-archived and redrained during the PRD 019 group 4 pass.
+
+  - school_id: uw
+    browse_url: https://www.washington.edu/opb/uw-data/external-reporting/common-data-set/
+    direct_archive_urls:
+      - { url: https://uw-s3-cdn.s3.us-west-2.amazonaws.com/wp-content/uploads/sites/162/2026/02/27111247/CDS_2025-2026_Seattle.pdf, year: "2025-26" }
+      - { url: https://uw-s3-cdn.s3.us-west-2.amazonaws.com/wp-content/uploads/sites/162/2025/04/01121035/CDS_2024-2025_Seattle.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        The canonical uw slug maps to University of Washington Seattle.
+        Reject Tacoma and Bothell CDS files for this slug; 2025-26 and
+        2024-25 Seattle PDFs were refreshed from the official OPB page in
+        the PRD 019 group 5 source-mapping pass.

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -127,3 +127,90 @@ overrides:
         The dmi.illinois.edu subdomain is effectively invisible to
         Brave's index — site:illinois.edu "Common Data Set" returns
         zero results. Per-school manual resolution only.
+
+  # PRD 019 source-mapping repairs, 2026-05-06. These schools surfaced
+  # false current/prior documents in the Top 200 freshness audit.
+  - school_id: upenn
+    browse_url: https://ira.upenn.edu/penn-numbers/common-data-set
+    direct_archive_urls:
+      - { url: https://upenn.box.com/s/ckv4frz37rzxa4u6bdiv2h4yzykqm4ef, year: "2024-25" }
+      - { url: https://upenn.box.com/s/0btxxmu1lmxgj1dc2pfzqewoun6miyn4, year: "2023-24" }
+    hosting_override:
+      file_storage: box
+      cms: custom
+      auth_required: none
+      notes: >-
+        Penn official CDS page publishes Box links; as of 2026-05-06 it
+        lists 2024-25 as the newest CDS. Do not archive commondataset.org
+        reference files such as the 2025-26 Summary of Changes docx as
+        Penn's CDS.
+
+  - school_id: osu
+    browse_url: https://irp.osu.edu/institutional-data-and-reports
+    direct_archive_urls:
+      - { url: https://irp.osu.edu/sites/default/files/documents/2026/03/CDS-2025-2026-OSU-Columbus-Campus.pdf, year: "2025-26" }
+      - { url: https://irp.osu.edu/media/276, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        OSU publishes multiple campus CDS files on one page. The canonical
+        school_id osu maps to Columbus Campus only; reject Lima, Mansfield,
+        Marion, Newark, and Wooster/ATI campus files for this row.
+
+  - school_id: the-university-of-tennessee-knoxville
+    browse_url: https://irsa.utk.edu/reporting/common-data-set/
+    direct_archive_urls:
+      - { url: http://irsa.utk.edu/wp-content/uploads/sites/107/2026/02/CDS_2025-26_All.pdf, year: "2025-26" }
+      - { url: http://irsa.utk.edu/wp-content/uploads/sites/107/2026/01/CDS_2024-2025_All.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      notes: >-
+        Current-year page includes section files and definitions alongside
+        the full CDS. Prior years live in the Reporting Archive. Prefer
+        *_All.pdf or *_Full.pdf; reject Definitions and section Appendix
+        PDFs as source-mapping false positives.
+
+  - school_id: university-of-illinois-chicago
+    browse_url: https://oir.uic.edu/institutional-research/common-data-set/
+    direct_archive_urls:
+      - { url: https://oir.uic.edu/wp-content/uploads/sites/213/2026/04/CDS_2025_2026.xlsx, year: "2025-26" }
+      - { url: https://oir.uic.edu/wp-content/uploads/sites/213/2025/04/CDS_UNL_2024_2025_section_C.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: mixed
+      cms: wordpress
+      auth_required: none
+      notes: >-
+        Public page exposes the current workbook and prior-year sections;
+        the previous-years Box archive is NetID-gated. For 2024-25, use
+        Section C for admissions change intelligence and reject Appendix
+        PDFs as source-mapping false positives.
+
+  - school_id: university-of-kansas
+    browse_url: https://aire.ku.edu/common-data-set/
+    direct_archive_urls:
+      - { url: https://aire.ku.edu/sites/aire/files/files/CDS/2025-2026/C.pdf, year: "2025-26" }
+      - { url: https://aire.ku.edu/sites/aire/files/files/CDS/2024-2025/C.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        KU publishes current-year CDS by section and older years as full
+        PDFs on a separate archive page. For admissions freshness, prefer
+        Section C when no full current-year PDF is available; do not let
+        Section J become the canonical document for the year.
+
+  - school_id: occidental-college
+    browse_url: https://www.oxy.edu/offices-services/institutional-research/institutional-data/common-data-set
+    direct_archive_urls:
+      - { url: https://www.oxy.edu/sites/default/files/assets/Institutional_Research/CDS_C_2526_0.pdf, year: "2025-26" }
+      - { url: https://www.oxy.edu/sites/default/files/assets/Institutional_Research/CDS%202023-24.pdf, year: "2023-24" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      notes: >-
+        Oxy publishes 2025-26 by section while older years are full files.
+        For admissions freshness, prefer Section C when no full current-year
+        PDF is available; do not let Section J become the canonical 2025-26
+        document.

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -145,6 +145,49 @@ overrides:
         reference files such as the 2025-26 Summary of Changes docx as
         Penn's CDS.
 
+  - school_id: johns-hopkins
+    browse_url: https://oira.jhu.edu/common-data-set/
+    direct_archive_urls:
+      - { url: https://oira.jhu.edu/wp-content/uploads/2025-2026-CDS-Johns-Hopkins-University.pdf, year: "2025-26" }
+      - { url: https://drive.usercontent.google.com/download?id=1493J-a9EGTyGekgy-NAohQ_LSEQ3jtDp&export=download, year: "2024-25" }
+    hosting_override:
+      file_storage: mixed
+      cms: wordpress
+      waf: cloudflare
+      notes: >-
+        JHU's current same-origin PDF may return a Cloudflare challenge to
+        non-browser archive fetches. Prefer the official OIRA landing page,
+        but use the WAF-aware headless downloader and reject HTML challenge
+        bodies before inserting source artifacts.
+
+  - school_id: williams-college
+    browse_url: https://www.williams.edu/institutional-research/common-data-set/
+    direct_archive_urls:
+      - { url: https://www.williams.edu/institutional-research/files/2026/04/Williams-CDS-2025-2026-V2.pdf, year: "2025-26" }
+      - { url: https://www.williams.edu/institutional-research/files/2025/06/CDS_2024_2025_Williams_V5.pdf, year: "2024-25" }
+    hosting_override:
+      file_storage: same_origin
+      cms: wordpress
+      waf: cloudflare
+      notes: >-
+        Williams publishes recent CDS PDFs on its IR landing page, but direct
+        archive fetches can receive a Cloudflare challenge page. Use the
+        WAF-aware headless downloader and verify source bytes are real PDFs.
+
+  - school_id: kent-state-university-at-kent
+    browse_url: https://www.kent.edu/ir/common-dataset-cds
+    direct_archive_urls:
+      - { url: https://www-s3-live.kent.edu/s3fs-root/s3fs-public/file/TU%20CDS_2025-2026-Final_web_1.docx?VersionId=8b11OcfWwv3GOtnZg.urP8_ZlgTVDMTY, year: "2025-26" }
+    hosting_override:
+      file_storage: same_origin
+      cms: drupal
+      waf: none
+      notes: >-
+        Kent publishes an SDT-preserving DOCX. The current worker stubs native
+        docx extraction, so browser projection relies on the existing
+        operator-generated Word-to-PDF Tier 4 canonical artifact until a
+        durable docx-to-PDF route is implemented.
+
   - school_id: osu
     browse_url: https://irp.osu.edu/institutional-data-and-reports
     direct_archive_urls:

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -471,18 +471,16 @@ overrides:
 
   - school_id: pomona-college
     browse_url: https://www.pomona.edu/administration/institutional-research/information-center/common-data-set
-    direct_archive_urls:
-      - { url: https://tableau.campus.pomona.edu/views/CDS2025-26/A_GeneralInformation, year: "2025-26" }
-      - { url: https://tableau.campus.pomona.edu/views/CDS2024-25/A_GeneralInformation, year: "2024-25" }
     hosting_override:
       file_storage: mixed
       cms: drupal
       rendering: js_required
       notes: >-
         Pomona's official page lists 2025-2026 and 2024-2025 CDS as Tableau
-        views, not PDFs. Do not archive the bare Tableau shell as a useful
-        source row until a Tableau extraction/export path exists; older years
-        remain Box-hosted PDFs.
+        views, not direct PDFs. Do not feed the bare Tableau shell URLs to
+        force_urls. Operator-exported PDFs from the Tableau Download UI are
+        valid manual-upload sources; Tier 4 0.3.9 recovers C1/C9 from this
+        Tableau PDF layout. Older years remain Box-hosted PDFs.
 
   - school_id: harvard
     browse_url: https://oira.harvard.edu/common-data-set/

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -109,7 +109,7 @@ schools:
   domain: bu.edu
   ipeds_id: '164988'
   scrape_policy: active
-  discovery_seed_url: https://www.bu.edu/asir/files/2020/02/cds-2018.pdf
+  discovery_seed_url: https://www.bu.edu/asir/bu-facts/common-data-set/
   probe_state:
     last_probed_at: '2026-04-14T15:35:44Z'
     last_result: found

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -413,7 +413,7 @@ schools:
   domain: osu.edu
   ipeds_id: '204796'
   scrape_policy: active
-  discovery_seed_url: https://irp.osu.edu/sites/default/files/documents/2025/11/CDS-2024-2025-The-Ohio-State-University-Columbus.pdf
+  discovery_seed_url: https://irp.osu.edu/institutional-data-and-reports
   probe_state:
     last_probed_at: '2026-04-14T15:35:52Z'
     last_result: found
@@ -5905,6 +5905,22 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+- id: connecticut-college
+  name: Connecticut College
+  domain: conncoll.edu
+  ipeds_id: '128902'
+  scrape_policy: active
+  probe_state:
+    last_probed_at: '2026-05-06T17:00:00Z'
+    last_result: found
+    last_method: manual
+    patterns_tried: 0
+    search_fallback_tried: true
+  discovery_seed_url: https://www.conncoll.edu/institutional-research/conn-facts/
+  browse_url: https://www.conncoll.edu/institutional-research/conn-facts/
+  notes: Manually resolved 2026-05-06 from a public CDS submission. Homepage
+    probing missed this institutional-research facts page, but the page lists
+    current and historical Common Data Set PDF links.
 - id: converse-university
   name: Converse University
   domain: converse.edu
@@ -15144,7 +15160,7 @@ schools:
   domain: oxy.edu
   ipeds_id: '120254'
   scrape_policy: active
-  discovery_seed_url: https://oxy.edu/common-data-set/
+  discovery_seed_url: https://www.oxy.edu/offices-services/institutional-research/institutional-data/common-data-set
   probe_state:
     last_probed_at: '2026-04-14T07:16:29Z'
     last_result: found
@@ -21305,7 +21321,7 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://irsa.utk.edu/common-data-set/
+  discovery_seed_url: https://irsa.utk.edu/reporting/common-data-set/
 - id: the-university-of-tennessee-martin
   name: The University of Tennessee-Martin
   domain: utm.edu

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -22386,7 +22386,7 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://uair.arizona.edu/sites/default/files/cds_2010-11.pdf
+  discovery_seed_url: https://uair.arizona.edu/content/common-data-set
 - id: university-of-arkansas
   name: University of Arkansas
   domain: uark.edu

--- a/tools/finder/waf_blocked_urls.yaml
+++ b/tools/finder/waf_blocked_urls.yaml
@@ -47,6 +47,12 @@ schools:
     urls:
     - url: https://oira.jhu.edu/wp-content/uploads/2025-2026-CDS-Johns-Hopkins-University.pdf
       year: 2025-26
+  johns-hopkins:
+    school_name: Johns Hopkins University
+    landing_url: https://oira.jhu.edu/common-data-set/
+    urls:
+    - url: https://oira.jhu.edu/wp-content/uploads/2025-2026-CDS-Johns-Hopkins-University.pdf
+      year: 2025-26
   new-york-university:
     school_name: New York University
     landing_url: https://www.nyu.edu/employees/resources-and-services/administrative-services/institutional-research/self-service-reporting-resources/factbook.html
@@ -87,6 +93,14 @@ schools:
       year: 2023-24
     - url: https://www.williams.edu/institutional-research/files/2023/06/CDS_2022_2023_Williams_June2023.pdf
       year: 2022-23
+  williams-college:
+    school_name: Williams College
+    landing_url: https://www.williams.edu/institutional-research/common-data-set/
+    urls:
+    - url: https://www.williams.edu/institutional-research/files/2026/04/Williams-CDS-2025-2026-V2.pdf
+      year: 2025-26
+    - url: https://www.williams.edu/institutional-research/files/2025/06/CDS_2024_2025_Williams_V5.pdf
+      year: 2024-25
   fordham-university:
     school_name: Fordham University
     landing_url: https://www.fordham.edu/about/leadership-and-administration/administrative-offices/office-of-the-provost/provost-office-units/institutional-research-and-assessment/consumer-information/common-data-set/

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -48,7 +48,7 @@ from openpyxl.utils import get_column_letter
 
 
 PRODUCER_NAME = "tier1_xlsx"
-PRODUCER_VERSION = "0.2.1"
+PRODUCER_VERSION = "0.2.2"
 MIN_TEMPLATE_FIELDS_BEFORE_FALLBACK = 25
 
 # Default template path relative to the repo root.
@@ -174,6 +174,11 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
         qnum_to_field,
         values,
     )
+    application_fields_recovered = recover_c1_application_values(
+        wb,
+        qnum_to_field,
+        values,
+    )
 
     wb.close()
 
@@ -190,6 +195,7 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
             "missing_sheets": sorted(missing_sheets),
             "extraction_layout": extraction_layout,
             "academic_profile_fields_recovered": academic_profile_recovered,
+            "application_fields_recovered": application_fields_recovered,
         },
         "values": values,
     }
@@ -355,6 +361,145 @@ def recover_c9_academic_profile_values(
     return count
 
 
+def recover_c1_application_values(
+    wb,
+    qnum_to_field: dict[str, dict],
+    values: dict,
+) -> int:
+    """Recover shifted C1 admissions rows from visible workbook labels.
+
+    Several schools publish the standard 2024-25 workbook with C1 answers in
+    the visible table's Total / residency columns instead of the template's
+    mapped answer cells. The row labels and section-C column order are stable
+    enough to recover the C1 values deterministically.
+    """
+    available_sheets = set(wb.sheetnames)
+    sheet_name = "CDS-C" if "CDS-C" in available_sheets else build_sheet_aliases(available_sheets).get("CDS-C")
+    if not sheet_name:
+        return 0
+    ws = wb[sheet_name]
+    recovered: dict[str, object] = {}
+
+    def lookup(gender: str, residency: str, action: str, unit_load: str = "All") -> str | None:
+        target_gender_aliases = {
+            "Males": {"men", "male", "males"},
+            "Females": {"women", "female", "females"},
+            "Another Gender": {"another gender"},
+            "Unknown": {"unknown", "students of unknown sex", "unknown gender"},
+            "All": {"all"},
+        }[gender]
+        for qnum, field in qnum_to_field.items():
+            if not str(qnum).startswith("C.1"):
+                continue
+            field_gender = _norm_label(field.get("gender"))
+            if field_gender not in target_gender_aliases:
+                continue
+            if str(field.get("residency") or "All") != residency:
+                continue
+            question = _norm_label(field.get("question"))
+            if action == "admitted":
+                if "admitted" not in question:
+                    continue
+            elif action == "applied":
+                if "applied" not in question:
+                    continue
+            elif action == "enrolled":
+                if "enrolled" not in question:
+                    continue
+                if unit_load == "FT" and "full time" not in question and field.get("unit_load") != "FT":
+                    continue
+                if unit_load == "PT" and "part time" not in question and field.get("unit_load") != "PT":
+                    continue
+                if unit_load == "All" and ("full time" in question or "part time" in question):
+                    continue
+            return qnum
+        return None
+
+    def first_number_after_label(row_values: list, label_col: int) -> object | None:
+        for value in row_values[label_col:]:
+            if _is_number_like(value):
+                return value
+        return None
+
+    for row in ws.iter_rows(max_col=12):
+        row_values = [cell.value for cell in row]
+        label_col = None
+        label = ""
+        for idx, value in enumerate(row_values):
+            normalized = _norm_label(value)
+            if "first time first year" in normalized and (
+                "applied" in normalized
+                or "admitted" in normalized
+                or "enrolled" in normalized
+            ):
+                label_col = idx
+                label = normalized
+                break
+        if label_col is None:
+            continue
+
+        action = None
+        if "admitted" in label:
+            action = "admitted"
+        elif "applied" in label:
+            action = "applied"
+        elif "enrolled" in label:
+            action = "enrolled"
+        if not action:
+            continue
+
+        gender = None
+        if " men " in f" {label} ":
+            gender = "Males"
+        elif " women " in f" {label} ":
+            gender = "Females"
+        elif "another gender" in label:
+            gender = "Another Gender"
+        elif "unknown gender" in label or "unknown sex" in label:
+            gender = "Unknown"
+
+        unit_load = "All"
+        if action == "enrolled":
+            if "full time" in label:
+                unit_load = "FT"
+            elif "part time" in label:
+                unit_load = "PT"
+
+        if gender:
+            value = first_number_after_label(row_values, label_col + 1)
+            qnum = lookup(gender, "All", action, unit_load)
+            if qnum and value is not None:
+                recovered[qnum] = value
+            continue
+
+        if " who " not in label:
+            continue
+
+        numeric_values = [value for value in row_values[label_col + 1:] if _is_number_like(value)]
+        if not numeric_values:
+            continue
+        for residency, value in zip(
+            ("All", "In-State", "Out-of-State", "Nonresidents", "Unknown"),
+            numeric_values,
+        ):
+            qnum = lookup("All", residency, action)
+            if qnum:
+                recovered[qnum] = value
+
+    count = 0
+    for qnum, raw_value in recovered.items():
+        if qnum not in qnum_to_field:
+            continue
+        value = str(raw_value).strip()
+        if not value:
+            continue
+        if values.get(qnum, {}).get("value") == value:
+            continue
+        values[qnum] = _field_record(qnum, value, qnum_to_field)
+        count += 1
+    return count
+
+
 def _row_value(row_values: list, zero_based_index: int):
     if zero_based_index < 0 or zero_based_index >= len(row_values):
         return None
@@ -397,6 +542,14 @@ def _is_c9_value(value) -> bool:
     if isinstance(value, bool):
         return False
     return bool(str(value).strip())
+
+
+def _is_number_like(value) -> bool:
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    return bool(re.fullmatch(r"\s*\d[\d,]*(?:\.\d+)?\s*", str(value)))
 
 
 def build_embedded_answer_cell_map(wb) -> dict[str, tuple[str, str]]:

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -184,6 +184,74 @@ class Tier1ExtractTests(unittest.TestCase):
         self.assertEqual(result["values"]["C.916"]["value"], "29")
         self.assertEqual(result["stats"]["academic_profile_fields_recovered"], 16)
 
+    def test_recovers_shifted_c1_application_rows_by_label(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Admission"
+        rows = [
+            ("B12", "Total first-time, first-year men who applied", "E12", 13836),
+            ("B13", "Total first-time, first-year women who applied", "E13", 17880),
+            ("B14", "Total first-time, first-year men who were admitted", "E14", 9914),
+            ("B15", "Total first-time, first-year women who were admitted", "E15", 13532),
+            ("B16", "Total full-time, first-time, first-year men who enrolled", "E16", 2525),
+            ("B17", "Total part-time, first-time, first-year men who enrolled", "E17", 222),
+            ("B18", "Total full-time, first-time, first-year women who enrolled", "E18", 3253),
+            ("B19", "Total part-time, first-time, first-year women who enrolled", "E19", 218),
+            ("B30", "Total first-time, first-year students who applied", "E30", 31716),
+            ("B31", "Total first-time, first-year students who were admitted", "E31", 23446),
+            ("B32", "Total first-time, first-year students who enrolled", "E32", 6218),
+        ]
+        for label_cell, label, value_cell, value in rows:
+            ws[label_cell] = label
+            ws[value_cell] = value
+
+        schema = {
+            "schema_version": "2024-25",
+            "fields": [
+                {
+                    "question_number": qnum,
+                    "word_tag": None,
+                    "question": question,
+                    "section": "First-Time, First-Year Admission",
+                    "subsection": "Applications",
+                    "value_type": "Number",
+                    "gender": gender,
+                    "residency": "All",
+                    "unit_load": unit_load,
+                }
+                for qnum, gender, unit_load, question in [
+                    ("C.101", "Men", "All", "Total first-time, first-year men who applied"),
+                    ("C.102", "Women", "All", "Total first-time, first-year women who applied"),
+                    ("C.105", "Men", "All", "Total first-time, first-year men who were admitted"),
+                    ("C.106", "Women", "All", "Total first-time, first-year women who were admitted"),
+                    ("C.109", "Men", "All", "Total full-time, first-time, first-year men who enrolled"),
+                    ("C.110", "Men", "PT", "Total part-time, first-time, first-year men who enrolled"),
+                    ("C.111", "Women", "FT", "Total full-time, first-time, first-year women who enrolled"),
+                    ("C.112", "Women", "PT", "Total part-time, first-time, first-year women who enrolled"),
+                    ("C.117", "All", "All", "Total first-time, first-year students who applied"),
+                    ("C.118", "All", "All", "Total first-time, first-year students who were admitted"),
+                    ("C.119", "All", "All", "Total first-time, first-year students who enrolled"),
+                ]
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(Path(tmp.name), schema, {"C.101": ("CDS-C", "D999")})
+
+        self.assertEqual(result["values"]["C.101"]["value"], "13836")
+        self.assertEqual(result["values"]["C.102"]["value"], "17880")
+        self.assertEqual(result["values"]["C.105"]["value"], "9914")
+        self.assertEqual(result["values"]["C.106"]["value"], "13532")
+        self.assertEqual(result["values"]["C.109"]["value"], "2525")
+        self.assertEqual(result["values"]["C.110"]["value"], "222")
+        self.assertEqual(result["values"]["C.111"]["value"], "3253")
+        self.assertEqual(result["values"]["C.112"]["value"], "218")
+        self.assertEqual(result["values"]["C.117"]["value"], "31716")
+        self.assertEqual(result["values"]["C.118"]["value"], "23446")
+        self.assertEqual(result["values"]["C.119"]["value"], "6218")
+        self.assertEqual(result["stats"]["application_fields_recovered"], 11)
+
     def test_recovers_freshman_c9_header_and_clears_blank_visible_rows(self):
         wb = openpyxl.Workbook()
         ws = wb.active


### PR DESCRIPTION
## Summary
- Add PRD 019 Top 200 freshness/change-intelligence watchlist and source hints.
- Repair Tier 4 visual OCR / layout extraction for C1 and C9 admissions fields.
- Repair Tier 1 XLSX shifted visible-row C1 recovery.
- Add visual OCR candidate audit and targeted regression tests.
- Redrain affected PRD 019 canaries and similar corpus candidates under versioned producers.

## Data Refresh Notes
- Final extractor versions: `tier4_docling 0.3.10`, `tier1_xlsx 0.2.2`.
- Versioned refresh processed 34 documents, projected 34 browser rows, no extraction failures.
- Targeted fixes cleared the PRD 019 canaries for UMich, Houston, GVSU, CSUSM, Pitt, and UMass Amherst.
- Similar-corpus sweep cleared `tier1_c1_missing = 0` and `sat_range_suspect = 0` for 2024+ rows checked.

## Verification
- GitHub CI passed on `a523c183f4afc240351de44ba1af5d25aea33a0e`.
- Local: `PYTHONPATH=tools/extraction_worker python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'`
- Local: `python3 -m unittest discover -s tools/tier1_extractor -p 'test_*.py'`
