### PR TITLE
Add IPEDS federal baseline coverage layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           python -m unittest tools.tier1_extractor.test_extract
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
+      - name: Run IPEDS loader tests
+        run: python -m unittest discover -s tools/ipeds -p "test_*.py"
       - name: Run change intelligence tests
         run: python -m unittest discover -s tools/change_intelligence -p "test_*.py"
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -117,6 +117,16 @@ Sections are ordered **Open → Resolved → Strategic context**. Every open ite
 
 ### Larger features / future tiers
 
+- **PRD 021 IPEDS coverage layer.** Drafted as
+  [PRD 021](prd/021-ipeds-coverage-layer.md). IPEDS should become the federal
+  baseline fact layer for non-CDS schools, keyed by UNITID and source-labeled as
+  provisional/final federal data. It should not replace CDS as the
+  school-authored source-document layer or current-year change-intelligence
+  input. Start with a build-vs-use spike over the annual Access bundle,
+  Complete Data Files, and third-party normalized packages; then map
+  ADM/EF/COST/SFA/GR/OM/Completions into curated facts. **Effort:** multi-PR
+  product/data layer; first mapping + loader spike likely 1-2 days.
+
 - **Tier 3 DOCX extractor (PRD 007).** Revised plan shipped 2026-04-29 in [PRD 007](prd/007-tier3-docx-extraction.md). Primary path is a deterministic OOXML SDT reader keyed by schema `word_tag` values, same lookup pattern as Tier 2. Fallback path is a measured Docling DOCX structural adapter that reuses Tier 4 cleaner/table logic for SDT-stripped Word files before considering any bespoke Word-table parser. Addressable corpus today is ~30-50 documents (Kent State's 14 SDT-preserving files are the largest family). The format sniffer now routes DOCX correctly; the remaining work is the extractor itself.
 
 - **Tier 4 cleaner — continue resolver coverage beyond the core product surfaces.** [PRD 005](prd/005-full-schema-extraction.md)'s Phase 6 architecture shipped 2026-04-20 (commit `aecca9b`): the section-family resolver framework backed by a shared `SchemaIndex` took the cleaner from 72 -> ~380 fields (Harvard 382, Yale 390, Dartmouth 343). PRD 016B and PRD 018 added targeted C21/C22 and H1/H2/H2A coverage. Remaining work is continuing to add resolvers for thinner sections as specific schools surface gaps; the ceiling is 1,105 fields, but full-schema parity is not urgent.

--- a/docs/prd/021-ipeds-coverage-layer.md
+++ b/docs/prd/021-ipeds-coverage-layer.md
@@ -1,0 +1,871 @@
+# PRD 021: IPEDS coverage layer for non-CDS schools
+
+**Status:** In implementation
+**Created:** 2026-05-08
+**Author:** Anthony + Codex
+**Related:** [PRD 010](010-queryable-data-browser.md), [PRD 015](015-institution-directory-and-cds-coverage.md), [PRD 019](019-cds-change-intelligence.md), [PRD 020](020-accessible-cds-table-view.md), [Scorecard join recipe](../research/scorecard-join-recipe.md)
+
+---
+
+## Executive summary
+
+IPEDS should become the federal baseline layer for collegedata.fyi.
+
+It should **not** fully replace the Common Data Set. It can close most of the
+coverage gap for directory-scale institution facts, enrollment, admissions,
+cost, aid, completions, outcomes, and staffing. It cannot replace the CDS as the
+best source for newest-year CDS-specific admissions detail, application-plan
+behavior, wait-list detail, some aid-table definitions, or institution-authored
+source-document accountability.
+
+The product move is:
+
+1. Keep CDS as the highest-authority source when a school publishes one.
+2. Load annual IPEDS bulk files for all Title IV institutions keyed by UNITID.
+3. Project a curated, source-labeled IPEDS fact layer into the same public
+   surfaces that already use CDS and Scorecard data.
+4. Use IPEDS to turn "no public CDS found" from an empty page into a useful,
+   honest institutional profile.
+
+This is likely the highest-leverage way to move from a CDS archive covering
+hundreds of schools to a college-data product covering thousands.
+
+## Official-source findings
+
+This PRD is based on the official NCES/IPEDS documentation and a live probe of
+the NCES data-file surfaces.
+
+Primary references:
+
+- IPEDS overview: https://nces.ed.gov/ipeds/use-the-data/overview-of-ipeds-data
+- IPEDS survey components: https://nces.ed.gov/ipeds/survey-components
+- IPEDS Access databases: https://nces.ed.gov/ipeds/use-the-data/download-access-database
+- IPEDS complete data files / Data Center: https://nces.ed.gov/ipeds/datacenter/Default.aspx?fromIpeds=true&gotoReportId=7
+- Component pages:
+  - Admissions: https://nces.ed.gov/ipeds/survey-components/6
+  - Fall Enrollment: https://nces.ed.gov/ipeds/survey-components/8
+  - 12-month Enrollment: https://nces.ed.gov/ipeds/survey-components/5
+  - Institutional Characteristics: https://nces.ed.gov/ipeds/survey-components/4
+  - Cost: https://nces.ed.gov/ipeds/survey-components/13
+  - Student Financial Aid: https://nces.ed.gov/ipeds/survey-components/12
+  - Completions: https://nces.ed.gov/ipeds/survey-components/7
+  - Graduation Rates: https://nces.ed.gov/ipeds/survey-components/9
+  - Outcome Measures: https://nces.ed.gov/ipeds/survey-components/11
+  - Human Resources: https://nces.ed.gov/ipeds/survey-components/3
+
+What NCES says IPEDS is:
+
+- A system of interrelated annual surveys run by NCES.
+- Submitted by about 6,400 colleges, universities, technical, and vocational
+  institutions participating in federal student aid programs.
+- Aggregated institution-level data, not student-level records.
+- Organized across 13 interrelated survey components and three reporting
+  periods.
+- Available through online tools, complete CSV data files, dictionaries, and
+  annual Microsoft Access bundles with metadata.
+
+Important release semantics:
+
+- Provisional releases have gone through NCES quality control and include
+  imputed values for nonresponding institutions.
+- Final releases include prior-year institutional revisions and are the most
+  up-to-date release for a collection year.
+- Official docs describe provisional data as released about one year after
+  initial collection and final data about two years after initial collection.
+- The current Access page shows `2024-25` as provisional, released March 2026,
+  and `2023-24` as final, also released March 2026.
+
+Operational finding:
+
+- The NCES Data Center complete-file UI is sessiony, but the download endpoints
+  are scriptable after a cookie-initializing request.
+- Current CSV endpoint shape observed through the Data Center:
+
+```text
+https://nces.ed.gov/ipeds/data-generator?year=2024&tableName=ADM2024&HasRV=0&type=csv
+```
+
+- Current dictionary endpoint shape:
+
+```text
+https://nces.ed.gov/ipeds/dictionary-generator?year=2024&tableName=ADM2024
+```
+
+- Dictionary downloads are zipped Excel workbooks containing sheets such as
+  `Varlist`, `Description`, `Frequencies`, `Statistics`, and `Imputation values`.
+- Example `ADM2024` dictionary confirms admissions variables for applicants,
+  admissions, enrolled students, SAT/ACT score percentiles, and admissions
+  considerations. It also shows code labels and imputation flags.
+
+### Input-source decision
+
+Use only official NCES/IPEDS sources for v1, but do **not** parse the Microsoft
+Access database in the first implementation. The Access page remains the release
+discovery/provenance surface, and the Access ZIP URL is recorded on the release,
+but the loader uses:
+
+1. **Official IPEDS Tablesdoc workbook** for table, variable, value-label, and
+   imputation metadata.
+2. **Official IPEDS complete data / Data Center CSV ZIP downloads** for table
+   rows, cached immutably under `scratch/ipeds/`.
+3. **No third-party normalized package** as an authoritative input. External
+   packages can be used later for comparison only if their transformations,
+   cadence, and attribution are reviewed.
+
+This keeps the v1 parser small, auditable, and source-labeled while avoiding
+Access-driver/platform complexity.
+
+### Measured starting coverage
+
+Production public counts as of 2026-05-08:
+
+- `institution_directory`: 6,322 rows, all keyed by IPEDS `ipeds_id`.
+- `institution_directory WHERE in_scope = true`: 2,924 rows.
+- `scorecard_summary`: 6,322 rows.
+- `cds_manifest`: 3,999 rows.
+- `cds_manifest` rows with `ipeds_id`: 3,840.
+- `cds_manifest` rows without `ipeds_id`: 159.
+
+This means the directory backbone is already UNITID-native. The immediate join
+risk is not the `institution_directory`; it is the remaining manifest gap,
+legacy slug variants, non-Title-IV/non-school rows, and sub-institutional cases
+where one CDS row should not inherit a parent-campus federal value without an
+explicit mapping.
+
+Before implementation, rerun the same measurement and add a distinct-school
+breakdown:
+
+```sql
+select count(*) from institution_directory;
+select count(*) from institution_directory where in_scope = true;
+select count(*) from cds_manifest;
+select count(*) from cds_manifest where ipeds_id is not null;
+select count(*) from cds_manifest where ipeds_id is null;
+select count(distinct school_id) from cds_manifest where ipeds_id is null;
+```
+
+### Product-identity risk
+
+Shipping PRD 021 changes the product shape. Today, collegedata.fyi is primarily
+"the CDS archive." If most public school pages become federal-baseline-only, the
+site risks becoming "an IPEDS viewer with some CDS documents."
+
+That is not a strong enough moat by itself. College Navigator is the official
+IPEDS consumer interface, and many commercial sites already package federal
+college data.
+
+Baseline-only pages are worth shipping only if they do work those alternatives
+do not:
+
+- clearly explain whether a school publishes a public CDS and preserve the
+  source when it does;
+- reconcile CDS, IPEDS, and Scorecard without hiding provenance;
+- expose source labels and imputation/release status better than consumer sites;
+- provide queryable/exportable open data and stable URLs;
+- show "federal baseline plus school-authored document, when available" rather
+  than generic college-marketing copy.
+
+Indexing federal-baseline-only pages should be a separate launch decision. It is
+reasonable to noindex those pages until source labels, attribution, and
+definition notes are polished.
+
+## Can IPEDS fully supplant CDS?
+
+No. It can supplant a large share of the *facts* families need from CDS, but not
+the CDS as a source type.
+
+### Where IPEDS can beat CDS
+
+IPEDS is stronger than CDS for broad coverage:
+
+- It covers the Title IV universe, not just voluntary CDS publishers.
+- It has a stable UNITID key, official metadata dictionaries, imputation flags,
+  release status, and long historical availability.
+- It is machine-readable from the start.
+- It has consistent federal definitions across institutions.
+- It covers many schools that will never publish a CDS.
+
+IPEDS is also stronger for some analytics:
+
+- Completions by 6-digit CIP code are richer than CDS Section J percentages.
+- Outcome Measures include non-first-time and part-time cohorts that CDS
+  graduation-rate tables do not fully cover.
+- Finance and Human Resources expose institutional operating context beyond CDS.
+- 12-month enrollment is better for year-round and nontraditional institutions.
+
+### Where CDS remains better
+
+CDS remains stronger for admissions-product specificity and public-document
+accountability:
+
+- **Current-year speed.** CDS files often publish months before equivalent IPEDS
+  data becomes public. For 2025-26 admissions and change intelligence, CDS can
+  show current institutional behavior while IPEDS remains a lagged federal
+  baseline.
+- **Admissions strategy detail.** IPEDS has admissions totals, acceptance/yield,
+  test scores, and admissions considerations for non-open-admissions schools.
+  CDS adds the strategy fields counselors and families actually ask about:
+  Early Decision, Early Action, wait-list behavior, deferrals, deadlines,
+  notification dates, application fees, fee waivers, class-rank distributions,
+  GPA distributions, and school-specific test-policy context.
+- **CDS-native C7 semantics.** CDS C7 reports the familiar "Very Important /
+  Important / Considered / Not Considered" factor-importance matrix. IPEDS
+  admissions consideration codes are valuable but more compliance-oriented and
+  should not be treated as a drop-in C7 replacement without a definition note.
+- **CDS-native C1 framing.** CDS C1 is the exact publisher-facing
+  applicants/admitted/enrolled table, including the row/column framing used by
+  schools, counselors, publishers, and institutional research offices. IPEDS ADM
+  can cover many of the same totals, but the population, release timing, and
+  gender/category treatment need explicit mapping before values are blended.
+- **Financial-aid table shape.** IPEDS SFA and Cost tables are strong federal
+  aid and net-price sources, but CDS H1/H2/H2A/H6/H7/H8 expose
+  institution-authored aid-package, need/non-need, and grant-aid framing that is
+  not always definitionally identical to IPEDS.
+- **Other CDS-specific context.** CDS also carries school-authored student-life,
+  housing, class-size, faculty, academic-offering, transfer, and policy fields
+  in the format expected by CDS users. Some have IPEDS analogs; many do not.
+- **Public-document provenance.** A CDS is a public document the institution
+  chose to publish. That source type matters independently from the extracted
+  facts because it supports archive, citation, and accountability use cases.
+- **Disclosure-change signal.** CDS lets us detect "the school stopped
+  publishing this field" or "the school changed how it reports this table" by
+  comparing public documents year over year. IPEDS is standardized, lagged,
+  imputed, and revised, so it is less useful for narratives about what a school
+  chose to disclose in the current public cycle.
+
+### Product conclusion
+
+IPEDS should **not** be framed as "the new CDS." It should be framed as:
+
+> Federal baseline facts for every Title IV institution, layered with
+> institution-published CDS data where available.
+
+That keeps trust high. We do not hide definition drift behind a common-looking
+number, and we do not give up the unique value of preserving the original CDS
+documents.
+
+## Field-family coverage map
+
+| Product family | IPEDS source | CDS replacement strength | Notes |
+| --- | --- | --- | --- |
+| Institution identity | HD, IC | Strong | UNITID, name, address, sector, control, calendar, awards, services. |
+| Enrollment totals | EF, E12, DRVEF | Strong | Fall and 12-month headcounts, full/part-time, race/ethnicity, gender, level. |
+| Retention | EF / DRVEF | Strong | First-time retention and student-to-faculty ratio are available. |
+| Admissions totals | ADM, DRVADM | Medium-strong | Applicants, admitted, enrolled, acceptance/yield, test scores for non-open-admissions institutions. Timing lags CDS. |
+| Admissions strategy | ADM | Medium | Admissions considerations exist, but not full CDS C7/C21/C22/wait-list semantics. |
+| Test scores | ADM | Medium-strong | SAT/ACT percentiles and submit behavior exist where tests are required/considered; definitions must be checked against CDS C9. |
+| Costs | IC, CST, DRVCOST | Strong | Tuition, fees, food/housing, cost of attendance, net price support. |
+| Financial aid | SFA, CST | Medium-strong | Aid counts/amounts by student category and net-price inputs. Not a perfect CDS H2/H2A replacement. |
+| Graduation rates | GR, GR200, DRVGR | Strong | Cohorts by race/gender/Pell and 150%/200% timing. |
+| Outcomes for transfer/nontraditional students | OM, DRVOM | Stronger than CDS | Particularly useful for two-year and transfer-heavy institutions. |
+| Degrees/majors | Completions, DRVC | Stronger analytically | CIP-coded awards by level/race/gender; different from CDS J presentation. |
+| Faculty/staff | HR, DRVHR | Medium-strong | Staff and faculty counts/salaries. Not the same as every CDS class-size/faculty item. |
+| Finance | F, DRVF | Additive | Useful institutional-health context, not a CDS replacement. |
+| Academic libraries | AL | Additive | Not central to current product surfaces. |
+
+## Product goals
+
+1. Expand useful school-level coverage from CDS-publishing schools to the full
+   Title IV institution universe we choose to list.
+2. Make every value source-labeled: `CDS`, `IPEDS provisional`, `IPEDS final`,
+   `College Scorecard`, or `school fact book`.
+3. Preserve CDS-first authority for source-backed admissions/change
+   intelligence.
+4. Create a stable federal-baseline profile for schools with `no_public_cds_found`.
+5. Use IPEDS to power broader comparison, filtering, and time-series analysis.
+6. Make definition differences visible enough that we do not accidentally compare
+   incompatible facts.
+
+## Non-goals
+
+- No claim that IPEDS and CDS fields are identical unless explicitly mapped.
+- No student-level data.
+- No scraping of authenticated IPEDS reporting portals.
+- No public editing of IPEDS values.
+- No attempt to ingest every IPEDS variable in v1.
+- No replacement of the CDS archive, finder, or extraction QA work.
+- No silent blending of CDS and IPEDS values into one unlabeled number.
+
+## User stories
+
+1. A family searches for a school that does not publish a CDS and still sees
+   enrollment, cost, aid, admission, and outcome facts with federal source labels.
+2. A counselor filters schools by admit rate, retention, student size, graduation
+   rate, and net price across thousands of institutions, not just CDS publishers.
+3. A journalist comparing 2025-26 CDS deltas can add IPEDS context without
+   confusing a latest CDS cycle with a lagged federal release.
+4. An analyst can query a stable table keyed by UNITID, year, field, source
+   table, variable, release status, and imputation flag.
+5. A maintainer can update the annual IPEDS release without hand-mapping every
+   CSV column again.
+
+## Data model
+
+### `ipeds_releases`
+
+One row per NCES collection/release pull.
+
+Fields:
+
+- `id`
+- `collection_year` such as `2024-25`
+- `data_year` such as `2024`
+- `release_type`: `provisional` or `final`
+- `release_date`
+- `downloaded_at`
+- `source_url`
+- `source_sha256`
+- `notes`
+
+### `ipeds_tables`
+
+One row per IPEDS source table in a release.
+
+Fields:
+
+- `release_id`
+- `table_name` such as `ADM2024`, `EF2024A`, `SFA2324`, `DRVADM2024`
+- `survey_component`
+- `title`
+- `data_url`
+- `dictionary_url`
+- `row_count`
+- `source_sha256`
+- `loaded_at`
+
+### `ipeds_columns`
+
+Metadata from dictionary workbooks.
+
+Fields:
+
+- `release_id`
+- `table_name`
+- `var_name`
+- `var_title`
+- `data_type`
+- `format`
+- `field_width`
+- `long_description`
+- `imputation_var`
+
+### `ipeds_value_labels`
+
+Categorical code labels from dictionary `Frequencies`.
+
+Fields:
+
+- `release_id`
+- `table_name`
+- `var_name`
+- `code_value`
+- `value_label`
+
+### Raw row storage
+
+Raw rows are for provenance and forensics, not for product filtering. Do not
+build browse/search on JSONB extraction at scale.
+
+Use a JSONB landing table for raw table preservation:
+
+```sql
+create table ipeds_raw_rows (
+  release_id uuid not null references ipeds_releases(id),
+  table_name text not null,
+  unitid integer not null,
+  row_data jsonb not null,
+  loaded_at timestamptz not null default now(),
+  primary key (release_id, table_name, unitid)
+);
+```
+
+The authoritative product storage is `ipeds_facts`, not `ipeds_raw_rows`. The
+loader should parse wide source rows once and write typed long-form facts with
+numeric values, units, source variables, release status, and imputation flags.
+That is what makes range filters across thousands of institutions practical.
+
+If later product surfaces need full-table analytical performance beyond
+`ipeds_facts`, add typed projection tables for those specific table families.
+
+### `ipeds_facts`
+
+Curated long-form fact table used by public products.
+
+Fields:
+
+- `unitid`
+- `institution_id` / `school_id` when mapped
+- `collection_year`
+- `data_year`
+- `field_key`
+- `value_numeric`
+- `value_text`
+- `value_label`
+- `unit`
+- `cohort`
+- `population`
+- `source_table`
+- `source_variable`
+- `source_title`
+- `release_type`
+- `imputation_flag`
+- `quality_flag`
+- `definition_alignment`: `direct`, `near`, `context_only`, `not_cds_equivalent`
+- `created_at`
+
+This table is the contract. Raw IPEDS data can be wide and weird; public
+consumers should not need to understand every IPEDS CSV layout.
+
+### `school_facts_unified`
+
+Public serving view that merges source layers without hiding provenance.
+
+Precedence rules:
+
+1. CDS value wins for CDS-native fields when a current selected primary CDS row
+   exists.
+2. IPEDS fills absent fields when the mapping is `direct` or `near`.
+3. IPEDS supersedes Scorecard for fields whose direct source is an IPEDS survey
+   table and where the IPEDS loader carries release/imputation metadata.
+4. Scorecard remains the source for consumer-outcome fields that are not fully
+   available from IPEDS raw, especially earnings, debt, repayment, and
+   borrower-outcome measures.
+5. Fact-book or arbitrary-layout extraction can fill only fields with explicit
+   source labels and confidence metadata.
+
+The view must expose both:
+
+- a `display_value` for UI cards and filters
+- all provenance columns needed to audit where the value came from
+
+## MVP field slice
+
+Start with fields that give maximum coverage and minimum definition risk.
+
+### Phase 1: Federal baseline profile
+
+Tables:
+
+- `HD2024`
+- `IC2024`
+- `EF2024A`
+- `EF2024D`
+- `DRVEF2024`
+- `COST1_2024`
+- `DRVCOST2024`
+- `SFA2324`
+- `DRVADM2024`
+- `ADM2024`
+- `DRVGR2024`
+- `DRVOM2024`
+- `DRVC2024`
+
+Fields:
+
+- school name, city, state, sector, control
+- undergraduate enrollment
+- graduate enrollment
+- total enrollment
+- full-time / part-time undergraduate counts
+- race/ethnicity enrollment counts
+- retention rate
+- student-to-faculty ratio
+- tuition and fees
+- food/housing / cost of attendance
+- average net price where available
+- applicants, admitted, enrolled, admit rate, yield
+- SAT/ACT 25th/50th/75th percentiles where available
+- graduation rate
+- outcome-measure completion/enrollment status
+- degrees awarded by level
+
+### Phase 2: CDS-aligned public comparison
+
+Map only fields with defensible CDS equivalents:
+
+- C1-like applicants/admitted/enrolled totals
+- C9-like score percentiles
+- B1/B2-like enrollment totals and demographic counts
+- G-like cost fields
+- selected H-like aid counts/amounts
+- B retention/graduation analogs
+
+Every mapped field needs an alignment note:
+
+- `direct`: same concept and population
+- `near`: usable comparison with a visible definition note
+- `context_only`: useful context, not a CDS replacement
+- `not_cds_equivalent`: do not surface in CDS-comparison UI
+
+### Phase 3: Full directory expansion
+
+Use `institution_directory` as the public list backbone:
+
+- CDS schools show archived documents plus the federal baseline.
+- Non-CDS Title IV schools show a federal baseline page.
+- Schools with no CDS and no useful IPEDS row remain directory stubs only.
+
+This should turn the product from "hundreds of CDS schools" into "thousands of
+college pages with honest source depth."
+
+## Pipeline
+
+### Annual release loader
+
+When the release checker detects a new or changed IPEDS release:
+
+1. Fetch the official Access database page and detect the latest annual bundle.
+2. Detect changed release rows by table name, release type, and SHA.
+3. Download the annual Access bundle and companion Excel metadata workbook.
+   Fallback to selected Complete Data Files only when the Access bundle path is
+   unavailable or a narrow emergency refresh is required.
+4. Store raw release bytes in Supabase Storage under:
+
+```text
+federal/ipeds/{collection_year}/{release_type}/access.zip
+federal/ipeds/{collection_year}/{release_type}/tablesdoc.xlsx
+federal/ipeds/{collection_year}/{release_type}/fallback/{table_name}.zip
+federal/ipeds/{collection_year}/{release_type}/fallback/{table_name}-dictionary.zip
+```
+
+5. Load metadata into `ipeds_releases`, `ipeds_tables`, `ipeds_columns`, and
+   `ipeds_value_labels`.
+6. Load CSV rows into `ipeds_raw_rows`.
+7. Project curated facts into `ipeds_facts`.
+8. Refresh `school_facts_unified` and public cache views.
+9. Emit a release report with row counts, missing tables, schema drift, and
+   changed variable definitions.
+
+### Schema drift guard
+
+Abort the whole release load only if:
+
+- the release artifact cannot be downloaded or checksummed
+- the metadata workbook/database cannot be parsed
+- core identity tables cannot be loaded
+- row counts are implausibly low across the release
+- imputation-value metadata is missing globally
+
+Do **not** block the entire release because one public field variable was
+renamed or removed. NCES variable churn is expected. Instead:
+
+- load the release;
+- mark the affected mapping as `inactive`, `renamed_candidate`, or `missing`;
+- suppress that field from public `ipeds_facts` until reviewed;
+- show the issue in the operator dashboard and release report.
+
+Allow the load but flag QA if:
+
+- a new relevant variable appears
+- a variable title changes but type remains stable
+- a provisional file is replaced by final
+- high-value fields have unexpected null spikes
+
+### Cadence
+
+- Check NCES monthly year-round.
+- Check weekly from September through March, when major collection releases and
+  final/provisional updates appear.
+- Manual operator run is allowed after NCES posts a new release memo.
+
+This cadence is separate from CDS finder cadence. IPEDS is a bulk federal data
+release process, not a per-school discovery process.
+
+### Provisional-to-final revisions
+
+Federal revisions are not school-disclosure changes. If a value changes because
+IPEDS provisional data was replaced by final data, treat it as a federal data
+revision:
+
+- preserve both release records;
+- update the current serving value to final;
+- expose previous provisional provenance in operator/audit views;
+- do not emit a PRD 019 school-facing change event unless the story explicitly
+  says "IPEDS revised" rather than "the school changed."
+
+## UI and API behavior
+
+### School pages
+
+Add a source-labeled federal profile section:
+
+- Show "IPEDS federal baseline" on all pages with UNITID.
+- On CDS-backed pages, keep CDS as the hero/source-document narrative.
+- On non-CDS pages, show "No public CDS archived yet" plus available IPEDS
+  facts.
+- Label release status: "IPEDS provisional 2024-25" or "IPEDS final 2023-24."
+- Show definition notes where a value is not CDS-equivalent.
+- Show reporting status on values that are not direct institutional reports:
+  `reported`, `imputed`, `not applicable`, or `suppressed/unusable`.
+
+Imputation UX rule:
+
+- A reported value may render as plain source text:
+  `IPEDS final 2023-24`.
+- An imputed value must render with a visible badge or parenthetical:
+  `IPEDS final 2023-24 · imputed`.
+- A hover/disclosure note should explain the NCES imputation flag in plain
+  language and link to the methodology page.
+- Imputed values may appear in baseline profiles, but they must not power
+  ranking badges, editorial claims, or change narratives without an explicit
+  "imputed federal value" label.
+- If the imputation flag is `not applicable` or `value not usable`, show
+  "Not applicable" or "Not reported in IPEDS" instead of coercing to zero.
+
+Open-admissions rule:
+
+- For open-admissions institutions or schools outside the ADM reporting universe,
+  admit-rate filters must treat admissions values as `not_applicable`, not as
+  zero or missing-by-error.
+- Browse should offer an explicit admissions availability facet:
+  `reported`, `open admissions / not applicable`, and `missing/unknown`.
+
+### Browse
+
+Add a coverage toggle:
+
+- `CDS only`
+- `CDS + IPEDS baseline`
+- `IPEDS baseline only`
+
+Default should remain CDS-focused until the federal-baseline QA gate passes.
+
+### API
+
+Expose:
+
+- `ipeds_facts`
+- `school_facts_unified`
+- `ipeds_releases`
+- `ipeds_tables`
+
+Do not expose raw JSONB rows as the default public API. They can be public later,
+but the product API should first privilege curated facts with provenance.
+
+Scorecard v1 position:
+
+- Keep Scorecard as the federal consumer-outcomes layer.
+- Use IPEDS as the preferred source for direct IPEDS-origin facts once PRD 021
+  has release/imputation metadata loaded.
+- Keep Scorecard fields for earnings, debt, repayment, and borrower outcomes
+  unless and until we separately prove a better official source path.
+- Do not build an opaque "federal arbiter" that silently chooses between
+  Scorecard and IPEDS. The source must remain visible.
+
+### Attribution
+
+Add persistent NCES/IPEDS attribution to the methodology page and source notes.
+Exact wording should be finalized during implementation, but every public
+IPEDS-backed surface must make clear that data comes from NCES/IPEDS and that
+collegedata.fyi is transforming and presenting it, not collecting it.
+
+### Accessibility
+
+All IPEDS-driven public tables should inherit PRD 020 constraints:
+
+- native table semantics
+- captions and source notes
+- no semantic collapse on mobile
+- explicit missing-data language
+- source labels visible in text, not color only
+
+## QA plan
+
+### Fixture schools
+
+Use a mixed fixture set:
+
+- Harvard, Yale, Michigan, UCLA: CDS + IPEDS comparison
+- Connecticut College: CDS discovered by submitter, useful for source precedence
+- Crowder College: non-CDS/fact-book-style use case with IPEDS facsimile already
+  inspected locally
+- Goshen and Crowder-style non-CDS publishers: compare IPEDS baseline to
+  school fact-book facts only as a manual validation exercise. This PRD does not
+  scope arbitrary fact-book ingestion.
+- Two-year publics and open-admissions schools: admissions-null behavior
+- Branch-campus systems: UNITID/source mapping stress tests
+
+### Validation checks
+
+- Compare 20 high-value fields from IPEDS Data Center facsimile PDFs against
+  loaded `ipeds_facts` values for the same UNITIDs.
+- Compare CDS C1/C9 values against ADM/DRVADM for 25 schools and classify
+  differences as definition drift, timing drift, extraction issue, or school
+  reporting inconsistency.
+- Verify imputation flags flow through to public source notes.
+- Verify final releases supersede provisional releases without erasing prior
+  provenance.
+- Verify no value appears in CDS change intelligence unless its source is CDS or
+  explicitly labeled as IPEDS context.
+
+### Success gates
+
+Phase 1 can ship when:
+
+- At least 95% of `institution_directory` rows with UNITID have a loaded IPEDS
+  identity row.
+- At least 90% of degree-granting Title IV rows have enrollment and cost facts.
+- All MVP variables have dictionary metadata and value labels loaded.
+- At least 50 fixture facts are manually validated against NCES facsimile or CSV
+  source rows.
+- Public UI source labels pass visual, keyboard, and screen-reader checks.
+
+Phase 2 can ship when:
+
+- Every observed CDS-vs-IPEDS mismatch in the 25-school fixture set is
+  classified into one of: timing drift, population drift, gender/category
+  treatment, imputation, extraction error, school inconsistency, or unresolved.
+- No `unresolved` mismatch remains for a field we plan to label `direct` or
+  expose in CDS-comparison UI.
+- Each CDS-aligned field has a `definition_alignment` classification.
+- Browse filters cannot silently mix CDS and IPEDS values without a visible
+  source-mode label.
+
+## Risks and mitigations
+
+### Definition drift
+
+Risk: A CDS value and an IPEDS value look identical but use different
+populations, cohorts, or reporting periods.
+
+Mitigation: classify field mappings and expose definition notes. Never collapse
+sources into one unlabeled value.
+
+### Timeliness
+
+Risk: IPEDS lags current CDS publication cycles.
+
+Mitigation: use IPEDS as baseline/context, not as the latest-year change source.
+Keep CDS finder/freshness work for schools publishing current CDS files.
+
+### Imputation and revisions
+
+Risk: Provisional/final revisions or imputed values create false year-over-year
+stories.
+
+Mitigation: keep release type and imputation flags in every projected fact.
+Change intelligence remains CDS-first.
+
+### UNITID complexity
+
+Risk: campus systems, branch campuses, and CDS sub-institutional rows do not
+align one-to-one with UNITID.
+
+Mitigation: preserve existing `sub_institutional` logic; add explicit mapping
+confidence and do not infer a campus-level federal value for a sub-campus CDS
+row without a verified UNITID.
+
+Verified UNITID means one of:
+
+- exact `schools.yaml` / `institution_directory` match on known `ipeds_id`;
+- deterministic `institution_slug_crosswalk` match with no competing alias;
+- manual operator review recorded with reviewer, date, source URL, and reason;
+- explicit sub-institution mapping row when the CDS publisher represents a
+  campus, system, college, or program that differs from the parent UNITID.
+
+If none of those conditions holds, the UI may show institution-directory
+coverage status but must not blend CDS and IPEDS values as if they describe the
+same reporting entity.
+
+### NCES endpoint fragility
+
+Risk: Data Center endpoints use session redirects or temporary downtime.
+
+Mitigation: prefer annual Access bundles; use cookie-initialized Data Center
+fetches only as a fallback; include a clear User-Agent, low concurrency,
+retry/backoff, immutable raw artifact storage, and release-level caching.
+
+### Product trust
+
+Risk: Users think "IPEDS baseline" means the same thing as "school-published
+CDS."
+
+Mitigation: source labels are part of the UI contract. Use language such as
+"Federal baseline" and "School-published CDS" consistently.
+
+## Rollout plan
+
+### M0: Field mapping spike
+
+- Download current IPEDS dictionaries for the MVP table set.
+- Decide input strategy after comparing Access bundle, Complete Data Files, and
+  third-party normalized packages. Default to Access bundle unless the spike
+  proves another path preserves metadata and reduces maintenance.
+- Build a mapping spreadsheet from IPEDS variables to product field keys.
+- Classify definition alignment.
+- Validate 10 schools manually.
+- Rerun UNITID coverage counts and produce a manifest gap list.
+
+Decision gate:
+
+- If the Access-bundle loader is materially harder than a third-party package
+  that preserves release metadata, imputation flags, and attribution, pause M1
+  and rewrite this PRD around that input.
+- If fewer than 15 high-value fields are direct/near mappings, do not build the
+  public unified serving view yet; ship only an internal loader spike.
+- If 15-30 high-value fields are direct/near mappings, limit v1 to a
+  federal-baseline profile and do not ship CDS-aligned comparison surfaces.
+- If 30+ high-value fields are direct/near mappings, proceed with both baseline
+  profile and carefully labeled CDS-aligned comparison fields.
+
+### M1: Loader and metadata
+
+- Add migrations for `ipeds_releases`, `ipeds_tables`, `ipeds_columns`,
+  `ipeds_value_labels`, and `ipeds_raw_rows`.
+- Build `tools/ipeds/download_release.py`.
+- Build `tools/ipeds/load_release.py`.
+- Add schema drift tests.
+
+### M2: Curated facts
+
+- Add `ipeds_facts`.
+- Project MVP fields.
+- Add unit tests around value labels, imputation flags, and release status.
+- Generate a QA report for fixture schools.
+
+### M3: Unified serving layer
+
+- Add `school_facts_unified`.
+- Thread source labels into TypeScript types.
+- Add API documentation.
+
+### M4: School page federal baseline
+
+- Add source-labeled IPEDS facts to school pages.
+- Add non-CDS federal baseline stub pages.
+- Add PRD 020-style accessible tables for high-value groups.
+
+### M5: Browse expansion
+
+- Add source-mode controls to browse.
+- Add filters backed by `school_facts_unified`.
+- Add export columns for source and release type.
+
+### M6: Annual operations
+
+- Add monthly/weekly scheduled release checker.
+- Add operator dashboard rows for last IPEDS load, tables loaded, row counts,
+  schema drift, and unresolved mapping issues.
+
+## Open questions
+
+1. What is the public institution universe we want to expose: all 6,400 Title IV
+   institutions, only degree-granting institutions, or the current
+   `institution_directory` filter set?
+2. Should non-CDS federal baseline pages be indexed immediately, or noindexed
+   until the UI and source labels are polished?
+3. How much UI copy should explain provisional vs final data without making pages
+   feel bureaucratic?
+4. Should IPEDS facsimile PDFs be stored as human-readable source artifacts, or
+   is CSV/dictionary provenance enough?
+
+## Recommendation
+
+Build this.
+
+The CDS archive stays the differentiated source-preservation product. IPEDS
+becomes the coverage engine that makes the site useful for the much larger
+universe of schools that do not publish a CDS. The right mental model is not
+"IPEDS replaces CDS"; it is "CDS is the school-authored primary source, IPEDS is
+the federal baseline, and collegedata.fyi is the place where both are reconciled
+with source labels."

--- a/supabase/functions/browser-search/browser_search.test.ts
+++ b/supabase/functions/browser-search/browser_search.test.ts
@@ -64,9 +64,42 @@ function row(overrides: Partial<BrowserRow>): BrowserRow {
     app_fee_amount: null,
     app_fee_waiver_offered: null,
     admission_strategy_card_quality: null,
+    federal_baseline_available: false,
+    federal_source_mode: "cds_only",
     ...overrides,
   };
 }
