### PR TITLE
Render remaining reconstructed CDS tables

### DIFF
--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -66,49 +66,7 @@ export function FieldsView({
 
         <div className="cd-fields__body">
           {sections.map((sec) => (
-            <section
-              key={sec.letter}
-              id={`sec-${sec.letter}`}
-              style={{ marginBottom: 36, scrollMarginTop: 24 }}
-            >
-              <header
-                style={{
-                  display: "flex",
-                  alignItems: "baseline",
-                  gap: 16,
-                  borderBottom: "1px solid var(--rule-strong)",
-                  paddingBottom: 8,
-                  marginBottom: 16,
-                }}
-              >
-                <h2
-                  className="serif"
-                  style={{
-                    fontWeight: 400,
-                    fontSize: 24,
-                    margin: 0,
-                    letterSpacing: "-0.01em",
-                  }}
-                >
-                  {sec.name}
-                </h2>
-                <span
-                  className="mono"
-                  style={{
-                    fontSize: 11,
-                    color: "var(--ink-3)",
-                    marginLeft: "auto",
-                    letterSpacing: "0.05em",
-                  }}
-                >
-                  {sec.subsections.length} TABLE
-                  {sec.subsections.length === 1 ? "" : "S"}
-                </span>
-              </header>
-              {sec.subsections.map((sub) => (
-                <SubsectionBlock key={sub.slug} sub={sub} />
-              ))}
-            </section>
+            <SectionBlock key={sec.letter} sec={sec} />
           ))}
         </div>
       </div>
@@ -116,15 +74,94 @@ export function FieldsView({
   );
 }
 
-function SubsectionBlock({ sub }: { sub: SubsectionGroup }) {
-  const subsectionValues = Object.fromEntries(
-    sub.fields.map(({ id, field }) => [id, field]),
+function SectionBlock({ sec }: { sec: ReturnType<typeof groupBySection>[number] }) {
+  const sectionValues = Object.fromEntries(
+    sec.subsections.flatMap((sub) => sub.fields.map(({ id, field }) => [id, field])),
   );
-  const reconstructedTables = buildReconstructedTables(subsectionValues);
+  const reconstructedTables = buildReconstructedTables(sectionValues);
   const reconstructedIds = new Set(
     reconstructedTables.flatMap((table) => table.usedFieldIds),
   );
-  const fallbackFields = sub.fields.filter(({ id }) => !reconstructedIds.has(id));
+  const subsectionByField = new Map<string, string>();
+  for (const sub of sec.subsections) {
+    for (const { id } of sub.fields) {
+      subsectionByField.set(id, sub.slug);
+    }
+  }
+  const tablesBySubsection = new Map<string, ReconstructedTable[]>();
+  for (const table of reconstructedTables) {
+    const slug =
+      table.usedFieldIds
+        .map((id) => subsectionByField.get(id))
+        .find((subSlug): subSlug is string => Boolean(subSlug)) ??
+      sec.subsections[0]?.slug;
+    if (!slug) continue;
+    const tables = tablesBySubsection.get(slug) ?? [];
+    tables.push(table);
+    tablesBySubsection.set(slug, tables);
+  }
+
+  return (
+    <section
+      id={`sec-${sec.letter}`}
+      style={{ marginBottom: 36, scrollMarginTop: 24 }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 16,
+          borderBottom: "1px solid var(--rule-strong)",
+          paddingBottom: 8,
+          marginBottom: 16,
+        }}
+      >
+        <h2
+          className="serif"
+          style={{
+            fontWeight: 400,
+            fontSize: 24,
+            margin: 0,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {sec.name}
+        </h2>
+        <span
+          className="mono"
+          style={{
+            fontSize: 11,
+            color: "var(--ink-3)",
+            marginLeft: "auto",
+            letterSpacing: "0.05em",
+          }}
+        >
+          {sec.subsections.length} TABLE
+          {sec.subsections.length === 1 ? "" : "S"}
+        </span>
+      </header>
+      {sec.subsections.map((sub) => (
+        <SubsectionBlock
+          key={sub.slug}
+          hiddenFieldIds={reconstructedIds}
+          reconstructedTables={tablesBySubsection.get(sub.slug) ?? []}
+          sub={sub}
+        />
+      ))}
+    </section>
+  );
+}
+
+function SubsectionBlock({
+  hiddenFieldIds,
+  reconstructedTables,
+  sub,
+}: {
+  hiddenFieldIds: Set<string>;
+  reconstructedTables: ReconstructedTable[];
+  sub: SubsectionGroup;
+}) {
+  const fallbackFields = sub.fields.filter(({ id }) => !hiddenFieldIds.has(id));
 
   return (
     <div
@@ -293,7 +330,7 @@ function ReconstructedTableView({ table }: { table: ReconstructedTable }) {
                       color: cell.missing ? "var(--ink-3)" : "var(--ink)",
                       borderBottom: "1px dashed var(--rule)",
                       fontWeight: cell.missing ? 400 : 500,
-                      overflowWrap: "anywhere",
+                      whiteSpace: "nowrap",
                     }}
                   >
                     {cell.display}

--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -121,6 +121,49 @@ describe("buildReconstructedTables", () => {
     expect(b2?.usedFieldIds).toContain("B.230");
   });
 
+  it("builds B3, B4, and B22 persistence and graduation tables", () => {
+    const tables = buildReconstructedTables({
+      "B.303": field("520", "Bachelor's degrees"),
+      "B.401": field("100", "Recipients of a Federal Pell Grant"),
+      "B.404": field("500", "Total"),
+      "B.429": field("88.5", "Six Year Grad Rate", "Whole Number or Round to Nearest Tenth"),
+      "B.501": field("90", "Recipients of a Federal Pell Grant"),
+      "B.532": field("91.2", "Total", "Whole Number or Round to Nearest Tenth"),
+      "B.1201": field("200", "2022 Cohort"),
+      "B.1202": field("180", "2021 Cohort"),
+      "B.2201": field("600", "Entering cohort"),
+      "B.2203": field("95", "Retention rate", "Whole Number or Round to Nearest Tenth"),
+    });
+
+    const degrees = tables.find((table) => table.key === "b3-degrees-awarded");
+    const currentGrad = tables.find((table) => table.key === "b4-current-graduation-rates");
+    const previousGrad = tables.find((table) => table.key === "b5-previous-graduation-rates");
+    const retention = tables.find((table) => table.key === "b22-first-year-retention");
+    const twoYear = tables.find((table) => table.key === "b12-b21-two-year-graduation-rates");
+
+    expect(degrees?.rows[2].cells[0].display).toBe("520");
+    expect(currentGrad?.columns).toEqual([
+      "Pell Grant",
+      "Subsidized Stafford, no Pell",
+      "Neither Pell nor subsidized Stafford",
+      "Total",
+    ]);
+    expect(currentGrad?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "100",
+      "Not reported",
+      "Not reported",
+      "500",
+    ]);
+    expect(currentGrad?.rows.at(-1)?.cells[0].display).toBe("88.5%");
+    expect(previousGrad?.rows.at(-1)?.cells.at(-1)?.display).toBe("91.2%");
+    expect(retention?.rows[0].cells[0].display).toBe("600");
+    expect(retention?.rows[2].cells[0].display).toBe("95%");
+    expect(twoYear?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "200",
+      "180",
+    ]);
+  });
+
   it("builds a 2025-style C1 table and leaves missing schema cells explicit", () => {
     const tables = buildReconstructedTables({
       "C.101": field("1200", "Total first-time, first-year males who applied"),
@@ -217,6 +260,54 @@ describe("buildReconstructedTables", () => {
     expect(c7?.usedFieldIds).toEqual(["C.701", "C.703"]);
   });
 
+  it("builds D2 transfer admissions and G cost tables", () => {
+    const tables = buildReconstructedTables({
+      "D.201": field("120", "Males"),
+      "D.202": field("150", "Females"),
+      "D.204": field("270", "Total"),
+      "D.212": field("40", "Total"),
+      "G.101": field("62000", "Tuition", "Nearest $1"),
+      "G.102": field("63000", "Tuition", "Nearest $1"),
+      "G.111": field("600", "Required Fees", "Nearest $1"),
+      "G.115": field("650", "Required Fees", "Nearest $1"),
+      "G.119": field("82000", "Comprehensive tuition and food and housing", "Nearest $1"),
+      "G.501": field("1200", "Books and supplies", "Nearest $1"),
+      "G.504": field("1100", "Books and supplies", "Nearest $1"),
+      "G.513": field("2000", "Other expenses", "Nearest $1"),
+    });
+
+    const d2 = tables.find((table) => table.key === "d2-transfer-admissions");
+    const g1 = tables.find((table) => table.key === "g1-undergraduate-costs");
+    const g5 = tables.find((table) => table.key === "g5-estimated-expenses");
+
+    expect(d2?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "120",
+      "150",
+      "Not reported",
+      "270",
+    ]);
+    expect(d2?.rows[2].cells.at(-1)?.display).toBe("40");
+    expect(g1?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "$62,000",
+      "$63,000",
+    ]);
+    expect(g1?.rows.at(-2)?.cells.map((cell) => cell.display)).toEqual([
+      "$82,000",
+      "Not reported",
+    ]);
+    expect(g5?.columns).toEqual([
+      "Residents",
+      "Commuters living at home",
+      "Commuters not living at home",
+    ]);
+    expect(g5?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "$1,200",
+      "$1,100",
+      "Not reported",
+    ]);
+    expect(g5?.rows.at(-1)?.cells.at(-1)?.display).toBe("$2,000");
+  });
+
   it("builds H2 as a need-based aid cohort grid", () => {
     const tables = buildReconstructedTables({
       "H.201": field("500", "A. Number of degree-seeking undergraduate students", "Number"),
@@ -277,5 +368,45 @@ describe("buildReconstructedTables", () => {
       "$12,500",
       "Not reported",
     ]);
+  });
+
+  it("builds H5, I1, I3, and J tables", () => {
+    const tables = buildReconstructedTables({
+      "H.501": field("200", "Any loan program", "Number"),
+      "H.506": field("40", "Any loan program", "Nearest 1%"),
+      "H.511": field("18000", "Any loan program", "Nearest $1"),
+      "I.101": field("90", "Total number of instructional faculty"),
+      "I.111": field("30", "Total number of instructional faculty"),
+      "I.121": field("120", "Total number of instructional faculty"),
+      "I.301": field("12", "2-9"),
+      "I.309": field("22", "2-9"),
+      "I.316": field("60", "Total"),
+      "J.187": field("12.5", "Computer and information sciences", "Whole Number or Round to Nearest Tenth"),
+      "J.220": field("100", "TOTAL", "Whole Number or Round to Nearest Tenth"),
+    });
+
+    const h5 = tables.find((table) => table.key === "h5-student-loans");
+    const i1 = tables.find((table) => table.key === "i1-instructional-faculty");
+    const i3 = tables.find((table) => table.key === "i3-undergraduate-class-size");
+    const j = tables.find((table) => table.key === "j-degrees-conferred");
+
+    expect(h5?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "200",
+      "40%",
+      "$18,000",
+    ]);
+    expect(i1?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "90",
+      "30",
+      "120",
+    ]);
+    expect(i3?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "12",
+      "22",
+    ]);
+    expect(i3?.rows.at(-1)?.cells.at(-1)?.display).toBe("60");
+    expect(j?.columns).toEqual(["Certificate/diploma", "Associate", "Bachelor's"]);
+    expect(j?.rows.find((row) => row.label === "Computer and information sciences")?.cells[2].display).toBe("12.5%");
+    expect(j?.rows.at(-1)?.cells[2].display).toBe("100%");
   });
 });

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -29,11 +29,21 @@ export function buildReconstructedTables(
   return [
     ...buildB1Tables(values),
     ...buildB2Tables(values),
+    ...buildB3Tables(values),
+    ...buildB4B5Tables(values),
+    ...buildB22Tables(values),
     ...buildC1Tables(values),
     ...buildC7Tables(values),
     ...buildC9Tables(values),
+    ...buildD2Tables(values),
+    ...buildG1Tables(values),
+    ...buildG5Tables(values),
     ...buildH2Tables(values),
     ...buildH2ATables(values),
+    ...buildH5Tables(values),
+    ...buildI1Tables(values),
+    ...buildI3Tables(values),
+    ...buildJTables(values),
   ].filter((table) => hasReportedCell(table));
 }
 
@@ -269,6 +279,141 @@ function bId(n: number): string {
   return `B.${n}`;
 }
 
+function buildB3Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^B\.30[1-9]$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "b3-degrees-awarded",
+      title: "B3 degrees awarded",
+      caption: "Degrees awarded by credential level in the reporting year.",
+      columns: ["Number awarded"],
+      rows: [
+        ["certificate", "Certificate/diploma", ["B.301"]],
+        ["associate", "Associate degrees", ["B.302"]],
+        ["bachelor", "Bachelor's degrees", ["B.303"]],
+        ["postbachelor", "Postbachelor's certificates", ["B.304"]],
+        ["master", "Master's degrees", ["B.305"]],
+        ["post-master", "Post-master's certificates", ["B.306"]],
+        ["doctoral-research", "Doctoral degrees, research/scholarship", ["B.307"]],
+        ["doctoral-practice", "Doctoral degrees, professional practice", ["B.308"]],
+        ["doctoral-other", "Doctoral degrees, other", ["B.309"]],
+      ],
+      values,
+    }),
+  ];
+}
+
+function buildB4B5Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^B\.[45](0[1-9]|[12][0-9]|3[0-2])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    graduationRateTable(values, "b4-current-graduation-rates", "B4 current graduation-rate cohort", 401),
+    graduationRateTable(values, "b5-previous-graduation-rates", "B5 previous graduation-rate cohort", 501),
+  ];
+}
+
+function graduationRateTable(
+  values: Record<string, FieldValue>,
+  key: string,
+  title: string,
+  firstIdNumber: number,
+): ReconstructedTable {
+  return withPercentRows(makeTable({
+    key,
+    title,
+    caption:
+      "Four-year institution graduation-rate cohort counts and six-year graduation rates by aid-recipient category.",
+    columns: [
+      "Pell Grant",
+      "Subsidized Stafford, no Pell",
+      "Neither Pell nor subsidized Stafford",
+      "Total",
+    ],
+    rows: [
+      graduationRateRow("initial-cohort", "Initial cohort", firstIdNumber),
+      graduationRateRow("did-not-persist", "Did not persist", firstIdNumber + 4),
+      graduationRateRow("final-cohort", "Final cohort", firstIdNumber + 8),
+      graduationRateRow("completed-four", "Completed in less than four years", firstIdNumber + 12),
+      graduationRateRow("completed-five", "Completed in less than five years", firstIdNumber + 16),
+      graduationRateRow("completed-six", "Completed in less than six years", firstIdNumber + 20),
+      graduationRateRow("completed-total", "Total completers", firstIdNumber + 24),
+      graduationRateRow("six-year-rate", "Six-year graduation rate", firstIdNumber + 28),
+    ],
+    values,
+  }), ["six-year-rate"]);
+}
+
+function graduationRateRow(
+  key: string,
+  label: string,
+  firstIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [bId(firstIdNumber), bId(firstIdNumber + 1), bId(firstIdNumber + 2), bId(firstIdNumber + 3)],
+  ];
+}
+
+function buildB22Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  const hasB22 = ids.some((id) => /^B\.220[1-3]$/.test(id));
+  const hasTwoYear = ids.some((id) => /^B\.(1[2-9]|20|21)0[1-2]$/.test(id));
+  if (!hasB22 && !hasTwoYear) {
+    return [];
+  }
+
+  return [
+    withPercentRows(makeTable({
+      key: "b22-first-year-retention",
+      title: "B22 first-year retention",
+      caption: "First-time full-time bachelor's cohort retention count and rate.",
+      columns: ["Value"],
+      rows: [
+        ["entering-cohort", "Entering cohort", ["B.2201"]],
+        ["still-enrolled", "Still enrolled next fall", ["B.2202"]],
+        ["retention-rate", "Retention rate", ["B.2203"]],
+      ],
+      values,
+    }), ["retention-rate"]),
+    makeTable({
+      key: "b12-b21-two-year-graduation-rates",
+      title: "B12-B21 two-year graduation rates",
+      caption:
+        "Two-year institution graduation-rate cohort outcomes for the current and previous cohorts.",
+      columns: ["Current cohort", "Previous cohort"],
+      rows: [
+        twoYearGradRow("initial-cohort", "Initial cohort", 12),
+        twoYearGradRow("did-not-persist", "Did not persist", 13),
+        twoYearGradRow("final-cohort", "Final cohort", 14),
+        twoYearGradRow("completed-two-total", "Completed program in less than two years", 15),
+        twoYearGradRow("completed-two-150", "Completed program in less than two years at 150% time", 16),
+        twoYearGradRow("completed-four-total", "Completed program in less than four years", 17),
+        twoYearGradRow("completed-four-150", "Completed program in less than four years at 150% time", 18),
+        twoYearGradRow("transfers-out", "Transfers out", 19),
+        twoYearGradRow("transfers-two-year", "Transfers to two-year institutions", 20),
+        twoYearGradRow("transfers-four-year", "Transfers to four-year institutions", 21),
+      ],
+      values,
+    }),
+  ];
+}
+
+function twoYearGradRow(
+  key: string,
+  label: string,
+  sectionNumber: number,
+): [string, string, (string | null)[]] {
+  return [key, label, [bId(sectionNumber * 100 + 1), bId(sectionNumber * 100 + 2)]];
+}
+
 function buildC1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
   const ids = Object.keys(values);
   if (!ids.some((id) => /^C\.1(0[1-9]|1[0-9]|2[0-9]|30)$/.test(id))) {
@@ -428,6 +573,90 @@ function buildC9Tables(values: Record<string, FieldValue>): ReconstructedTable[]
   ];
 }
 
