### PR TITLE
Add IPEDS release probe and no-CDS page polish

### DIFF
--- a/.github/workflows/ipeds-release-probe.yml
+++ b/.github/workflows/ipeds-release-probe.yml
@@ -1,0 +1,199 @@
+name: IPEDS release probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      as_of:
+        description: "Optional probe date override, YYYY-MM-DD."
+        required: false
+        default: ""
+      force_probe:
+        description: "Probe even before the computed due date."
+        type: boolean
+        required: false
+        default: false
+      probe_delay_months:
+        description: "Months after the last Access release before probing."
+        required: false
+        default: "10"
+  schedule:
+    # GitHub cron has no year field. Run monthly; the probe script no-ops
+    # until the due date computed from ipeds_releases.release_date.
+    - cron: "24 15 5 * *"
+
+concurrency:
+  group: ipeds-release-probe
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  probe:
+    name: Probe NCES Access releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      INPUT_AS_OF: ${{ github.event_name == 'workflow_dispatch' && inputs.as_of || '' }}
+      INPUT_FORCE_PROBE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_probe || false }}
+      INPUT_PROBE_DELAY_MONTHS: ${{ github.event_name == 'workflow_dispatch' && inputs.probe_delay_months || '10' }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/ci-requirements.txt
+
+      - name: Install probe dependencies
+        run: python -m pip install -r tools/ci-requirements.txt
+
+      - name: Run release probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${SUPABASE_URL}" || -z "${SUPABASE_SERVICE_ROLE_KEY}" ]]; then
+            echo "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY secrets are required." >&2
+            exit 2
+          fi
+          if ! [[ "${INPUT_PROBE_DELAY_MONTHS}" =~ ^[0-9]+$ ]]; then
+            echo "probe_delay_months must be an integer" >&2
+            exit 2
+          fi
+          mkdir -p ipeds-release-probe
+          args=(
+            --out-json ipeds-release-probe/summary.json
+            --probe-delay-months "${INPUT_PROBE_DELAY_MONTHS}"
+          )
+          if [[ -n "${INPUT_AS_OF}" ]]; then
+            args+=(--as-of "${INPUT_AS_OF}")
+          fi
+          if [[ "${INPUT_FORCE_PROBE}" == "true" ]]; then
+            args+=(--force)
+          fi
+          python tools/ipeds/probe_releases.py "${args[@]}" | tee ipeds-release-probe/probe.log
+
+      - name: Add run summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f ipeds-release-probe/summary.json ]]; then
+            {
+              echo "## IPEDS release probe"
+              echo
+              jq -r '"As of: \(.as_of)\nProbe delay months: \(.probe_delay_months)\nAvailable targets: \(.available_count)"' ipeds-release-probe/summary.json
+              echo
+              echo "### Targets"
+              jq -r '.targets[]? | "- \(.collection_year) \(.release_type): \(.status), due \(.due_on)"' ipeds-release-probe/summary.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No summary.json was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Create release-available issues
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          import textwrap
+
+          path = "ipeds-release-probe/summary.json"
+          repo = os.environ["REPO"]
+          with open(path, "r", encoding="utf-8") as f:
+              summary = json.load(f)
+
+          available = [target for target in summary.get("targets", []) if target.get("status") == "available"]
+          if not available:
+              print("No available IPEDS releases to notify.")
+              sys.exit(0)
+
+          minted = 0
+          for target in available:
+              collection_year = target["collection_year"]
+              release_type = target["release_type"]
+              remote = target.get("remote_release") or {}
+              title = f"ipeds_release_available: {collection_year} {release_type}"
+              existing = subprocess.run(
+                  [
+                      "gh", "issue", "list",
+                      "--repo", repo,
+                      "--state", "open",
+                      "--search", f'in:title "{title}"',
+                      "--json", "title",
+                  ],
+                  check=True,
+                  text=True,
+                  stdout=subprocess.PIPE,
+              )
+              titles = [row.get("title") for row in json.loads(existing.stdout or "[]")]
+              if title in titles:
+                  print(f"Existing issue found for {title}; skipping.")
+                  continue
+
+              release_date = remote.get("release_date") or ""
+              release_date_text = remote.get("release_date_text") or release_date
+              metadata_url = remote.get("metadata_url") or ""
+              access_url = remote.get("access_url") or ""
+              data_year = remote.get("data_year") or int(collection_year[:4])
+              reference = summary.get("reference_release") or {}
+              body = textwrap.dedent(f"""\
+              NCES/IPEDS now lists the `{collection_year}` `{release_type}` Access Database release.
+
+              Probe due date: `{target.get('due_on')}`
+              NCES release date: `{release_date_text}`
+              Reference loaded release: `{reference.get('collection_year')} {reference.get('release_type')}` released `{reference.get('release_date')}`
+
+              Source page: {summary.get('source_page_url')}
+              Metadata: {metadata_url}
+              Access ZIP: {access_url}
+
+              Suggested operator flow:
+
+              ```bash
+              python tools/ipeds/download_release.py --collection-year {collection_year} --data-year {data_year}
+
+              python tools/ipeds/load_release.py \\
+                --metadata-xlsx scratch/ipeds/{collection_year}-{release_type}/IPEDS{collection_year.replace('-', '')}Tablesdoc.xlsx \\
+                --data-dir scratch/ipeds/{collection_year}-{release_type} \\
+                --collection-year {collection_year} \\
+                --data-year {data_year} \\
+                --release-type {release_type} \\
+                --release-date {release_date} \\
+                --release-date-text "{release_date_text}" \\
+                --metadata-url {metadata_url} \\
+                --access-url {access_url}
+              ```
+
+              Review the dry-run report, then apply from a fresh `main` checkout per `CLAUDE.md`.
+              """)
+              subprocess.run(
+                  [
+                      "gh", "issue", "create",
+                      "--repo", repo,
+                      "--title", title,
+                      "--body", body,
+                  ],
+                  check=True,
+              )
+              minted += 1
+          print(f"Created {minted} IPEDS release issue(s).")
+          PY
+
+      - name: Upload probe artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ipeds-release-probe
+          path: ipeds-release-probe/
+          if-no-files-found: warn

--- a/docs/prd/021-ipeds-coverage-layer.md
+++ b/docs/prd/021-ipeds-coverage-layer.md
@@ -74,6 +74,10 @@ Important release semantics:
   initial collection and final data about two years after initial collection.
 - The current Access page shows `2024-25` as provisional, released March 2026,
   and `2023-24` as final, also released March 2026.
+- Operational probe cadence starts 10 months after the latest loaded
+  provisional Access release date, so the March 2026 reference begins checking
+  for `2025-26` provisional and `2024-25` final in January 2027. The earlier
+  check leaves room for NCES to publish faster in future cycles.
 
 Operational finding:
 
@@ -843,7 +847,9 @@ Decision gate:
 
 ### M6: Annual operations
 
-- Add monthly/weekly scheduled release checker.
+- Add monthly/weekly scheduled release checker. **Shipped follow-up:** monthly
+  GitHub Actions release probe with a 10-month no-op window from the latest
+  loaded provisional Access release date.
 - Add operator dashboard rows for last IPEDS load, tables loaded, row counts,
   schema drift, and unresolved mapping issues.
 

--- a/supabase/migrations/20260509130000_backfill_ipeds_release_date.sql
+++ b/supabase/migrations/20260509130000_backfill_ipeds_release_date.sql
@@ -1,0 +1,21 @@
+-- Backfill official month-level release provenance for the first PRD 021 load.
+--
+-- NCES lists the 2024-25 Access Database as Provisional, released March 2026.
+-- Store that as 2026-03-01 with month precision in notes; the release probe
+-- starts checking for the next bundle 10 months later.
+
+begin;
+
+update public.ipeds_releases
+set
+  release_date = '2026-03-01'::date,
+  notes = coalesce(notes, '{}'::jsonb) || jsonb_build_object(
+    'release_date_text', 'March 2026',
+    'release_date_precision', 'month',
+    'release_probe_due_on', '2027-01-01'
+  )
+where collection_year = '2024-25'
+  and release_type = 'provisional'
+  and metadata_url like '%IPEDS202425Tablesdoc.xlsx';
+
+commit;

--- a/tools/ipeds/README.md
+++ b/tools/ipeds/README.md
@@ -22,6 +22,8 @@ python tools/ipeds/load_release.py \
   --collection-year 2024-25 \
   --data-year 2024 \
   --release-type provisional \
+  --release-date 2026-03-01 \
+  --release-date-text "March 2026" \
   --metadata-url https://nces.ed.gov/ipeds/tablefiles/tableDocs/IPEDS202425Tablesdoc.xlsx
 ```
 
@@ -41,6 +43,26 @@ python tools/ipeds/load_release.py ... --apply
 - Raw rows are preserved in `ipeds_raw_rows`; public products query
   `ipeds_facts`, `ipeds_current_facts`, or `school_facts_unified`.
 
+## Release probe
+
+The monthly GitHub Actions workflow `.github/workflows/ipeds-release-probe.yml`
+checks the official NCES Access Database page for the next bundle. It no-ops
+until 10 months after the latest loaded provisional Access release date, then
+looks for both:
+
+- the final release for the current collection year, and
+- the provisional release for the next collection year.
+
+For the `2024-25 provisional` Access release dated `March 2026`, the first
+automatic due date is `2027-01-01`. When NCES publishes a matching release, the
+workflow opens a GitHub issue with the exact download and dry-run commands.
+
+Manual dry run:
+
+```bash
+python tools/ipeds/probe_releases.py --as-of 2027-01-01
+```
+
 ## Public defaults
 
 - Public school pages show facts from `school_facts_unified`, which only joins
@@ -50,4 +72,3 @@ python tools/ipeds/load_release.py ... --apply
   intelligence unless a future PRD explicitly opts in.
 - Baseline-only pages are marked `noindex` until the methodology and QA surface
   mature.
-

--- a/tools/ipeds/download_release.py
+++ b/tools/ipeds/download_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import http.cookiejar
+import json
 import sys
 import urllib.request
 from pathlib import Path
@@ -12,7 +13,7 @@ from pathlib import Path
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from tools.ipeds.metadata import DATA_GENERATOR_URL, NCES_IPEDS_ACCESS_PAGE, parse_access_page
+from tools.ipeds.metadata import DATA_GENERATOR_URL, NCES_IPEDS_ACCESS_PAGE, normalize_release_date_text, parse_access_page
 from tools.ipeds.mappings import MVP_FACT_MAPPINGS
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -36,6 +37,7 @@ def main() -> int:
     data_year = args.data_year or release.data_year
     out_dir = args.out_dir / f"{release.collection_year}-{release.release_type}"
     out_dir.mkdir(parents=True, exist_ok=True)
+    release_date, release_date_precision = normalize_release_date_text(release.release_date)
 
     metadata_path = out_dir / Path(release.metadata_url).name
     download(opener, release.metadata_url, metadata_path)
@@ -51,7 +53,23 @@ def main() -> int:
         download(opener, url, path)
         print(f"table: {path}")
 
+    manifest = {
+        "collection_year": release.collection_year,
+        "data_year": data_year,
+        "release_type": release.release_type,
+        "release_date": release_date,
+        "release_date_text": release.release_date,
+        "release_date_precision": release_date_precision,
+        "source_page_url": NCES_IPEDS_ACCESS_PAGE,
+        "metadata_url": release.metadata_url,
+        "access_url": release.access_url,
+    }
+    manifest_path = out_dir / "release.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"manifest: {manifest_path}")
     print(f"release: {release.collection_year} {release.release_type}")
+    if release.release_date:
+        print(f"release date: {release.release_date}")
     return 0
 
 
@@ -68,4 +86,3 @@ def download(opener: urllib.request.OpenerDirector, url: str, path: Path) -> Non
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/ipeds/load_release.py
+++ b/tools/ipeds/load_release.py
@@ -15,7 +15,7 @@ import os
 import sys
 import zipfile
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +23,7 @@ if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from tools.ipeds.mappings import MVP_FACT_MAPPINGS
-from tools.ipeds.metadata import DATA_GENERATOR_URL, TablesDoc, parse_tablesdoc, sha256_file
+from tools.ipeds.metadata import DATA_GENERATOR_URL, TablesDoc, normalize_release_date_text, parse_tablesdoc, sha256_file
 from tools.ipeds.project import project_rows_to_facts
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -38,6 +38,8 @@ def main() -> int:
     parser.add_argument("--collection-year", required=True, help="Release collection year, e.g. 2024-25.")
     parser.add_argument("--data-year", required=True, type=int, help="IPEDS data year used in table names, e.g. 2024.")
     parser.add_argument("--release-type", default="provisional", choices=["preliminary", "provisional", "final"])
+    parser.add_argument("--release-date", help="Normalized official release date, YYYY-MM-DD. Month-level releases use the first day of the month.")
+    parser.add_argument("--release-date-text", help='Raw official release date text, e.g. "March 2026".')
     parser.add_argument("--metadata-url", required=True)
     parser.add_argument("--access-url")
     parser.add_argument("--apply", action="store_true", help="Upsert into Supabase using service role credentials.")
@@ -131,6 +133,7 @@ def build_report(
         "collection_year": args.collection_year,
         "data_year": args.data_year,
         "release_type": args.release_type,
+        **release_date_report(args),
         "metadata_xlsx": str(args.metadata_xlsx),
         "metadata_sha256": sha256_file(args.metadata_xlsx),
         "source_tables_requested": sorted({mapping.table_name.upper() for mapping in MVP_FACT_MAPPINGS}),
@@ -167,6 +170,18 @@ def apply_to_supabase(
         raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for --apply")
 
     client = create_client(supabase_url, service_key)
+    release_date, release_date_precision = release_date_metadata(args)
+    release_notes = {
+        "loader": "tools/ipeds/load_release.py",
+        "mapping_count": len(MVP_FACT_MAPPINGS),
+    }
+    if args.release_date_text:
+        release_notes["release_date_text"] = args.release_date_text
+    if release_date_precision:
+        release_notes["release_date_precision"] = release_date_precision
+    if release_date:
+        release_notes["release_probe_due_on"] = add_months(release_date, 10)
+
     release_payload = {
         "collection_year": args.collection_year,
         "data_year": args.data_year,
@@ -175,8 +190,10 @@ def apply_to_supabase(
         "metadata_url": args.metadata_url,
         "metadata_sha256": sha256_file(args.metadata_xlsx),
         "access_url": args.access_url,
-        "notes": {"loader": "tools/ipeds/load_release.py", "mapping_count": len(MVP_FACT_MAPPINGS)},
+        "notes": release_notes,
     }
+    if release_date:
+        release_payload["release_date"] = release_date
     release_result = client.table("ipeds_releases").upsert(
         release_payload,
         on_conflict="collection_year,release_type,metadata_sha256",
@@ -252,6 +269,43 @@ def dedupe_rows(rows: list[dict[str, Any]], on_conflict: str) -> list[dict[str, 
     for row in rows:
         seen[tuple(row.get(key) for key in keys)] = row
     return list(seen.values())
+
+
+def release_date_metadata(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    if args.release_date:
+        date.fromisoformat(args.release_date)
+        precision = "month" if args.release_date.endswith("-01") and args.release_date_text else "day"
+        return args.release_date, precision
+    return normalize_release_date_text(args.release_date_text)
+
+
+def release_date_report(args: argparse.Namespace) -> dict[str, str | None]:
+    release_date, precision = release_date_metadata(args)
+    return {
+        "release_date": release_date,
+        "release_date_text": args.release_date_text,
+        "release_date_precision": precision,
+        "release_probe_due_on": add_months(release_date, 10) if release_date else None,
+    }
+
+
+def add_months(value: str, months: int) -> str:
+    parsed = date.fromisoformat(value)
+    month_index = parsed.month - 1 + months
+    year = parsed.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(parsed.day, days_in_month(year, month))
+    return f"{year:04d}-{month:02d}-{day:02d}"
+
+
+def days_in_month(year: int, month: int) -> int:
+    if month == 2:
+        if year % 400 == 0 or (year % 4 == 0 and year % 100 != 0):
+            return 29
+        return 28
+    if month in {4, 6, 9, 11}:
+        return 30
+    return 31
 
 
 def load_env(path: Path) -> None:

--- a/tools/ipeds/metadata.py
+++ b/tools/ipeds/metadata.py
@@ -14,6 +14,20 @@ from openpyxl import load_workbook
 
 NCES_IPEDS_ACCESS_PAGE = "https://nces.ed.gov/ipeds/use-the-data/download-access-database"
 DATA_GENERATOR_URL = "https://nces.ed.gov/ipeds/data-generator?year={year}&tableName={table_name}&HasRV=0&type=csv"
+MONTHS = {
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
+}
 
 
 @dataclass(frozen=True)
@@ -100,6 +114,47 @@ def release_type_from_text(value: str) -> str:
     return "provisional"
 
 
+def normalize_release_date_text(value: str | None) -> tuple[str | None, str | None]:
+    """Convert NCES release-date text into an ISO date and precision.
+
+    The IPEDS Access Database page currently publishes month-level dates like
+    "March 2026". Other NCES pages use day-level dates, so the normalizer
+    supports both while preserving precision for provenance notes.
+    """
+    if value is None:
+        return None, None
+    text = value.strip()
+    if not text:
+        return None, None
+
+    day_match = re.fullmatch(
+        r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),\s*(\d{4})",
+        text,
+        flags=re.I,
+    )
+    if day_match:
+        month = MONTHS[day_match.group(1).lower()]
+        day = int(day_match.group(2))
+        year = int(day_match.group(3))
+        return f"{year:04d}-{month:02d}-{day:02d}", "day"
+
+    month_match = re.fullmatch(
+        r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})",
+        text,
+        flags=re.I,
+    )
+    if month_match:
+        month = MONTHS[month_match.group(1).lower()]
+        year = int(month_match.group(2))
+        return f"{year:04d}-{month:02d}-01", "month"
+
+    iso_match = re.fullmatch(r"\d{4}-\d{2}-\d{2}", text)
+    if iso_match:
+        return text, "day"
+
+    return None, None
+
+
 def parse_access_page(html: str, base_url: str = NCES_IPEDS_ACCESS_PAGE) -> list[ReleaseLink]:
     """Extract official release links from the NCES Access database page.
 
@@ -127,6 +182,7 @@ def parse_access_page(html: str, base_url: str = NCES_IPEDS_ACCESS_PAGE) -> list
     releases: list[ReleaseLink] = []
     for collection_year, metadata_url in sorted(metadata_by_collection.items(), reverse=True):
         start_year = int(collection_year[:4])
+        access_url = access_by_collection.get(collection_year)
         row_match = re.search(
             rf"{re.escape(collection_year)}\s+Access.*?"
             rf"{re.escape(collection_year)}\s+Excel.*?"
@@ -140,13 +196,15 @@ def parse_access_page(html: str, base_url: str = NCES_IPEDS_ACCESS_PAGE) -> list
             r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}",
             window,
         )
+        access_lower = (access_url or "").lower()
+        release_type_text = access_url if any(token in access_lower for token in ("final", "provisional", "preliminary")) else window
         releases.append(
             ReleaseLink(
                 collection_year=collection_year,
                 data_year=start_year,
-                release_type=release_type_from_text(window),
+                release_type=release_type_from_text(release_type_text),
                 release_date=date_match.group(0) if date_match else None,
-                access_url=access_by_collection.get(collection_year),
+                access_url=access_url,
                 metadata_url=metadata_url,
             )
         )

--- a/tools/ipeds/probe_releases.py
+++ b/tools/ipeds/probe_releases.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Probe NCES/IPEDS for the next Access Database releases.
+
+The probe is intentionally read-only. It checks the official NCES Access
+Database page against the latest loaded provisional release and reports when
+the next provisional bundle or the matching final bundle appears.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from tools.ipeds.metadata import NCES_IPEDS_ACCESS_PAGE, normalize_release_date_text, parse_access_page
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PROBE_DELAY_MONTHS = 10
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--as-of", help="Override today's date for dry runs, YYYY-MM-DD.")
+    parser.add_argument("--probe-delay-months", type=int, default=DEFAULT_PROBE_DELAY_MONTHS)
+    parser.add_argument("--force", action="store_true", help="Probe targets even before their computed due date.")
+    parser.add_argument("--out-json", type=Path, help="Write the full probe summary to this path.")
+    parser.add_argument("--env", type=Path, default=REPO_ROOT / ".env", help="Optional .env file for local runs.")
+    args = parser.parse_args()
+
+    load_env(args.env)
+    as_of = date.fromisoformat(args.as_of) if args.as_of else datetime.now(timezone.utc).date()
+    loaded_releases = fetch_loaded_releases()
+    remote_releases = fetch_remote_releases()
+    summary = summarize_probe(
+        loaded_releases,
+        remote_releases,
+        as_of=as_of,
+        probe_delay_months=args.probe_delay_months,
+        force=args.force,
+    )
+    summary["generated_at"] = datetime.now(timezone.utc).isoformat()
+    summary["source_page_url"] = NCES_IPEDS_ACCESS_PAGE
+
+    body = json.dumps(summary, indent=2, sort_keys=True)
+    print(body)
+    if args.out_json:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(body + "\n", encoding="utf-8")
+    return 0
+
+
+def fetch_loaded_releases() -> list[dict[str, Any]]:
+    try:
+        from supabase import create_client
+    except ImportError as exc:
+        raise SystemExit("supabase package is required to read loaded IPEDS releases") from exc
+
+    supabase_url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("SUPABASE_ANON_KEY")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    )
+    if not supabase_url or not key:
+        raise SystemExit("SUPABASE_URL and a Supabase API key are required")
+
+    client = create_client(supabase_url, key)
+    response = (
+        client.table("ipeds_releases")
+        .select("collection_year,data_year,release_type,release_date,metadata_url,access_url,notes")
+        .execute()
+    )
+    return response.data or []
+
+
+def fetch_remote_releases() -> list[dict[str, Any]]:
+    request = urllib.request.Request(
+        NCES_IPEDS_ACCESS_PAGE,
+        headers={"User-Agent": "collegedata-fyi-ipeds-release-probe/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        html = response.read().decode("utf-8", errors="replace")
+
+    releases = []
+    for release in parse_access_page(html):
+        normalized_date, precision = normalize_release_date_text(release.release_date)
+        releases.append({
+            "collection_year": release.collection_year,
+            "data_year": release.data_year,
+            "release_type": release.release_type,
+            "release_date": normalized_date,
+            "release_date_text": release.release_date,
+            "release_date_precision": precision,
+            "metadata_url": release.metadata_url,
+            "access_url": release.access_url,
+        })
+    return releases
+
+
+def summarize_probe(
+    loaded_releases: list[dict[str, Any]],
+    remote_releases: list[dict[str, Any]],
+    *,
+    as_of: date,
+    probe_delay_months: int,
+    force: bool = False,
+) -> dict[str, Any]:
+    loaded_keys = {(row["collection_year"], row["release_type"]) for row in loaded_releases}
+    remote_by_key = {(row["collection_year"], row["release_type"]): row for row in remote_releases}
+    reference = latest_loaded_provisional(loaded_releases, remote_by_key)
+
+    targets: list[dict[str, Any]] = []
+    if reference is not None:
+        due_on = add_months(date.fromisoformat(reference["release_date"]), probe_delay_months)
+        for collection_year, release_type in [
+            (reference["collection_year"], "final"),
+            (next_collection_year(reference["collection_year"]), "provisional"),
+        ]:
+            key = (collection_year, release_type)
+            remote = remote_by_key.get(key)
+            if key in loaded_keys:
+                status = "loaded"
+            elif as_of < due_on and not force:
+                status = "not_due"
+            elif remote is not None:
+                status = "available"
+            else:
+                status = "not_available"
+            targets.append({
+                "collection_year": collection_year,
+                "release_type": release_type,
+                "due_on": due_on.isoformat(),
+                "status": status,
+                "remote_release": remote,
+            })
+
+    return {
+        "as_of": as_of.isoformat(),
+        "probe_delay_months": probe_delay_months,
+        "reference_release": reference,
+        "available_count": sum(1 for target in targets if target["status"] == "available"),
+        "targets": targets,
+        "remote_releases": remote_releases[:5],
+    }
+
+
+def latest_loaded_provisional(
+    loaded_releases: list[dict[str, Any]],
+    remote_by_key: dict[tuple[str, str], dict[str, Any]],
+) -> dict[str, Any] | None:
+    candidates = []
+    for row in loaded_releases:
+        if row.get("release_type") != "provisional":
+            continue
+        release_date = release_date_from_loaded_row(row)
+        if release_date is None:
+            remote = remote_by_key.get((row["collection_year"], row["release_type"]))
+            release_date = remote.get("release_date") if remote else None
+        if release_date is None:
+            continue
+        candidates.append({
+            "collection_year": row["collection_year"],
+            "data_year": row["data_year"],
+            "release_type": row["release_type"],
+            "release_date": release_date,
+            "metadata_url": row.get("metadata_url"),
+            "access_url": row.get("access_url"),
+        })
+    if not candidates:
+        return None
+    return max(candidates, key=lambda row: (row["release_date"], row["data_year"], row["collection_year"]))
+
+
+def release_date_from_loaded_row(row: dict[str, Any]) -> str | None:
+    release_date = row.get("release_date")
+    if release_date:
+        return str(release_date)[:10]
+    notes = row.get("notes") or {}
+    if isinstance(notes, str):
+        try:
+            notes = json.loads(notes)
+        except json.JSONDecodeError:
+            notes = {}
+    normalized, _precision = normalize_release_date_text(notes.get("release_date_text"))
+    return normalized
+
+
+def next_collection_year(collection_year: str) -> str:
+    start_text, end_text = collection_year.split("-", 1)
+    start = int(start_text) + 1
+    end = (int(end_text) + 1) % 100
+    return f"{start}-{end:02d}"
+
+
+def add_months(value: date, months: int) -> date:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(value.day, days_in_month(year, month))
+    return date(year, month, day)
+
+
+def days_in_month(year: int, month: int) -> int:
+    if month == 2:
+        if year % 400 == 0 or (year % 4 == 0 and year % 100 != 0):
+            return 29
+        return 28
+    if month in {4, 6, 9, 11}:
+        return 30
+    return 31
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ipeds/test_metadata.py
+++ b/tools/ipeds/test_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from openpyxl import Workbook
 
-from tools.ipeds.metadata import parse_access_page, parse_tablesdoc
+from tools.ipeds.metadata import normalize_release_date_text, parse_access_page, parse_tablesdoc
 
 
 class IpedsMetadataTests(unittest.TestCase):
@@ -28,6 +28,11 @@ class IpedsMetadataTests(unittest.TestCase):
         self.assertTrue(releases[0].metadata_url.endswith("IPEDS202425Tablesdoc.xlsx"))
         self.assertTrue(releases[0].access_url.endswith("IPEDS_2024-25_Provisional.zip"))
         self.assertEqual(releases[1].release_type, "final")
+
+    def test_normalize_release_date_text_handles_month_and_day_precision(self) -> None:
+        self.assertEqual(normalize_release_date_text("March 2026"), ("2026-03-01", "month"))
+        self.assertEqual(normalize_release_date_text("January 6, 2026"), ("2026-01-06", "day"))
+        self.assertEqual(normalize_release_date_text("2026-03-01"), ("2026-03-01", "day"))
 
     def test_parse_tablesdoc_reads_core_sheets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/ipeds/test_probe_releases.py
+++ b/tools/ipeds/test_probe_releases.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from tools.ipeds.probe_releases import next_collection_year, summarize_probe
+
+
+class IpedsReleaseProbeTests(unittest.TestCase):
+    def test_next_collection_year_rolls_two_digit_suffix(self) -> None:
+        self.assertEqual(next_collection_year("2024-25"), "2025-26")
+        self.assertEqual(next_collection_year("2099-00"), "2100-01")
+
+    def test_probe_noops_until_ten_month_due_date(self) -> None:
+        loaded = [{
+            "collection_year": "2024-25",
+            "data_year": 2024,
+            "release_type": "provisional",
+            "release_date": "2026-03-01",
+            "metadata_url": "https://example.test/IPEDS202425Tablesdoc.xlsx",
+            "access_url": "https://example.test/IPEDS_2024-25_Provisional.zip",
+        }]
+        remote = [{
+            "collection_year": "2025-26",
+            "data_year": 2025,
+            "release_type": "provisional",
+            "release_date": "2027-01-01",
+            "release_date_text": "January 2027",
+            "metadata_url": "https://example.test/IPEDS202526Tablesdoc.xlsx",
+            "access_url": "https://example.test/IPEDS_2025-26_Provisional.zip",
+        }]
+        summary = summarize_probe(loaded, remote, as_of=date(2026, 12, 31), probe_delay_months=10)
+        self.assertEqual({target["status"] for target in summary["targets"]}, {"not_due"})
+
+        summary = summarize_probe(loaded, remote, as_of=date(2027, 1, 1), probe_delay_months=10)
+        by_key = {(target["collection_year"], target["release_type"]): target for target in summary["targets"]}
+        self.assertEqual(by_key[("2025-26", "provisional")]["status"], "available")
+        self.assertEqual(by_key[("2024-25", "final")]["status"], "not_available")
+
+    def test_probe_marks_already_loaded_target(self) -> None:
+        loaded = [
+            {
+                "collection_year": "2024-25",
+                "data_year": 2024,
+                "release_type": "provisional",
+                "release_date": "2026-03-01",
+            },
+            {
+                "collection_year": "2024-25",
+                "data_year": 2024,
+                "release_type": "final",
+                "release_date": "2027-01-01",
+            },
+        ]
+        summary = summarize_probe(loaded, [], as_of=date(2027, 1, 1), probe_delay_months=10)
+        by_key = {(target["collection_year"], target["release_type"]): target for target in summary["targets"]}
+        self.assertEqual(by_key[("2024-25", "final")]["status"], "loaded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -590,15 +590,15 @@ async function DirectoryOnlySchoolPage({
             </a>
           </p>
         )}
+        {coverage.can_submit_source && (
+          <SubmissionForm
+            compact
+            school_id={school_id}
+            school_name={coverage.school_name}
+            coverage_status={coverage.coverage_status}
+          />
+        )}
       </section>
-
-      {coverage.can_submit_source && (
-        <SubmissionForm
-          school_id={school_id}
-          school_name={coverage.school_name}
-          coverage_status={coverage.coverage_status}
-        />
-      )}
 
       <FederalBaselineTable facts={federalFacts} compact />
 

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -278,6 +278,32 @@
   outline: 2px solid var(--forest);
   outline-offset: -2px;
 }
+.federal-source {
+  display: inline-grid;
+  gap: 4px;
+  min-width: 0;
+  cursor: help;
+}
+.federal-source:focus-visible {
+  outline: 2px solid var(--forest);
+  outline-offset: 3px;
+}
+.federal-source__meta {
+  display: none;
+  max-width: 38ch;
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.federal-source:hover .federal-source__meta,
+.federal-source:focus .federal-source__meta,
+.federal-source:focus-visible .federal-source__meta {
+  display: grid;
+  gap: 2px;
+}
 @media (max-width: 640px) {
   .cd-reconstructed__head {
     padding: 9px 10px !important;

--- a/web/src/components/FederalBaselineTable.tsx
+++ b/web/src/components/FederalBaselineTable.tsx
@@ -37,10 +37,20 @@ export function FederalBaselineTable({
           Source-labeled federal facts
         </h2>
         <p style={{ margin: "10px 0 0", maxWidth: 760, color: "var(--ink-2)", lineHeight: 1.55 }}>
-          These values come from official NCES/IPEDS tables. They are not Common Data Set fields unless the definition column says the alignment is direct or near.
+          These values come from official NCES/IPEDS tables. They are not Common Data Set fields unless the source note says the alignment is direct or near.
         </p>
         {releaseLabel && (
-          <p className="meta" style={{ margin: "8px 0 0", color: "var(--ink-3)" }}>
+          <p
+            className="mono"
+            style={{
+              margin: "14px 0 0",
+              color: "var(--ink)",
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+            }}
+          >
             {releaseLabel}
           </p>
         )}
@@ -58,22 +68,33 @@ export function FederalBaselineTable({
           >
             {group.name}
           </h3>
-          <div style={{ overflowX: "auto" }}>
-            <table style={{ width: "100%", minWidth: 720, borderCollapse: "collapse", fontSize: 14 }}>
+          <div
+            className="cd-reconstructed"
+            style={{
+              border: "1px solid var(--rule)",
+              borderRadius: 8,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              className="cd-reconstructed__table-wrap"
+              tabIndex={0}
+              aria-label={`${group.name} IPEDS baseline facts table. Scroll horizontally to read all columns.`}
+              style={{ overflowX: "auto" }}
+            >
+            <table className="cd-reconstructed__table" style={{ width: "100%", minWidth: 660, borderCollapse: "collapse", fontSize: 14 }}>
               <caption className="sr-only">{group.name} IPEDS baseline facts</caption>
               <thead>
                 <tr className="meta" style={{ textAlign: "left", borderBottom: "1px solid var(--rule-strong)" }}>
-                  <th style={{ padding: "8px 10px 8px 0", width: "28%" }}>Fact</th>
-                  <th style={{ padding: "8px 10px" }}>Value</th>
-                  <th style={{ padding: "8px 10px" }}>Status</th>
-                  <th style={{ padding: "8px 10px" }}>Definition</th>
-                  <th style={{ padding: "8px 0 8px 10px" }}>Source</th>
+                  <th style={{ padding: "9px 12px", width: "42%" }}>Fact</th>
+                  <th style={{ padding: "9px 12px", width: "18%" }}>Value</th>
+                  <th style={{ padding: "9px 12px", width: "40%" }}>Source</th>
                 </tr>
               </thead>
               <tbody>
                 {group.facts.map((fact) => (
                   <tr key={`${fact.field_key}-${fact.source_table}-${fact.source_variable}`} className="rule">
-                    <th scope="row" style={{ padding: "11px 10px 11px 0", textAlign: "left", fontWeight: 500 }}>
+                    <th scope="row" style={{ padding: "11px 12px", textAlign: "left", fontWeight: 500 }}>
                       {fact.field_label}
                       {fact.population && (
                         <div className="meta" style={{ marginTop: 3, lineHeight: 1.35 }}>
@@ -81,27 +102,17 @@ export function FederalBaselineTable({
                         </div>
                       )}
                     </th>
-                    <td className="nums" style={{ padding: "11px 10px", whiteSpace: "nowrap" }}>
+                    <td className="nums" style={{ padding: "11px 12px", whiteSpace: "nowrap" }}>
                       {formatFactValue(fact)}
                     </td>
-                    <td style={{ padding: "11px 10px" }}>
-                      <StatusBadge fact={fact} />
-                    </td>
-                    <td style={{ padding: "11px 10px", color: "var(--ink-2)" }}>
-                      {definitionLabel(fact.definition_alignment)}
-                      {fact.definition_note && (
-                        <div className="meta" style={{ marginTop: 4, lineHeight: 1.35 }}>
-                          {fact.definition_note}
-                        </div>
-                      )}
-                    </td>
-                    <td className="mono" style={{ padding: "11px 0 11px 10px", color: "var(--ink-3)", fontSize: 12 }}>
-                      {fact.source_table}.{fact.source_variable}
+                    <td style={{ padding: "11px 12px" }}>
+                      <SourceCell fact={fact} />
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
+            </div>
           </div>
         </div>
       ))}
@@ -125,14 +136,28 @@ function formatFactValue(fact: SchoolFactUnifiedRow): string {
   return fact.display_value ?? fact.value_text ?? (fact.value_numeric == null ? "-" : String(fact.value_numeric));
 }
 
-function StatusBadge({ fact }: { fact: SchoolFactUnifiedRow }) {
-  const label = fact.quality_flag === "reported" ? "reported" : fact.quality_flag.replaceAll("_", " ");
-  const title = fact.imputation_label ?? label;
+function SourceCell({ fact }: { fact: SchoolFactUnifiedRow }) {
+  const source = `${fact.source_table}.${fact.source_variable}`;
+  const status = statusLabel(fact);
+  const definition = definitionLabel(fact.definition_alignment);
+  const note = fact.definition_note ? ` ${fact.definition_note}` : "";
+  const title = `${source}. Status: ${status}. Definition: ${definition}.${note}`;
   return (
-    <span className={fact.quality_flag === "imputed" ? "cd-chip" : "meta"} title={title}>
-      {label}
+    <span className="federal-source" tabIndex={0} title={title} aria-label={title}>
+      <span className="mono" style={{ color: "var(--ink-3)", fontSize: 12 }}>
+        {source}
+      </span>
+      <span className="federal-source__meta" aria-hidden="true">
+        <span>Status: {status}</span>
+        <span>Definition: {definition}{fact.definition_note ? ` · ${fact.definition_note}` : ""}</span>
+      </span>
     </span>
   );
+}
+
+function statusLabel(fact: SchoolFactUnifiedRow): string {
+  const label = fact.quality_flag === "reported" ? "reported" : fact.quality_flag.replaceAll("_", " ");
+  return fact.imputation_label ? `${label} (${fact.imputation_label})` : label;
 }
 
 function definitionLabel(value: SchoolFactUnifiedRow["definition_alignment"]): string {
@@ -154,4 +179,3 @@ function releaseSummary(facts: SchoolFactUnifiedRow[]): string | null {
   const releaseType = first.release_type.charAt(0).toUpperCase() + first.release_type.slice(1);
   return `${releaseType} ${first.collection_year} release, data year ${first.data_year}`;
 }
-

--- a/web/src/components/SubmissionForm.tsx
+++ b/web/src/components/SubmissionForm.tsx
@@ -4,10 +4,8 @@
 // no-public-CDS-found schools (anywhere can_submit_source is true).
 //
 // Posts to a Formspree endpoint when NEXT_PUBLIC_FORMSPREE_ENDPOINT is
-// configured; falls back to a mailto: link otherwise so the CTA is
-// never broken in environments missing the env var. The fallback uses
-// the same destination address Formspree forwards to so behavior is
-// consistent across paths.
+// configured. If the endpoint is missing, the component renders an honest
+// unavailable state instead of falling back to a mailto link.
 //
 // Form fields:
 //   school_id       hidden, identifies the submission
@@ -26,20 +24,21 @@
 import { useState } from "react";
 import type { CoverageStatus } from "@/lib/types";
 
-const MAILTO_FALLBACK = "anthony+collegedata@bolewood.com";
-
 export function SubmissionForm({
   school_id,
   school_name,
   coverage_status,
+  compact = false,
 }: {
   school_id: string;
   school_name: string;
   coverage_status: CoverageStatus;
+  compact?: boolean;
 }) {
   const formspreeEndpoint = process.env.NEXT_PUBLIC_FORMSPREE_ENDPOINT;
   const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [compactFormOpen, setCompactFormOpen] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -59,26 +58,77 @@ export function SubmissionForm({
         const body = await response.json().catch(() => ({}));
         setErrorMessage(
           (body as { error?: string })?.error ??
-            `Submission failed (HTTP ${response.status}). Try again or email ${MAILTO_FALLBACK}.`,
+            `Submission failed (HTTP ${response.status}). Please try again.`,
         );
         setStatus("error");
       }
     } catch (err) {
       setErrorMessage(
-        `Network error: ${(err as Error).message}. Try again or email ${MAILTO_FALLBACK}.`,
+        `Network error: ${(err as Error).message}. Please try again.`,
       );
       setStatus("error");
     }
   }
 
-  // ── Mailto fallback when Formspree isn't configured ──────────────
-  // Encodes school context into the subject + body so the operator
-  // doesn't have to ask the submitter to identify the school.
-  if (!formspreeEndpoint) {
-    const subject = encodeURIComponent(`[CDS source] ${school_name}`);
-    const body = encodeURIComponent(
-      `School: ${school_name}\nschool_id: ${school_id}\ncoverage_status: ${coverage_status}\n\nWhere I found the CDS:\n\n\nNotes:\n`,
+  if (compact) {
+    return (
+      <div style={{ marginTop: 22 }}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 14,
+            alignItems: "center",
+          }}
+        >
+          <button
+            className="cd-btn"
+            type="button"
+            disabled={!formspreeEndpoint}
+            aria-expanded={formspreeEndpoint ? compactFormOpen : undefined}
+            aria-controls={formspreeEndpoint ? `submission-form-${school_id}` : undefined}
+            onClick={() => {
+              if (formspreeEndpoint) setCompactFormOpen((open) => !open);
+            }}
+            style={{
+              fontSize: 15,
+              padding: "12px 16px",
+              opacity: formspreeEndpoint ? 1 : 0.62,
+              cursor: formspreeEndpoint ? "pointer" : "not-allowed",
+            }}
+          >
+            Email us!
+          </button>
+          <p style={{ margin: 0, color: "var(--ink-2)", fontSize: 14, lineHeight: 1.5 }}>
+            {formspreeEndpoint
+              ? "Know where the CDS lives? Send the link and we’ll archive it."
+              : "Source submissions are temporarily unavailable."}
+          </p>
+        </div>
+        {status === "success" ? (
+          <p style={{ margin: "14px 0 0", fontSize: 14, lineHeight: 1.5, color: "var(--forest)" }}>
+            Thanks. We’ll review the link for {school_name} and archive it if it’s a public CDS source.
+          </p>
+        ) : (
+          formspreeEndpoint && compactFormOpen && (
+            <div id={`submission-form-${school_id}`}>
+              <SubmissionFields
+                errorMessage={errorMessage}
+                handleSubmit={handleSubmit}
+                school_name={school_name}
+                school_id={school_id}
+                coverage_status={coverage_status}
+                status={status}
+                compact
+              />
+            </div>
+          )
+        )}
+      </div>
     );
+  }
+
+  if (!formspreeEndpoint) {
     return (
       <div
         className="cd-card"
@@ -88,10 +138,7 @@ export function SubmissionForm({
           § Help us find this one
         </div>
         <p style={{ margin: 0, fontSize: 15, lineHeight: 1.55 }}>
-          Know where {school_name} publishes its Common Data Set?{" "}
-          <a href={`mailto:${MAILTO_FALLBACK}?subject=${subject}&body=${body}`}>
-            Send us the link.
-          </a>
+          Source submissions are temporarily unavailable.
         </p>
       </div>
     );
@@ -116,17 +163,53 @@ export function SubmissionForm({
 
   // ── Active form ──────────────────────────────────────────────────
   return (
+    <SubmissionFields
+      errorMessage={errorMessage}
+      handleSubmit={handleSubmit}
+      school_name={school_name}
+      school_id={school_id}
+      coverage_status={coverage_status}
+      status={status}
+    />
+  );
+}
+
+function SubmissionFields({
+  errorMessage,
+  handleSubmit,
+  school_name,
+  school_id,
+  coverage_status,
+  status,
+  compact = false,
+}: {
+  errorMessage: string | null;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  school_name: string;
+  school_id: string;
+  coverage_status: CoverageStatus;
+  status: "idle" | "submitting" | "success" | "error";
+  compact?: boolean;
+}) {
+  return (
     <form
       onSubmit={handleSubmit}
-      className="cd-card"
-      style={{ padding: "24px 28px", marginTop: 24 }}
+      className={compact ? undefined : "cd-card"}
+      style={{
+        padding: compact ? "14px 0 0" : "24px 28px",
+        marginTop: compact ? 0 : 24,
+      }}
     >
-      <div className="meta" style={{ marginBottom: 10 }}>
-        § Help us find this one
-      </div>
-      <p style={{ margin: "0 0 20px", fontSize: 15, lineHeight: 1.55 }}>
-        {`Know where ${school_name} publishes its Common Data Set? Send us the link and we’ll archive it.`}
-      </p>
+      {!compact && (
+        <>
+          <div className="meta" style={{ marginBottom: 10 }}>
+            § Help us find this one
+          </div>
+          <p style={{ margin: "0 0 20px", fontSize: 15, lineHeight: 1.55 }}>
+            {`Know where ${school_name} publishes its Common Data Set? Send us the link and we’ll archive it.`}
+          </p>
+        </>
+      )}
 
       <input type="hidden" name="school_id" value={school_id} />
       <input type="hidden" name="school_name" value={school_name} />


### PR DESCRIPTION
## Summary
- Add a monthly IPEDS Access release probe that no-ops for 10 months after the latest loaded provisional release, then opens issues when the current final or next provisional bundle appears.
- Persist official release-date provenance through download/load tooling and backfill the March 2026 reference date for the 2024-25 provisional release.
- Polish no-CDS school pages: compact Formspree CTA in the missing-CDS card, bolder IPEDS release date, and accessible federal facts tables with status/definition details on hover/focus under Source.

## Verification
- `python3 -m unittest discover -s tools/ipeds -p 'test_*.py'`
- GitHub workflow YAML parse via Python `yaml.safe_load`
- `git diff --check`
- `npm run typecheck` in `web/`
- `npm run build` in `web/`
- `PLAYWRIGHT_WEB_SERVER_COMMAND='npm run start' npm run test:smoke` in `web/` (17 passed, 1 skipped; non-blocking existing Supabase statement-timeout warnings appeared during web server logs)
- Local Playwright check on `/schools/goshen-college` with a dummy `NEXT_PUBLIC_FORMSPREE_ENDPOINT`: Email Us opens the inline form and no `mailto:` links are present

## Ops notes
- Includes Supabase migration `20260509130000_backfill_ipeds_release_date.sql` to backfill the 2024-25 provisional release date as `2026-03-01` with month precision and a `2027-01-01` probe due date.
- The compact source CTA requires `NEXT_PUBLIC_FORMSPREE_ENDPOINT` in the web runtime, matching the existing Formspree-backed submission form.
