### PR TITLE
Render accessible B1 enrollment tables

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -41,26 +42,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -759,6 +751,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -1588,6 +1581,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1786,6 +1780,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bail": {
@@ -3374,6 +3378,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -3505,6 +3510,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3537,6 +3543,7 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3588,6 +3595,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3597,6 +3605,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4122,6 +4131,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -55,6 +55,28 @@
         "playwright-core": ">= 1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -751,7 +773,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -1581,7 +1602,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3378,7 +3398,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -3510,7 +3529,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3543,7 +3561,6 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3595,7 +3612,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3605,7 +3621,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4131,7 +4146,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -270,6 +270,48 @@
   white-space: nowrap;
   border: 0;
 }
+.cd-reconstructed__table-wrap {
+  scrollbar-gutter: stable;
+  overscroll-behavior-x: contain;
+}
+.cd-reconstructed__table-wrap:focus-visible {
+  outline: 2px solid var(--forest);
+  outline-offset: -2px;
+}
+@media (max-width: 640px) {
+  .cd-reconstructed__head {
+    padding: 9px 10px !important;
+  }
+  .cd-reconstructed__title {
+    font-size: 16px !important;
+  }
+  .cd-reconstructed__table-wrap {
+    box-shadow: inset -14px 0 14px -14px color-mix(in srgb, var(--ink) 45%, transparent);
+  }
+  .cd-reconstructed__table {
+    font-size: 12.5px !important;
+  }
+  .cd-reconstructed__table th,
+  .cd-reconstructed__table td {
+    padding: 8px 9px !important;
+    vertical-align: top;
+  }
+  .cd-reconstructed__stub,
+  .cd-reconstructed__rowhead {
+    position: sticky;
+    left: 0;
+    min-width: 176px;
+    max-width: 212px;
+    background: var(--paper);
+    box-shadow: 1px 0 0 var(--rule);
+  }
+  .cd-reconstructed__stub {
+    z-index: 3;
+  }
+  .cd-reconstructed__rowhead {
+    z-index: 2;
+  }
+}
 @media (max-width: 820px) {
   .cd-nav-row { flex-wrap: wrap; row-gap: 10px; }
   .cd-header-search { order: 3; flex-basis: 100%; max-width: none; min-width: 0; }

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -153,6 +153,8 @@ function SubsectionBlock({ sub }: { sub: SubsectionGroup }) {
 }
 
 function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
+  const minWidth = table.columns.length >= 5 ? 760 : 620;
+
   return (
     <div
       className="cd-reconstructed"
@@ -164,16 +166,18 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
         width: "100%",
         maxWidth: "100%",
         overflow: "hidden",
+        position: "relative",
       }}
     >
       <div
+        className="cd-reconstructed__head"
         style={{
           padding: "10px 12px",
           borderBottom: "1px solid var(--rule)",
         }}
       >
         <div
