### PR TITLE
Broaden homepage open-data positioning

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -33,17 +33,17 @@ const jetbrains = JetBrains_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.collegedata.fyi"),
   title: {
-    default: "collegedata.fyi - Common Data Set Archive",
+    default: "collegedata.fyi - Open College Data",
     template: "%s | collegedata.fyi",
   },
   description:
-    "An open-source archive of U.S. college Common Data Set documents. Browse admissions, enrollment, financial aid, and more across hundreds of schools.",
+    "Open-source college data with source-linked Common Data Set files, NCES/IPEDS baselines, College Scorecard context, and a public API.",
   alternates: {
     canonical: "/",
   },
   openGraph: {
     title: "collegedata.fyi",
-    description: "Open-source Common Data Set archive for U.S. colleges",
+    description: "Open-source college data with source links, federal baselines, and a public API.",
     url: "/",
     siteName: "collegedata.fyi",
     type: "website",

--- a/web/src/app/opengraph-image.tsx
+++ b/web/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { fetchManifest, computeStats } from "@/lib/queries";
 
-export const alt = "collegedata.fyi - Open-source Common Data Set archive";
+export const alt = "collegedata.fyi - Open-source college data";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const revalidate = 3600;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -92,14 +92,14 @@ export default async function HomePage() {
         }}
       >
         <div className="meta cd-marginalia-left" style={{ textAlign: "right", paddingRight: 18 }}>
-          <div style={{ lineHeight: 1.8 }}>§ ARCHIVE</div>
-          <div style={{ lineHeight: 1.8 }}>EST. 2024</div>
-          <div style={{ lineHeight: 1.8 }}>VOL. III</div>
+          <div style={{ lineHeight: 1.8 }}>§ OPEN DATA</div>
+          <div style={{ lineHeight: 1.8 }}>SOURCE LINKS</div>
+          <div style={{ lineHeight: 1.8 }}>PUBLIC API</div>
         </div>
 
         <div style={{ textAlign: "center", maxWidth: 780, margin: "0 auto" }}>
           <div className="meta" style={{ marginBottom: 24 }}>
-            An open archive of U.S. Common Data Set documents
+            Open-source college data with source links, federal baselines, and an API
           </div>
           <h1
             style={{
@@ -126,9 +126,10 @@ export default async function HomePage() {
               textWrap: "balance",
             }}
           >
-            Every fact on this site starts with a school&rsquo;s own Common Data Set. We archive the source file and map it
-            into a queryable schema; some formats extract cleanly, while flattened PDFs still need template-specific
-            cleaners that improve over time.{" "}
+            CollegeData.FYI is building a public data layer for college decisions: school-published
+            Common Data Set files, NCES/IPEDS baseline facts, College Scorecard outcomes, and
+            source-linked APIs in one place. Compare schools, check affordability signals, build
+            match lists, audit missing data, or power your own tools.{" "}
             <Link href="/about">Read the method.</Link>
           </p>
 
@@ -161,9 +162,9 @@ export default async function HomePage() {
         </div>
 
         <div className="meta cd-marginalia-right" style={{ paddingLeft: 18 }}>
-          <div style={{ lineHeight: 1.8 }}>§C · ADMISSIONS</div>
-          <div style={{ lineHeight: 1.8 }}>§B · ENROLLMENT</div>
-          <div style={{ lineHeight: 1.8 }}>§H · FIN. AID</div>
+          <div style={{ lineHeight: 1.8 }}>ADMISSIONS</div>
+          <div style={{ lineHeight: 1.8 }}>AFFORDABILITY</div>
+          <div style={{ lineHeight: 1.8 }}>OUTCOMES</div>
         </div>
       </section>
 
@@ -178,8 +179,8 @@ export default async function HomePage() {
             gap: 40,
           }}
         >
-          <StatCell label="Schools archived" value={schoolsValue} note={`${stats.extracted_count.toLocaleString()} extracted`} />
-          <StatCell label="CDS documents" value={docsValue} note={`${yearRangeValue} source span`} />
+          <StatCell label="Schools in archive" value={schoolsValue} note={`${stats.extracted_count.toLocaleString()} extracted`} />
+          <StatCell label="Source documents" value={docsValue} note={`${yearRangeValue} CDS span`} />
           <StatCell label="Queryable fields" value={queryableFieldsValue} note={`${formatCount(stats.schema_field_count)} field schema`} />
           <StatCell label="Browser rows" value={browserRowsValue} note={`${formatCount(stats.browser_school_count)} schools; refreshed ${formatShortDate(stats.browser_updated_at)}`} />
         </div>
@@ -195,8 +196,8 @@ export default async function HomePage() {
           <div>
             <div className="meta" style={{ marginBottom: 6 }}>§ Latest drain</div>
             <div style={{ fontSize: 14, color: "var(--ink-3)", lineHeight: 1.5 }}>
-              The most recent additions to the archive. Every row is a real
-              CDS document we discovered, downloaded, and indexed.
+              The newest school-published source files added to the archive.
+              Each row links back to the original document and its extracted facts.
             </div>
           </div>
           <div>

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -23,9 +23,9 @@ export function Footer() {
         <div>
           <Wordmark size={18} variant="dotted" />
           <div style={{ marginTop: 10, maxWidth: 520, lineHeight: 1.55 }}>
-            An open-source archive of U.S. college Common Data Set documents.
-            MIT License. Data sourced from each school&rsquo;s IR office via the
-            CDS Initiative template.
+            Open-source college data with source-linked school publications,
+            NCES/IPEDS baselines, College Scorecard context, and public APIs.
+            MIT License.
           </div>
         </div>
         <div className="cd-footer-links" style={{ display: "flex", gap: 24, alignSelf: "end" }}>


### PR DESCRIPTION
## Summary
- broaden homepage copy from CDS-only archive toward open-source college data
- mention source links, NCES/IPEDS baselines, Scorecard context, public APIs, and practical uses
- align footer, metadata, and Open Graph alt text with the broader positioning

## Verification
- `npm run typecheck`
- `npm run build`
- `git diff --check`