+
+Deno.test("federal source mode is filterable and exportable", () => {
+  const result = searchBrowserRows(
+    [
+      row({
+        school_id: "a",
+        school_name: "A College",
+        federal_baseline_available: true,
+        federal_source_mode: "cds_plus_ipeds_baseline",
+      }),
+      row({
+        document_id: "00000000-0000-0000-0000-000000000002",
+        school_id: "b",
+        school_name: "B College",
+        federal_source_mode: "cds_only",
+      }),
+    ],
+    {
+      filters: [{ field: "federal_source_mode", op: "=", value: "cds_plus_ipeds_baseline" }],
+      columns: ["school_id", "federal_baseline_available", "federal_source_mode"],
+    },
+  );
+
+  assertEquals(result.rows, [
+    {
+      school_id: "a",
+      federal_baseline_available: true,
+      federal_source_mode: "cds_plus_ipeds_baseline",
+    },
+  ]);
+});
 
 Deno.test("required fields derive from operators", () => {
   assertEquals(isRequiredOperator("="), true);

--- a/supabase/functions/browser-search/browser_search.ts
+++ b/supabase/functions/browser-search/browser_search.ts
@@ -66,6 +66,8 @@ export type BrowserRow = {
   app_fee_amount: number | null;
   app_fee_waiver_offered: boolean | null;
   admission_strategy_card_quality: string | null;
+  federal_baseline_available: boolean;
+  federal_source_mode: "cds_only" | "cds_plus_ipeds_baseline" | "ipeds_baseline_only";
 };
 
 export type BrowserFilter = {
@@ -180,6 +182,8 @@ export const ALLOWED_FIELDS = new Set([
   "app_fee_amount",
   "app_fee_waiver_offered",
   "admission_strategy_card_quality",
+  "federal_baseline_available",
+  "federal_source_mode",
 ]);
 
 const NUMERIC_FIELDS = new Set([

--- a/supabase/migrations/20260509090000_ipeds_coverage_layer.sql
+++ b/supabase/migrations/20260509090000_ipeds_coverage_layer.sql
@@ -1,0 +1,376 @@
+-- PRD 021 — IPEDS federal baseline coverage layer.
+--
+-- Adds official NCES/IPEDS release metadata, raw row preservation, curated
+-- long-form facts, and a public serving view that keeps provenance visible.
+-- Loaders live in tools/ipeds/. This migration is schema-only; production
+-- applies still happen from main per CLAUDE.md.
+
+begin;
+
+create table public.ipeds_releases (
+  id                 uuid primary key default gen_random_uuid(),
+  collection_year    text not null,
+  data_year          integer not null,
+  release_type       text not null,
+  release_date       date,
+  source_page_url    text not null,
+  source_page_sha256 text,
+  metadata_url       text not null,
+  metadata_sha256    text not null,
+  access_url         text,
+  access_sha256      text,
+  downloaded_at      timestamptz not null default now(),
+  notes              jsonb not null default '{}'::jsonb,
+  created_at         timestamptz not null default now(),
+
+  constraint ipeds_releases_release_type_valid
+    check (release_type in ('preliminary', 'provisional', 'final')),
+  constraint ipeds_releases_unique_source
+    unique (collection_year, release_type, metadata_sha256)
+);
+
+comment on table public.ipeds_releases is
+  'One row per official NCES/IPEDS release load. Preserves source URLs, checksums, release type, and collection/data-year metadata for PRD 021 provenance.';
+
+create table public.ipeds_tables (
+  release_id       uuid not null references public.ipeds_releases(id) on delete cascade,
+  table_name       text not null,
+  survey_component text,
+  year_coverage    text,
+  table_number     integer,
+  table_title      text,
+  description      text,
+  table_release    text,
+  table_release_date text,
+  data_url         text,
+  dictionary_url   text,
+  row_count        integer,
+  source_sha256    text,
+  loaded_at        timestamptz,
+  created_at       timestamptz not null default now(),
+
+  primary key (release_id, table_name)
+);
+
+comment on table public.ipeds_tables is
+  'IPEDS table metadata from the official Tablesdoc workbook plus loader-observed row counts and table-file checksums.';
+
+create table public.ipeds_columns (
+  release_id       uuid not null references public.ipeds_releases(id) on delete cascade,
+  table_name       text not null,
+  var_name         text not null,
+  survey_component text,
+  table_number     integer,
+  table_title      text,
+  var_number       integer,
+  var_order        integer,
+  imputation_var   text,
+  var_title        text,
+  data_type        text,
+  field_width      integer,
+  format           text,
+  multi_record     boolean,
+  has_rv           text,
+  file_number      integer,
+  section_number   integer,
+  long_description text,
+  var_source       text,
+  file_title       text,
+  section_title    text,
+  created_at       timestamptz not null default now(),
+
+  primary key (release_id, table_name, var_name),
+  foreign key (release_id, table_name)
+    references public.ipeds_tables (release_id, table_name)
+    on delete cascade
+);
+
+comment on table public.ipeds_columns is
+  'Variable metadata from the official IPEDS table documentation workbook. imputation_var points at the matching X* reporting-status column when NCES provides one.';
+
+create table public.ipeds_value_labels (
+  release_id    uuid not null references public.ipeds_releases(id) on delete cascade,
+  table_name    text not null,
+  var_name      text not null,
+  code_value    text not null,
+  value_label   text,
+  frequency     integer,
+  percent       numeric,
+  value_order   integer,
+  var_title     text,
+  created_at    timestamptz not null default now(),
+
+  primary key (release_id, table_name, var_name, code_value),
+  foreign key (release_id, table_name, var_name)
+    references public.ipeds_columns (release_id, table_name, var_name)
+    on delete cascade
+);
+
+comment on table public.ipeds_value_labels is
+  'Categorical code labels from the official IPEDS metadata workbook, including reporting-status and imputation-code labels.';
+
+create table public.ipeds_raw_rows (
+  release_id uuid not null references public.ipeds_releases(id) on delete cascade,
+  table_name text not null,
+  unitid     integer not null,
+  row_data   jsonb not null,
+  loaded_at  timestamptz not null default now(),
+
+  primary key (release_id, table_name, unitid),
+  foreign key (release_id, table_name)
+    references public.ipeds_tables (release_id, table_name)
+    on delete cascade
+);
+
+comment on table public.ipeds_raw_rows is
+  'Forensic landing table for official IPEDS rows. Public products should query ipeds_facts or serving views, not this JSONB table.';
+
+create index ipeds_raw_rows_table_idx
+  on public.ipeds_raw_rows (table_name, unitid);
+
+create table public.ipeds_facts (
+  release_id           uuid not null references public.ipeds_releases(id) on delete cascade,
+  unitid               integer not null,
+  ipeds_id             text generated always as (lpad(unitid::text, 6, '0')) stored,
+  school_id            text,
+  collection_year      text not null,
+  data_year            integer not null,
+  field_key            text not null,
+  field_label          text not null,
+  value_numeric        numeric,
+  value_text           text,
+  value_label          text,
+  unit                 text,
+  cohort               text,
+  population           text,
+  source_table         text not null,
+  source_variable      text not null,
+  source_title         text,
+  release_type         text not null,
+  imputation_flag      text,
+  imputation_label     text,
+  quality_flag         text not null default 'reported',
+  definition_alignment text not null,
+  definition_note      text,
+  display_group        text not null,
+  public_visible       boolean not null default true,
+  created_at           timestamptz not null default now(),
+
+  primary key (release_id, unitid, field_key, source_table, source_variable),
+
+  constraint ipeds_facts_value_present
+    check (value_numeric is not null or value_text is not null or value_label is not null),
+  constraint ipeds_facts_release_type_valid
+    check (release_type in ('preliminary', 'provisional', 'final')),
+  constraint ipeds_facts_quality_flag_valid
+    check (quality_flag in (
+      'reported',
+      'imputed',
+      'not_applicable',
+      'suppressed',
+      'missing',
+      'unusable'
+    )),
+  constraint ipeds_facts_definition_alignment_valid
+    check (definition_alignment in (
+      'direct',
+      'near',
+      'context_only',
+      'not_cds_equivalent'
+    ))
+);
+
+comment on table public.ipeds_facts is
+  'Curated long-form IPEDS facts used by public products. Carries source table/variable, release type, imputation status, definition alignment, and public visibility per fact.';
+
+create index ipeds_facts_school_field_idx
+  on public.ipeds_facts (school_id, field_key, data_year desc);
+
+create index ipeds_facts_ipeds_field_idx
+  on public.ipeds_facts (ipeds_id, field_key, data_year desc);
+
+create index ipeds_facts_field_numeric_idx
+  on public.ipeds_facts (field_key, value_numeric)
+  where public_visible = true and value_numeric is not null;
+
+create index ipeds_facts_group_idx
+  on public.ipeds_facts (display_group, field_key)
+  where public_visible = true;
+
+alter table public.ipeds_releases enable row level security;
+alter table public.ipeds_tables enable row level security;
+alter table public.ipeds_columns enable row level security;
+alter table public.ipeds_value_labels enable row level security;
+alter table public.ipeds_raw_rows enable row level security;
+alter table public.ipeds_facts enable row level security;
+
+create policy ipeds_releases_public_read
+  on public.ipeds_releases
+  for select to anon, authenticated using (true);
+
+create policy ipeds_tables_public_read
+  on public.ipeds_tables
+  for select to anon, authenticated using (true);
+
+create policy ipeds_columns_public_read
+  on public.ipeds_columns
+  for select to anon, authenticated using (true);
+
+create policy ipeds_value_labels_public_read
+  on public.ipeds_value_labels
+  for select to anon, authenticated using (true);
+
+create policy ipeds_raw_rows_public_read
+  on public.ipeds_raw_rows
+  for select to anon, authenticated using (false);
+
+create policy ipeds_facts_public_read
+  on public.ipeds_facts
+  for select to anon, authenticated using (public_visible);
+
+grant select on public.ipeds_releases to anon, authenticated;
+grant select on public.ipeds_tables to anon, authenticated;
+grant select on public.ipeds_columns to anon, authenticated;
+grant select on public.ipeds_value_labels to anon, authenticated;
+grant select on public.ipeds_facts to anon, authenticated;
+
+create view public.ipeds_current_facts
+with (security_invoker = true) as
+with ranked as (
+  select
+    f.*,
+    row_number() over (
+      partition by f.unitid, f.field_key
+      order by
+        f.data_year desc,
+        case f.release_type
+          when 'final' then 3
+          when 'provisional' then 2
+          when 'preliminary' then 1
+          else 0
+        end desc,
+        f.created_at desc
+    ) as rn
+  from public.ipeds_facts f
+  where f.public_visible = true
+)
+select *
+from ranked
+where rn = 1;
+
+comment on view public.ipeds_current_facts is
+  'Latest public IPEDS fact per UNITID + field_key. Prefers newer data_year, then final over provisional over preliminary within the same data year.';
+
+grant select on public.ipeds_current_facts to anon, authenticated;
+
+create view public.school_facts_unified
+with (security_invoker = true) as
+select
+  d.ipeds_id,
+  d.school_id,
+  d.school_name,
+  d.city,
+  d.state,
+  d.in_scope,
+  f.collection_year,
+  f.data_year,
+  f.field_key,
+  f.field_label,
+  coalesce(
+    f.value_label,
+    f.value_text,
+    case
+      when f.unit = 'percent' and f.value_numeric is not null
+        then trim(to_char(f.value_numeric, 'FM999999990.099')) || '%'
+      when f.value_numeric is not null
+        then trim(to_char(f.value_numeric, 'FM999999999999990.999999'))
+      else null
+    end
+  ) as display_value,
+  f.value_numeric,
+  f.value_text,
+  f.value_label,
+  f.unit,
+  f.cohort,
+  f.population,
+  'ipeds'::text as source_layer,
+  f.source_table,
+  f.source_variable,
+  f.source_title,
+  f.release_type,
+  f.imputation_flag,
+  f.imputation_label,
+  f.quality_flag,
+  f.definition_alignment,
+  f.definition_note,
+  f.display_group,
+  f.created_at
+from public.ipeds_current_facts f
+join public.institution_directory d
+  on d.ipeds_id = f.ipeds_id
+where d.in_scope = true;
+
+comment on view public.school_facts_unified is
+  'Public PRD 021 serving view. Exposes source-labeled federal baseline facts for in-scope institutions without hiding provenance or definition alignment.';
+
+grant select on public.school_facts_unified to anon, authenticated;
+
+alter table public.school_browser_rows
+  add column if not exists federal_baseline_available boolean not null default false,
+  add column if not exists federal_source_mode text not null default 'cds_only';
+
+alter table public.school_browser_rows
+  drop constraint if exists school_browser_rows_federal_source_mode_valid,
+  add constraint school_browser_rows_federal_source_mode_valid
+    check (federal_source_mode in (
+      'cds_only',
+      'cds_plus_ipeds_baseline',
+      'ipeds_baseline_only'
+    ));
+
+comment on column public.school_browser_rows.federal_baseline_available is
+  'True when the row has a UNITID that can join to source-labeled IPEDS baseline facts. Browser defaults remain CDS-first until PRD 021 QA gates pass.';
+
+comment on column public.school_browser_rows.federal_source_mode is
+  'Source mode for browse/export UI. Existing CDS rows default to cds_only; future projections may mark CDS+IPEDS or IPEDS-only rows.';
+
+create or replace function public.refresh_ipeds_browser_source_modes()
+returns integer
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  updated_count integer;
+begin
+  update public.school_browser_rows as sbr
+  set
+    federal_baseline_available = exists (
+      select 1
+      from public.ipeds_current_facts f
+      where f.ipeds_id = sbr.ipeds_id
+      limit 1
+    ),
+    federal_source_mode = case
+      when exists (
+        select 1
+        from public.ipeds_current_facts f
+        where f.ipeds_id = sbr.ipeds_id
+        limit 1
+      )
+        then 'cds_plus_ipeds_baseline'
+      else 'cds_only'
+    end;
+
+  get diagnostics updated_count = row_count;
+  return updated_count;
+end;
+$$;
+
+comment on function public.refresh_ipeds_browser_source_modes() is
+  'Marks existing CDS browser rows that have a matching IPEDS baseline after an IPEDS fact load. Service-role loader calls this after upserting facts.';
+
+revoke all on function public.refresh_ipeds_browser_source_modes() from public;
+grant execute on function public.refresh_ipeds_browser_source_modes() to service_role;
+
+commit;

--- a/tools/ipeds/README.md
+++ b/tools/ipeds/README.md
@@ -1,0 +1,53 @@
+# IPEDS coverage layer
+
+PRD 021 adds a federal NCES/IPEDS baseline for schools that do not publish a
+Common Data Set and for CDS schools where a source-labeled federal context row
+is useful. The public UI reads curated facts, not raw IPEDS JSON.
+
+## Workflow
+
+1. Download the official NCES metadata workbook and mapped CSV table ZIPs:
+
+```bash
+python tools/ipeds/download_release.py
+```
+
+2. Dry-run the loader. This parses metadata, reads the ZIPs, projects public
+facts, and writes `scratch/ipeds/ipeds-<year>-<release>-report.json`.
+
+```bash
+python tools/ipeds/load_release.py \
+  --metadata-xlsx scratch/ipeds/2024-25-provisional/IPEDS202425Tablesdoc.xlsx \
+  --data-dir scratch/ipeds/2024-25-provisional \
+  --collection-year 2024-25 \
+  --data-year 2024 \
+  --release-type provisional \
+  --metadata-url https://nces.ed.gov/ipeds/tablefiles/tableDocs/IPEDS202425Tablesdoc.xlsx
+```
+
+3. After reviewing the report and after the migration has landed/applied from
+`main`, re-run with `--apply`. This requires `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY` in `.env`.
+
+```bash
+python tools/ipeds/load_release.py ... --apply
+```
+
+## Source discipline
+
+- Metadata comes from the official IPEDS Tablesdoc workbook.
+- Table data comes from the official IPEDS data-generator CSV ZIP endpoints.
+- The Access database ZIP is recorded as release provenance but not parsed.
+- Raw rows are preserved in `ipeds_raw_rows`; public products query
+  `ipeds_facts`, `ipeds_current_facts`, or `school_facts_unified`.
+
+## Public defaults
+
+- Public school pages show facts from `school_facts_unified`, which only joins
+  `institution_directory.in_scope = true`.
+- Imputed values remain visible but labeled.
+- Imputed values should not feed rankings, editorial claims, or change
+  intelligence unless a future PRD explicitly opts in.
+- Baseline-only pages are marked `noindex` until the methodology and QA surface
+  mature.
+

--- a/tools/ipeds/__init__.py
+++ b/tools/ipeds/__init__.py
@@ -1,0 +1,2 @@
+"""IPEDS ingestion helpers for PRD 021."""
+

--- a/tools/ipeds/download_release.py
+++ b/tools/ipeds/download_release.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Download official NCES/IPEDS metadata and table CSV ZIPs."""
+
+from __future__ import annotations
+
+import argparse
+import http.cookiejar
+import sys
+import urllib.request
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from tools.ipeds.metadata import DATA_GENERATOR_URL, NCES_IPEDS_ACCESS_PAGE, parse_access_page
+from tools.ipeds.mappings import MVP_FACT_MAPPINGS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--collection-year", help="Release collection year, e.g. 2024-25. Defaults to latest.")
+    parser.add_argument("--data-year", type=int, help="Data year for table downloads, e.g. 2024.")
+    parser.add_argument("--out-dir", type=Path, default=REPO_ROOT / "scratch" / "ipeds")
+    parser.add_argument("--tables", nargs="*", help="Specific table names to download. Defaults to mapped PRD 021 tables.")
+    args = parser.parse_args()
+
+    opener = build_opener()
+    html = opener.open(NCES_IPEDS_ACCESS_PAGE).read().decode("utf-8", errors="replace")
+    releases = parse_access_page(html)
+    if not releases:
+        raise SystemExit("No IPEDS releases found on NCES Access database page")
+
+    release = next((item for item in releases if item.collection_year == args.collection_year), releases[0])
+    data_year = args.data_year or release.data_year
+    out_dir = args.out_dir / f"{release.collection_year}-{release.release_type}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata_path = out_dir / Path(release.metadata_url).name
+    download(opener, release.metadata_url, metadata_path)
+    print(f"metadata: {metadata_path}")
+
+    table_names = sorted({name.upper() for name in (args.tables or [m.table_name for m in MVP_FACT_MAPPINGS])})
+    # The data generator endpoint returns CSV ZIP bytes. Visiting the page first
+    # initializes the same session cookies a browser gets from the NCES app.
+    opener.open(f"https://nces.ed.gov/ipeds/datacenter/DataFiles.aspx?year={data_year}&surveyNumber=1").read()
+    for table_name in table_names:
+        url = DATA_GENERATOR_URL.format(year=data_year, table_name=table_name)
+        path = out_dir / f"{table_name}.zip"
+        download(opener, url, path)
+        print(f"table: {path}")
+
+    print(f"release: {release.collection_year} {release.release_type}")
+    return 0
+
+
+def build_opener() -> urllib.request.OpenerDirector:
+    jar = http.cookiejar.CookieJar()
+    return urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+
+
+def download(opener: urllib.request.OpenerDirector, url: str, path: Path) -> None:
+    req = urllib.request.Request(url, headers={"User-Agent": "collegedata-fyi-ipeds-loader/1.0"})
+    with opener.open(req) as response, path.open("wb") as f:
+        f.write(response.read())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/ipeds/load_release.py
+++ b/tools/ipeds/load_release.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Load an official NCES/IPEDS release into the PRD 021 schema.
+
+Dry run is the default: parse metadata, read selected table CSV ZIPs, project
+curated facts, and write a JSON report under scratch/ipeds/. Use --apply only
+after reviewing the report and the target database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import zipfile
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from tools.ipeds.mappings import MVP_FACT_MAPPINGS
+from tools.ipeds.metadata import DATA_GENERATOR_URL, TablesDoc, parse_tablesdoc, sha256_file
+from tools.ipeds.project import project_rows_to_facts
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_DIR = REPO_ROOT / "scratch" / "ipeds"
+ACCESS_PAGE_URL = "https://nces.ed.gov/ipeds/use-the-data/download-access-database"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata-xlsx", required=True, type=Path, help="Official IPEDS Tablesdoc workbook.")
+    parser.add_argument("--data-dir", required=True, type=Path, help="Directory containing table CSV ZIP downloads.")
+    parser.add_argument("--collection-year", required=True, help="Release collection year, e.g. 2024-25.")
+    parser.add_argument("--data-year", required=True, type=int, help="IPEDS data year used in table names, e.g. 2024.")
+    parser.add_argument("--release-type", default="provisional", choices=["preliminary", "provisional", "final"])
+    parser.add_argument("--metadata-url", required=True)
+    parser.add_argument("--access-url")
+    parser.add_argument("--apply", action="store_true", help="Upsert into Supabase using service role credentials.")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    args = parser.parse_args()
+
+    tablesdoc = parse_tablesdoc(args.metadata_xlsx)
+    table_names = sorted({mapping.table_name.upper() for mapping in MVP_FACT_MAPPINGS})
+    rows_by_table: dict[str, list[dict[str, Any]]] = {}
+    table_sources: dict[str, dict[str, Any]] = {}
+
+    for table_name in table_names:
+        source = find_table_zip(args.data_dir, table_name)
+        if source is None:
+            print(f"warning: missing {table_name} CSV ZIP in {args.data_dir}", file=sys.stderr)
+            continue
+        rows = read_table_zip(source)
+        rows_by_table[table_name] = rows
+        table_sources[table_name] = {
+            "path": str(source),
+            "row_count": len(rows),
+            "sha256": sha256_file(source),
+            "data_url": DATA_GENERATOR_URL.format(year=args.data_year, table_name=table_name),
+        }
+
+    facts = project_rows_to_facts(
+        rows_by_table,
+        MVP_FACT_MAPPINGS,
+        tablesdoc.columns,
+        tablesdoc.value_labels,
+        release_id=None,
+        collection_year=args.collection_year,
+        data_year=args.data_year,
+        release_type=args.release_type,
+    )
+
+    report = build_report(args, tablesdoc, rows_by_table, table_sources, facts)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.out_dir / f"ipeds-{args.collection_year}-{args.release_type}-report.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"wrote {report_path}")
+
+    if args.apply:
+        apply_to_supabase(args, tablesdoc, rows_by_table, table_sources, facts)
+    else:
+        print("dry run only; re-run with --apply to write Supabase")
+    return 0
+
+
+def find_table_zip(data_dir: Path, table_name: str) -> Path | None:
+    candidates = [
+        data_dir / f"{table_name}.zip",
+        data_dir / f"{table_name}.csv",
+        data_dir / f"{table_name.lower()}.zip",
+        data_dir / f"{table_name.lower()}.csv",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    matches = sorted(data_dir.glob(f"{table_name}*")) + sorted(data_dir.glob(f"{table_name.lower()}*"))
+    return matches[0] if matches else None
+
+
+def read_table_zip(path: Path) -> list[dict[str, str]]:
+    if path.suffix.lower() == ".csv":
+        with path.open("r", encoding="utf-8-sig", newline="") as f:
+            return [{k.upper(): v for k, v in row.items()} for row in csv.DictReader(f)]
+    with zipfile.ZipFile(path) as zf:
+        csv_name = next((name for name in zf.namelist() if name.lower().endswith(".csv")), None)
+        if csv_name is None:
+            raise ValueError(f"{path} does not contain a CSV file")
+        with zf.open(csv_name) as raw:
+            text = (line.decode("utf-8-sig") for line in raw)
+            return [{k.upper(): v for k, v in row.items()} for row in csv.DictReader(text)]
+
+
+def build_report(
+    args: argparse.Namespace,
+    tablesdoc: TablesDoc,
+    rows_by_table: dict[str, list[dict[str, Any]]],
+    table_sources: dict[str, dict[str, Any]],
+    facts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    facts_by_group: dict[str, int] = {}
+    quality_counts: dict[str, int] = {}
+    for fact in facts:
+        facts_by_group[fact["display_group"]] = facts_by_group.get(fact["display_group"], 0) + 1
+        quality_counts[fact["quality_flag"]] = quality_counts.get(fact["quality_flag"], 0) + 1
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "collection_year": args.collection_year,
+        "data_year": args.data_year,
+        "release_type": args.release_type,
+        "metadata_xlsx": str(args.metadata_xlsx),
+        "metadata_sha256": sha256_file(args.metadata_xlsx),
+        "source_tables_requested": sorted({mapping.table_name.upper() for mapping in MVP_FACT_MAPPINGS}),
+        "source_tables_loaded": table_sources,
+        "metadata_counts": {
+            "tables": len(tablesdoc.tables),
+            "columns": len(tablesdoc.columns),
+            "value_labels": len(tablesdoc.value_labels),
+        },
+        "raw_row_counts": {table: len(rows) for table, rows in sorted(rows_by_table.items())},
+        "fact_count": len(facts),
+        "facts_by_group": facts_by_group,
+        "quality_counts": quality_counts,
+        "sample_facts": facts[:20],
+    }
+
+
+def apply_to_supabase(
+    args: argparse.Namespace,
+    tablesdoc: TablesDoc,
+    rows_by_table: dict[str, list[dict[str, Any]]],
+    table_sources: dict[str, dict[str, Any]],
+    facts: list[dict[str, Any]],
+) -> None:
+    load_env(REPO_ROOT / ".env")
+    try:
+        from supabase import create_client
+    except ImportError as exc:
+        raise SystemExit("supabase package is required for --apply") from exc
+
+    supabase_url = os.environ.get("SUPABASE_URL")
+    service_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not supabase_url or not service_key:
+        raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for --apply")
+
+    client = create_client(supabase_url, service_key)
+    release_payload = {
+        "collection_year": args.collection_year,
+        "data_year": args.data_year,
+        "release_type": args.release_type,
+        "source_page_url": ACCESS_PAGE_URL,
+        "metadata_url": args.metadata_url,
+        "metadata_sha256": sha256_file(args.metadata_xlsx),
+        "access_url": args.access_url,
+        "notes": {"loader": "tools/ipeds/load_release.py", "mapping_count": len(MVP_FACT_MAPPINGS)},
+    }
+    release_result = client.table("ipeds_releases").upsert(
+        release_payload,
+        on_conflict="collection_year,release_type,metadata_sha256",
+    ).execute()
+    release_id = release_result.data[0]["id"]
+
+    table_payloads = []
+    for table in tablesdoc.tables:
+        source = table_sources.get(table.table_name.upper(), {})
+        table_payloads.append({
+            "release_id": release_id,
+            "table_name": table.table_name.upper(),
+            "survey_component": table.survey_component,
+            "year_coverage": table.year_coverage,
+            "table_number": table.table_number,
+            "table_title": table.table_title,
+            "description": table.description,
+            "table_release": table.table_release,
+            "table_release_date": table.table_release_date,
+            "data_url": source.get("data_url"),
+            "row_count": source.get("row_count"),
+            "source_sha256": source.get("sha256"),
+            "loaded_at": datetime.now(timezone.utc).isoformat() if source else None,
+        })
+    batch_upsert(client, "ipeds_tables", table_payloads, "release_id,table_name")
+
+    batch_upsert(client, "ipeds_columns", [
+        {"release_id": release_id, **{**asdict(column), "table_name": column.table_name.upper(), "var_name": column.var_name.upper()}}
+        for column in tablesdoc.columns
+    ], "release_id,table_name,var_name")
+    batch_upsert(client, "ipeds_value_labels", [
+        {"release_id": release_id, **{**asdict(label), "table_name": label.table_name.upper(), "var_name": label.var_name.upper()}}
+        for label in tablesdoc.value_labels
+    ], "release_id,table_name,var_name,code_value")
+
+    raw_payloads = []
+    for table_name, rows in rows_by_table.items():
+        for row in rows:
+            unitid = row.get("UNITID")
+            if unitid in (None, ""):
+                continue
+            raw_payloads.append({
+                "release_id": release_id,
+                "table_name": table_name,
+                "unitid": int(float(unitid)),
+                "row_data": row,
+            })
+    batch_upsert(client, "ipeds_raw_rows", raw_payloads, "release_id,table_name,unitid")
+
+    fact_payloads = []
+    for fact in facts:
+        payload = dict(fact)
+        payload["release_id"] = release_id
+        fact_payloads.append(payload)
+    batch_upsert(client, "ipeds_facts", fact_payloads, "release_id,unitid,field_key,source_table,source_variable")
+    try:
+        refreshed = client.rpc("refresh_ipeds_browser_source_modes").execute()
+        print(f"refreshed browser source modes: {refreshed.data}")
+    except Exception as exc:  # pragma: no cover - defensive around optional post-load helper.
+        print(f"warning: could not refresh browser source modes: {exc}", file=sys.stderr)
+    print(f"applied release {release_id}: {len(raw_payloads)} raw rows, {len(fact_payloads)} facts")
+
+
+def batch_upsert(client: Any, table: str, rows: list[dict[str, Any]], on_conflict: str, size: int = 500) -> None:
+    for start in range(0, len(rows), size):
+        client.table(table).upsert(rows[start : start + size], on_conflict=on_conflict).execute()
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ipeds/mappings.py
+++ b/tools/ipeds/mappings.py
@@ -1,0 +1,84 @@
+"""Curated IPEDS fact mapping for the PRD 021 federal baseline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FactMapping:
+    field_key: str
+    field_label: str
+    table_name: str
+    var_name: str
+    value_kind: str
+    display_group: str
+    definition_alignment: str
+    unit: str | None = None
+    cohort: str | None = None
+    population: str | None = None
+    definition_note: str | None = None
+    public_visible: bool = True
+
+
+MVP_FACT_MAPPINGS: tuple[FactMapping, ...] = (
+    FactMapping("institution_name", "Institution name", "HD2024", "INSTNM", "text", "Identity", "direct"),
+    FactMapping("city", "City", "HD2024", "CITY", "text", "Identity", "direct"),
+    FactMapping("state", "State", "HD2024", "STABBR", "text", "Identity", "direct"),
+    FactMapping("sector", "IPEDS sector", "HD2024", "SECTOR", "label", "Identity", "context_only"),
+    FactMapping("control", "Control", "HD2024", "CONTROL", "label", "Identity", "context_only"),
+    FactMapping("institution_level", "Institution level", "HD2024", "ICLEVEL", "label", "Identity", "context_only"),
+    FactMapping("highest_offering", "Highest level of offering", "HD2024", "HLOFFER", "label", "Identity", "context_only"),
+    FactMapping("degree_granting_status", "Degree-granting status", "HD2024", "DEGGRANT", "label", "Identity", "context_only"),
+    FactMapping("locale", "Locale", "HD2024", "LOCALE", "label", "Identity", "context_only"),
+    FactMapping("institution_size", "Institution size category", "HD2024", "INSTSIZE", "label", "Identity", "context_only"),
+    FactMapping("open_admissions_policy", "Open admissions policy", "IC2024", "OPENADMP", "label", "Admissions", "context_only"),
+    FactMapping("applicants_total", "Applicants total", "ADM2024", "APPLCN", "number", "Admissions", "near", population="first-time degree/certificate-seeking undergraduates"),
+    FactMapping("admissions_total", "Admissions total", "ADM2024", "ADMSSN", "number", "Admissions", "near", population="first-time degree/certificate-seeking undergraduates"),
+    FactMapping("enrolled_total", "Enrolled total", "ADM2024", "ENRLT", "number", "Admissions", "near", population="first-time degree/certificate-seeking undergraduates"),
+    FactMapping("enrolled_full_time", "Enrolled full time", "ADM2024", "ENRLFT", "number", "Admissions", "near", population="first-time degree/certificate-seeking undergraduates"),
+    FactMapping("admit_rate_total", "Admit rate", "DRVADM2024", "DVADM01", "number", "Admissions", "near", unit="percent"),
+    FactMapping("yield_rate_total", "Yield rate", "DRVADM2024", "DVADM04", "number", "Admissions", "near", unit="percent"),
+    FactMapping("sat_submit_rate", "SAT submit rate", "ADM2024", "SATPCT", "number", "Admissions testing", "near", unit="percent"),
+    FactMapping("act_submit_rate", "ACT submit rate", "ADM2024", "ACTPCT", "number", "Admissions testing", "near", unit="percent"),
+    FactMapping("sat_ebrw_p25", "SAT EBRW 25th percentile", "ADM2024", "SATVR25", "number", "Admissions testing", "near"),
+    FactMapping("sat_ebrw_p50", "SAT EBRW 50th percentile", "ADM2024", "SATVR50", "number", "Admissions testing", "near"),
+    FactMapping("sat_ebrw_p75", "SAT EBRW 75th percentile", "ADM2024", "SATVR75", "number", "Admissions testing", "near"),
+    FactMapping("sat_math_p25", "SAT math 25th percentile", "ADM2024", "SATMT25", "number", "Admissions testing", "near"),
+    FactMapping("sat_math_p50", "SAT math 50th percentile", "ADM2024", "SATMT50", "number", "Admissions testing", "near"),
+    FactMapping("sat_math_p75", "SAT math 75th percentile", "ADM2024", "SATMT75", "number", "Admissions testing", "near"),
+    FactMapping("act_composite_p25", "ACT composite 25th percentile", "ADM2024", "ACTCM25", "number", "Admissions testing", "near"),
+    FactMapping("act_composite_p50", "ACT composite 50th percentile", "ADM2024", "ACTCM50", "number", "Admissions testing", "near"),
+    FactMapping("act_composite_p75", "ACT composite 75th percentile", "ADM2024", "ACTCM75", "number", "Admissions testing", "near"),
+    FactMapping("undergraduate_enrollment", "Undergraduate enrollment", "DRVEF2024", "EFUG", "number", "Enrollment", "near"),
+    FactMapping("graduate_enrollment", "Graduate enrollment", "DRVEF2024", "EFGRAD", "number", "Enrollment", "near"),
+    FactMapping("total_enrollment", "Total enrollment", "DRVEF2024", "ENRTOT", "number", "Enrollment", "near"),
+    FactMapping("full_time_undergraduate_enrollment", "Full-time undergraduate enrollment", "DRVEF2024", "EFUGFT", "number", "Enrollment", "near"),
+    FactMapping("part_time_undergraduate_enrollment", "Part-time undergraduate enrollment", "DRVEF2024", "EFUGPT", "number", "Enrollment", "near"),
+    FactMapping("retention_rate_full_time", "Full-time retention rate", "EF2024D", "RET_PCF", "number", "Outcomes", "near", unit="percent", cohort="first-time full-time students"),
+    FactMapping("retention_rate_part_time", "Part-time retention rate", "EF2024D", "RET_PCP", "number", "Outcomes", "near", unit="percent", cohort="first-time part-time students"),
+    FactMapping("student_faculty_ratio", "Student-faculty ratio", "EF2024D", "STUFACR", "number", "Academics", "context_only"),
+    FactMapping("graduation_rate_total_150pct", "Graduation rate, 150% time", "DRVGR2024", "GRRTTOT", "number", "Outcomes", "near", unit="percent"),
+    FactMapping("transfer_out_rate_total", "Transfer-out rate", "DRVGR2024", "TRRTTOT", "number", "Outcomes", "near", unit="percent"),
+    FactMapping("bachelor_4yr_grad_rate", "Bachelor graduation rate, 4 years", "DRVGR2024", "GBA4RTT", "number", "Outcomes", "near", unit="percent"),
+    FactMapping("bachelor_5yr_grad_rate", "Bachelor graduation rate, 5 years", "DRVGR2024", "GBA5RTT", "number", "Outcomes", "near", unit="percent"),
+    FactMapping("bachelor_6yr_grad_rate", "Bachelor graduation rate, 6 years", "DRVGR2024", "GBA6RTT", "number", "Outcomes", "near", unit="percent"),
+    FactMapping("tuition_in_state", "In-state tuition", "COST1_2024", "TUITION2", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("tuition_out_of_state", "Out-of-state tuition", "COST1_2024", "TUITION3", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("fees_in_state", "In-state required fees", "COST1_2024", "FEE2", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("fees_out_of_state", "Out-of-state required fees", "COST1_2024", "FEE3", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("room_and_board_on_campus", "On-campus room and board", "COST1_2024", "RMBRDAMT", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("total_price_in_state_on_campus", "Total price, in-state on campus", "DRVCOST2024", "CINSON", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("total_price_out_of_state_on_campus", "Total price, out-of-state on campus", "DRVCOST2024", "COTSON", "number", "Costs", "context_only", unit="usd"),
+    FactMapping("any_aid_rate", "Any aid rate", "SFA2324", "ANYAIDP", "number", "Financial aid", "context_only", unit="percent"),
+    FactMapping("federal_grant_rate", "Federal grant aid rate", "SFA2324", "FGRNT_P", "number", "Financial aid", "context_only", unit="percent"),
+    FactMapping("federal_grant_average", "Average federal grant aid", "SFA2324", "FGRNT_A", "number", "Financial aid", "context_only", unit="usd"),
+    FactMapping("pell_grant_rate", "Pell grant rate", "SFA2324", "PGRNT_P", "number", "Financial aid", "context_only", unit="percent"),
+    FactMapping("pell_grant_average", "Average Pell grant", "SFA2324", "PGRNT_A", "number", "Financial aid", "context_only", unit="usd"),
+    FactMapping("federal_loan_rate", "Federal loan rate", "SFA2324", "LOAN_P", "number", "Financial aid", "context_only", unit="percent"),
+    FactMapping("federal_loan_average", "Average federal loan", "SFA2324", "LOAN_A", "number", "Financial aid", "context_only", unit="usd"),
+    FactMapping("bachelor_degrees_awarded", "Bachelor's degrees awarded", "DRVC2024", "BASDEG", "number", "Completions", "context_only"),
+    FactMapping("master_degrees_awarded", "Master's degrees awarded", "DRVC2024", "MASDEG", "number", "Completions", "context_only"),
+    FactMapping("doctor_degrees_awarded", "Doctor's degrees awarded", "DRVC2024", "DOCDEGRS", "number", "Completions", "context_only"),
+)
+

--- a/tools/ipeds/metadata.py
+++ b/tools/ipeds/metadata.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Parse official NCES/IPEDS release metadata and table documentation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urljoin
+
+from openpyxl import load_workbook
+
+NCES_IPEDS_ACCESS_PAGE = "https://nces.ed.gov/ipeds/use-the-data/download-access-database"
+DATA_GENERATOR_URL = "https://nces.ed.gov/ipeds/data-generator?year={year}&tableName={table_name}&HasRV=0&type=csv"
+
+
+@dataclass(frozen=True)
+class ReleaseLink:
+    collection_year: str
+    data_year: int
+    release_type: str
+    release_date: str | None
+    access_url: str | None
+    metadata_url: str
+
+
+@dataclass(frozen=True)
+class IpedsTable:
+    table_name: str
+    survey_component: str | None
+    year_coverage: str | None
+    table_number: int | None
+    table_title: str | None
+    description: str | None
+    table_release: str | None
+    table_release_date: str | None
+
+
+@dataclass(frozen=True)
+class IpedsColumn:
+    table_name: str
+    var_name: str
+    survey_component: str | None
+    table_number: int | None
+    table_title: str | None
+    var_number: int | None
+    var_order: int | None
+    imputation_var: str | None
+    var_title: str | None
+    data_type: str | None
+    field_width: int | None
+    format: str | None
+    multi_record: bool | None
+    has_rv: str | None
+    file_number: int | None
+    section_number: int | None
+    long_description: str | None
+    var_source: str | None
+    file_title: str | None
+    section_title: str | None
+
+
+@dataclass(frozen=True)
+class IpedsValueLabel:
+    table_name: str
+    var_name: str
+    code_value: str
+    value_label: str | None
+    frequency: int | None
+    percent: float | None
+    value_order: int | None
+    var_title: str | None
+
+
+@dataclass(frozen=True)
+class TablesDoc:
+    tables: list[IpedsTable]
+    columns: list[IpedsColumn]
+    value_labels: list[IpedsValueLabel]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def release_type_from_text(value: str) -> str:
+    normalized = value.lower()
+    if "final" in normalized:
+        return "final"
+    if "preliminary" in normalized:
+        return "preliminary"
+    return "provisional"
+
+
+def parse_access_page(html: str, base_url: str = NCES_IPEDS_ACCESS_PAGE) -> list[ReleaseLink]:
+    """Extract official release links from the NCES Access database page.
+
+    The page exposes paired Access ZIP and Excel metadata links. We intentionally
+    avoid scraping data values here; this only discovers official source URLs.
+    """
+    hrefs = re.findall(r'href=["\']([^"\']+)["\']', html, flags=re.I)
+    metadata_by_collection: dict[str, str] = {}
+    access_by_collection: dict[str, str] = {}
+    for href in hrefs:
+        absolute = urljoin(base_url, href)
+        lower = absolute.lower()
+        if "tablesdoc.xlsx" in lower:
+            match = re.search(r"ipeds[_-]?(\d{4})(\d{2})?tablesdoc\.xlsx", lower, flags=re.I)
+            if match:
+                start = int(match.group(1))
+                end = int(match.group(2) or ((start + 1) % 100))
+                metadata_by_collection[f"{start}-{end:02d}"] = absolute
+        elif "ipeds_" in lower and lower.endswith(".zip"):
+            match = re.search(r"ipeds_(\d{4})-(\d{2})", lower, flags=re.I)
+            if match:
+                access_by_collection[f"{int(match.group(1))}-{int(match.group(2)):02d}"] = absolute
+
+    text = re.sub(r"\s+", " ", html)
+    releases: list[ReleaseLink] = []
+    for collection_year, metadata_url in sorted(metadata_by_collection.items(), reverse=True):
+        start_year = int(collection_year[:4])
+        window = text[max(0, text.find(collection_year) - 400) : text.find(collection_year) + 800]
+        date_match = re.search(
+            r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}",
+            window,
+        )
+        releases.append(
+            ReleaseLink(
+                collection_year=collection_year,
+                data_year=start_year,
+                release_type=release_type_from_text(window),
+                release_date=date_match.group(0) if date_match else None,
+                access_url=access_by_collection.get(collection_year),
+                metadata_url=metadata_url,
+            )
+        )
+    return releases
+
+
+def parse_tablesdoc(path: Path) -> TablesDoc:
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    try:
+        tables = [_table_from_row(row) for row in _sheet_dicts(workbook, "tables")]
+        columns = [_column_from_row(row) for row in _sheet_dicts(workbook, "vartable")]
+        labels = [_label_from_row(row) for row in _sheet_dicts(workbook, "valuesets")]
+    finally:
+        workbook.close()
+    return TablesDoc(
+        tables=[table for table in tables if table.table_name],
+        columns=[column for column in columns if column.table_name and column.var_name],
+        value_labels=[label for label in labels if label.table_name and label.var_name and label.code_value != ""],
+    )
+
+
+def _sheet_dicts(workbook: Any, prefix: str) -> Iterable[dict[str, Any]]:
+    sheet_name = next((name for name in workbook.sheetnames if name.lower().startswith(prefix.lower())), None)
+    if sheet_name is None:
+        raise ValueError(f"Workbook is missing a {prefix} sheet")
+    rows = workbook[sheet_name].iter_rows(values_only=True)
+    headers = [str(cell).strip() if cell is not None else "" for cell in next(rows)]
+    for row in rows:
+        if not any(cell not in (None, "") for cell in row):
+            continue
+        yield {headers[i].lower(): row[i] if i < len(row) else None for i in range(len(headers))}
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool(value: Any) -> bool | None:
+    text = _text(value)
+    if text is None:
+        return None
+    if text.lower() in {"1", "true", "yes", "y"}:
+        return True
+    if text.lower() in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _table_from_row(row: dict[str, Any]) -> IpedsTable:
+    return IpedsTable(
+        table_name=_text(row.get("tablename")) or "",
+        survey_component=_text(row.get("survey")),
+        year_coverage=_text(row.get("yearcoverage")),
+        table_number=_int(row.get("tablenumber")),
+        table_title=_text(row.get("tabletitle")),
+        description=_text(row.get("description")),
+        table_release=_text(row.get("release")),
+        table_release_date=_text(row.get("release_date")),
+    )
+
+
+def _column_from_row(row: dict[str, Any]) -> IpedsColumn:
+    return IpedsColumn(
+        table_name=_text(row.get("tablename")) or "",
+        var_name=(_text(row.get("varname")) or "").upper(),
+        survey_component=_text(row.get("survey")),
+        table_number=_int(row.get("tablenumber")),
+        table_title=_text(row.get("tabletitle")),
+        var_number=_int(row.get("varnumber")),
+        var_order=_int(row.get("varorder")),
+        imputation_var=(_text(row.get("imputationvar")) or "").upper() or None,
+        var_title=_text(row.get("vartitle")),
+        data_type=_text(row.get("datatype")),
+        field_width=_int(row.get("fieldwidth")),
+        format=_text(row.get("format")),
+        multi_record=_bool(row.get("multirecord")),
+        has_rv=_text(row.get("hasrv")),
+        file_number=_int(row.get("filenumber")),
+        section_number=_int(row.get("sectionnumber")),
+        long_description=_text(row.get("longdescription")),
+        var_source=_text(row.get("varsource")),
+        file_title=_text(row.get("filetitle")),
+        section_title=_text(row.get("sectiontitle")),
+    )
+
+
+def _label_from_row(row: dict[str, Any]) -> IpedsValueLabel:
+    return IpedsValueLabel(
+        table_name=_text(row.get("tablename")) or "",
+        var_name=(_text(row.get("varname")) or "").upper(),
+        code_value=_text(row.get("codevalue")) or "",
+        value_label=_text(row.get("valuelabel")),
+        frequency=_int(row.get("frequency")),
+        percent=_float(row.get("percent")),
+        value_order=_int(row.get("valueorder")),
+        var_title=_text(row.get("vartitle")),
+    )

--- a/tools/ipeds/project.py
+++ b/tools/ipeds/project.py
@@ -1,0 +1,244 @@
+"""Project raw IPEDS table rows into public long-form facts."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from .mappings import FactMapping
+from .metadata import IpedsColumn, IpedsValueLabel
+
+NEGATIVE_STATUS_WORDS = {
+    "not_applicable": ("not applicable", "not in universe", "not offered"),
+    "suppressed": ("suppressed", "privacy", "confidential"),
+    "missing": ("not reported", "not available", "missing", "unknown"),
+}
+
+
+def normalize_unitid(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_decimal(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip().replace(",", "")
+    if text.lower() in {"null", "privacysuppressed"}:
+        return None
+    try:
+        return Decimal(text)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def label_lookup(labels: list[IpedsValueLabel]) -> dict[tuple[str, str, str], str]:
+    return {
+        (label.table_name.upper(), label.var_name.upper(), label.code_value.strip()): label.value_label or ""
+        for label in labels
+    }
+
+
+def column_lookup(columns: list[IpedsColumn]) -> dict[tuple[str, str], IpedsColumn]:
+    return {(column.table_name.upper(), column.var_name.upper()): column for column in columns}
+
+
+def project_rows_to_facts(
+    rows_by_table: dict[str, list[dict[str, Any]]],
+    mappings: list[FactMapping] | tuple[FactMapping, ...],
+    columns: list[IpedsColumn],
+    labels: list[IpedsValueLabel],
+    *,
+    release_id: str | None,
+    collection_year: str,
+    data_year: int,
+    release_type: str,
+    school_id_by_unitid: dict[int, str] | None = None,
+) -> list[dict[str, Any]]:
+    facts: list[dict[str, Any]] = []
+    by_label = label_lookup(labels)
+    by_column = column_lookup(columns)
+    school_ids = school_id_by_unitid or {}
+
+    for mapping in mappings:
+        table_name = mapping.table_name.upper()
+        var_name = mapping.var_name.upper()
+        column = by_column.get((table_name, var_name))
+        imputation_var = (column.imputation_var if column else None) or f"X{var_name}"
+        for row in rows_by_table.get(table_name, []):
+            unitid = normalize_unitid(row.get("UNITID") or row.get("unitid"))
+            if unitid is None:
+                continue
+            fact = project_fact(
+                row,
+                mapping,
+                column,
+                by_label,
+                imputation_var=imputation_var,
+                unitid=unitid,
+                release_id=release_id,
+                collection_year=collection_year,
+                data_year=data_year,
+                release_type=release_type,
+                school_id=school_ids.get(unitid),
+            )
+            if fact is not None:
+                facts.append(fact)
+    return facts
+
+
+def project_fact(
+    row: dict[str, Any],
+    mapping: FactMapping,
+    column: IpedsColumn | None,
+    labels: dict[tuple[str, str, str], str],
+    *,
+    imputation_var: str | None,
+    unitid: int,
+    release_id: str | None,
+    collection_year: str,
+    data_year: int,
+    release_type: str,
+    school_id: str | None,
+) -> dict[str, Any] | None:
+    table_name = mapping.table_name.upper()
+    var_name = mapping.var_name.upper()
+    raw_value = _row_value(row, var_name)
+    if raw_value in (None, ""):
+        return None
+
+    text_value = str(raw_value).strip()
+    value_numeric: Decimal | None = None
+    value_text: str | None = None
+    value_label = labels.get((table_name, var_name, text_value))
+    quality_flag = quality_from_label(value_label) if value_label else "reported"
+
+    numeric = coerce_decimal(text_value)
+    if numeric is not None and numeric < 0 and value_label:
+        return _status_fact(
+            mapping,
+            column,
+            unitid,
+            release_id,
+            collection_year,
+            data_year,
+            release_type,
+            school_id,
+            text_value,
+            value_label,
+            quality_flag,
+            imputation_var,
+            row,
+        )
+
+    if mapping.value_kind == "number":
+        if numeric is None:
+            return None
+        value_numeric = numeric
+    elif mapping.value_kind == "label":
+        value_label = value_label or text_value
+        value_text = text_value
+    else:
+        value_text = text_value
+
+    imputation_flag = _row_value(row, imputation_var) if imputation_var else None
+    imputation_label = (
+        labels.get((table_name, imputation_var.upper(), str(imputation_flag).strip()))
+        if imputation_flag not in (None, "") and imputation_var
+        else None
+    )
+    imputation_quality = quality_from_label(imputation_label) if imputation_label else None
+    if imputation_quality == "imputed":
+        quality_flag = "imputed"
+
+    return {
+        "release_id": release_id,
+        "unitid": unitid,
+        "school_id": school_id,
+        "collection_year": collection_year,
+        "data_year": data_year,
+        "field_key": mapping.field_key,
+        "field_label": mapping.field_label,
+        "value_numeric": str(value_numeric) if value_numeric is not None else None,
+        "value_text": value_text,
+        "value_label": value_label,
+        "unit": mapping.unit,
+        "cohort": mapping.cohort,
+        "population": mapping.population,
+        "source_table": table_name,
+        "source_variable": var_name,
+        "source_title": column.var_title if column else None,
+        "release_type": release_type,
+        "imputation_flag": str(imputation_flag).strip() if imputation_flag not in (None, "") else None,
+        "imputation_label": imputation_label,
+        "quality_flag": quality_flag,
+        "definition_alignment": mapping.definition_alignment,
+        "definition_note": mapping.definition_note,
+        "display_group": mapping.display_group,
+        "public_visible": mapping.public_visible,
+    }
+
+
+def quality_from_label(label: str | None) -> str:
+    if not label:
+        return "reported"
+    normalized = label.lower()
+    if "imput" in normalized:
+        return "imputed"
+    for status, words in NEGATIVE_STATUS_WORDS.items():
+        if any(word in normalized for word in words):
+            return status
+    return "reported"
+
+
+def _row_value(row: dict[str, Any], key: str | None) -> Any:
+    if not key:
+        return None
+    return row.get(key) if key in row else row.get(key.upper()) if key.upper() in row else row.get(key.lower())
+
+
+def _status_fact(
+    mapping: FactMapping,
+    column: IpedsColumn | None,
+    unitid: int,
+    release_id: str | None,
+    collection_year: str,
+    data_year: int,
+    release_type: str,
+    school_id: str | None,
+    raw_value: str,
+    value_label: str,
+    quality_flag: str,
+    imputation_var: str | None,
+    row: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "release_id": release_id,
+        "unitid": unitid,
+        "school_id": school_id,
+        "collection_year": collection_year,
+        "data_year": data_year,
+        "field_key": mapping.field_key,
+        "field_label": mapping.field_label,
+        "value_numeric": None,
+        "value_text": raw_value,
+        "value_label": value_label,
+        "unit": mapping.unit,
+        "cohort": mapping.cohort,
+        "population": mapping.population,
+        "source_table": mapping.table_name.upper(),
+        "source_variable": mapping.var_name.upper(),
+        "source_title": column.var_title if column else None,
+        "release_type": release_type,
+        "imputation_flag": str(_row_value(row, imputation_var)).strip() if imputation_var and _row_value(row, imputation_var) not in (None, "") else None,
+        "imputation_label": None,
+        "quality_flag": quality_flag,
+        "definition_alignment": mapping.definition_alignment,
+        "definition_note": mapping.definition_note,
+        "display_group": mapping.display_group,
+        "public_visible": mapping.public_visible,
+    }

--- a/tools/ipeds/test_metadata.py
+++ b/tools/ipeds/test_metadata.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from tools.ipeds.metadata import parse_access_page, parse_tablesdoc
+
+
+class IpedsMetadataTests(unittest.TestCase):
+    def test_parse_access_page_finds_latest_excel_and_zip(self) -> None:
+        html = """
+        <a href="/ipeds/tablefiles/zipfiles/IPEDS_2024-25_Provisional.zip">2024-25 Access</a>
+        <a href="/ipeds/tablefiles/tableDocs/IPEDS202425Tablesdoc.xlsx">2024-25 Excel</a>
+        Provisional Data: March 2026
+        """
+        releases = parse_access_page(html)
+        self.assertEqual(releases[0].collection_year, "2024-25")
+        self.assertEqual(releases[0].data_year, 2024)
+        self.assertEqual(releases[0].release_type, "provisional")
+        self.assertTrue(releases[0].metadata_url.endswith("IPEDS202425Tablesdoc.xlsx"))
+        self.assertTrue(releases[0].access_url.endswith("IPEDS_2024-25_Provisional.zip"))
+
+    def test_parse_tablesdoc_reads_core_sheets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tablesdoc.xlsx"
+            workbook = Workbook()
+            ws = workbook.active
+            ws.title = "tables24"
+            ws.append(["Survey", "YearCoverage", "TableName", "Tablenumber", "TableTitle", "Description", "Release", "Release_date"])
+            ws.append(["HD", "2024", "HD2024", 1, "Directory", "Header", "Provisional", "March 2026"])
+            ws = workbook.create_sheet("varTable24")
+            ws.append(["Survey", "TableNumber", "TableName", "TableTitle", "VarNumber", "VarOrder", "VarName", "ImputationVar", "VarTitle", "DataType", "FieldWidth", "Format", "MultiRecord", "HasRV", "FileNumber", "SectionNumber", "LongDescription", "VarSource", "FileTitle", "SectionTitle"])
+            ws.append(["HD", 1, "HD2024", "Directory", 1, 1, "INSTNM", "", "Institution name", "Alpha", 100, "", "No", "No", 1, 1, "Name", "Source", "File", "Section"])
+            ws = workbook.create_sheet("valueSets24")
+            ws.append(["TableName", "VarName", "Codevalue", "Frequency", "Percent", "ValueOrder", "ValueLabel", "VarTitle"])
+            ws.append(["HD2024", "CONTROL", "1", 10, 50.0, 1, "Public", "Control"])
+            workbook.save(path)
+
+            parsed = parse_tablesdoc(path)
+            self.assertEqual(parsed.tables[0].table_name, "HD2024")
+            self.assertEqual(parsed.columns[0].var_name, "INSTNM")
+            self.assertEqual(parsed.value_labels[0].value_label, "Public")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tools/ipeds/test_project.py
+++ b/tools/ipeds/test_project.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from tools.ipeds.load_release import read_table_zip
+from tools.ipeds.mappings import FactMapping
+from tools.ipeds.metadata import IpedsColumn, IpedsValueLabel
+from tools.ipeds.project import project_rows_to_facts, quality_from_label
+
+
+class IpedsProjectionTests(unittest.TestCase):
+    def test_imputed_fact_keeps_visible_status(self) -> None:
+        rows = {"EF2024D": [{"UNITID": "123456", "RET_PCF": "88", "XRET_PCF": "2"}]}
+        mapping = FactMapping(
+            "retention_rate_full_time",
+            "Full-time retention rate",
+            "EF2024D",
+            "RET_PCF",
+            "number",
+            "Outcomes",
+            "near",
+            unit="percent",
+        )
+        columns = [IpedsColumn("EF2024D", "RET_PCF", None, None, None, None, None, "XRET_PCF", "Retention rate", None, None, None, None, None, None, None, None, None, None, None)]
+        labels = [IpedsValueLabel("EF2024D", "XRET_PCF", "2", "Imputed value", None, None, None, None)]
+        facts = project_rows_to_facts(rows, [mapping], columns, labels, release_id=None, collection_year="2024-25", data_year=2024, release_type="provisional")
+        self.assertEqual(facts[0]["value_numeric"], "88")
+        self.assertEqual(facts[0]["quality_flag"], "imputed")
+        self.assertEqual(facts[0]["imputation_label"], "Imputed value")
+
+    def test_negative_code_becomes_status_fact(self) -> None:
+        rows = {"ADM2024": [{"UNITID": "123456", "SATPCT": "-2"}]}
+        mapping = FactMapping("sat_submit_rate", "SAT submit rate", "ADM2024", "SATPCT", "number", "Admissions testing", "near", unit="percent")
+        columns = [IpedsColumn("ADM2024", "SATPCT", None, None, None, None, None, "XSATPCT", "SAT percent", None, None, None, None, None, None, None, None, None, None, None)]
+        labels = [IpedsValueLabel("ADM2024", "SATPCT", "-2", "Not applicable", None, None, None, None)]
+        facts = project_rows_to_facts(rows, [mapping], columns, labels, release_id=None, collection_year="2024-25", data_year=2024, release_type="provisional")
+        self.assertEqual(facts[0]["value_numeric"], None)
+        self.assertEqual(facts[0]["value_label"], "Not applicable")
+        self.assertEqual(facts[0]["quality_flag"], "not_applicable")
+
+    def test_read_table_zip_handles_utf8_bom_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "HD2024.zip"
+            with zipfile.ZipFile(path, "w") as zf:
+                zf.writestr("hd2024.csv", "\ufeffUNITID,INSTNM\n123456,Example College\n")
+            rows = read_table_zip(path)
+            self.assertEqual(rows, [{"UNITID": "123456", "INSTNM": "Example College"}])
+
+    def test_quality_from_label(self) -> None:
+        self.assertEqual(quality_from_label("Value was imputed"), "imputed")
+        self.assertEqual(quality_from_label("Not in universe"), "not_applicable")
+        self.assertEqual(quality_from_label("Privacy suppressed"), "suppressed")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -248,7 +248,56 @@ export default async function ApiDocsPage() {
             "app_fee_amount",
             "app_fee_waiver_offered",
             "admission_strategy_card_quality",
+            "federal_baseline_available",
+            "federal_source_mode",
             "updated_at",
+          ]}
+        />
+        <Resource
+          name="school_facts_unified"
+          description="Source-labeled NCES/IPEDS baseline facts for in-scope institutions. This is the public serving view for the IPEDS coverage layer; raw IPEDS JSON rows are intentionally not exposed."
+          fields={[
+            "school_id",
+            "school_name",
+            "ipeds_id",
+            "field_key",
+            "field_label",
+            "display_value",
+            "quality_flag",
+            "definition_alignment",
+            "source_table",
+            "source_variable",
+          ]}
+          allFields={[
+            "ipeds_id",
+            "school_id",
+            "school_name",
+            "city",
+            "state",
+            "in_scope",
+            "collection_year",
+            "data_year",
+            "field_key",
+            "field_label",
+            "display_value",
+            "value_numeric",
+            "value_text",
+            "value_label",
+            "unit",
+            "cohort",
+            "population",
+            "source_layer",
+            "source_table",
+            "source_variable",
+            "source_title",
+            "release_type",
+            "imputation_flag",
+            "imputation_label",
+            "quality_flag",
+            "definition_alignment",
+            "definition_note",
+            "display_group",
+            "created_at",
           ]}
         />
         <Resource

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchAdmissionStrategyBySchoolId,
   fetchMeritProfileBySchoolId,
   fetchChangeEventsBySchoolId,
+  fetchSchoolFederalFacts,
 } from "@/lib/queries";
 import { OutcomesSection } from "@/components/OutcomesSection";
 import { PositioningCard } from "@/components/PositioningCard";
@@ -21,6 +22,7 @@ import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
 import { Sparkline } from "@/components/Sparkline";
 import { CoverageBadge } from "@/components/CoverageBadge";
 import { SubmissionForm } from "@/components/SubmissionForm";
+import { FederalBaselineTable } from "@/components/FederalBaselineTable";
 import { storageUrl, yearRange } from "@/lib/format";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
 
@@ -44,6 +46,7 @@ export async function generateMetadata({
         title: `${coverage.school_name} - ${coverage.coverage_label}`,
         description: coverage.coverage_summary,
         alternates: { canonical: path },
+        robots: { index: false, follow: true },
         openGraph: {
           url: path,
           title: coverage.school_name,
@@ -158,6 +161,7 @@ export default async function SchoolDetailPage({
     meritProfile,
     changeEvents,
     coverage,
+    federalFacts,
   ] = await Promise.all([
     fetchScorecardByIpedsId(ipedsId),
     fetchBrowserRowBySchoolId(school_id),
@@ -166,6 +170,7 @@ export default async function SchoolDetailPage({
     fetchMeritProfileBySchoolId(school_id),
     fetchChangeEventsBySchoolId(school_id),
     fetchInstitutionCoverage(school_id),
+    fetchSchoolFederalFacts(school_id),
   ]);
   const positioningSchool = browserRow
     ? { ...browserRow, ...gpaProfile }
@@ -418,6 +423,8 @@ export default async function SchoolDetailPage({
 
       <WhatChangedCard events={changeEvents} />
 
+      <FederalBaselineTable facts={federalFacts} />
+
       {scorecard ? (
         <OutcomesSection scorecard={scorecard} />
       ) : ipedsId ? (
@@ -461,7 +468,10 @@ async function DirectoryOnlySchoolPage({
   coverage: InstitutionCoverage;
   school_id: string;
 }) {
-  const scorecard = await fetchScorecardByIpedsId(coverage.ipeds_id);
+  const [scorecard, federalFacts] = await Promise.all([
+    fetchScorecardByIpedsId(coverage.ipeds_id),
+    fetchSchoolFederalFacts(school_id),
+  ]);
 
   const { head, tail } = splitInstitutionalSuffix(coverage.school_name);
   const location = formatLocation(coverage);
@@ -590,6 +600,8 @@ async function DirectoryOnlySchoolPage({
         />
       )}
 
+      <FederalBaselineTable facts={federalFacts} compact />
+
       {scorecard ? (
         <div style={{ marginTop: 56 }}>
           <OutcomesSection scorecard={scorecard} />
@@ -623,8 +635,9 @@ async function DirectoryOnlySchoolPage({
         }}
       >
         We track every active, undergraduate-serving Title-IV institution
-        and refresh CDS coverage every 15 minutes. Federal data above
-        comes from College Scorecard. <Link href="/about">Read the method</Link>.
+        and refresh CDS coverage every 15 minutes. Federal data above comes
+        from NCES/IPEDS and College Scorecard when available.{" "}
+        <Link href="/about">Read the method</Link>.
       </p>
     </div>
   );

--- a/web/src/components/FederalBaselineTable.tsx
+++ b/web/src/components/FederalBaselineTable.tsx
@@ -1,0 +1,157 @@
+import type { SchoolFactUnifiedRow } from "@/lib/types";
+import { formatCurrency } from "@/lib/format";
+
+type FactGroup = {
+  name: string;
+  facts: SchoolFactUnifiedRow[];
+};
+
+export function FederalBaselineTable({
+  facts,
+  compact = false,
+}: {
+  facts: SchoolFactUnifiedRow[];
+  compact?: boolean;
+}) {
+  if (facts.length === 0) return null;
+
+  const groups = groupFacts(facts);
+  const releaseLabel = releaseSummary(facts);
+
+  return (
+    <section style={{ marginTop: compact ? 36 : 52 }} aria-labelledby="federal-baseline-heading">
+      <div className="rule-2" style={{ paddingTop: 18, marginBottom: 18 }}>
+        <div className="meta" style={{ marginBottom: 8 }}>
+          NCES/IPEDS baseline
+        </div>
+        <h2
+          id="federal-baseline-heading"
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: compact ? 30 : 36,
+            lineHeight: 1.05,
+            margin: 0,
+          }}
+        >
+          Source-labeled federal facts
+        </h2>
+        <p style={{ margin: "10px 0 0", maxWidth: 760, color: "var(--ink-2)", lineHeight: 1.55 }}>
+          These values come from official NCES/IPEDS tables. They are not Common Data Set fields unless the definition column says the alignment is direct or near.
+        </p>
+        {releaseLabel && (
+          <p className="meta" style={{ margin: "8px 0 0", color: "var(--ink-3)" }}>
+            {releaseLabel}
+          </p>
+        )}
+      </div>
+
+      {groups.map((group) => (
+        <div key={group.name} style={{ marginTop: 24 }}>
+          <h3
+            className="meta"
+            style={{
+              margin: "0 0 8px",
+              color: "var(--ink)",
+              letterSpacing: "0.06em",
+            }}
+          >
+            {group.name}
+          </h3>
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", minWidth: 720, borderCollapse: "collapse", fontSize: 14 }}>
+              <caption className="sr-only">{group.name} IPEDS baseline facts</caption>
+              <thead>
+                <tr className="meta" style={{ textAlign: "left", borderBottom: "1px solid var(--rule-strong)" }}>
+                  <th style={{ padding: "8px 10px 8px 0", width: "28%" }}>Fact</th>
+                  <th style={{ padding: "8px 10px" }}>Value</th>
+                  <th style={{ padding: "8px 10px" }}>Status</th>
+                  <th style={{ padding: "8px 10px" }}>Definition</th>
+                  <th style={{ padding: "8px 0 8px 10px" }}>Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.facts.map((fact) => (
+                  <tr key={`${fact.field_key}-${fact.source_table}-${fact.source_variable}`} className="rule">
+                    <th scope="row" style={{ padding: "11px 10px 11px 0", textAlign: "left", fontWeight: 500 }}>
+                      {fact.field_label}
+                      {fact.population && (
+                        <div className="meta" style={{ marginTop: 3, lineHeight: 1.35 }}>
+                          {fact.population}
+                        </div>
+                      )}
+                    </th>
+                    <td className="nums" style={{ padding: "11px 10px", whiteSpace: "nowrap" }}>
+                      {formatFactValue(fact)}
+                    </td>
+                    <td style={{ padding: "11px 10px" }}>
+                      <StatusBadge fact={fact} />
+                    </td>
+                    <td style={{ padding: "11px 10px", color: "var(--ink-2)" }}>
+                      {definitionLabel(fact.definition_alignment)}
+                      {fact.definition_note && (
+                        <div className="meta" style={{ marginTop: 4, lineHeight: 1.35 }}>
+                          {fact.definition_note}
+                        </div>
+                      )}
+                    </td>
+                    <td className="mono" style={{ padding: "11px 0 11px 10px", color: "var(--ink-3)", fontSize: 12 }}>
+                      {fact.source_table}.{fact.source_variable}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function groupFacts(facts: SchoolFactUnifiedRow[]): FactGroup[] {
+  const map = new Map<string, SchoolFactUnifiedRow[]>();
+  for (const fact of facts) {
+    const group = map.get(fact.display_group) ?? [];
+    group.push(fact);
+    map.set(fact.display_group, group);
+  }
+  return Array.from(map, ([name, rows]) => ({ name, facts: rows }));
+}
+
+function formatFactValue(fact: SchoolFactUnifiedRow): string {
+  if (fact.value_label) return fact.value_label;
+  if (fact.unit === "usd" && fact.value_numeric != null) return formatCurrency(fact.value_numeric) ?? String(fact.value_numeric);
+  return fact.display_value ?? fact.value_text ?? (fact.value_numeric == null ? "-" : String(fact.value_numeric));
+}
+
+function StatusBadge({ fact }: { fact: SchoolFactUnifiedRow }) {
+  const label = fact.quality_flag === "reported" ? "reported" : fact.quality_flag.replaceAll("_", " ");
+  const title = fact.imputation_label ?? label;
+  return (
+    <span className={fact.quality_flag === "imputed" ? "cd-chip" : "meta"} title={title}>
+      {label}
+    </span>
+  );
+}
+
+function definitionLabel(value: SchoolFactUnifiedRow["definition_alignment"]): string {
+  switch (value) {
+    case "direct":
+      return "Direct";
+    case "near":
+      return "Near CDS";
+    case "context_only":
+      return "Context only";
+    case "not_cds_equivalent":
+      return "Not CDS-equivalent";
+  }
+}
+
+function releaseSummary(facts: SchoolFactUnifiedRow[]): string | null {
+  const first = facts[0];
+  if (!first) return null;
+  const releaseType = first.release_type.charAt(0).toUpperCase() + first.release_type.slice(1);
+  return `${releaseType} ${first.collection_year} release, data year ${first.data_year}`;
+}
+

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -142,6 +142,8 @@ function downloadCsv(rows: BrowserRow[]) {
     { key: "act_composite_p75", label: "act_composite_p75" },
     { key: "source_format", label: "source_format" },
     { key: "data_quality_flag", label: "data_quality_flag" },
+    { key: "federal_baseline_available", label: "federal_baseline_available" },
+    { key: "federal_source_mode", label: "federal_source_mode" },
     { key: "archive_url", label: "archive_url" },
   ];
   const body = rows.map((row) => columns.map((col) => csvEscape(row[col.key])).join(","));

--- a/web/src/lib/browser-search.ts
+++ b/web/src/lib/browser-search.ts
@@ -53,7 +53,9 @@ export type BrowserField =
   | "sat_math_p75"
   | "act_composite_p25"
   | "act_composite_p50"
-  | "act_composite_p75";
+  | "act_composite_p75"
+  | "federal_baseline_available"
+  | "federal_source_mode";
 
 export type BrowserSort = {
   field: BrowserField;
@@ -126,6 +128,8 @@ export type BrowserRow = {
   source_format: string | null;
   data_quality_flag: string | null;
   archive_url: string;
+  federal_baseline_available: boolean;
+  federal_source_mode: "cds_only" | "cds_plus_ipeds_baseline" | "ipeds_baseline_only";
 };
 
 export type BrowserSearchResponse = {
@@ -165,7 +169,18 @@ export const BROWSER_COLUMNS: BrowserField[] = [
   "source_format",
   "data_quality_flag",
   "archive_url",
+  "federal_baseline_available",
+  "federal_source_mode",
 ];
+
+const FEDERAL_BROWSER_COLUMNS = new Set<BrowserField>([
+  "federal_baseline_available",
+  "federal_source_mode",
+]);
+
+const LEGACY_BROWSER_COLUMNS = BROWSER_COLUMNS.filter(
+  (column) => !FEDERAL_BROWSER_COLUMNS.has(column),
+);
 
 export async function searchBrowserRows(
   request: BrowserSearchRequest,
@@ -177,6 +192,36 @@ export async function searchBrowserRows(
     throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY");
   }
 
+  const body = {
+    columns: BROWSER_COLUMNS,
+    ...request,
+  };
+  const response = await fetch(`${supabaseUrl}/functions/v1/browser-search`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      apikey: anonKey,
+      authorization: `Bearer ${anonKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const payload = await response.json();
+  if (!response.ok && canRetryWithoutFederalColumns(payload, request)) {
+    return searchBrowserRowsWithoutFederalColumns(supabaseUrl, anonKey, request);
+  }
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Browser search failed");
+  }
+
+  return withFederalDefaults(payload as BrowserSearchResponse);
+}
+
+async function searchBrowserRowsWithoutFederalColumns(
+  supabaseUrl: string,
+  anonKey: string,
+  request: BrowserSearchRequest,
+): Promise<BrowserSearchResponse> {
   const response = await fetch(`${supabaseUrl}/functions/v1/browser-search`, {
     method: "POST",
     headers: {
@@ -185,7 +230,7 @@ export async function searchBrowserRows(
       authorization: `Bearer ${anonKey}`,
     },
     body: JSON.stringify({
-      columns: BROWSER_COLUMNS,
+      columns: LEGACY_BROWSER_COLUMNS,
       ...request,
     }),
   });
@@ -194,6 +239,29 @@ export async function searchBrowserRows(
   if (!response.ok) {
     throw new Error(payload?.error ?? "Browser search failed");
   }
+  return withFederalDefaults(payload as BrowserSearchResponse);
+}
 
-  return payload as BrowserSearchResponse;
+function canRetryWithoutFederalColumns(
+  payload: unknown,
+  request: BrowserSearchRequest,
+): boolean {
+  const error = (payload as { error?: string } | null)?.error ?? "";
+  if (!/unsupported column: federal_/.test(error)) return false;
+  const federalFilter = request.filters?.some((filter) =>
+    FEDERAL_BROWSER_COLUMNS.has(filter.field),
+  );
+  const federalSort = request.sort && FEDERAL_BROWSER_COLUMNS.has(request.sort.field);
+  return !federalFilter && !federalSort;
+}
+
+function withFederalDefaults(response: BrowserSearchResponse): BrowserSearchResponse {
+  return {
+    ...response,
+    rows: response.rows.map((row) => ({
+      ...row,
+      federal_baseline_available: row.federal_baseline_available ?? false,
+      federal_source_mode: row.federal_source_mode ?? "cds_only",
+    })),
+  };
 }

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -17,6 +17,7 @@ import type {
   ChangeEventVerificationStatus,
   MeritProfileQuality,
   MeritProfileRow,
+  SchoolFactUnifiedRow,
 } from "./types";
 import type { SchoolAcademicProfile } from "./positioning";
 import type { AdmissionStrategyQuality, AdmissionStrategySchool } from "./admission-strategy";
@@ -413,6 +414,37 @@ export const fetchSchoolDocuments = cache(async function fetchSchoolDocuments(
     throw new Error(`Failed to fetch school documents: ${error.message}`);
   return data ?? [];
 });
+
+// PRD 021 — source-labeled NCES/IPEDS baseline facts.
+//
+// This intentionally tolerates missing-table/view errors so the web build can
+// ship before the production migration is applied from main. The UI simply
+// omits the federal baseline table until data exists.
+export const fetchSchoolFederalFacts = cache(
+  async function fetchSchoolFederalFacts(
+    schoolId: string,
+  ): Promise<SchoolFactUnifiedRow[]> {
+    try {
+      const { data, error } = await (supabase as unknown as UntypedSupabase)
+        .from("school_facts_unified")
+        .select(
+          "ipeds_id, school_id, school_name, city, state, in_scope, collection_year, data_year, field_key, field_label, display_value, value_numeric, value_text, value_label, unit, cohort, population, source_layer, source_table, source_variable, source_title, release_type, imputation_flag, imputation_label, quality_flag, definition_alignment, definition_note, display_group, created_at",
+        )
+        .eq("school_id", schoolId)
+        .order("display_group", { ascending: true })
+        .order("field_label", { ascending: true });
+
+      if (error) {
+        console.warn(`fetchSchoolFederalFacts: ${error.message}`);
+        return [];
+      }
+      return (data as SchoolFactUnifiedRow[]) ?? [];
+    } catch (error) {
+      console.warn(`fetchSchoolFederalFacts: ${String(error)}`);
+      return [];
+    }
+  },
+);
 
 export const fetchBrowserRowBySchoolId = cache(
   async function fetchBrowserRowBySchoolId(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -214,6 +214,52 @@ export interface InstitutionCoverage {
   can_submit_source: boolean;
 }
 
+export type FederalFactQuality =
+  | "reported"
+  | "imputed"
+  | "not_applicable"
+  | "suppressed"
+  | "missing"
+  | "unusable";
+
+export type FederalFactDefinitionAlignment =
+  | "direct"
+  | "near"
+  | "context_only"
+  | "not_cds_equivalent";
+
+export interface SchoolFactUnifiedRow {
+  ipeds_id: string;
+  school_id: string;
+  school_name: string;
+  city: string | null;
+  state: string | null;
+  in_scope: boolean;
+  collection_year: string;
+  data_year: number;
+  field_key: string;
+  field_label: string;
+  display_value: string | null;
+  value_numeric: number | null;
+  value_text: string | null;
+  value_label: string | null;
+  unit: string | null;
+  cohort: string | null;
+  population: string | null;
+  source_layer: "ipeds";
+  source_table: string;
+  source_variable: string;
+  source_title: string | null;
+  release_type: string;
+  imputation_flag: string | null;
+  imputation_label: string | null;
+  quality_flag: FederalFactQuality;
+  definition_alignment: FederalFactDefinitionAlignment;
+  definition_note: string | null;
+  display_group: string;
+  created_at: string;
+}
+
 export interface CorpusStats {
   total_schools: number;
   total_documents: number;


### PR DESCRIPTION
## Summary

- Add PRD 021 and schema for an NCES/IPEDS federal baseline layer: release provenance, metadata tables, raw row preservation, curated public facts, and `school_facts_unified` serving view.
- Add `tools/ipeds` downloader/loader/projection pipeline using official Tablesdoc metadata plus official CSV ZIP table downloads, with dry-run reports by default and guarded `--apply` writes.
- Wire the frontend to render source-labeled federal fact tables on school pages when data exists, document the API view, and extend browser export/search fields with federal source mode metadata.

## Verification

- `python3 -m unittest discover -s tools/ipeds -p 'test_*.py'`
- `python3 -m unittest tools.scorecard.test_load_directory`
- `deno test --allow-env --allow-read supabase/functions/browser-search/*.test.ts`
- `cd web && npm run typecheck`
- `git diff --check`

## Migration / operations

This PR includes `supabase/migrations/20260509090000_ipeds_coverage_layer.sql`.
Per `CLAUDE.md`, do not apply the migration from this feature branch. After this PR merges, apply from a fresh `main` checkout with:

```bash
cd /Users/santhonys/Projects/Owen/colleges/collegedata-fyi
git switch main && git pull --ff-only
supabase db push --linked
```

Then run the IPEDS loader dry-run and apply path from `tools/ipeds/README.md` after reviewing the generated report.

## Notes

Local `next build` is blocked in this Conductor workspace by macOS rejecting installed native `.node` packages for Next SWC/lightningcss code-signature validation. Typecheck and targeted tests pass; CI should run the Linux build path normally.
