### PR TITLE
Render accessible B2 and H2 tables

### DIFF
--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -85,6 +85,42 @@ describe("buildReconstructedTables", () => {
     ]);
   });
 
+  it("builds B2 as a race and ethnicity cohort table", () => {
+    const tables = buildReconstructedTables({
+      "B.201": field("25", "Nonresidents"),
+      "B.202": field("80", "Hispanic/Latino"),
+      "B.211": field("120", "Nonresidents"),
+      "B.212": field("420", "Hispanic/Latino"),
+      "B.221": field("150", "Nonresidents"),
+      "B.222": field("500", "Hispanic/Latino"),
+      "B.230": field("2500", "TOTAL"),
+    });
+
+    const b2 = tables.find((table) => table.key === "b2-race-ethnicity");
+
+    expect(b2?.columns).toEqual([
+      "First-time first-year",
+      "Degree-seeking undergraduates",
+      "Total undergraduates",
+    ]);
+    expect(b2?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "25",
+      "120",
+      "150",
+    ]);
+    expect(b2?.rows[1].cells.map((cell) => cell.display)).toEqual([
+      "80",
+      "420",
+      "500",
+    ]);
+    expect(b2?.rows.at(-1)?.cells.map((cell) => cell.display)).toEqual([
+      "Not reported",
+      "Not reported",
+      "2,500",
+    ]);
+    expect(b2?.usedFieldIds).toContain("B.230");
+  });
+
   it("builds a 2025-style C1 table and leaves missing schema cells explicit", () => {
     const tables = buildReconstructedTables({
       "C.101": field("1200", "Total first-time, first-year males who applied"),
@@ -179,6 +215,42 @@ describe("buildReconstructedTables", () => {
       "—",
     ]);
     expect(c7?.usedFieldIds).toEqual(["C.701", "C.703"]);
+  });
+
+  it("builds H2 as a need-based aid cohort grid", () => {
+    const tables = buildReconstructedTables({
+      "H.201": field("500", "A. Number of degree-seeking undergraduate students", "Number"),
+      "H.202": field("320", "B. Number of students in line a who applied for need-based financial aid", "Number"),
+      "H.209": field("95", "I. On average, the percentage of need that was met", "Nearest 1%"),
+      "H.210": field("72000", "J. The average financial aid package", "Nearest $1"),
+      "H.214": field("1800", "A. Number of degree-seeking undergraduate students", "Number"),
+      "H.222": field("90", "I. On average, the percentage of need that was met", "Nearest 1%"),
+      "H.223": field("65000", "J. The average financial aid package", "Nearest $1"),
+      "H.227": field("50", "A. Number of degree-seeking undergraduate students", "Number"),
+    });
+
+    const h2 = tables.find((table) => table.key === "h2-aid-awarded");
+
+    expect(h2?.columns).toEqual([
+      "First-year full-time",
+      "All undergraduates full-time",
+      "All undergraduates less-than-full-time",
+    ]);
+    expect(h2?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "500",
+      "1,800",
+      "50",
+    ]);
+    expect(h2?.rows[8].cells.map((cell) => cell.display)).toEqual([
+      "95%",
+      "90%",
+      "Not reported",
+    ]);
+    expect(h2?.rows[9].cells.map((cell) => cell.display)).toEqual([
+      "$72,000",
+      "$65,000",
+      "Not reported",
+    ]);
   });
 
   it("builds H2A as a cohort grid", () => {

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -28,9 +28,11 @@ export function buildReconstructedTables(
 ): ReconstructedTable[] {
   return [
     ...buildB1Tables(values),
+    ...buildB2Tables(values),
     ...buildC1Tables(values),
     ...buildC7Tables(values),
     ...buildC9Tables(values),
+    ...buildH2Tables(values),
     ...buildH2ATables(values),
   ].filter((table) => hasReportedCell(table));
 }
@@ -210,6 +212,60 @@ function row2024(
 }
 
 function b1Id(n: number): string {
+  return `B.${n}`;
+}
+
+function buildB2Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^B\.2(0[1-9]|[12][0-9]|30)$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "b2-race-ethnicity",
+      title: "B2 enrollment by race and ethnicity",
+      caption:
+        "Undergraduate enrollment by race or ethnicity for first-time first-year, degree-seeking, and total undergraduate cohorts.",
+      columns: [
+        "First-time first-year",
+        "Degree-seeking undergraduates",
+        "Total undergraduates",
+      ],
+      rows: [
+        b2Row("nonresidents", "Nonresidents", 201),
+        b2Row("hispanic-latino", "Hispanic/Latino", 202),
+        b2Row("black", "Black or African American, non-Hispanic", 203),
+        b2Row("white", "White, non-Hispanic", 204),
+        b2Row("american-indian", "American Indian or Alaska Native, non-Hispanic", 205),
+        b2Row("asian", "Asian, non-Hispanic", 206),
+        b2Row("pacific-islander", "Native Hawaiian or other Pacific Islander, non-Hispanic", 207),
+        b2Row("two-or-more", "Two or more races, non-Hispanic", 208),
+        b2Row("unknown", "Race and/or ethnicity unknown", 209),
+        b2Row("total", "Total", 210),
+      ],
+      values,
+    }),
+  ];
+}
+
+function b2Row(
+  key: string,
+  label: string,
+  firstYearIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [
+      bId(firstYearIdNumber),
+      bId(firstYearIdNumber + 10),
+      bId(firstYearIdNumber + 20),
+    ],
+  ];
+}
+
+function bId(n: number): string {
   return `B.${n}`;
 }
 
