### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Python unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -63,7 +63,7 @@ jobs:
     name: Migration filename hygiene
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate migration filenames
         run: |
           set -euo pipefail
@@ -98,7 +98,7 @@ jobs:
     name: Supabase function tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -112,8 +112,8 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: "https://api.collegedata.fyi"
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzZHV3bXlndm1kb3pocHZ6YWl4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxMDk3NTksImV4cCI6MjA5MTY4NTc1OX0.fYZOIHyrOWzidgc-CVxWCY5Fe9pQk12-6YjDIS6y9qs"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/ipeds-release-probe.yml
+++ b/.github/workflows/ipeds-release-probe.yml
@@ -43,9 +43,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -72,9 +72,9 @@ jobs:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Summary
- update first-party GitHub Actions pins to Node 24 runtime releases
- replace `actions/checkout@v4` with `actions/checkout@v5`
- replace `actions/setup-python@v5` with `actions/setup-python@v6`
- replace `actions/setup-node@v4` with `actions/setup-node@v5`

## Verification
- parsed all workflow YAML with `python3` + PyYAML
- `git diff --check`
- confirmed no remaining `actions/checkout@v4`, `actions/setup-python@v5`, or `actions/setup-node@v4` pins under `.github/workflows`

## Notes
- This targets the Node 20 deprecation warnings emitted by GitHub Actions on PR #72 / main CI.