### PR TITLE
Fix IPEDS loader live-load edge cases

### DIFF
--- a/supabase/migrations/20260509120000_fix_ipeds_browser_source_modes.sql
+++ b/supabase/migrations/20260509120000_fix_ipeds_browser_source_modes.sql
@@ -1,0 +1,102 @@
+-- PRD 021 follow-up.
+--
+-- Production has a safe-update guard that rejects UPDATE statements without
+-- an explicit WHERE clause, even inside RPC functions. Recreate the post-load
+-- helper with an always-true key predicate. Also tighten numeric display for
+-- school_facts_unified so integer values render as "1970", not "1970.".
+
+begin;
+
+create or replace view public.school_facts_unified
+with (security_invoker = true) as
+select
+  d.ipeds_id,
+  d.school_id,
+  d.school_name,
+  d.city,
+  d.state,
+  d.in_scope,
+  f.collection_year,
+  f.data_year,
+  f.field_key,
+  f.field_label,
+  coalesce(
+    f.value_label,
+    f.value_text,
+    case
+      when f.unit = 'percent' and f.value_numeric is not null
+        then trim(trailing '.' from trim(trailing '0' from trim(to_char(f.value_numeric, 'FM999999990.099')))) || '%'
+      when f.value_numeric is not null
+        then trim(trailing '.' from trim(trailing '0' from trim(to_char(f.value_numeric, 'FM999999999999990.999999'))))
+      else null
+    end
+  ) as display_value,
+  f.value_numeric,
+  f.value_text,
+  f.value_label,
+  f.unit,
+  f.cohort,
+  f.population,
+  'ipeds'::text as source_layer,
+  f.source_table,
+  f.source_variable,
+  f.source_title,
+  f.release_type,
+  f.imputation_flag,
+  f.imputation_label,
+  f.quality_flag,
+  f.definition_alignment,
+  f.definition_note,
+  f.display_group,
+  f.created_at
+from public.ipeds_current_facts f
+join public.institution_directory d
+  on d.ipeds_id = f.ipeds_id
+where d.in_scope = true;
+
+comment on view public.school_facts_unified is
+  'Public PRD 021 serving view. Exposes source-labeled federal baseline facts for in-scope institutions without hiding provenance or definition alignment.';
+
+grant select on public.school_facts_unified to anon, authenticated;
+
+create or replace function public.refresh_ipeds_browser_source_modes()
+returns integer
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  updated_count integer;
+begin
+  update public.school_browser_rows as sbr
+  set
+    federal_baseline_available = exists (
+      select 1
+      from public.ipeds_current_facts f
+      where f.ipeds_id = sbr.ipeds_id
+      limit 1
+    ),
+    federal_source_mode = case
+      when exists (
+        select 1
+        from public.ipeds_current_facts f
+        where f.ipeds_id = sbr.ipeds_id
+        limit 1
+      )
+        then 'cds_plus_ipeds_baseline'
+      else 'cds_only'
+    end
+  where sbr.document_id is not null;
+
+  get diagnostics updated_count = row_count;
+  return updated_count;
+end;
+$$;
+
+comment on function public.refresh_ipeds_browser_source_modes() is
+  'Marks existing CDS browser rows that have a matching IPEDS baseline after an IPEDS fact load. Service-role loader calls this after upserting facts.';
+
+revoke all on function public.refresh_ipeds_browser_source_modes() from public;
+grant execute on function public.refresh_ipeds_browser_source_modes() to service_role;
+
+commit;

