### PR TITLE
Render accessible C1 and C9 CDS tables

### DIFF
--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -2,12 +2,16 @@ import type { FieldValue } from "@/lib/types";
 import { FIELD_LABELS } from "@/lib/labels";
 import { groupBySection, type SubsectionGroup } from "@/lib/sections";
 import { formatFieldValue } from "@/lib/format";
+import {
+  buildReconstructedTables,
+  type ReconstructedTable,
+} from "@/lib/reconstructed-tables";
 
 // FieldsView — textbook-gutter layout. Sticky section/subsection index on
 // the left, KV groups on the right. Each subsection renders the extracted
-// fields as a label/value list with dashed rules between rows; future work
-// can swap in reconstructed CDS tables for select subsections (B1, C9,
-// H2A, etc.) without changing the surrounding layout.
+// fields as a label/value list with dashed rules between rows. High-value
+// subsections can render reconstructed CDS-shaped tables first, while keeping
+// the KV rows as the fallback for unsupported or long-tail fields.
 export function FieldsView({
   values,
   totalFields,
@@ -113,6 +117,15 @@ export function FieldsView({
 }
 
 function SubsectionBlock({ sub }: { sub: SubsectionGroup }) {
+  const subsectionValues = Object.fromEntries(
+    sub.fields.map(({ id, field }) => [id, field]),
+  );
+  const reconstructedTables = buildReconstructedTables(subsectionValues);
+  const reconstructedIds = new Set(
+    reconstructedTables.flatMap((table) => table.usedFieldIds),
+  );
+  const fallbackFields = sub.fields.filter(({ id }) => !reconstructedIds.has(id));
+
   return (
     <div
       id={`sub-${sub.slug}`}
@@ -122,7 +135,162 @@ function SubsectionBlock({ sub }: { sub: SubsectionGroup }) {
         {sub.code ? `${sub.code} · ` : ""}
         {sub.name}
       </div>
-      <KVRows fields={sub.fields} />
+      {reconstructedTables.map((table) => (
+        <ReconstructedTableView key={table.key} table={table} />
+      ))}
+      {fallbackFields.length > 0 && (
+        <div style={{ marginTop: reconstructedTables.length > 0 ? 14 : 0 }}>
+          {reconstructedTables.length > 0 && (
+            <div className="meta" style={{ marginBottom: 6 }}>
+              Other extracted fields
+            </div>
+          )}
+          <KVRows fields={fallbackFields} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
+  return (
+    <div
+      className="cd-reconstructed"
+      style={{
+        marginBottom: 14,
+        border: "1px solid var(--rule)",
+        borderRadius: 8,
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          padding: "10px 12px",
+          borderBottom: "1px solid var(--rule)",
+        }}
+      >
+        <div
+          className="serif"
+          style={{
+            fontSize: 18,
+            color: "var(--ink)",
+            marginBottom: 2,
+          }}
+        >
+          {table.title}
+        </div>
+        <div
+          style={{
+            color: "var(--ink-2)",
+            fontSize: 13,
+            lineHeight: 1.45,
+            maxWidth: "100%",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {table.caption}
+        </div>
+      </div>
+      <div
+        className="cd-reconstructed__table-wrap"
+        style={{
+          overflowX: "auto",
+          maxWidth: "100%",
+        }}
+      >
+        <table
+          className="cd-reconstructed__table nums"
+          style={{
+            width: "100%",
+            minWidth: table.columns.length >= 5 ? 760 : 620,
+            borderCollapse: "collapse",
+            fontSize: 13.5,
+          }}
+        >
+          <caption
+            style={{
+              position: "absolute",
+              width: 1,
+              height: 1,
+              padding: 0,
+              margin: -1,
+              overflow: "hidden",
+              clip: "rect(0, 0, 0, 0)",
+              whiteSpace: "nowrap",
+              border: 0,
+            }}
+          >
+            {table.title}. {table.caption}
+          </caption>
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                style={{
+                  textAlign: "left",
+                  padding: "9px 12px",
+                  color: "var(--ink-2)",
+                  borderBottom: "1px solid var(--rule)",
+                  fontWeight: 600,
+                  whiteSpace: "normal",
+                }}
+              >
+                Measure
+              </th>
+              {table.columns.map((column) => (
+                <th
+                  key={column}
+                  scope="col"
+                  style={{
+                    textAlign: "right",
+                    padding: "9px 12px",
+                    color: "var(--ink-2)",
+                    borderBottom: "1px solid var(--rule)",
+                    fontWeight: 600,
+                    whiteSpace: "normal",
+                  }}
+                >
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {table.rows.map((row) => (
+              <tr key={row.key}>
+                <th
+                  scope="row"
+                  style={{
+                    textAlign: "left",
+                    padding: "9px 12px",
+                    color: "var(--ink-2)",
+                    borderBottom: "1px dashed var(--rule)",
+                    fontWeight: 500,
+                    width: "28%",
+                  }}
+                >
+                  {row.label}
+                </th>
+                {row.cells.map((cell, i) => (
+                  <td
+                    key={`${row.key}-${cell.fieldId ?? i}`}
+                    style={{
+                      textAlign: "right",
+                      padding: "9px 12px",
+                      color: cell.missing ? "var(--ink-4)" : "var(--ink)",
+                      borderBottom: "1px dashed var(--rule)",
+                      fontWeight: cell.missing ? 400 : 500,
+                      overflowWrap: "anywhere",
+                    }}
+                  >
+                    {cell.display}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -161,6 +161,9 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
         border: "1px solid var(--rule)",
         borderRadius: 8,
         minWidth: 0,
+        width: "100%",
+        maxWidth: "100%",
+        overflow: "hidden",
       }}
     >
       <div
@@ -195,7 +198,9 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
         className="cd-reconstructed__table-wrap"
         style={{
           overflowX: "auto",
+          width: "100%",
           maxWidth: "100%",
+          minWidth: 0,
         }}
       >
         <table

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,4 +1,4 @@
-import { STORAGE_BASE_URL } from "./supabase";
+const STORAGE_BASE_URL = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/sources`;
 
 export function formatBadgeLabel(format: string | null): string {
   switch (format) {

--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -74,4 +74,58 @@ describe("buildReconstructedTables", () => {
       "1,560",
     ]);
   });
+
+  it("builds C7 as a selected-choice matrix", () => {
+    const tables = buildReconstructedTables({
+      "C.701": field("Very Important", "Rigor of secondary school record", "Text"),
+      "C.703": field("Considered", "Academic GPA", "Text"),
+    });
+
+    const c7 = tables.find((table) => table.key === "c7-factors");
+    expect(c7?.columns).toEqual([
+      "Very important",
+      "Important",
+      "Considered",
+      "Not considered",
+    ]);
+    expect(c7?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "Yes",
+      "—",
+      "—",
+      "—",
+    ]);
+    expect(c7?.rows[2].cells.map((cell) => cell.display)).toEqual([
+      "—",
+      "—",
+      "Yes",
+      "—",
+    ]);
+    expect(c7?.usedFieldIds).toEqual(["C.701", "C.703"]);
+  });
+
+  it("builds H2A as a cohort grid", () => {
+    const tables = buildReconstructedTables({
+      "H.2A01": field("120", "N. Number of students...", "Number"),
+      "H.2A02": field("18000", "O. Average dollar amount...", "Nearest $1"),
+      "H.2A05": field("400", "N. Number of students...", "Number"),
+      "H.2A06": field("12500", "O. Average dollar amount...", "Nearest $1"),
+    });
+
+    const h2a = tables.find((table) => table.key === "h2a-non-need-aid");
+    expect(h2a?.columns).toEqual([
+      "First-year full-time",
+      "All undergraduates full-time",
+      "All undergraduates less-than-full-time",
+    ]);
+    expect(h2a?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "120",
+      "400",
+      "Not reported",
+    ]);
+    expect(h2a?.rows[1].cells.map((cell) => cell.display)).toEqual([
+      "$18,000",
+      "$12,500",
+      "Not reported",
+    ]);
+  });
 });

--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { buildReconstructedTables } from "./reconstructed-tables";
+import type { FieldValue } from "./types";
+
+function field(value: string, question = "Question", value_type = "Number"): FieldValue {
+  return { value, question, value_type };
+}
+
+describe("buildReconstructedTables", () => {
+  it("builds a 2025-style C1 table and leaves missing schema cells explicit", () => {
+    const tables = buildReconstructedTables({
+      "C.101": field("1200", "Total first-time, first-year males who applied"),
+      "C.102": field("1300", "Total first-time, first-year females who applied"),
+      "C.116": field("2500", "Total first-time, first-year students who applied"),
+      "C.117": field("300", "Total first-time, first-year students who were admitted"),
+    });
+
+    const c1 = tables.find((table) => table.key === "c1-admissions");
+    expect(c1?.columns).toEqual(["Males", "Females", "Unknown sex", "Total"]);
+    expect(c1?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "1,200",
+      "1,300",
+      "Not reported",
+      "2,500",
+    ]);
+    expect(c1?.usedFieldIds).toContain("C.101");
+    expect(c1?.usedFieldIds).toContain("C.117");
+  });
+
+  it("uses the 2024 C1 layout when the question text exposes another gender fields", () => {
+    const tables = buildReconstructedTables({
+      "C.101": field("1200", "Total first-time, first-year men who applied"),
+      "C.103": field("3", "Total first-time, first-year another gender who applied"),
+      "C.104": field("2", "Total first-time, first-year unknown gender who applied"),
+      "C.117": field("2505", "Total first-time, first-year students who applied"),
+    });
+
+    const c1 = tables.find((table) => table.key === "c1-admissions");
+    expect(c1?.columns).toEqual([
+      "Men",
+      "Women",
+      "Another gender",
+      "Unknown gender",
+      "Total",
+    ]);
+    expect(c1?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "1,200",
+      "Not reported",
+      "3",
+      "2",
+      "2,505",
+    ]);
+  });
+
+  it("builds C9 submission and percentile tables", () => {
+    const tables = buildReconstructedTables({
+      "C.901": field("60.5", "Percent Submitting SAT Scores", "Whole Number or Round to Nearest Tenth"),
+      "C.903": field("600", "Number Submitting SAT Scores"),
+      "C.905": field("1400", "SAT Composite: 25th Percentile", "Whole Number or Round to Nearest Tenth"),
+      "C.906": field("1500", "SAT Composite: 50th Percentile", "Whole Number or Round to Nearest Tenth"),
+      "C.907": field("1560", "SAT Composite: 75th Percentile", "Whole Number or Round to Nearest Tenth"),
+    });
+
+    const submission = tables.find((table) => table.key === "c9-submission");
+    const percentiles = tables.find((table) => table.key === "c9-percentiles");
+
+    expect(submission?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "60.5",
+      "600",
+    ]);
+    expect(percentiles?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "1,400",
+      "1,500",
+      "1,560",
+    ]);
+  });
+});

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -1,0 +1,190 @@
+import { formatFieldValue } from "./format";
+import type { FieldValue } from "./types";
+
+export type ReconstructedCell = {
+  fieldId: string | null;
+  label: string;
+  display: string;
+  missing: boolean;
+};
+
+export type ReconstructedRow = {
+  key: string;
+  label: string;
+  cells: ReconstructedCell[];
+};
+
+export type ReconstructedTable = {
+  key: string;
+  title: string;
+  caption: string;
+  columns: string[];
+  rows: ReconstructedRow[];
+  usedFieldIds: string[];
+};
+
+export function buildReconstructedTables(
+  values: Record<string, FieldValue>,
+): ReconstructedTable[] {
+  return [
+    ...buildC1Tables(values),
+    ...buildC9Tables(values),
+  ].filter((table) => hasReportedCell(table));
+}
+
+function buildC1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^C\.1(0[1-9]|1[0-9]|2[0-9]|30)$/.test(id))) {
+    return [];
+  }
+
+  return [isC12024Layout(values) ? c1Table2024(values) : c1Table2025(values)];
+}
+
+function isC12024Layout(values: Record<string, FieldValue>): boolean {
+  const c103 = values["C.103"]?.question?.toLowerCase() ?? "";
+  const c104 = values["C.104"]?.question?.toLowerCase() ?? "";
+  const c117 = values["C.117"]?.question?.toLowerCase() ?? "";
+  return (
+    c103.includes("another gender") ||
+    c104.includes("unknown gender who applied") ||
+    c117.includes("students who applied")
+  );
+}
+
+function c1Table2025(values: Record<string, FieldValue>): ReconstructedTable {
+  return makeTable({
+    key: "c1-admissions",
+    title: "C1 first-year admissions",
+    caption:
+      "First-time, first-year applicants, admits, and enrolled students by sex or status.",
+    columns: ["Males", "Females", "Unknown sex", "Total"],
+    rows: [
+      ["applied", "Applied", ["C.101", "C.102", "C.103", "C.116"]],
+      ["admitted", "Admitted", ["C.104", "C.105", "C.106", "C.117"]],
+      ["enrolled", "Enrolled", ["C.107", "C.108", "C.109", "C.118"]],
+      ["enrolled-ft", "Enrolled full-time", ["C.110", "C.112", "C.114", null]],
+      ["enrolled-pt", "Enrolled part-time", ["C.111", "C.113", "C.115", null]],
+    ],
+    values,
+  });
+}
+
+function c1Table2024(values: Record<string, FieldValue>): ReconstructedTable {
+  return makeTable({
+    key: "c1-admissions",
+    title: "C1 first-year admissions",
+    caption:
+      "First-time, first-year applicants, admits, and enrolled students by gender or status.",
+    columns: ["Men", "Women", "Another gender", "Unknown gender", "Total"],
+    rows: [
+      ["applied", "Applied", ["C.101", "C.102", "C.103", "C.104", "C.117"]],
+      ["admitted", "Admitted", ["C.105", "C.106", "C.107", "C.108", "C.118"]],
+      ["enrolled-ft", "Enrolled full-time", ["C.109", "C.111", "C.113", "C.115", null]],
+      ["enrolled-pt", "Enrolled part-time", ["C.110", "C.112", "C.114", "C.116", null]],
+      ["enrolled-total", "Enrolled total", [null, null, null, null, "C.119"]],
+    ],
+    values,
+  });
+}
+
+function buildC9Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^C\.9(0[1-9]|[1-5][0-9])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "c9-submission",
+      title: "C9 test-score submission",
+      caption: "Share and count of enrolled first-year students who submitted SAT or ACT scores.",
+      columns: ["Percent", "Number"],
+      rows: [
+        ["sat", "SAT", ["C.901", "C.903"]],
+        ["act", "ACT", ["C.902", "C.904"]],
+      ],
+      values,
+    }),
+    makeTable({
+      key: "c9-percentiles",
+      title: "C9 test-score percentiles",
+      caption: "Reported 25th, 50th, and 75th percentile scores for enrolled first-year students.",
+      columns: ["25th percentile", "50th percentile", "75th percentile"],
+      rows: [
+        ["sat-composite", "SAT composite", ["C.905", "C.906", "C.907"]],
+        ["sat-ebrw", "SAT evidence-based reading and writing", ["C.908", "C.909", "C.910"]],
+        ["sat-math", "SAT math", ["C.911", "C.912", "C.913"]],
+        ["act-composite", "ACT composite", ["C.914", "C.915", "C.916"]],
+        ["act-math", "ACT math", ["C.917", "C.918", "C.919"]],
+        ["act-english", "ACT English", ["C.920", "C.921", "C.922"]],
+        ["act-writing", "ACT Writing", ["C.923", "C.924", "C.925"]],
+        ["act-science", "ACT Science", ["C.926", "C.927", "C.928"]],
+        ["act-reading", "ACT Reading", ["C.929", "C.930", "C.931"]],
+      ],
+      values,
+    }),
+  ];
+}
+
+function makeTable({
+  key,
+  title,
+  caption,
+  columns,
+  rows,
+  values,
+}: {
+  key: string;
+  title: string;
+  caption: string;
+  columns: string[];
+  rows: [string, string, (string | null)[]][];
+  values: Record<string, FieldValue>;
+}): ReconstructedTable {
+  const usedFieldIds: string[] = [];
+  const reconstructedRows = rows.map(([rowKey, rowLabel, fieldIds]) => ({
+    key: rowKey,
+    label: rowLabel,
+    cells: fieldIds.map((fieldId, i) => {
+      const field = fieldId ? values[fieldId] : undefined;
+      if (fieldId && field) usedFieldIds.push(fieldId);
+      const display = field ? displayField(field) : "Not reported";
+      return {
+        fieldId,
+        label: columns[i],
+        display,
+        missing: !field || isMissingDisplay(display),
+      };
+    }),
+  }));
+
+  return {
+    key,
+    title,
+    caption,
+    columns,
+    rows: reconstructedRows,
+    usedFieldIds,
+  };
+}
+
+function displayField(field: FieldValue): string {
+  const raw = field.value_decoded ?? field.value ?? "";
+  const display = formatFieldValue(raw, field.value_type);
+  return display || "Not reported";
+}
+
+function hasReportedCell(table: ReconstructedTable): boolean {
+  return table.rows.some((row) => row.cells.some((cell) => !cell.missing));
+}
+
+function isMissingDisplay(display: string): boolean {
+  const normalized = display.trim().toLowerCase();
+  return (
+    normalized === "" ||
+    normalized === "—" ||
+    normalized === "not reported" ||
+    normalized.includes("not provided")
+  );
+}

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -28,7 +28,9 @@ export function buildReconstructedTables(
 ): ReconstructedTable[] {
   return [
     ...buildC1Tables(values),
+    ...buildC7Tables(values),
     ...buildC9Tables(values),
+    ...buildH2ATables(values),
   ].filter((table) => hasReportedCell(table));
 }
 
@@ -88,6 +90,70 @@ function c1Table2024(values: Record<string, FieldValue>): ReconstructedTable {
   });
 }
 
+function buildC7Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^C\.7(0[1-9]|1[0-9])$/.test(id))) {
+    return [];
+  }
+
+  return [c7Table(values)];
+}
+
+const C7_COLUMNS = ["Very important", "Important", "Considered", "Not considered"];
+
+function c7Table(values: Record<string, FieldValue>): ReconstructedTable {
+  const factors: [string, string][] = [
+    ["C.701", "Rigor of secondary school record"],
+    ["C.702", "Class rank"],
+    ["C.703", "Academic GPA"],
+    ["C.704", "Standardized test scores"],
+    ["C.705", "Application essay"],
+    ["C.706", "Recommendations"],
+    ["C.707", "Interview"],
+    ["C.708", "Extracurricular activities"],
+    ["C.709", "Talent or ability"],
+    ["C.710", "Character and personal qualities"],
+    ["C.711", "First generation"],
+    ["C.712", "Alumni relation"],
+    ["C.713", "Geographical residence"],
+    ["C.714", "State residency"],
+    ["C.715", "Religious affiliation or commitment"],
+    ["C.716", "Volunteer work"],
+    ["C.717", "Work experience"],
+    ["C.718", "Level of applicant interest"],
+  ];
+
+  const usedFieldIds: string[] = [];
+  const rows = factors.map(([fieldId, label]) => {
+    const field = values[fieldId];
+    if (field) usedFieldIds.push(fieldId);
+    const selected = normalizeChoice(field ? displayField(field) : "");
+    return {
+      key: fieldId.toLowerCase().replace(".", "-"),
+      label,
+      cells: C7_COLUMNS.map((column) => {
+        const isSelected = selected === normalizeChoice(column);
+        return {
+          fieldId: isSelected ? fieldId : null,
+          label: column,
+          display: field ? (isSelected ? "Yes" : "—") : "Not reported",
+          missing: !field || !isSelected,
+        };
+      }),
+    };
+  });
+
+  return {
+    key: "c7-factors",
+    title: "C7 basis for selection",
+    caption:
+      "Relative importance of academic and nonacademic factors in first-year admissions decisions.",
+    columns: C7_COLUMNS,
+    rows,
+    usedFieldIds,
+  };
+}
+
 function buildC9Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
   const ids = Object.keys(values);
   if (!ids.some((id) => /^C\.9(0[1-9]|[1-5][0-9])$/.test(id))) {
@@ -121,6 +187,34 @@ function buildC9Tables(values: Record<string, FieldValue>): ReconstructedTable[]
         ["act-writing", "ACT Writing", ["C.923", "C.924", "C.925"]],
         ["act-science", "ACT Science", ["C.926", "C.927", "C.928"]],
         ["act-reading", "ACT Reading", ["C.929", "C.930", "C.931"]],
+      ],
+      values,
+    }),
+  ];
+}
+
+function buildH2ATables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^H\.2A(0[1-9]|1[0-2])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "h2a-non-need-aid",
+      title: "H2A non-need-based aid",
+      caption:
+        "Non-need-based scholarship and grant aid recipients and average awards by undergraduate cohort.",
+      columns: [
+        "First-year full-time",
+        "All undergraduates full-time",
+        "All undergraduates less-than-full-time",
+      ],
+      rows: [
+        ["institutional-grant-count", "Institutional non-need grant recipients", ["H.2A01", "H.2A05", "H.2A09"]],
+        ["institutional-grant-average", "Average institutional non-need grant", ["H.2A02", "H.2A06", "H.2A10"]],
+        ["athletic-grant-count", "Athletic grant recipients", ["H.2A03", "H.2A07", "H.2A11"]],
+        ["athletic-grant-average", "Average athletic grant", ["H.2A04", "H.2A08", "H.2A12"]],
       ],
       values,
     }),
@@ -187,4 +281,8 @@ function isMissingDisplay(display: string): boolean {
     normalized === "not reported" ||
     normalized.includes("not provided")
   );
+}
+
+function normalizeChoice(value: string): string {
+  return value.trim().toLowerCase().replace(/[-\s]+/g, " ");
 }

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -62,7 +62,7 @@ test("facts endpoint returns flat JSON", async ({ request }) => {
   expect(typeof body.raw).toBe("object");
 });
 
-test("school-year page renders reconstructed C1 and C9 tables", async ({ page }) => {
+test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await page.goto("/schools/bowdoin/2024-25");
   await expect(
     page.getByRole("heading", { name: /Bowdoin College/i }),
@@ -81,6 +81,16 @@ test("school-year page renders reconstructed C1 and C9 tables", async ({ page })
   await expect(c9Percentiles).toBeVisible();
   await expect(c9Percentiles.getByRole("columnheader", { name: /75th percentile/i })).toBeVisible();
   await expect(c9Percentiles.getByRole("rowheader", { name: "SAT composite" })).toBeVisible();
+
+  const c7 = page.getByRole("table", { name: /C7 basis for selection/i });
+  await expect(c7).toBeVisible();
+  await expect(c7.getByRole("columnheader", { name: "Very important" })).toBeVisible();
+  await expect(c7.getByRole("rowheader", { name: "Academic GPA" })).toBeVisible();
+
+  const h2a = page.getByRole("table", { name: /H2A non-need-based aid/i });
+  await expect(h2a).toBeVisible();
+  await expect(h2a.getByRole("columnheader", { name: /First-year full-time/i })).toBeVisible();
+  await expect(h2a.getByRole("rowheader", { name: /Average institutional non-need grant/i })).toBeVisible();
 });
 
 test("mobile launch surfaces do not overflow", async ({ page, isMobile }) => {

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -62,10 +62,31 @@ test("facts endpoint returns flat JSON", async ({ request }) => {
   expect(typeof body.raw).toBe("object");
 });
 
+test("school-year page renders reconstructed C1 and C9 tables", async ({ page }) => {
+  await page.goto("/schools/bowdoin/2024-25");
+  await expect(
+    page.getByRole("heading", { name: /Bowdoin College/i }),
+  ).toBeVisible();
+
+  const c1 = page.getByRole("table", { name: /C1 first-year admissions/i });
+  await expect(c1).toBeVisible();
+  await expect(c1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();
+  await expect(c1.getByRole("rowheader", { name: "Applied" })).toBeVisible();
+
+  const c9Submission = page.getByRole("table", { name: /C9 test-score submission/i });
+  await expect(c9Submission).toBeVisible();
+  await expect(c9Submission.getByRole("rowheader", { name: "SAT" })).toBeVisible();
+
+  const c9Percentiles = page.getByRole("table", { name: /C9 test-score percentiles/i });
+  await expect(c9Percentiles).toBeVisible();
+  await expect(c9Percentiles.getByRole("columnheader", { name: /75th percentile/i })).toBeVisible();
+  await expect(c9Percentiles.getByRole("rowheader", { name: "SAT composite" })).toBeVisible();
+});
+
 test("mobile launch surfaces do not overflow", async ({ page, isMobile }) => {
   test.skip(!isMobile, "mobile project only");
 
-  for (const path of ["/", "/coverage", "/browse"]) {
+  for (const path of ["/", "/coverage", "/browse", "/schools/bowdoin/2024-25"]) {
     await page.goto(path);
     await expectNoBodyOverflow(page);
   }


### PR DESCRIPTION
## Summary
- render reconstructed native HTML tables for C1 admissions and C9 test-score fields in the existing school-year FieldsView
- keep key/value rows as fallback for unsupported or remaining fields
- support 2024-style and 2025-style C1 canonical layouts
- add unit coverage for table reconstruction and Playwright smoke coverage for local school-year rendering/mobile overflow

## Validation
- npm run test
- npm run typecheck
- npm run build
- PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test

Local dev server used for Playwright: http://localhost:3000