@@ -398,6 +454,63 @@ function buildH2ATables(values: Record<string, FieldValue>): ReconstructedTable[
       values,
     }),
   ];
+}
+
+function buildH2Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^H\.2(0[1-9]|[1-3][0-9])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "h2-aid-awarded",
+      title: "H2 students awarded aid",
+      caption:
+        "Need-based aid counts, need met, and average awards by undergraduate cohort.",
+      columns: [
+        "First-year full-time",
+        "All undergraduates full-time",
+        "All undergraduates less-than-full-time",
+      ],
+      rows: [
+        h2Row("degree-seeking", "Degree-seeking undergraduates", 201),
+        h2Row("applied-need", "Applied for need-based aid", 202),
+        h2Row("need-determined", "Determined to have financial need", 203),
+        h2Row("any-aid", "Awarded any aid", 204),
+        h2Row("need-grant", "Awarded need-based scholarship or grant aid", 205),
+        h2Row("need-self-help", "Awarded need-based self-help aid", 206),
+        h2Row("non-need-grant", "Awarded non-need-based scholarship or grant aid", 207),
+        h2Row("need-fully-met", "Need fully met", 208),
+        h2Row("average-need-met", "Average percentage of need met", 209),
+        h2Row("average-aid-package", "Average financial aid package", 210),
+        h2Row("average-need-grant", "Average need-based scholarship or grant", 211),
+        h2Row("average-need-self-help", "Average need-based self-help award", 212),
+        h2Row("average-need-loan", "Average need-based loan", 213),
+      ],
+      values,
+    }),
+  ];
+}
+
+function h2Row(
+  key: string,
+  label: string,
+  firstYearIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [
+      h2Id(firstYearIdNumber),
+      h2Id(firstYearIdNumber + 13),
+      h2Id(firstYearIdNumber + 26),
+    ],
+  ];
+}
+
+function h2Id(n: number): string {
+  return `H.${n}`;
 }
 
 function makeTable({

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -73,6 +73,11 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await expect(b1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();
   await expect(b1.getByRole("rowheader", { name: "Total undergraduates", exact: true })).toBeVisible();
 
+  const b2 = page.getByRole("table", { name: /B2 enrollment by race and ethnicity/i });
+  await expect(b2).toBeVisible();
+  await expect(b2.getByRole("columnheader", { name: /Degree-seeking undergraduates/i })).toBeVisible();
+  await expect(b2.getByRole("rowheader", { name: "Hispanic/Latino" })).toBeVisible();
+
   const c1 = page.getByRole("table", { name: /C1 first-year admissions/i });
   await expect(c1).toBeVisible();
   await expect(c1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();
@@ -91,6 +96,11 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await expect(c7).toBeVisible();
   await expect(c7.getByRole("columnheader", { name: "Very important" })).toBeVisible();
   await expect(c7.getByRole("rowheader", { name: "Academic GPA" })).toBeVisible();
+
+  const h2 = page.getByRole("table", { name: /H2 students awarded aid/i });
+  await expect(h2).toBeVisible();
+  await expect(h2.getByRole("columnheader", { name: /All undergraduates full-time/i })).toBeVisible();
+  await expect(h2.getByRole("rowheader", { name: "Average financial aid package" })).toBeVisible();
 
   const h2a = page.getByRole("table", { name: /H2A non-need-based aid/i });
   await expect(h2a).toBeVisible();


### PR DESCRIPTION
## Summary
- render B2 race/ethnicity enrollment as an accessible reconstructed table
- render H2 aid-awarded counts, need met, and average awards as an accessible reconstructed table
- add unit and smoke coverage for B2/H2 table reconstruction

## Tests
- npm run test
- npm run typecheck
- npm run build
- npx playwright test --workers=4