+function buildD2Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^D\.2(0[1-9]|1[0-2])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "d2-transfer-admissions",
+      title: "D2 transfer admissions",
+      caption:
+        "Transfer applicants, admits, and enrolled students by reported sex or status.",
+      columns: ["Males", "Females", "Unknown", "Total"],
+      rows: [
+        ["applied", "Applied", ["D.201", "D.202", "D.203", "D.204"]],
+        ["admitted", "Admitted", ["D.205", "D.206", "D.207", "D.208"]],
+        ["enrolled", "Enrolled", ["D.209", "D.210", "D.211", "D.212"]],
+      ],
+      values,
+    }),
+  ];
+}
+
+function buildG1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^G\.1(0[1-9]|1[0-9]|20)$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "g1-undergraduate-costs",
+      title: "G1 undergraduate costs",
+      caption:
+        "Published undergraduate tuition, required fees, and on-campus food and housing charges.",
+      columns: ["First-year", "All undergraduates"],
+      rows: [
+        ["tuition", "Tuition", ["G.101", "G.102"]],
+        ["tuition-in-district", "Tuition: in-district", ["G.103", "G.107"]],
+        ["tuition-in-state", "Tuition: in-state", ["G.104", "G.108"]],
+        ["tuition-out-of-state", "Tuition: out-of-state", ["G.105", "G.109"]],
+        ["tuition-nonresident", "Tuition: nonresident", ["G.106", "G.110"]],
+        ["required-fees", "Required fees", ["G.111", "G.115"]],
+        ["food-housing", "Food and housing, on-campus", ["G.112", "G.116"]],
+        ["housing-only", "Housing only, on-campus", ["G.113", "G.117"]],
+        ["food-only", "Food only, on-campus meal plan", ["G.114", "G.118"]],
+        ["comprehensive", "Comprehensive tuition, food, and housing", ["G.119", null]],
+        ["other", "Other", ["G.120", null]],
+      ],
+      values,
+    }),
+  ];
+}
+
+function buildG5Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^G\.5(0[1-9]|1[0-3])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "g5-estimated-expenses",
+      title: "G5 estimated expenses",
+      caption:
+        "Estimated books, supplies, transportation, food, housing, and personal expenses by living arrangement.",
+      columns: [
+        "Residents",
+        "Commuters living at home",
+        "Commuters not living at home",
+      ],
+      rows: [
+        ["books-supplies", "Books and supplies", ["G.501", "G.504", "G.508"]],
+        ["food-only", "Food only", [null, "G.505", "G.510"]],
+        ["housing-only", "Housing only", [null, null, "G.509"]],
+        ["food-housing", "Food and housing total", [null, null, "G.511"]],
+        ["transportation", "Transportation", ["G.502", "G.506", "G.512"]],
+        ["other", "Other expenses", ["G.503", "G.507", "G.513"]],
+      ],
+      values,
+    }),
+  ];
+}
+
 function buildH2ATables(values: Record<string, FieldValue>): ReconstructedTable[] {
   const ids = Object.keys(values);
   if (!ids.some((id) => /^H\.2A(0[1-9]|1[0-2])$/.test(id))) {
@@ -511,6 +740,231 @@ function h2Row(
 
 function h2Id(n: number): string {
   return `H.${n}`;
+}
+
+function buildH5Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^H\.5(0[1-9]|1[0-5])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "h5-student-loans",
+      title: "H5 student loans",
+      caption:
+        "Graduating first-time student loan borrowers by loan source, share of class, and average per-borrower debt.",
+      columns: ["Number in class", "Percent of class", "Average per borrower"],
+      rows: [
+        h5Row("any-loan", "Any loan program", 501),
+        h5Row("federal-loans", "Federal loan programs", 502),
+        h5Row("institutional-loans", "Institutional loan programs", 503),
+        h5Row("state-loans", "State loan programs", 504),
+        h5Row("private-loans", "Private student loans", 505),
+      ],
+      values,
+    }),
+  ];
+}
+
+function h5Row(
+  key: string,
+  label: string,
+  countIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [hId(countIdNumber), hId(countIdNumber + 5), hId(countIdNumber + 10)],
+  ];
+}
+
+function hId(n: number): string {
+  return `H.${n}`;
+}
+
+function buildI1Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^I\.1(0[1-9]|[12][0-9]|30)$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "i1-instructional-faculty",
+      title: "I1 instructional faculty",
+      caption:
+        "Instructional faculty counts by full-time status and selected demographic or credential category.",
+      columns: ["Full-time", "Part-time", "Total"],
+      rows: [
+        i1Row("total", "Total instructional faculty", 101),
+        i1Row("minority", "Members of minority groups", 102),
+        i1Row("female", "Females", 103),
+        i1Row("male", "Males", 104),
+        i1Row("nonresident", "Nonresidents", 105),
+        i1Row("terminal-degree", "Doctorate or other terminal degree", 106),
+        i1Row("masters", "Master's, but not terminal master's", 107),
+        i1Row("bachelors", "Bachelor's degree", 108),
+        i1Row("unknown-degree", "Unknown or other highest degree", 109),
+        i1Row("graduate-only", "Stand-alone graduate/professional programs", 110),
+      ],
+      values,
+    }),
+  ];
+}
+
+function i1Row(
+  key: string,
+  label: string,
+  fullTimeIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [
+    key,
+    label,
+    [iId(fullTimeIdNumber), iId(fullTimeIdNumber + 10), iId(fullTimeIdNumber + 20)],
+  ];
+}
+
+function buildI3Tables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^I\.3(0[1-9]|1[0-6])$/.test(id))) {
+    return [];
+  }
+
+  return [
+    makeTable({
+      key: "i3-undergraduate-class-size",
+      title: "I3 undergraduate class size",
+      caption:
+        "Undergraduate class sections and subsections by enrollment size band.",
+      columns: ["Class sections", "Class subsections"],
+      rows: [
+        i3Row("2-9", "2-9 students", 301),
+        i3Row("10-19", "10-19 students", 302),
+        i3Row("20-29", "20-29 students", 303),
+        i3Row("30-39", "30-39 students", 304),
+        i3Row("40-49", "40-49 students", 305),
+        i3Row("50-99", "50-99 students", 306),
+        i3Row("100-plus", "100+ students", 307),
+        i3Row("total", "Total", 308),
+      ],
+      values,
+    }),
+  ];
+}
+
+function i3Row(
+  key: string,
+  label: string,
+  sectionIdNumber: number,
+): [string, string, (string | null)[]] {
+  return [key, label, [iId(sectionIdNumber), iId(sectionIdNumber + 8)]];
+}
+
+function iId(n: number): string {
+  return `I.${n}`;
+}
+
+function buildJTables(values: Record<string, FieldValue>): ReconstructedTable[] {
+  const ids = Object.keys(values);
+  if (!ids.some((id) => /^J\.(1\d{2}|2[0-2]\d)$/.test(id))) {
+    return [];
+  }
+
+  return [
+    withPercentCells(makeTable({
+      key: "j-degrees-conferred",
+      title: "J degrees conferred by discipline",
+      caption:
+        "Percentage distribution of degrees conferred by discipline and award level.",
+      columns: ["Certificate/diploma", "Associate", "Bachelor's"],
+      rows: J_DISCIPLINES.map((label, i) => [
+        label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+        label,
+        [jId(101 + i), jId(141 + i), jId(181 + i)],
+      ]),
+      values,
+    })),
+  ];
+}
+
+const J_DISCIPLINES = [
+  "Agriculture",
+  "Natural resources and conservation",
+  "Architecture",
+  "Area, ethnic, and gender studies",
+  "Communication/journalism",
+  "Communication technologies",
+  "Computer and information sciences",
+  "Personal and culinary services",
+  "Education",
+  "Engineering",
+  "Engineering technologies",
+  "Foreign languages, literatures, and linguistics",
+  "Family and consumer sciences",
+  "Law/legal studies",
+  "English",
+  "Liberal arts/general studies",
+  "Library science",
+  "Biological/life sciences",
+  "Mathematics and statistics",
+  "Military science and military technologies",
+  "Interdisciplinary studies",
+  "Parks and recreation",
+  "Philosophy and religious studies",
+  "Theology and religious vocations",
+  "Physical sciences",
+  "Science technologies",
+  "Psychology",
+  "Homeland Security, law enforcement, firefighting, and protective services",
+  "Public administration and social services",
+  "Social sciences",
+  "Construction trades",
+  "Mechanic and repair technologies",
+  "Precision production",
+  "Transportation and materials moving",
+  "Visual and performing arts",
+  "Health professions and related programs",
+  "Business/marketing",
+  "History",
+  "Other",
+  "Total",
+];
+
+function jId(n: number): string {
+  return `J.${n}`;
+}
+
+function withPercentRows(
+  table: ReconstructedTable,
+  rowKeys: string[],
+): ReconstructedTable {
+  const percentRows = new Set(rowKeys);
+  return {
+    ...table,
+    rows: table.rows.map((row) =>
+      percentRows.has(row.key)
+        ? { ...row, cells: row.cells.map(formatPercentCell) }
+        : row,
+    ),
+  };
+}
+
+function withPercentCells(table: ReconstructedTable): ReconstructedTable {
+  return {
+    ...table,
+    rows: table.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map(formatPercentCell),
+    })),
+  };
+}
+
+function formatPercentCell(cell: ReconstructedCell): ReconstructedCell {
+  if (cell.missing || cell.display.endsWith("%")) {
+    return cell;
+  }
+  return { ...cell, display: `${cell.display}%` };
 }
 
 function makeTable({

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -78,6 +78,19 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await expect(b2.getByRole("columnheader", { name: /Degree-seeking undergraduates/i })).toBeVisible();
   await expect(b2.getByRole("rowheader", { name: "Hispanic/Latino" })).toBeVisible();
 
+  const b3 = page.getByRole("table", { name: /B3 degrees awarded/i });
+  await expect(b3).toBeVisible();
+  await expect(b3.getByRole("rowheader", { name: "Bachelor's degrees" })).toBeVisible();
+
+  const b4 = page.getByRole("table", { name: /B4 current graduation-rate cohort/i });
+  await expect(b4).toBeVisible();
+  await expect(b4.getByRole("columnheader", { name: /Pell Grant/i })).toBeVisible();
+  await expect(b4.getByRole("rowheader", { name: "Six-year graduation rate" })).toBeVisible();
+
+  const b5 = page.getByRole("table", { name: /B5 previous graduation-rate cohort/i });
+  await expect(b5).toBeVisible();
+  await expect(b5.getByRole("rowheader", { name: "Initial cohort" })).toBeVisible();
+
   const c1 = page.getByRole("table", { name: /C1 first-year admissions/i });
   await expect(c1).toBeVisible();
   await expect(c1.getByRole("columnheader", { name: /^(Males|Men)$/i })).toBeVisible();
@@ -97,6 +110,18 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await expect(c7.getByRole("columnheader", { name: "Very important" })).toBeVisible();
   await expect(c7.getByRole("rowheader", { name: "Academic GPA" })).toBeVisible();
 
+  const d2 = page.getByRole("table", { name: /D2 transfer admissions/i });
+  await expect(d2).toBeVisible();
+  await expect(d2.getByRole("rowheader", { name: "Enrolled" })).toBeVisible();
+
+  const g1 = page.getByRole("table", { name: /G1 undergraduate costs/i });
+  await expect(g1).toBeVisible();
+  await expect(g1.getByRole("rowheader", { name: "Tuition", exact: true })).toBeVisible();
+
+  const g5 = page.getByRole("table", { name: /G5 estimated expenses/i });
+  await expect(g5).toBeVisible();
+  await expect(g5.getByRole("columnheader", { name: /Commuters not living at home/i })).toBeVisible();
+
   const h2 = page.getByRole("table", { name: /H2 students awarded aid/i });
   await expect(h2).toBeVisible();
   await expect(h2.getByRole("columnheader", { name: /All undergraduates full-time/i })).toBeVisible();
@@ -106,6 +131,23 @@ test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await expect(h2a).toBeVisible();
   await expect(h2a.getByRole("columnheader", { name: /First-year full-time/i })).toBeVisible();
   await expect(h2a.getByRole("rowheader", { name: /Average institutional non-need grant/i })).toBeVisible();
+
+  const h5 = page.getByRole("table", { name: /H5 student loans/i });
+  await expect(h5).toBeVisible();
+  await expect(h5.getByRole("columnheader", { name: /Average per borrower/i })).toBeVisible();
+
+  const i1 = page.getByRole("table", { name: /I1 instructional faculty/i });
+  await expect(i1).toBeVisible();
+  await expect(i1.getByRole("rowheader", { name: "Total instructional faculty" })).toBeVisible();
+
+  const i3 = page.getByRole("table", { name: /I3 undergraduate class size/i });
+  await expect(i3).toBeVisible();
+  await expect(i3.getByRole("rowheader", { name: "100+ students" })).toBeVisible();
+
+  const j = page.getByRole("table", { name: /J degrees conferred by discipline/i });
+  await expect(j).toBeVisible();
+  await expect(j.getByRole("columnheader", { name: "Bachelor's" })).toBeVisible();
+  await expect(j.getByRole("rowheader", { name: "Computer and information sciences" })).toBeVisible();
 });
 
 test("mobile launch surfaces do not overflow", async ({ page, isMobile }) => {


### PR DESCRIPTION
## Summary
- add reconstructed tables for B3, B4/B5, B22/two-year graduation, D2, G1/G5, H5, I1/I3, and J degrees conferred
- build reconstructed tables once per CDS section so cross-subsection tables render once with complete rows
- add table-local percent formatting for graduation/retention rates and J degree-share values
- expand unit and smoke coverage for the broader reconstructed table set

## Tests
- npm run test
- npm run typecheck
- npm run build
- npx playwright test --workers=4

## Visual QA
- reviewed local desktop/mobile screenshots for B4, G1, H5, I3, and J on Bowdoin 2024-25
- fixed wrapped percentage values in narrow numeric columns