### PR TITLE
Add seasonal archive freshness cadence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run Deno tests
-        run: deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts
+        run: deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/archive-process/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts
 
   web:
     name: Next.js build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run Deno tests
-        run: deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/archive-process/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts
+        run: deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/archive-enqueue/*.test.ts supabase/functions/archive-process/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts
 
   web:
     name: Next.js build

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ collegedata.fyi sits between official higher-education data systems and the docu
 ## Docs and decisions
 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — ten-pipeline map of the whole system (schema, corpus, discovery, mirror, extraction, scorecard, institution directory + coverage, change intelligence, consumer API, frontend)
+- [`docs/data-extraction-pipeline.md`](docs/data-extraction-pipeline.md) — operational diagram of the discovery/archive/extraction/projection flow, including cadence, storage, and known issues
 - [`docs/extraction-quality.md`](docs/extraction-quality.md) — current accuracy by tier, per-section corpus-wide coverage, and reproducible scoring commands
 - [`docs/recipes/`](docs/recipes/) — worked examples with real data: interactive visualizations, XLSX starters, and API queries. Start with [acceptance rate vs yield](docs/recipes/acceptance-vs-yield.md)
 - [`docs/plans/prd-019-spike-and-qa.md`](docs/plans/prd-019-spike-and-qa.md) — PRD 019 spike and QA summary, including the first calibration-run numbers and review gates

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # collegedata.fyi — Architecture
 
-How the pieces fit together at runtime. Complements [`docs/v1-plan.md`](v1-plan.md) (engineering plan, data model details) and [`docs/prd/001-collegedata-fyi-v1.md`](prd/001-collegedata-fyi-v1.md) (product-level framing).
+How the pieces fit together at runtime. Complements [`docs/v1-plan.md`](v1-plan.md) (engineering plan, data model details), [`docs/prd/001-collegedata-fyi-v1.md`](prd/001-collegedata-fyi-v1.md) (product-level framing), and the focused [data extraction pipeline map](data-extraction-pipeline.md) for operator cadence, storage, and known extraction issues.
 
 ---
 

--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -33,10 +33,10 @@ CMS, file_storage, auth_required, rendering, and WAF. The
 `latest_school_hosting` view exposes the most-recent observation per
 school for consumers that don't want history.
 
-The monthly enqueuer applies a per-outcome cooldown so schools whose
-most recent probe was `unchanged_verified` (30d), `auth_walled_*` (90d),
-`dead_url` (14d), etc. are skipped for the relevant window — typically
-~67% of active schools per cron.
+The cadence-aware enqueuer applies a per-outcome cooldown so schools whose
+most recent probe was `unchanged_verified` (7d during March-June freshness
+season, 30d otherwise), `auth_walled_*` (90d), `dead_url` (14d), etc. are
+skipped for the relevant window — typically ~67% of active schools per cron.
 
 Archive discovery runs on Supabase Edge Functions + pg_cron + pg_net. One
 school per edge function invocation so the 400 s wall clock, 256 MB memory, and
@@ -57,9 +57,9 @@ clock.
 │                != null AND sub_institutions is null          │
 │    2b. Cooldown filter: drop schools whose most-recent       │
 │                         last_outcome's window hasn't expired │
-│    3. Derive run_id = sha256('archive-enqueue:YYYY-MM')      │
+│    3. Derive run_id = sha256(weekly Mar-Jun, monthly else)   │
 │    4. Bulk upsert one archive_queue row per school,          │
-│       ignoreDuplicates=true → same month is a no-op          │
+│       ignoreDuplicates=true → same bucket is a no-op         │
 └──────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -249,7 +249,7 @@ low-field docs, extraction counts, and projection counts.
 | One-school pipeline orchestrator | `supabase/functions/_shared/archive.ts` |
 | Resolver dev entry (dry-run, no writes) | `supabase/functions/discover/index.ts` |
 | Queue consumer (30 s cron target + `force_school` backfill) | `supabase/functions/archive-process/index.ts` |
-| Monthly seeder (daily cron target, deterministic per-month run_id) | `supabase/functions/archive-enqueue/index.ts` |
+| Cadence-aware seeder (daily cron target; weekly March-June, monthly otherwise) | `supabase/functions/archive-enqueue/index.ts` |
 | Operator-triggered seeder for Scorecard-only directory rows (PRD 015 M2) | `supabase/functions/directory-enqueue/index.ts` |
 | Public-safe coverage table refresh, on 15-min pg_cron (PRD 015 M3) | `supabase/functions/refresh-coverage/index.ts` |
 | Coverage table + status precedence + atomic refresh RPC (PRD 015 M3) | `supabase/migrations/<ts>_institution_cds_coverage.sql` |
@@ -374,7 +374,7 @@ touching the database or Storage.
    ```json
    {
      "mode": "enqueue",
-     "run_id": "<deterministic per-month uuid>",
+     "run_id": "<deterministic cadence-bucket uuid>",
      "enqueued": 837,
      "skipped": 2,
      "skipped_invalid_yaml": 0,

--- a/docs/data-extraction-pipeline.md
+++ b/docs/data-extraction-pipeline.md
@@ -161,5 +161,12 @@ flowchart TD
 
 # Full browser projection rebuild after a projection/schema change.
 python tools/browser_backend/project_browser_data.py --full-rebuild --apply
-```
 
+# One-command automation health check: GitHub Actions, pg_cron,
+# async Edge Function HTTP responses, archive queue, extraction movement,
+# and coverage freshness.
+python3 tools/ops/automation_health.py \
+  --env /path/to/.env \
+  --markdown-out scratch/automation-health.md \
+  --json-out scratch/automation-health.json
+```

--- a/docs/data-extraction-pipeline.md
+++ b/docs/data-extraction-pipeline.md
@@ -1,0 +1,165 @@
+# Data Extraction Pipeline Map
+
+This is the operational map for how collegedata.fyi turns decentralized Common
+Data Set files into public, queryable rows. It focuses on where each step lives,
+how often it runs, what it writes, and the constraints that matter during data
+quality work.
+
+For deeper design context, see [ARCHITECTURE.md](ARCHITECTURE.md),
+[archive-pipeline.md](archive-pipeline.md), and
+[extraction-quality.md](extraction-quality.md).
+
+## End-to-End Flow
+
+```mermaid
+flowchart TD
+    A[Official CDS templates<br/>commondataset.org] --> B[Schema builder<br/>tools/schema_builder]
+    B --> C[Committed schema JSON<br/>schemas/cds_schema_*.json]
+
+    D[IPEDS + curated school hints<br/>tools/finder/schools.yaml<br/>tools/finder/school_overrides.yaml] --> E[Archive enqueue<br/>Supabase Edge Function]
+    E --> F[archive_queue<br/>Supabase Postgres]
+    F --> G[Archive process<br/>Supabase Edge Function]
+    G --> H[Source bytes<br/>Supabase Storage: sources bucket]
+    G --> I[Document metadata<br/>cds_documents]
+    G --> J[Source artifact row<br/>cds_artifacts kind=source]
+
+    H --> K[Format probe / worker sniff<br/>tools/tier_probe + worker.py]
+    I --> K
+    K --> L[cds_documents.source_format]
+
+    L --> M{Tier router<br/>tools/extraction_worker/worker.py}
+    C --> M
+    M --> N[Tier 1 XLSX<br/>tools/tier1_extractor]
+    M --> O[Tier 2 fillable PDF<br/>tools/tier2_extractor]
+    M --> P[Tier 4 flat PDF<br/>Docling + tier4_cleaner]
+    M --> Q[Tier 5 scanned PDF<br/>Tier 4 + force OCR]
+    M --> R[Tier 6 HTML<br/>html_to_markdown + tier4_cleaner]
+    M --> S[Tier 3 DOCX<br/>routed, extractor pending]
+
+    N --> T[Canonical artifact<br/>cds_artifacts kind=canonical]
+    O --> T
+    P --> T
+    Q --> T
+    R --> T
+    S --> U[Failed/stub status<br/>operator follow-up]
+
+    T --> V[Optional Tier 4 LLM fallback<br/>separate cleaned artifact]
+    T --> W[Browser projection<br/>tools/browser_backend/project_browser_data.py]
+    V --> W
+    W --> X[Long-form fields<br/>cds_fields]
+    W --> Y[Curated school-year rows<br/>school_browser_rows]
+
+    Y --> Z[PRD 019 change events<br/>tools/change_intelligence]
+    Z --> AA[cds_field_change_events<br/>review gated]
+
+    X --> AB[PostgREST API + frontend]
+    Y --> AB
+    AA --> AB
+```
+
+## Operating Table
+
+| Step | Primary code | Housed data | Cadence | Constraints and known issues |
+|---|---|---|---|---|
+| Schema extraction | `tools/schema_builder/build_from_xlsx.py`, `tools/schema_builder/decode_checkboxes.py` | `schemas/cds_schema_YYYY_YY.json`, `schemas/templates/` | Once per CDS template year, operator-run | Extractors depend on schema-year coverage. If a school publishes older template variants, deterministic maps may fall back to the newest known schema and record schema fallback notes. |
+| Corpus and hints | `tools/finder/build_school_list.py`, `tools/finder/probe_urls.py`, `tools/finder/school_overrides.yaml` | `tools/finder/schools.yaml` and override hints | Monthly/ad-hoc operator work | Search misses Box/Drive-hosted files, thinly indexed subdomains, JS-only interfaces, and landing pages with no searchable CDS text. Manual hints should cover current year, prior year, and future finder behavior. |
+| Archive enqueue | `supabase/functions/archive-enqueue` | `archive_queue` | Daily at `02:00 UTC`; monthly `run_id` makes repeat daily calls mostly no-op | Requires Vault secrets for function base URL and service-role key. Enqueues active schools with hints, minus cooldowned outcomes. |
+| Archive process | `supabase/functions/archive-process`, shared resolver code in `supabase/functions/_shared/` | `cds_documents`, source `cds_artifacts`, Supabase Storage `sources` bucket, `school_hosting_observations` | Every `30 seconds` by pg_cron; one school per invocation | Edge runtime limits are why work is one school at a time. Handles SHA-addressed source storage, SSRF guard, 50 MB file cap, 30 s fetch timeout, retry/lease semantics, and cooldown outcomes. WAF/Cloudflare pages must be rejected before insertion; some schools need operator manual uploads. |
+| Manual upload / force archive | `tools/upload/`, `archive-process?force_urls`, `archive-upload` | Same as archive process, usually `source_provenance='operator_manual'` or explicit mirror provenance | Ad-hoc | Use when the public resolver is blocked by WAF, Tableau/PowerBI export, Box/Drive, SharePoint viewers, or no crawlable landing page. New source bytes flip the document back to `extraction_pending`. |
+| Format classification | `tools/tier_probe/probe.py`; fallback sniffing in `tools/extraction_worker/worker.py` | `cds_documents.source_format` | Once per archive drain; worker also corrects stale/missing labels | Classification is byte-derived. DOCX and XLSX both start as ZIP files, so internals must be inspected. `source_format='other'` exits fast for operator review. |
+| Extraction worker | `tools/extraction_worker/worker.py` | `cds_artifacts kind=canonical`, `cds_documents.extraction_status`, `cds_documents.detected_year` | Small daily GitHub Actions drain at `09:17 UTC`; managed large drains run on an operator laptop or self-hosted runner | GitHub-hosted ops runs are capped at 100 rows and 60 minutes. Full Docling/OCR drains belong locally. Worker is idempotent by `(document_id, producer, producer_version, schema_version)`, so version bumps are required before redraining cleaner changes. |
+| Tier 1 XLSX | `tools/tier1_extractor/extract.py` | Canonical artifact with `producer='tier1_xlsx'` | Triggered by extraction worker | Deterministic for standard templates and embedded question/answer columns. Custom workbooks or old template layouts may produce sparse rows. |
+| Tier 2 fillable PDF | `tools/tier2_extractor/extract.py` | Canonical artifact with `producer='tier2_acroform'` | Triggered by extraction worker | Near deterministic when populated AcroForm fields exist. Header identity fields may be blank even when visible in the PDF, so school identity should come from `cds_documents`/corpus metadata. |
+| Tier 3 DOCX | Routed in `worker.py`; extractor scoped by PRD 007 | No successful canonical DOCX tier yet | Not built | DOCX routing is fixed so files no longer masquerade as XLSX, but extraction is still a stub. Rows fail fast and need future SDT extraction. |
+| Tier 4 flat PDF | `tools/extraction_worker/tier4_extractor.py`, `tier4_cleaner.py`, `tier4_native_tables.py` | Canonical artifact with `producer='tier4_docling'`; raw markdown/native table notes in `cds_artifacts.notes` | Triggered by worker; redrains are operator-managed | Highest volume and highest variance path. Docling table serialization can lose layout, merge columns, or omit visually present values. Recent repairs include visual OCR for C1/C9 and cleaner fixes for C1/C9 layouts, but narrative-grade changes still need canary/source review. |
+| Tier 5 scanned PDF | Same Tier 4 path with `force_ocr=True` | Canonical artifact with `producer='tier4_docling'` and scanned source format | Triggered by worker for `pdf_scanned` | Force OCR is required; Docling auto-OCR is not reliable enough. OCR is slower and can still miss small tables or low-quality scans. |
+| Tier 6 HTML | `tools/extraction_worker/html_to_markdown.py` plus Tier 4 cleaner | Canonical artifact with `producer='tier6_html'` | Triggered by worker | Works when the archived HTML contains real table content. JS-rendered dashboards usually require manual export to PDF/XLSX first. |
+| LLM fallback | `tools/extraction_worker/llm_fallback_worker.py`, `tier4_llm_fallback.py` | Separate `cds_artifacts` cleaned row, usually `producer='tier4_llm_fallback'` | Operator-run, not routine CI | Fallback is a gap-fill overlay only. Deterministic base cleaner wins conflicts; fallback must match the selected Tier 4 base artifact before projection can merge it. |
+| Browser projection | `tools/browser_backend/project_browser_data.py` and replacement RPCs | `cds_fields`, `school_browser_rows`, metadata tables/views | Incremental after successful worker writes; full rebuild operator-run after migrations/projection changes | Serving rows are materialized. Rates are stored as fractions. Projection filters/normalizes invalid SAT/ACT/rate values rather than exposing obvious canaries. Full rebuild is required after schema/alias/projection logic changes. |
+| Data quality audits | `tools/data_quality/*`, `tools/browser_backend/prd*_audit.py`, `tools/change_intelligence/audit_watchlist_freshness.py` | Reports under `.context/reports/`; optional flags in `cds_documents.data_quality_flag` | Ad-hoc and before narrative/reporting work | Audits do not own data. They find canaries, low-field artifacts, visual OCR candidates, stale producer versions, and source-mapping gaps. For canaries, search for similar files and redrain the class, not only the one school. |
+| PRD 019 change intelligence | `tools/change_intelligence/project_change_events.py`, `review_change_event.py`, watchlists under `data/watchlists/` | `cds_field_change_events`, `cds_field_change_event_reviews`, `.context/reports/` | Operator-run; no cron | Compares selected `school_browser_rows`, not raw artifacts. Major changes and `newly_missing` events require human source review before publication. Events default to `public_visible=false`. |
+| Coverage refresh | `supabase/functions/refresh-coverage`, `refresh_institution_cds_coverage()` SQL | `institution_cds_coverage`, coverage statuses | Every 15 minutes | Public coverage can lag archive/extraction by up to one refresh interval. Operator overrides and hosting observations affect status classification. |
+| Public API/frontend | PostgREST at `api.collegedata.fyi`, `browser-search`, Next.js web app | Public views/tables: `cds_documents`, `cds_artifacts`, `cds_fields`, `school_browser_rows`, `school_merit_profile`, reviewed `cds_field_change_events` | On demand | Frontend surfaces curated browser rows, archive downloads, and reviewed change events. Unreviewed PRD 019 events remain operator-only. |
+
+## Tier Routing Summary
+
+| `source_format` | Tier | Producer | Quality expectation | Main failure modes |
+|---|---:|---|---|---|
+| `xlsx` | 1 | `tier1_xlsx` | Very high for standard CDS workbooks | Custom layouts, older templates without a matching schema/template map, sparse section-only workbooks |
+| `pdf_fillable` | 2 | `tier2_acroform` | Very high when form fields are populated | Flattened PDFs route away; visible header fields can be absent from AcroForm data |
+| `docx` | 3 | pending | Expected high once SDT extractor ships | Extractor not built; rows are intentionally failed/stubbed |
+| `pdf_flat` | 4 | `tier4_docling` | Good for launch-certified fields, variable across long tail | Table flattening, merged columns, missing visually present values, section fragments, wrong source files |
+| `pdf_scanned` | 5 | `tier4_docling` with OCR | Variable | OCR misses, noisy scans, slow drains, C1/C9 visual text gaps |
+| `html` | 6 | `tier6_html` | Good for structured HTML tables | JS-only dashboards, Tableau/PowerBI shells, incomplete HTML snapshots |
+| `other` | none | none | Not extractable | Wrong file, challenge HTML, unsupported content, bad archive bytes |
+
+## Freshness and Redrain Rules
+
+- **Source freshness starts at discovery.** The archive pipeline preserves bytes
+  as soon as a CDS-ish file is found. If the source bytes change, the document is
+  marked `extraction_pending` again.
+- **Content year wins.** URL year guesses are resolver hints only. The worker
+  writes `cds_documents.detected_year` from document content, and browser rows
+  use the resolved canonical year.
+- **Producer version is the redrain key.** Cleaner or extractor behavior changes
+  must bump `producer_version`; otherwise the worker can correctly skip a row as
+  already extracted.
+- **Projection is separate from extraction.** A new canonical artifact is not
+  useful to the website until `cds_fields` and `school_browser_rows` are refreshed.
+  Worker drains do this incrementally unless `--skip-projection-refresh` is set.
+- **Canary fixes should be corpus fixes.** When a visible extraction bug is found,
+  audit for similar artifacts, redrain the whole candidate set, and re-run the
+  serving projection.
+- **Finder/source fixes should cover time.** When a source discovery issue is
+  found, find the most recent two years if available, archive/backfill both, and
+  add a durable hint or override so the next year is findable.
+
+## Known Operational Blind Spots
+
+| Blind spot | Current mitigation |
+|---|---|
+| Schools publish on Box, Drive, SharePoint, Tableau, PowerBI, or WAF-protected hosts | Add `school_overrides.yaml` hints, use WAF-aware/manual downloads, or upload operator-exported PDFs/XLSX files. |
+| Public landing page lists sections instead of full CDS | Prefer full `*_All.pdf`/`*_Full.pdf` when available; otherwise archive relevant Section C/H files with clear section scope. Future work may merge section PDFs. |
+| Wrong-campus or wrong-source files | Add source-mapping overrides and reject notes, e.g. OSU Columbus vs Wooster/ATI, UW Seattle vs Tacoma/Bothell, Penn CDS vs commondataset.org template docs. |
+| Current year is not public yet | Record the official landing page and notes. Treat as `targetable_gap` rather than extraction failure. Recheck during publication season. |
+| Tier 4 stale artifacts after cleaner improvements | Use freshness audits to identify stale `tier4_docling` versions and targeted redrain document IDs. |
+| Major PRD 019 changes can be real but surprising | Require PDF/source review before narrative reporting, especially for large C1 applicant/admit/enrollment deltas and `newly_missing` fields. |
+| Public data cannot answer unique-student demand by itself | CDS C1 applicant counts are per-school application counts, not deduplicated people. Aggregate application totals answer application volume, not birth-cohort demand directly. |
+
+## Common Operator Commands
+
+```bash
+# Freshness audit for the Top 200 watchlist.
+/Users/santhonys/docling-eval/bin/python \
+  tools/change_intelligence/audit_watchlist_freshness.py \
+  --env /path/to/.env \
+  --watchlist data/watchlists/top_200_change_intelligence.yaml \
+  --from-year 2024 \
+  --to-year 2025 \
+  --out-dir .context/reports/prd019-top200-current-analysis
+
+# Project PRD 019 candidate events without publishing them.
+/Users/santhonys/docling-eval/bin/python \
+  tools/change_intelligence/project_change_events.py \
+  --env /path/to/.env \
+  --from-year 2024 \
+  --to-year 2025 \
+  --watchlist data/watchlists/top_200_change_intelligence.yaml \
+  --csv .context/reports/change-events.csv \
+  --report .context/reports/change-events.md \
+  --summary-json .context/reports/change-events-summary.json
+
+# Targeted extraction redrain after a cleaner/version bump.
+/Users/santhonys/docling-eval/bin/python \
+  tools/extraction_worker/worker.py \
+  --env /path/to/.env \
+  --requeue-document-ids <uuid>,<uuid> \
+  --document-ids <uuid>,<uuid> \
+  --min-year-start 2024 \
+  --seed-projection-metadata \
+  --summary-json .context/reports/redrain-summary.json
+
+# Full browser projection rebuild after a projection/schema change.
+python tools/browser_backend/project_browser_data.py --full-rebuild --apply
+```
+

--- a/supabase/functions/archive-enqueue/index.ts
+++ b/supabase/functions/archive-enqueue/index.ts
@@ -1,21 +1,20 @@
-// archive-enqueue — monthly seeder for the archive pipeline.
+// archive-enqueue — cadence-aware seeder for the archive pipeline.
 //
 // Invoked daily by pg_cron (PR 5). The daily cadence (rather than monthly)
 // exists so a transient schools.yaml fetch failure on any given day
-// self-heals on the next tick, instead of losing a whole month of
-// enqueueing. Idempotency is guaranteed by a deterministic run_id derived
-// from the current calendar month: within a month, repeated calls are
-// no-ops for rows that already landed, because the archive_queue
-// UNIQUE (enqueued_run_id, school_id) constraint fires under ignoreDuplicates
-// and skips them.
+// self-heals on the next tick. Idempotency is guaranteed by a deterministic
+// run_id: weekly during March-June freshness season, monthly the rest of
+// the year. Repeated calls within the same cadence bucket are no-ops for
+// rows that already landed, because the archive_queue UNIQUE
+// (enqueued_run_id, school_id) constraint fires under ignoreDuplicates and
+// skips them.
 //
-// At the start of each new calendar month, run_id changes, which seeds a
-// fresh batch alongside any unprocessed rows from the prior month.
-// archive-process claims in enqueued_at order so older batches drain
-// first.
+// At the start of each new cadence bucket, run_id changes, which seeds a
+// fresh batch alongside any unprocessed rows from the prior bucket.
+// archive-process claims in enqueued_at order so older batches drain first.
 //
 // Operator retry semantics: re-running archive-enqueue within the same
-// calendar month is a no-op for existing rows, including rows that are
+// cadence bucket is a no-op for existing rows, including rows that are
 // currently in status='failed_permanent'. This is deliberate. To retry
 // a specific failed row, use the archive-process operator backfill:
 //
@@ -39,10 +38,11 @@ import {
   fetchSchoolsYaml,
   filterArchivable,
 } from "../_shared/schools.ts";
+import { ProbeOutcome } from "../_shared/probe_outcome.ts";
 import {
-  DEFAULT_COOLDOWN_DAYS,
-  ProbeOutcome,
-} from "../_shared/probe_outcome.ts";
+  archiveCooldownDaysForOutcome,
+  archiveEnqueueRunId,
+} from "./schedule.ts";
 
 Deno.serve(async (req: Request) => {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -58,14 +58,15 @@ Deno.serve(async (req: Request) => {
 
   const supabase = createClient(supabaseUrl, serviceRoleKey);
 
-  // run_id is deterministic on the calendar month (UTC). Daily cron calls
-  // within the same month collide on the unique (run_id, school_id) index
-  // and no-op via ignoreDuplicates. At the start of a new month, run_id
-  // changes, seeding a fresh batch. Operators can override via ?run_id=...
-  // when manually reprocessing or testing.
+  // run_id is deterministic on the cadence bucket (UTC): weekly during
+  // March-June freshness season, monthly otherwise. Daily cron calls within
+  // the same bucket collide on the unique (run_id, school_id) index and no-op
+  // via ignoreDuplicates. Operators can override via ?run_id=... when manually
+  // reprocessing or testing.
   const url = new URL(req.url);
   const overrideRunId = url.searchParams.get("run_id");
-  const runId = overrideRunId ?? await monthlyRunId(new Date());
+  const now = new Date();
+  const runId = overrideRunId ?? await archiveEnqueueRunId(now);
 
   const started = Date.now();
   logEvent({ event: "enqueue_start", run_id: runId });
@@ -109,10 +110,10 @@ Deno.serve(async (req: Request) => {
   }
 
   // Cooldown: skip schools whose most recent terminal row has an
-  // outcome whose DEFAULT_COOLDOWN_DAYS window hasn't elapsed yet.
+  // outcome whose archive cadence window hasn't elapsed yet.
   // PR 2 expanded this from a single hardcoded check on
   // unchanged_verified to a per-outcome policy:
-  //   unchanged_verified → 30d
+  //   unchanged_verified → 7d during March-June, 30d otherwise
   //   auth_walled_*      → 90d (rarely change)
   //   dead_url           → 14d (schools fix broken URLs in days/weeks)
   //   no_pdfs_found      → 14d
@@ -182,11 +183,12 @@ Deno.serve(async (req: Request) => {
           });
         }
       }
-      const now = Date.now();
+      const nowMs = now.getTime();
       for (const [schoolId, latest] of latestBySchool) {
-        const cooldownDays = uniformDays ?? DEFAULT_COOLDOWN_DAYS[latest.last_outcome] ?? 0;
+        const cooldownDays = uniformDays ??
+          archiveCooldownDaysForOutcome(latest.last_outcome, now);
         if (cooldownDays <= 0) continue;
-        const elapsedMs = now - new Date(latest.processed_at).getTime();
+        const elapsedMs = nowMs - new Date(latest.processed_at).getTime();
         if (elapsedMs < cooldownDays * 24 * 60 * 60 * 1000) {
           inCooldown.add(schoolId);
         }
@@ -286,30 +288,6 @@ Deno.serve(async (req: Request) => {
   });
 });
 
-// Deterministic UUID derived from the (year, month) of the supplied date.
-// Ensures repeated archive-enqueue calls within the same calendar month
-// collide on the unique (run_id, school_id) index so existing rows are
-// no-ops and only new schools land. First byte of the uuid v5-style layout
-// is tagged with namespace string 'archive-enqueue:' so a future skill
-// or tool with a different key doesn't collide with our namespace.
-async function monthlyRunId(now: Date): Promise<string> {
-  const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
-  const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");
-  const key = `archive-enqueue:${yyyy}-${mm}`;
-  const data = new TextEncoder().encode(key);
-  const hashBuf = await crypto.subtle.digest("SHA-256", data);
-  const hex = Array.from(new Uint8Array(hashBuf).slice(0, 16))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return (
-    hex.slice(0, 8) + "-" +
-    hex.slice(8, 12) + "-" +
-    hex.slice(12, 16) + "-" +
-    hex.slice(16, 20) + "-" +
-    hex.slice(20, 32)
-  );
-}
-
 function logEvent(payload: Record<string, unknown>): void {
   console.log(JSON.stringify({
     ts: new Date().toISOString(),
@@ -331,7 +309,10 @@ function json(body: unknown, status = 200): Response {
 // Accept both service-role credential formats. See archive-process/index.ts
 // for the full explanation — legacy JWT (eyJ...) and new sb_secret_ format
 // both need to work during the Supabase key rotation transition window.
-function isServiceRoleAuth(authHeader: string, envServiceRoleKey: string): boolean {
+function isServiceRoleAuth(
+  authHeader: string,
+  envServiceRoleKey: string,
+): boolean {
   if (!authHeader.startsWith("Bearer ")) return false;
   const token = authHeader.slice(7).trim();
   if (!token) return false;

--- a/supabase/functions/archive-enqueue/schedule.test.ts
+++ b/supabase/functions/archive-enqueue/schedule.test.ts
@@ -1,0 +1,77 @@
+import { assertEquals, assertNotEquals } from "jsr:@std/assert";
+
+import {
+  archiveCooldownDaysForOutcome,
+  archiveEnqueueRunId,
+  archiveEnqueueRunKey,
+  isFreshnessSeason,
+} from "./schedule.ts";
+
+Deno.test("archiveEnqueueRunKey uses weekly buckets during March-June freshness season", () => {
+  assertEquals(
+    archiveEnqueueRunKey(new Date("2026-05-08T02:00:00Z")),
+    "archive-enqueue:2026-W19",
+  );
+  assertEquals(
+    archiveEnqueueRunKey(new Date("2026-05-11T02:00:00Z")),
+    "archive-enqueue:2026-W20",
+  );
+});
+
+Deno.test("archiveEnqueueRunKey keeps monthly buckets outside freshness season", () => {
+  assertEquals(
+    archiveEnqueueRunKey(new Date("2026-02-28T02:00:00Z")),
+    "archive-enqueue:2026-02",
+  );
+  assertEquals(
+    archiveEnqueueRunKey(new Date("2026-07-01T02:00:00Z")),
+    "archive-enqueue:2026-07",
+  );
+});
+
+Deno.test("isFreshnessSeason includes March through June in UTC", () => {
+  assertEquals(isFreshnessSeason(new Date("2026-02-28T23:59:59Z")), false);
+  assertEquals(isFreshnessSeason(new Date("2026-03-01T00:00:00Z")), true);
+  assertEquals(isFreshnessSeason(new Date("2026-06-30T23:59:59Z")), true);
+  assertEquals(isFreshnessSeason(new Date("2026-07-01T00:00:00Z")), false);
+});
+
+Deno.test("archiveCooldownDaysForOutcome shortens only unchanged_verified during freshness season", () => {
+  assertEquals(
+    archiveCooldownDaysForOutcome(
+      "unchanged_verified",
+      new Date("2026-05-08T02:00:00Z"),
+    ),
+    7,
+  );
+  assertEquals(
+    archiveCooldownDaysForOutcome(
+      "unchanged_verified",
+      new Date("2026-10-08T02:00:00Z"),
+    ),
+    30,
+  );
+  assertEquals(
+    archiveCooldownDaysForOutcome(
+      "auth_walled_microsoft",
+      new Date("2026-05-08T02:00:00Z"),
+    ),
+    90,
+  );
+  assertEquals(
+    archiveCooldownDaysForOutcome(
+      "transient",
+      new Date("2026-05-08T02:00:00Z"),
+    ),
+    0,
+  );
+});
+
+Deno.test("archiveEnqueueRunId remains deterministic and changes across weekly freshness buckets", async () => {
+  const first = await archiveEnqueueRunId(new Date("2026-05-08T02:00:00Z"));
+  const repeat = await archiveEnqueueRunId(new Date("2026-05-10T02:00:00Z"));
+  const nextWeek = await archiveEnqueueRunId(new Date("2026-05-11T02:00:00Z"));
+
+  assertEquals(first, repeat);
+  assertNotEquals(first, nextWeek);
+});

--- a/supabase/functions/archive-enqueue/schedule.ts
+++ b/supabase/functions/archive-enqueue/schedule.ts
@@ -1,0 +1,66 @@
+import {
+  DEFAULT_COOLDOWN_DAYS,
+  ProbeOutcome,
+} from "../_shared/probe_outcome.ts";
+
+const FRESHNESS_SEASON_START_MONTH = 3;
+const FRESHNESS_SEASON_END_MONTH = 6;
+const FRESHNESS_SEASON_UNCHANGED_COOLDOWN_DAYS = 7;
+
+export function isFreshnessSeason(now: Date): boolean {
+  const month = now.getUTCMonth() + 1;
+  return month >= FRESHNESS_SEASON_START_MONTH &&
+    month <= FRESHNESS_SEASON_END_MONTH;
+}
+
+export function archiveEnqueueRunKey(now: Date): string {
+  if (isFreshnessSeason(now)) {
+    const { year, week } = isoWeek(now);
+    return `archive-enqueue:${year}-W${week.toString().padStart(2, "0")}`;
+  }
+
+  const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
+  const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");
+  return `archive-enqueue:${yyyy}-${mm}`;
+}
+
+export async function archiveEnqueueRunId(now: Date): Promise<string> {
+  const data = new TextEncoder().encode(archiveEnqueueRunKey(now));
+  const hashBuf = await crypto.subtle.digest("SHA-256", data);
+  const hex = Array.from(new Uint8Array(hashBuf).slice(0, 16))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return (
+    hex.slice(0, 8) + "-" +
+    hex.slice(8, 12) + "-" +
+    hex.slice(12, 16) + "-" +
+    hex.slice(16, 20) + "-" +
+    hex.slice(20, 32)
+  );
+}
+
+export function archiveCooldownDaysForOutcome(
+  outcome: ProbeOutcome,
+  now: Date,
+): number {
+  if (outcome === "unchanged_verified" && isFreshnessSeason(now)) {
+    return FRESHNESS_SEASON_UNCHANGED_COOLDOWN_DAYS;
+  }
+  return DEFAULT_COOLDOWN_DAYS[outcome] ?? 0;
+}
+
+function isoWeek(now: Date): { year: number; week: number } {
+  const date = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  ));
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const year = date.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil(
+    (((date.getTime() - yearStart.getTime()) / 86400000) + 1) / 7,
+  );
+  return { year, week };
+}

--- a/supabase/functions/archive-process/index.ts
+++ b/supabase/functions/archive-process/index.ts
@@ -37,6 +37,13 @@ import {
   resolveSchoolName,
   UnknownSchoolError,
 } from "../_shared/schools.ts";
+import {
+  buildAttemptBudgetExhaustedUpdate,
+  hasExceededAttemptBudget,
+  isEmptyClaimResult,
+  MAX_ATTEMPTS,
+  type ArchiveQueueRow,
+} from "./queue.ts";
 
 // Relaxed client typing. supabase-js v2's strict generics collapse to never
 // when no Database type parameter is supplied, which breaks .update() with
@@ -44,22 +51,6 @@ import {
 // restores ergonomic typing for this project.
 // deno-lint-ignore no-explicit-any
 type Client = SupabaseClient<any, any, any>;
-
-const MAX_ATTEMPTS = 3;
-
-interface ArchiveQueueRow {
-  id: string;
-  enqueued_run_id: string;
-  school_id: string;
-  school_name: string;
-  cds_url_hint: string;
-  status: string;
-  attempts: number;
-  last_error: string | null;
-  enqueued_at: string;
-  claimed_at: string | null;
-  processed_at: string | null;
-}
 
 Deno.serve(async (req: Request) => {
   // ── Auth: require the service role key via Bearer ────────────────────
@@ -232,7 +223,7 @@ async function runQueueClaim(
     return json({ error: `claim failed: ${claimErr.message}` }, 500);
   }
 
-  if (!claimed) {
+  if (isEmptyClaimResult(claimed)) {
     logEvent({ event: "queue_drained" });
     return json({ status: "queue_drained" });
   }
@@ -255,6 +246,41 @@ async function runQueueClaim(
     return json({ error: "RPC returned row with null claimed_at" }, 500);
   }
   const claimLease: string = row.claimed_at;
+
+  if (hasExceededAttemptBudget(row)) {
+    const update = buildAttemptBudgetExhaustedUpdate(
+      row,
+      new Date().toISOString(),
+    );
+    const { error: updErr } = await supabase
+      .from("archive_queue")
+      .update(update)
+      .eq("id", row.id)
+      .eq("claimed_at", claimLease);
+    if (updErr) {
+      logEvent({
+        event: "attempt_budget_terminal_update_failed",
+        id: row.id,
+        school_id: row.school_id,
+        attempts,
+        error: updErr.message,
+      });
+      return json({ error: `terminal update failed: ${updErr.message}` }, 500);
+    }
+    logEvent({
+      event: "attempt_budget_exhausted",
+      id: row.id,
+      school_id: row.school_id,
+      attempts,
+    });
+    return json({
+      status: "failed_permanent",
+      reason: "attempt_budget_exhausted_before_processing",
+      school_id: row.school_id,
+      attempts,
+    });
+  }
+
   let finalStatus: "ready" | "done" | "failed_permanent" = "ready";
   let finalError: string | null = null;
   let outcome: ArchiveOutcome | null = null;

--- a/supabase/functions/archive-process/queue.test.ts
+++ b/supabase/functions/archive-process/queue.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildAttemptBudgetExhaustedUpdate,
+  hasExceededAttemptBudget,
+  isEmptyClaimResult,
+  MAX_ATTEMPTS,
+} from "./queue.ts";
+
+Deno.test("isEmptyClaimResult treats null-like composite rows as queue drained", () => {
+  if (!isEmptyClaimResult(null)) {
+    throw new Error("null should be empty");
+  }
+  if (!isEmptyClaimResult({ id: null, school_id: null, claimed_at: null })) {
+    throw new Error("all-null composite should be empty");
+  }
+  if (!isEmptyClaimResult([{ id: null, school_id: null, claimed_at: null }])) {
+    throw new Error("all-null composite array should be empty");
+  }
+});
+
+Deno.test("isEmptyClaimResult keeps real claimed rows", () => {
+  if (isEmptyClaimResult({
+    id: "row-1",
+    school_id: "example-school",
+    claimed_at: "2026-05-07T00:00:00Z",
+  })) {
+    throw new Error("real row should not be empty");
+  }
+});
+
+Deno.test("hasExceededAttemptBudget only short-circuits rows past the retry budget", () => {
+  if (hasExceededAttemptBudget({ attempts: MAX_ATTEMPTS })) {
+    throw new Error("final allowed attempt should still run");
+  }
+  if (!hasExceededAttemptBudget({ attempts: MAX_ATTEMPTS + 1 })) {
+    throw new Error("attempts past budget should short-circuit");
+  }
+});
+
+Deno.test("buildAttemptBudgetExhaustedUpdate marks poison rows terminal", () => {
+  const update = buildAttemptBudgetExhaustedUpdate(
+    { attempts: 2701 },
+    "2026-05-07T18:00:00Z",
+  );
+
+  if (update.status !== "failed_permanent") {
+    throw new Error(`unexpected status ${update.status}`);
+  }
+  if (update.last_outcome !== "transient") {
+    throw new Error(`unexpected last_outcome ${update.last_outcome}`);
+  }
+  if (update.processed_at !== "2026-05-07T18:00:00Z") {
+    throw new Error(`unexpected processed_at ${update.processed_at}`);
+  }
+  if (!String(update.last_error).includes("reclaimed 2701 times")) {
+    throw new Error(`unexpected last_error ${update.last_error}`);
+  }
+});

--- a/supabase/functions/archive-process/queue.ts
+++ b/supabase/functions/archive-process/queue.ts
@@ -1,0 +1,51 @@
+export const MAX_ATTEMPTS = 3;
+
+export interface ArchiveQueueRow {
+  id: string;
+  enqueued_run_id: string;
+  school_id: string;
+  school_name: string;
+  cds_url_hint: string;
+  status: string;
+  attempts: number;
+  last_error: string | null;
+  enqueued_at: string;
+  claimed_at: string | null;
+  processed_at: string | null;
+}
+
+export function isEmptyClaimResult(claimed: unknown): boolean {
+  if (claimed == null) return true;
+
+  if (Array.isArray(claimed)) {
+    return claimed.length === 0 || isEmptyClaimResult(claimed[0]);
+  }
+
+  if (typeof claimed !== "object") return false;
+
+  const row = claimed as Partial<ArchiveQueueRow>;
+  return row.id == null && row.school_id == null && row.claimed_at == null;
+}
+
+export function hasExceededAttemptBudget(
+  row: Pick<ArchiveQueueRow, "attempts">,
+  maxAttempts = MAX_ATTEMPTS,
+): boolean {
+  return (row.attempts ?? 0) > maxAttempts;
+}
+
+export function buildAttemptBudgetExhaustedUpdate(
+  row: Pick<ArchiveQueueRow, "attempts">,
+  processedAt: string,
+  maxAttempts = MAX_ATTEMPTS,
+): Record<string, unknown> {
+  const attempts = row.attempts ?? 0;
+  return {
+    status: "failed_permanent",
+    processed_at: processedAt,
+    last_outcome: "transient",
+    last_error:
+      `exhausted ${maxAttempts} attempts before processing ` +
+      `(row was reclaimed ${attempts} times without a terminal update, likely prior edge-function timeout)`,
+  };
+}

--- a/tools/ops/automation_health.py
+++ b/tools/ops/automation_health.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""One-command health check for automated archive/extraction workers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import urllib.parse
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ENV = Path("/Users/santhonys/Projects/Owen/colleges/collegedata-fyi/.env")
+DEFAULT_POOLER_URL = Path("supabase/.temp/pooler-url")
+DEFAULT_REPO = "bolewood/collegedata-fyi"
+CRON_JOBS = (
+    "archive-enqueue-daily",
+    "archive-process-every-30s",
+    "refresh-coverage-every-15min",
+)
+
+
+class HealthError(RuntimeError):
+    """Raised when the health check cannot inspect production state."""
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def parse_time(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    value = raw.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def hours_since(raw: str | None, now: datetime) -> float | None:
+    parsed = parse_time(raw)
+    if parsed is None:
+        return None
+    return max(0.0, (now - parsed).total_seconds() / 3600)
+
+
+def json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def rows_to_dicts(cursor: Any) -> list[dict[str, Any]]:
+    columns = [column.name for column in cursor.description]
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+
+def pooler_dsn(env: dict[str, str], pooler_url_path: Path) -> str:
+    database_url = env.get("DATABASE_URL")
+    password = env.get("SUPABASE_DB_PASSWORD")
+    if not password:
+        raise HealthError("SUPABASE_DB_PASSWORD is required for cron/net health queries.")
+    if pooler_url_path.exists():
+        parsed = urllib.parse.urlparse(pooler_url_path.read_text(encoding="utf-8").strip())
+    elif database_url:
+        parsed = urllib.parse.urlparse(database_url)
+    else:
+        raise HealthError(f"Missing {pooler_url_path} and DATABASE_URL.")
+    user = parsed.username or "postgres"
+    encoded_password = urllib.parse.quote(password, safe="")
+    port = parsed.port or 5432
+    return f"{parsed.scheme}://{user}:{encoded_password}@{parsed.hostname}:{port}{parsed.path}?sslmode=require"
+
+
+def http_content_category(content: str | None, status_code: int | None) -> str:
+    body = content or ""
+    if "RPC returned row with null claimed_at" in body:
+        return "archive_process_null_claim"
+    if "IDLE_TIMEOUT" in body or "Request idle timeout" in body:
+        return "edge_idle_timeout"
+    if "queue_drained" in body:
+        return "archive_process_queue_drained"
+    if "attempt_budget_exhausted_before_processing" in body:
+        return "archive_process_attempt_budget_exhausted"
+    if "rows_written" in body and "coverage_status_histogram" in body:
+        return "refresh_coverage"
+    if status_code and 200 <= status_code < 300:
+        return "success_other"
+    return "error_other"
+
+
+def fetch_db_health(dsn: str, *, hours: int) -> dict[str, Any]:
+    try:
+        import psycopg  # type: ignore
+    except ImportError as exc:
+        raise HealthError("Install psycopg first: python3 -m pip install 'psycopg[binary]'") from exc
+
+    queries: dict[str, tuple[str, tuple[Any, ...]]] = {
+        "cron_jobs": (
+            """
+            select jobid, jobname, schedule, active
+            from cron.job
+            where jobname = any(%s)
+            order by jobname
+            """,
+            (list(CRON_JOBS),),
+        ),
+        "cron_recent_summary": (
+            """
+            select j.jobname, r.status, count(*) as n,
+                   max(r.start_time) as last_start, max(r.end_time) as last_end
+            from cron.job_run_details r
+            join cron.job j on j.jobid = r.jobid
+            where r.start_time >= now() - (%s || ' hours')::interval
+              and j.jobname = any(%s)
+            group by j.jobname, r.status
+            order by j.jobname, r.status
+            """,
+            (hours, list(CRON_JOBS)),
+        ),
+        "cron_recent_failures": (
+            """
+            select j.jobname, r.status, r.start_time, r.end_time,
+                   left(coalesce(r.return_message, ''), 500) as message
+            from cron.job_run_details r
+            join cron.job j on j.jobid = r.jobid
+            where r.start_time >= now() - (%s || ' hours')::interval
+              and j.jobname = any(%s)
+              and r.status <> 'succeeded'
+            order by r.start_time desc
+            limit 20
+            """,
+            (hours, list(CRON_JOBS)),
+        ),
+        "http_responses": (
+            """
+            select status_code, timed_out, left(coalesce(content, ''), 220) as content, count(*) as n,
+                   min(created) as first_created, max(created) as last_created
+            from net._http_response
+            where created >= now() - (%s || ' hours')::interval
+            group by status_code, timed_out, left(coalesce(content, ''), 220)
+            order by n desc
+            """,
+            (hours,),
+        ),
+        "archive_queue_recent": (
+            """
+            select status, coalesce(last_outcome, '(null)') as last_outcome, source,
+                   count(*) as n, max(processed_at) as last_processed
+            from public.archive_queue
+            where processed_at >= now() - (%s || ' hours')::interval
+            group by status, coalesce(last_outcome, '(null)'), source
+            order by n desc
+            """,
+            (hours,),
+        ),
+        "archive_queue_open": (
+            """
+            select id, school_id, school_name, status, attempts, source,
+                   enqueued_at, claimed_at, left(coalesce(last_error, ''), 240) as last_error
+            from public.archive_queue
+            where status in ('ready', 'processing')
+            order by coalesce(claimed_at, enqueued_at) asc
+            limit 30
+            """,
+            (),
+        ),
+        "documents_recent": (
+            """
+            select extraction_status, count(*) as n, max(updated_at) as last_updated
+            from public.cds_documents
+            where updated_at >= now() - (%s || ' hours')::interval
+            group by extraction_status
+            order by n desc
+            """,
+            (hours,),
+        ),
+        "artifacts_recent": (
+            """
+            select kind, producer, producer_version, count(*) as n,
+                   min(created_at) as first_created, max(created_at) as last_created
+            from public.cds_artifacts
+            where created_at >= now() - (%s || ' hours')::interval
+            group by kind, producer, producer_version
+            order by n desc
+            """,
+            (hours,),
+        ),
+        "coverage_refresh": (
+            """
+            select count(*) as rows, min(updated_at) as oldest_updated, max(updated_at) as newest_updated
+            from public.institution_cds_coverage
+            """,
+            (),
+        ),
+        "coverage_histogram": (
+            """
+            select coverage_status, count(*) as n
+            from public.institution_cds_coverage
+            group by coverage_status
+            order by n desc
+            """,
+            (),
+        ),
+        "pending_documents": (
+            """
+            select extraction_status, count(*) as n
+            from public.cds_documents
+            where extraction_status in ('extraction_pending', 'discovered', 'failed')
+            group by extraction_status
+            order by extraction_status
+            """,
+            (),
+        ),
+        "bot_challenged": (
+            """
+            select count(*) as n, max(last_challenge_at) as latest
+            from public.bot_challenged_documents
+            """,
+            (),
+        ),
+    }
+
+    out: dict[str, Any] = {}
+    with psycopg.connect(dsn, connect_timeout=20) as conn:
+        for name, (sql, params) in queries.items():
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                out[name] = rows_to_dicts(cur)
+
+    category_counts: Counter[str] = Counter()
+    for row in out["http_responses"]:
+        category_counts[http_content_category(row.get("content"), row.get("status_code"))] += int(row["n"])
+    out["http_response_categories"] = dict(sorted(category_counts.items()))
+    return out
+
+
+def fetch_github_actions(*, repo: str, hours: int, limit: int) -> dict[str, Any]:
+    if not shutil.which("gh"):
+        return {"available": False, "error": "gh not found"}
+    command = [
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--limit",
+        str(limit),
+        "--json",
+        "databaseId,workflowName,event,status,conclusion,createdAt,updatedAt,headBranch,url,displayTitle",
+    ]
+    completed = subprocess.run(command, text=True, capture_output=True, timeout=45)
+    if completed.returncode != 0:
+        return {"available": False, "error": completed.stderr.strip() or completed.stdout.strip()}
+    runs = json.loads(completed.stdout or "[]")
+    now = datetime.now(timezone.utc)
+    cutoff_hours = float(hours)
+    recent = [
+        run for run in runs
+        if (age := hours_since(run.get("createdAt"), now)) is not None and age <= cutoff_hours
+    ]
+    by_workflow: dict[str, Counter[str]] = {}
+    for run in recent:
+        workflow = run.get("workflowName") or "unknown"
+        conclusion = run.get("conclusion") or run.get("status") or "unknown"
+        by_workflow.setdefault(workflow, Counter())[conclusion] += 1
+    latest_by_workflow: dict[str, dict[str, Any]] = {}
+    for run in recent:
+        workflow = run.get("workflowName") or "unknown"
+        current = latest_by_workflow.get(workflow)
+        if current is None or str(run.get("createdAt")) > str(current.get("createdAt")):
+            latest_by_workflow[workflow] = run
+    return {
+        "available": True,
+        "recent_runs": recent,
+        "by_workflow": {k: dict(v) for k, v in sorted(by_workflow.items())},
+        "latest_by_workflow": latest_by_workflow,
+    }
+
+
+def evaluate(report: dict[str, Any], now: datetime) -> list[str]:
+    issues: list[str] = []
+    db = report["database"]
+
+    inactive = [row["jobname"] for row in db["cron_jobs"] if not row.get("active")]
+    if inactive:
+        issues.append(f"inactive cron jobs: {', '.join(inactive)}")
+
+    if db["cron_recent_failures"]:
+        issues.append(f"{len(db['cron_recent_failures'])} pg_cron failures in window")
+
+    categories = db.get("http_response_categories", {})
+    bad_http = {
+        key: value
+        for key, value in categories.items()
+        if key not in {
+            "refresh_coverage",
+            "archive_process_queue_drained",
+            "archive_process_attempt_budget_exhausted",
+            "success_other",
+        }
+    }
+    if bad_http:
+        issues.append(f"edge HTTP errors: {bad_http}")
+
+    open_rows = db["archive_queue_open"]
+    poison = [
+        row for row in open_rows
+        if row.get("status") == "processing" and int(row.get("attempts") or 0) > 3
+    ]
+    if poison:
+        schools = ", ".join(str(row.get("school_id")) for row in poison[:5])
+        issues.append(f"archive queue poison rows over retry budget: {schools}")
+
+    coverage = (db["coverage_refresh"] or [{}])[0]
+    coverage_age = hours_since(json_default(coverage.get("newest_updated")), now)
+    if coverage_age is None or coverage_age > 0.5:
+        issues.append(f"coverage refresh stale: {coverage_age if coverage_age is not None else 'unknown'} hours")
+
+    gha = report.get("github_actions") or {}
+    if gha.get("available"):
+        failed = [
+            run for run in gha.get("recent_runs", [])
+            if run.get("status") == "completed" and run.get("conclusion") not in ("success", "skipped")
+        ]
+        if failed:
+            issues.append(f"{len(failed)} GitHub Actions runs failed in window")
+    else:
+        issues.append(f"GitHub Actions unavailable: {gha.get('error')}")
+
+    return issues
+
+
+def render_markdown(report: dict[str, Any], issues: list[str]) -> str:
+    db = report["database"]
+    gha = report.get("github_actions") or {}
+    verdict = "ATTENTION" if issues else "HEALTHY"
+    lines = [
+        f"# Automation Health: {verdict}",
+        "",
+        f"- Generated: `{report['generated_at']}`",
+        f"- Window: `{report['hours']}h`",
+    ]
+    if issues:
+        lines.append("- Issues:")
+        lines.extend(f"  - {issue}" for issue in issues)
+    lines.extend(["", "## GitHub Actions"])
+    if gha.get("available"):
+        for workflow, counts in gha.get("by_workflow", {}).items():
+            latest = gha.get("latest_by_workflow", {}).get(workflow, {})
+            lines.append(
+                f"- `{workflow}`: {counts}; latest `{latest.get('conclusion') or latest.get('status')}` "
+                f"at `{latest.get('createdAt')}`"
+            )
+    else:
+        lines.append(f"- unavailable: {gha.get('error')}")
+
+    lines.extend(["", "## Cron Jobs"])
+    for row in db["cron_jobs"]:
+        lines.append(f"- `{row['jobname']}`: active={row['active']} schedule=`{row['schedule']}`")
+    lines.append("")
+    lines.append("Recent cron summaries:")
+    for row in db["cron_recent_summary"]:
+        lines.append(f"- `{row['jobname']}` `{row['status']}`: {row['n']} latest `{json_default(row['last_end'])}`")
+
+    lines.extend(["", "## Edge HTTP Responses"])
+    for category, count in db.get("http_response_categories", {}).items():
+        lines.append(f"- `{category}`: {count}")
+
+    lines.extend(["", "## Archive Queue"])
+    if db["archive_queue_open"]:
+        for row in db["archive_queue_open"][:10]:
+            lines.append(
+                f"- `{row['school_id']}` `{row['status']}` attempts={row['attempts']} "
+                f"claimed=`{json_default(row['claimed_at'])}`"
+            )
+    else:
+        lines.append("- no ready/processing rows")
+    lines.append("")
+    lines.append("Recent terminal outcomes:")
+    if db["archive_queue_recent"]:
+        for row in db["archive_queue_recent"]:
+            lines.append(f"- `{row['status']}` `{row['last_outcome']}` source=`{row['source']}`: {row['n']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Extraction And Coverage"])
+    lines.append("- Recent document updates:")
+    if db["documents_recent"]:
+        for row in db["documents_recent"]:
+            lines.append(
+                f"  - `{row['extraction_status']}`: {row['n']} latest `{json_default(row['last_updated'])}`"
+            )
+    else:
+        lines.append("  - none")
+    lines.append("- Recent artifacts:")
+    if db["artifacts_recent"]:
+        for row in db["artifacts_recent"]:
+            lines.append(
+                f"  - `{row['kind']}` `{row['producer']}` `{row['producer_version']}`: "
+                f"{row['n']} latest `{json_default(row['last_created'])}`"
+            )
+    else:
+        lines.append("  - none")
+    lines.append("- Pending/discovered/failed docs:")
+    if db["pending_documents"]:
+        for row in db["pending_documents"]:
+            lines.append(f"  - `{row['extraction_status']}`: {row['n']}")
+    else:
+        lines.append("  - none")
+    coverage = (db["coverage_refresh"] or [{}])[0]
+    lines.append(
+        f"- Coverage rows: `{coverage.get('rows')}`, refreshed `{json_default(coverage.get('newest_updated'))}`"
+    )
+    lines.append("- Coverage histogram:")
+    for row in db["coverage_histogram"]:
+        lines.append(f"  - `{row['coverage_status']}`: {row['n']}")
+    bot = (db["bot_challenged"] or [{}])[0]
+    lines.append(f"- Bot-challenged docs: `{bot.get('n', 0)}` latest `{json_default(bot.get('latest'))}`")
+    return "\n".join(lines) + "\n"
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    now = datetime.now(timezone.utc)
+    env = load_env_file(args.env)
+    db = fetch_db_health(pooler_dsn(env, args.pooler_url), hours=args.hours)
+    gha = fetch_github_actions(repo=args.github_repo, hours=args.hours, limit=args.github_limit)
+    report = {
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "hours": args.hours,
+        "database": db,
+        "github_actions": gha,
+    }
+    return report, evaluate(report, now)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", type=Path, default=DEFAULT_ENV)
+    parser.add_argument("--pooler-url", type=Path, default=DEFAULT_POOLER_URL)
+    parser.add_argument("--hours", type=float, default=24.0)
+    parser.add_argument("--github-repo", default=DEFAULT_REPO)
+    parser.add_argument("--github-limit", type=int, default=50)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    parser.add_argument("--fail-on-unhealthy", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        report, issues = build_report(args)
+    except HealthError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    markdown = render_markdown(report, issues)
+    print(markdown)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, default=json_default, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown, encoding="utf-8")
+    return 1 if issues and args.fail_on_unhealthy else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ops/test_automation_health.py
+++ b/tools/ops/test_automation_health.py
@@ -1,0 +1,89 @@
+import unittest
+from datetime import datetime, timezone
+
+from tools.ops import automation_health as health
+
+
+class AutomationHealthTests(unittest.TestCase):
+    def test_http_content_category_classifies_archive_failures(self):
+        self.assertEqual(
+            health.http_content_category('{"error":"RPC returned row with null claimed_at"}', 500),
+            "archive_process_null_claim",
+        )
+        self.assertEqual(
+            health.http_content_category('{"code":"IDLE_TIMEOUT"}', 504),
+            "edge_idle_timeout",
+        )
+        self.assertEqual(
+            health.http_content_category('{"status":"queue_drained"}', 200),
+            "archive_process_queue_drained",
+        )
+        self.assertEqual(
+            health.http_content_category('{"rows_written":6322,"coverage_status_histogram":{}}', 200),
+            "refresh_coverage",
+        )
+
+    def test_evaluate_flags_poison_archive_rows_and_edge_errors(self):
+        now = datetime(2026, 5, 7, 19, 0, tzinfo=timezone.utc)
+        report = {
+            "database": {
+                "cron_jobs": [
+                    {"jobname": "archive-process-every-30s", "active": True},
+                    {"jobname": "refresh-coverage-every-15min", "active": True},
+                ],
+                "cron_recent_failures": [],
+                "http_response_categories": {
+                    "refresh_coverage": 4,
+                    "archive_process_null_claim": 10,
+                },
+                "archive_queue_open": [
+                    {
+                        "school_id": "los-angeles-pacific-university",
+                        "status": "processing",
+                        "attempts": 2701,
+                    }
+                ],
+                "coverage_refresh": [
+                    {"newest_updated": "2026-05-07T18:45:00Z"},
+                ],
+            },
+            "github_actions": {
+                "available": True,
+                "recent_runs": [],
+            },
+        }
+
+        issues = health.evaluate(report, now)
+
+        self.assertTrue(any("edge HTTP errors" in issue for issue in issues))
+        self.assertTrue(any("poison rows" in issue for issue in issues))
+
+    def test_evaluate_accepts_clean_report(self):
+        now = datetime(2026, 5, 7, 19, 0, tzinfo=timezone.utc)
+        report = {
+            "database": {
+                "cron_jobs": [
+                    {"jobname": "archive-process-every-30s", "active": True},
+                    {"jobname": "refresh-coverage-every-15min", "active": True},
+                ],
+                "cron_recent_failures": [],
+                "http_response_categories": {
+                    "refresh_coverage": 4,
+                    "archive_process_queue_drained": 100,
+                },
+                "archive_queue_open": [],
+                "coverage_refresh": [
+                    {"newest_updated": "2026-05-07T18:45:00Z"},
+                ],
+            },
+            "github_actions": {
+                "available": True,
+                "recent_runs": [],
+            },
+        }
+
+        self.assertEqual(health.evaluate(report, now), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -32,7 +32,8 @@ export async function generateMetadata({
   const doc = docs[0];
   const path = `/schools/${school_id}/${year}`;
   const title = `${doc.school_name} Common Data Set ${year}`;
-  const description = `Common Data Set ${year} for ${doc.school_name}. Admissions, enrollment, financial aid, and more, extracted from the official CDS document.`;
+  const description =
+    `View ${doc.school_name} Common Data Set ${year}: official source download plus extracted admissions, enrollment, SAT/ACT, financial aid, and field-level CDS data.`;
 
   return {
     title,

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -55,18 +55,24 @@ export async function generateMetadata({
   }
 
   const name = docs[0].school_name;
+  const coverage = await fetchInstitutionCoverage(school_id);
+  const location = formatLocation(coverage);
   const years = docs
     .map((d) => d.canonical_year)
     .filter((y): y is string => y != null)
     .sort();
   const path = `/schools/${school_id}`;
-  const description = `${docs.length} archived Common Data Set document${docs.length !== 1 ? "s" : ""} for ${name}, ${yearRange(years[0], years[years.length - 1])}.`;
+  const archiveCount = `${docs.length} CDS document${docs.length !== 1 ? "s" : ""}`;
+  const locationLead = location ? ` for ${location}` : "";
+  const description =
+    `Download ${name} Common Data Set files${locationLead}. Browse extracted admissions, enrollment, financial aid, SAT/ACT, and source links. ${archiveCount}, ${yearRange(years[0], years[years.length - 1])}.`;
+  const title = `${name} Common Data Set (CDS) Archive`;
 
   return {
-    title: `${name} - Common Data Set Archive`,
+    title,
     description,
     alternates: { canonical: path },
-    openGraph: { url: path, title: `${name} - Common Data Set Archive`, description },
+    openGraph: { url: path, title, description },
   };
 }
 
@@ -94,6 +100,14 @@ function splitInstitutionalSuffix(name: string): {
     }
   }
   return { head: name, tail: null };
+}
+
+function formatLocation(
+  source: Pick<InstitutionCoverage, "city" | "state"> | null | undefined,
+): string | null {
+  if (!source) return null;
+  const parts = [source.city, source.state].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : null;
 }
 
 // Ascending step series of the school's archived document count over time.
@@ -136,13 +150,22 @@ export default async function SchoolDetailPage({
   // only need the first one. Scorecard data is per-school-per-vintage, not
   // per-document, so one query returns everything.
   const ipedsId = docs.find((d) => d.ipeds_id)?.ipeds_id ?? null;
-  const [scorecard, browserRow, gpaProfile, admissionStrategySchool, meritProfile, changeEvents] = await Promise.all([
+  const [
+    scorecard,
+    browserRow,
+    gpaProfile,
+    admissionStrategySchool,
+    meritProfile,
+    changeEvents,
+    coverage,
+  ] = await Promise.all([
     fetchScorecardByIpedsId(ipedsId),
     fetchBrowserRowBySchoolId(school_id),
     fetchAvgGpaBySchoolId(school_id),
     fetchAdmissionStrategyBySchoolId(school_id),
     fetchMeritProfileBySchoolId(school_id),
     fetchChangeEventsBySchoolId(school_id),
+    fetchInstitutionCoverage(school_id),
   ]);
   const positioningSchool = browserRow
     ? { ...browserRow, ...gpaProfile }
@@ -150,6 +173,7 @@ export default async function SchoolDetailPage({
 
   const name = docs[0].school_name ?? "Unknown school";
   const { head, tail } = splitInstitutionalSuffix(name);
+  const location = formatLocation(coverage);
   const years = docs
     .map((d) => d.canonical_year)
     .filter((y): y is string => y != null)
@@ -185,6 +209,15 @@ export default async function SchoolDetailPage({
       name,
       url: schoolUrl,
       description: `Common Data Set archive for ${name}. ${docs.length} document${docs.length !== 1 ? "s" : ""} archived${years.length > 0 ? `, ${yearRange(years[0], years[years.length - 1])}` : ""}.`,
+      ...(coverage?.city || coverage?.state
+        ? {
+            address: {
+              "@type": "PostalAddress",
+              addressLocality: coverage.city ?? undefined,
+              addressRegion: coverage.state ?? undefined,
+            },
+          }
+        : {}),
     },
     {
       "@context": "https://schema.org",
@@ -302,6 +335,18 @@ export default async function SchoolDetailPage({
               fontSize: 14,
             }}
           >
+            {location && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 11.5,
+                  color: "var(--ink)",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                {location.toUpperCase()}
+              </span>
+            )}
             {ipedsId && (
               <span
                 className="mono"
@@ -419,7 +464,7 @@ async function DirectoryOnlySchoolPage({
   const scorecard = await fetchScorecardByIpedsId(coverage.ipeds_id);
 
   const { head, tail } = splitInstitutionalSuffix(coverage.school_name);
-  const location = [coverage.city, coverage.state].filter(Boolean).join(", ");
+  const location = formatLocation(coverage);
   const lastChecked = coverage.last_checked_at
     ? new Date(coverage.last_checked_at).toLocaleDateString("en-US", {
         month: "long",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -36,6 +36,46 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.5,
     },
+    {
+      url: `${SITE_URL}/api`,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/methodology`,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/methodology/positioning`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/methodology/admission-strategy`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/methodology/merit-profile`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/recipes`,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/recipes/acceptance-vs-yield`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/recipes/test-optional-tracker`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 
   const schoolPages: MetadataRoute.Sitemap = schools.map((s) => ({
@@ -58,5 +98,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     }));
 
-  return [...staticPages, ...schoolPages, ...yearPages];
+  return [...staticPages, ...schoolPages, ...yearPages].filter((entry, index, entries) =>
+    entries.findIndex((candidate) => candidate.url === entry.url) === index
+  );
 }

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -1477,10 +1477,19 @@
   gap: 12px;
   padding-bottom: 8px;
 }
+.match-tier-group__head-text {
+  min-width: 0;
+}
 .match-tier-group__head h3 {
   margin: 0;
   font-size: 28px;
   line-height: 1;
+}
+.match-tier-group__sub {
+  margin: 6px 0 0;
+  color: var(--ink-3);
+  font-size: 13px;
+  line-height: 1.4;
 }
 .match-tier-group__head span {
   color: var(--ink-3);

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -15,7 +15,12 @@ import {
   type TestPolicySignal,
 } from "@/lib/list-builder";
 import { decodeProfileCode, encodeProfileCode } from "@/lib/savecode";
-import { academicFitLabel, type AcademicFit, type StudentProfile } from "@/lib/positioning";
+import {
+  academicFitLabel,
+  academicFitSubtitle,
+  type AcademicFit,
+  type StudentProfile,
+} from "@/lib/positioning";
 import { SchoolListItem } from "./SchoolListItem";
 
 const STORAGE_KEY = "cdfyi.matchProfile.v1";
@@ -342,7 +347,12 @@ export function MatchListBuilder({
                   className={`match-tier-group match-tier-group--${fit}`}
                 >
                   <div className="match-tier-group__head">
-                    <h3 className="serif">{academicFitLabel(fit)}</h3>
+                    <div className="match-tier-group__head-text">
+                      <h3 className="serif">{academicFitLabel(fit)}</h3>
+                      {academicFitSubtitle(fit) ? (
+                        <p className="match-tier-group__sub">{academicFitSubtitle(fit)}</p>
+                      ) : null}
+                    </div>
                     <span className="mono">{rows.length}</span>
                   </div>
                   <div className="match-tier-group__rows">

--- a/web/src/lib/positioning.ts
+++ b/web/src/lib/positioning.ts
@@ -175,6 +175,21 @@ export function academicFitLabel(fit: AcademicFit): string {
   }
 }
 
+export function academicFitSubtitle(fit: AcademicFit): string | null {
+  switch (fit) {
+    case "strong_academic_fit":
+      return "Your score is at or above the 75th percentile of recent admits.";
+    case "above_range":
+      return "Your score is well above the 75th percentile (more than 100 SAT or 2 ACT points past it).";
+    case "in_range":
+      return "Your score lands in the middle 50% of recent admits (25th–75th percentile).";
+    case "below_range":
+      return "Your score is below the 25th percentile of recent admits.";
+    case "unknown":
+      return null;
+  }
+}
+
 export function admissionsOutlookLabel(outlook: AdmissionsOutlook): string {
   switch (outlook) {
     case "likely":


### PR DESCRIPTION
## Summary

- add March-June weekly archive-enqueue run IDs for curated `schools.yaml` schools
- shorten `unchanged_verified` archive cooldown to 7 days during March-June, keeping the existing 30-day default the rest of the year
- add pure schedule helpers and archive-enqueue Deno tests, and include archive-enqueue tests in CI
- update archive pipeline docs for the new cadence

Note: this branch also contains the recently deployed ops/SEO commits because `santhonys/data-extract-diagram` did not have an open PR against `main`.

## Validation

- `deno fmt --check supabase/functions/archive-enqueue/index.ts supabase/functions/archive-enqueue/schedule.ts supabase/functions/archive-enqueue/schedule.test.ts`
- `deno check supabase/functions/archive-enqueue/index.ts supabase/functions/archive-enqueue/schedule.test.ts`
- `deno test --allow-env --allow-read supabase/functions/_shared/*.test.ts supabase/functions/archive-enqueue/*.test.ts supabase/functions/archive-process/*.test.ts supabase/functions/browser-search/*.test.ts supabase/functions/directory-enqueue/*.test.ts`