-          className="serif"
+          className="cd-reconstructed__title serif"
           style={{
             fontSize: 18,
             color: "var(--ink)",
@@ -196,6 +200,8 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
       </div>
       <div
         className="cd-reconstructed__table-wrap"
+        tabIndex={0}
+        aria-label={`${table.title} table. Scroll horizontally to read all columns.`}
         style={{
           overflowX: "auto",
           width: "100%",
@@ -207,7 +213,7 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
           className="cd-reconstructed__table nums"
           style={{
             width: "100%",
-            minWidth: table.columns.length >= 5 ? 760 : 620,
+            minWidth,
             borderCollapse: "collapse",
             fontSize: 13.5,
           }}
@@ -230,6 +236,7 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
           <thead>
             <tr>
               <th
+                className="cd-reconstructed__stub"
                 scope="col"
                 style={{
                   textAlign: "left",
@@ -264,6 +271,7 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
             {table.rows.map((row) => (
               <tr key={row.key}>
                 <th
+                  className="cd-reconstructed__rowhead"
                   scope="row"
                   style={{
                     textAlign: "left",
@@ -282,7 +290,7 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
                     style={{
                       textAlign: "right",
                       padding: "9px 12px",
-                      color: cell.missing ? "var(--ink-4)" : "var(--ink)",
+                      color: cell.missing ? "var(--ink-3)" : "var(--ink)",
                       borderBottom: "1px dashed var(--rule)",
                       fontWeight: cell.missing ? 400 : 500,
                       overflowWrap: "anywhere",

--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -7,6 +7,84 @@ function field(value: string, question = "Question", value_type = "Number"): Fie
 }
 
 describe("buildReconstructedTables", () => {
+  it("builds 2025-style B1 undergraduate, graduate, and overall enrollment tables", () => {
+    const tables = buildReconstructedTables({
+      "B.101": field("100", "Degree-seeking, first-time first-year students: males"),
+      "B.126": field("140", "Degree-seeking, first-time first-year students: females"),
+      "B.151": field("5", "Degree-seeking, first-time first-year students: Unknown"),
+      "B.113": field("500", "Total undergraduate students: males"),
+      "B.138": field("600", "Total undergraduate students: females"),
+      "B.163": field("10", "Total undergraduate students: Unknown"),
+      "B.176": field("1110", "Total all undergraduates"),
+      "B.125": field("800", "Total All Students: males"),
+      "B.150": field("900", "Total All Students: females"),
+      "B.175": field("12", "Total All Students: Unknown"),
+      "B.178": field("1712", "Grand Total All Students"),
+    });
+
+    const undergrad = tables.find((table) => table.key === "b1-undergraduate");
+    const overall = tables.find((table) => table.key === "b1-overall");
+
+    expect(undergrad?.columns).toEqual(["Males", "Females", "Unknown", "Total"]);
+    expect(undergrad?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "100",
+      "140",
+      "5",
+      "Not reported",
+    ]);
+    expect(undergrad?.rows.at(-1)?.cells.map((cell) => cell.display)).toEqual([
+      "500",
+      "600",
+      "10",
+      "1,110",
+    ]);
+    expect(overall?.rows.at(-1)?.cells.map((cell) => cell.display)).toEqual([
+      "800",
+      "900",
+      "12",
+      "1,712",
+    ]);
+    expect(undergrad?.usedFieldIds).toContain("B.176");
+  });
+
+  it("builds 2024-style B1 tables with another gender columns", () => {
+    const tables = buildReconstructedTables({
+      "B.101": field("100", "Degree-seeking, first-time first-year students: men"),
+      "B.102": field("120", "Degree-seeking, first-time first-year students: women"),
+      "B.103": field("2", "Degree-seeking, first-time first-year students: another gender"),
+      "B.104": field("3", "Degree-seeking, first-time first-year students: unknown"),
+      "B.149": field("500", "Total undergraduate students: men"),
+      "B.150": field("600", "Total undergraduate students: women"),
+      "B.151": field("4", "Total undergraduate students: another gender"),
+      "B.152": field("5", "Total undergraduate students: unknown"),
+      "B.193": field("1109", "Total all undergraduates"),
+    });
+
+    const undergrad = tables.find((table) => table.key === "b1-undergraduate");
+
+    expect(undergrad?.columns).toEqual([
+      "Men",
+      "Women",
+      "Another gender",
+      "Unknown",
+      "Total",
+    ]);
+    expect(undergrad?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "100",
+      "120",
+      "2",
+      "3",
+      "Not reported",
+    ]);
+    expect(undergrad?.rows.at(-1)?.cells.map((cell) => cell.display)).toEqual([
+      "500",
+      "600",
+      "4",
+      "5",
+      "1,109",
+    ]);
+  });
+
   it("builds a 2025-style C1 table and leaves missing schema cells explicit", () => {
     const tables = buildReconstructedTables({
       "C.101": field("1200", "Total first-time, first-year males who applied"),

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -27,11 +27,190 @@ export function buildReconstructedTables(
   values: Record<string, FieldValue>,
 ): ReconstructedTable[] {
   return [
+    ...buildB1Tables(values),
     ...buildC1Tables(values),
     ...buildC7Tables(values),
     ...buildC9Tables(values),
     ...buildH2ATables(values),
   ].filter((table) => hasReportedCell(table));
+}
+
+function buildB1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^B\.1\d{2}$/.test(id))) {
+    return [];
+  }
+
+  return isB12024Layout(values) ? b1Tables2024(values) : b1Tables2025(values);
+}
+
+function isB12024Layout(values: Record<string, FieldValue>): boolean {
+  const b103 = values["B.103"]?.question?.toLowerCase() ?? "";
+  return (
+    b103.includes("another gender") ||
+    ["B.189", "B.190", "B.191", "B.192", "B.193", "B.194", "B.195"].some(
+      (id) => id in values,
+    )
+  );
+}
+
+function b1Tables2025(values: Record<string, FieldValue>): ReconstructedTable[] {
+  return [
+    makeTable({
+      key: "b1-undergraduate",
+      title: "B1 undergraduate enrollment",
+      caption:
+        "Full-time, part-time, and total undergraduate enrollment by reported sex or status.",
+      columns: ["Males", "Females", "Unknown", "Total"],
+      rows: [
+        row2025("ug-ft-first-year", "Full-time first-time first-year degree-seeking", 101),
+        row2025("ug-ft-other-first-year", "Full-time other first-year degree-seeking", 102),
+        row2025("ug-ft-other-degree", "Full-time all other degree-seeking", 103),
+        row2025("ug-ft-total-degree", "Full-time total degree-seeking", 104),
+        row2025("ug-ft-other-credit", "Full-time other credit-course undergraduates", 105),
+        row2025("ug-ft-total", "Full-time total undergraduates", 106),
+        row2025("ug-pt-first-year", "Part-time first-time first-year degree-seeking", 107),
+        row2025("ug-pt-other-first-year", "Part-time other first-year degree-seeking", 108),
+        row2025("ug-pt-other-degree", "Part-time all other degree-seeking", 109),
+        row2025("ug-pt-total-degree", "Part-time total degree-seeking", 110),
+        row2025("ug-pt-other-credit", "Part-time other credit-course undergraduates", 111),
+        row2025("ug-pt-total", "Part-time total undergraduates", 112),
+        row2025("ug-total", "Total undergraduates", 113, "B.176"),
+      ],
+      values,
+    }),
+    makeTable({
+      key: "b1-graduate",
+      title: "B1 graduate enrollment",
+      caption:
+        "Full-time, part-time, and total graduate enrollment by reported sex or status.",
+      columns: ["Males", "Females", "Unknown", "Total"],
+      rows: [
+        row2025("grad-ft-first-time", "Full-time first-time degree-seeking", 114),
+        row2025("grad-ft-other-degree", "Full-time all other degree-seeking", 115),
+        row2025("grad-ft-other-credit", "Full-time other credit-course graduates", 116),
+        row2025("grad-ft-total", "Full-time total graduates", 117),
+        row2025("grad-pt-first-time", "Part-time first-time degree-seeking", 118),
+        row2025("grad-pt-other-degree", "Part-time all other degree-seeking", 119),
+        row2025("grad-pt-other-credit", "Part-time other credit-course graduates", 120),
+        row2025("grad-pt-total", "Part-time total graduates", 121),
+        row2025("grad-total", "Total graduate students", 122, "B.177"),
+      ],
+      values,
+    }),
+    makeTable({
+      key: "b1-overall",
+      title: "B1 overall enrollment",
+      caption:
+        "Institution-wide full-time, part-time, and total enrollment by reported sex or status.",
+      columns: ["Males", "Females", "Unknown", "Total"],
+      rows: [
+        row2025("all-ft", "Total full-time students", 123),
+        row2025("all-pt", "Total part-time students", 124),
+        row2025("all-total", "Grand total all students", 125, "B.178"),
+      ],
+      values,
+    }),
+  ];
+}
+
+function b1Tables2024(values: Record<string, FieldValue>): ReconstructedTable[] {
+  return [
+    makeTable({
+      key: "b1-undergraduate",
+      title: "B1 undergraduate enrollment",
+      caption:
+        "Full-time, part-time, and total undergraduate enrollment by reported gender or status.",
+      columns: ["Men", "Women", "Another gender", "Unknown", "Total"],
+      rows: [
+        row2024("ug-ft-first-year", "Full-time first-time first-year degree-seeking", 101),
+        row2024("ug-ft-other-first-year", "Full-time other first-year degree-seeking", 105),
+        row2024("ug-ft-other-degree", "Full-time all other degree-seeking", 109),
+        row2024("ug-ft-total-degree", "Full-time total degree-seeking", 113),
+        row2024("ug-ft-other-credit", "Full-time other credit-course undergraduates", 117),
+        row2024("ug-ft-total", "Full-time total undergraduates", 121),
+        row2024("ug-pt-first-year", "Part-time first-time first-year degree-seeking", 125),
+        row2024("ug-pt-other-first-year", "Part-time other first-year degree-seeking", 129),
+        row2024("ug-pt-other-degree", "Part-time all other degree-seeking", 133),
+        row2024("ug-pt-total-degree", "Part-time total degree-seeking", 137),
+        row2024("ug-pt-other-credit", "Part-time other credit-course undergraduates", 141),
+        row2024("ug-pt-total", "Part-time total undergraduates", 145),
+        row2024("ug-total", "Total undergraduates", 149, "B.193"),
+      ],
+      values,
+    }),
+    makeTable({
+      key: "b1-graduate",
+      title: "B1 graduate enrollment",
+      caption:
+        "Full-time, part-time, and total graduate enrollment by reported gender or status.",
+      columns: ["Men", "Women", "Another gender", "Unknown", "Total"],
+      rows: [
+        row2024("grad-ft-first-time", "Full-time first-time degree-seeking", 153),
+        row2024("grad-ft-other-degree", "Full-time all other degree-seeking", 157),
+        row2024("grad-ft-other-credit", "Full-time other credit-course graduates", 161),
+        row2024("grad-ft-total", "Full-time total graduates", 165),
+        row2024("grad-pt-first-time", "Part-time first-time degree-seeking", 169),
+        row2024("grad-pt-other-degree", "Part-time all other degree-seeking", 173),
+        row2024("grad-pt-other-credit", "Part-time other credit-course graduates", 177),
+        row2024("grad-pt-total", "Part-time total graduates", 181),
+        row2024("grad-total", "Total graduate students", 185, "B.194"),
+      ],
+      values,
+    }),
+    makeTable({
+      key: "b1-overall",
+      title: "B1 overall enrollment",
+      caption:
+        "Institution-wide total enrollment by reported gender or status.",
+      columns: ["Men", "Women", "Another gender", "Unknown", "Total"],
+      rows: [
+        row2024("all-total", "Grand total all students", 189, "B.195"),
+      ],
+      values,
+    }),
+  ];
+}
+
+function row2025(
+  key: string,
+  label: string,
+  maleIdNumber: number,
+  totalId: string | null = null,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [
+      b1Id(maleIdNumber),
+      b1Id(maleIdNumber + 25),
+      b1Id(maleIdNumber + 50),
+      totalId,
+    ],
+  ];
+}
+
+function row2024(
+  key: string,
+  label: string,
+  firstIdNumber: number,
+  totalId: string | null = null,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [
+      b1Id(firstIdNumber),
+      b1Id(firstIdNumber + 1),
+      b1Id(firstIdNumber + 2),
+      b1Id(firstIdNumber + 3),
+      totalId,
+    ],
+  ];
+}
+
+function b1Id(n: number): string {
+  return `B.${n}`;
 }
 
 function buildC1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {

--- a/web/tests/accessibility.spec.ts
+++ b/web/tests/accessibility.spec.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("reconstructed CDS tables have no automated WCAG violations", async ({ page }) => {
+  await page.goto("/schools/bowdoin/2024-25");
+  await expect(
+    page.getByRole("table", { name: /B1 undergraduate enrollment/i }),
+  ).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .include(".cd-reconstructed")
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+    .analyze();
+
+  expect(results.violations).toEqual([]);
+});

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -68,6 +68,11 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
     page.getByRole("heading", { name: /Bowdoin College/i }),
   ).toBeVisible();
 
+  const b1 = page.getByRole("table", { name: /B1 undergraduate enrollment/i });
+  await expect(b1).toBeVisible();
+  await expect(b1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();
+  await expect(b1.getByRole("rowheader", { name: "Total undergraduates", exact: true })).toBeVisible();
+
   const c1 = page.getByRole("table", { name: /C1 first-year admissions/i });
   await expect(c1).toBeVisible();
   await expect(c1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();


### PR DESCRIPTION
## Summary
- Adds reconstructed B1 enrollment tables for undergraduate, graduate, and overall enrollment.
- Supports both 2025-style B1 IDs and the 2024 layout with another-gender fields.
- Improves reconstructed table mobile UX with sticky row labels, focusable horizontal scroll regions, tighter spacing, and clearer scroll affordance.
- Adds focused axe-core Playwright coverage for reconstructed CDS tables on desktop and mobile.
- Raises contrast for missing table cells so `Not reported` values pass automated WCAG contrast checks.
- Repairs the web lockfile so GitHub Actions `npm ci` works with the new axe dependency.

## Test Coverage
All new code paths have test coverage.

## Pre-Landing Review
No issues found in local review.

## Design Review
Mobile reconstructed table UX was checked through Playwright smoke coverage. The table pattern keeps native table semantics and avoids body overflow on mobile.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
No plan file detected.

## Verification Results
- `npm run test` — 43 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npx playwright test --workers=4` — 15 passed, 1 skipped
- `npx npm@10 ci` — passed

## TODOs
No TODO items completed in this PR.

## Notes
A broader full-page axe sweep surfaced pre-existing accessibility issues outside this PR scope: low-contrast brand/footer text, coverage dashboard virtualized grid ARIA structure, and school-year gutter target sizes. This PR scopes axe enforcement to the reconstructed CDS table region being changed.

## Test plan
- [x] Vitest tests pass
- [x] TypeScript typecheck passes
- [x] Next production build passes
- [x] Playwright smoke and accessibility tests pass
- [x] npm 10 clean install passes