--- a/tools/ipeds/load_release.py
+++ b/tools/ipeds/load_release.py
@@ -241,8 +241,17 @@ def apply_to_supabase(
 
 
 def batch_upsert(client: Any, table: str, rows: list[dict[str, Any]], on_conflict: str, size: int = 500) -> None:
-    for start in range(0, len(rows), size):
-        client.table(table).upsert(rows[start : start + size], on_conflict=on_conflict).execute()
+    deduped = dedupe_rows(rows, on_conflict)
+    for start in range(0, len(deduped), size):
+        client.table(table).upsert(deduped[start : start + size], on_conflict=on_conflict).execute()
+
+
+def dedupe_rows(rows: list[dict[str, Any]], on_conflict: str) -> list[dict[str, Any]]:
+    keys = [key.strip() for key in on_conflict.split(",")]
+    seen: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in rows:
+        seen[tuple(row.get(key) for key in keys)] = row
+    return list(seen.values())
 
 
 def load_env(path: Path) -> None:

--- a/tools/ipeds/metadata.py
+++ b/tools/ipeds/metadata.py
@@ -91,10 +91,12 @@ def sha256_file(path: Path) -> str:
 
 def release_type_from_text(value: str) -> str:
     normalized = value.lower()
-    if "final" in normalized:
-        return "final"
     if "preliminary" in normalized:
         return "preliminary"
+    if "provisional" in normalized:
+        return "provisional"
+    if "final" in normalized:
+        return "final"
     return "provisional"
 
 
@@ -125,7 +127,15 @@ def parse_access_page(html: str, base_url: str = NCES_IPEDS_ACCESS_PAGE) -> list
     releases: list[ReleaseLink] = []
     for collection_year, metadata_url in sorted(metadata_by_collection.items(), reverse=True):
         start_year = int(collection_year[:4])
-        window = text[max(0, text.find(collection_year) - 400) : text.find(collection_year) + 800]
+        row_match = re.search(
+            rf"{re.escape(collection_year)}\s+Access.*?"
+            rf"{re.escape(collection_year)}\s+Excel.*?"
+            rf"(Preliminary|Provisional|Final)\s+"
+            rf"((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{{4}})",
+            text,
+            flags=re.I,
+        )
+        window = row_match.group(0) if row_match else text[max(0, text.find(collection_year) - 400) : text.find(collection_year) + 800]
         date_match = re.search(
             r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}",
             window,

--- a/tools/ipeds/test_metadata.py
+++ b/tools/ipeds/test_metadata.py
@@ -12,16 +12,22 @@ from tools.ipeds.metadata import parse_access_page, parse_tablesdoc
 class IpedsMetadataTests(unittest.TestCase):
     def test_parse_access_page_finds_latest_excel_and_zip(self) -> None:
         html = """
+        Final release data include revisions to provisional release data.
         <a href="/ipeds/tablefiles/zipfiles/IPEDS_2024-25_Provisional.zip">2024-25 Access</a>
         <a href="/ipeds/tablefiles/tableDocs/IPEDS202425Tablesdoc.xlsx">2024-25 Excel</a>
-        Provisional Data: March 2026
+        (IPEDS202425Tablesdoc.xlsx, 1261kb) Provisional March 2026
+        <a href="/ipeds/tablefiles/zipfiles/IPEDS_2023-24.zip">2023-24 Access</a>
+        <a href="/ipeds/tablefiles/tableDocs/IPEDS202324Tablesdoc.xlsx">2023-24 Excel</a>
+        (IPEDS202324Tablesdoc.xlsx, 1348kb) Final March 2026
         """
         releases = parse_access_page(html)
         self.assertEqual(releases[0].collection_year, "2024-25")
         self.assertEqual(releases[0].data_year, 2024)
         self.assertEqual(releases[0].release_type, "provisional")
+        self.assertEqual(releases[0].release_date, "March 2026")
         self.assertTrue(releases[0].metadata_url.endswith("IPEDS202425Tablesdoc.xlsx"))
         self.assertTrue(releases[0].access_url.endswith("IPEDS_2024-25_Provisional.zip"))
+        self.assertEqual(releases[1].release_type, "final")
 
     def test_parse_tablesdoc_reads_core_sheets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -47,4 +53,3 @@ class IpedsMetadataTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tools/ipeds/test_project.py
+++ b/tools/ipeds/test_project.py
@@ -6,6 +6,7 @@ import zipfile
 from pathlib import Path
 
 from tools.ipeds.load_release import read_table_zip
+from tools.ipeds.load_release import dedupe_rows
 from tools.ipeds.mappings import FactMapping
 from tools.ipeds.metadata import IpedsColumn, IpedsValueLabel
 from tools.ipeds.project import project_rows_to_facts, quality_from_label
@@ -54,7 +55,16 @@ class IpedsProjectionTests(unittest.TestCase):
         self.assertEqual(quality_from_label("Not in universe"), "not_applicable")
         self.assertEqual(quality_from_label("Privacy suppressed"), "suppressed")
 
+    def test_dedupe_rows_uses_conflict_key(self) -> None:
+        rows = [
+            {"release_id": "r1", "table_name": "HD2024", "var_name": "CONTROL", "code_value": "1", "value_label": "Public"},
+            {"release_id": "r1", "table_name": "HD2024", "var_name": "CONTROL", "code_value": "1", "value_label": "Public duplicate"},
+            {"release_id": "r1", "table_name": "HD2024", "var_name": "CONTROL", "code_value": "2", "value_label": "Private"},
+        ]
+        out = dedupe_rows(rows, "release_id,table_name,var_name,code_value")
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0]["value_label"], "Public duplicate")
+
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary

- Dedupe IPEDS upsert payloads by conflict key so duplicate official workbook value labels do not break release applies.
- Parse the Access Database page release type from the exact release row so 2024-25 stays `provisional` despite nearby explanatory text about final releases.
- Add a follow-up migration that gives `refresh_ipeds_browser_source_modes()` an explicit `WHERE` clause for production safe-update guards and cleans up `school_facts_unified.display_value` formatting.

## Verification

- `python3 -m unittest discover -s tools/ipeds -p 'test_*.py'`
- `git diff --check`

## Operational context

This follows the successful live 2024-25 IPEDS provisional load. The data is already loaded; this PR records the loader hardening and fixes the post-load helper for future runs.
