### PR TITLE
QA polish coverage and academic profile pages

### DIFF
--- a/web/src/app/coverage/page.tsx
+++ b/web/src/app/coverage/page.tsx
@@ -58,58 +58,52 @@ export default async function CoveragePage() {
         <CoverageDashboard rows={rows} />
       </Suspense>
 
-      <section style={{ marginTop: 64 }}>
+      <section style={{ marginTop: 64, maxWidth: 760 }}>
         <h2
           className="serif"
           style={{ fontSize: 22, lineHeight: 1.2, margin: "0 0 16px" }}
         >
           Methodology
         </h2>
-        <ul
+        <div
           style={{
-            margin: 0,
-            paddingLeft: 22,
             fontSize: 14,
-            lineHeight: 1.7,
+            lineHeight: 1.65,
             color: "var(--ink-2)",
-            maxWidth: 720,
+            display: "grid",
+            gap: 14,
           }}
         >
-          <li>
-            <strong>The CDS is voluntary.</strong> No school is required to
-            publish one, and there&rsquo;s no central registry. We have to
-            find each one ourselves.
-          </li>
-          <li>
-            <strong>Our discovery is automated.</strong> A resolver fetches
-            each school&rsquo;s website and looks for CDS-shaped links. It
-            misses sources buried behind logins, JavaScript-only pages, or
-            non-obvious filenames. <em>No public CDS found</em> means the
-            resolver tried and didn&rsquo;t see one — not that the school
-            doesn&rsquo;t publish one.
-          </li>
-          <li>
-            <strong>Not checked yet</strong> means we know the school exists
-            and is in scope, but our resolver hasn&rsquo;t scanned it. Coverage
-            refreshes every 15 minutes from{" "}
+          <p style={{ margin: 0 }}>
+            We start with active Title-IV institutions that serve
+            undergraduates, then look for public Common Data Set files on
+            school-controlled sites and known public archives. The table shows
+            our current best status for each school, plus the last time we
+            checked.
+          </p>
+          <p style={{ margin: 0 }}>
+            A school marked <em>No public CDS found</em> was checked without a
+            usable public source turning up. That is different from saying the
+            school never publishes one: CDS files are voluntary, and some are
+            posted in places automated discovery cannot reliably reach.
+            <em> Not checked yet</em> means the school is in scope, but the
+            resolver has not scanned it.
+          </p>
+          <p style={{ margin: 0 }}>
+            Coverage refreshes every 15 minutes from{" "}
             <a href="https://collegescorecard.ed.gov/" target="_blank" rel="noopener noreferrer">
               College Scorecard
-            </a>
-            ; the directory expands faster than discovery does.
-          </li>
-          <li>
-            <strong>Federal data is older than CDS.</strong> Scorecard uses
-            two-year-old cohorts; the most recent CDS is the current academic
-            year. They answer different questions and shouldn&rsquo;t be
-            compared directly.
-          </li>
-          <li>
-            <strong>Know where one of these is published?</strong> Click into
-            the school page and{" "}
+            </a>. CDS files are often newer than federal outcome datasets, while
+            NCES/IPEDS and Scorecard provide broader baseline context. We keep
+            those sources labeled separately so readers can tell what came from
+            a school publication and what came from federal data.
+          </p>
+          <p style={{ margin: 0 }}>
+            Know where one of these is published? Open the school page and{" "}
             <Link href="/about">send us the link</Link>. We&rsquo;ll archive
-            it. This page is how we make the gaps visible — not a final word.
-          </li>
-        </ul>
+            the source and update the coverage status.
+          </p>
+        </div>
       </section>
     </div>
   );

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -611,10 +611,17 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+.positioning-range__head span:first-child {
+  white-space: nowrap;
+}
+.positioning-range__head span:last-child {
+  color: var(--ink-3);
+  font-size: 10.5px;
+}
 .positioning-range__track {
   position: relative;
-  height: 18px;
-  margin-top: 9px;
+  height: 14px;
+  margin-top: 11px;
   border-left: 1px solid var(--ink);
   border-right: 1px solid var(--ink);
 }
@@ -623,14 +630,44 @@
   position: absolute;
   left: 0;
   right: 0;
-  top: 8px;
+  top: 6px;
   border-top: 2px solid var(--ink);
 }
 .positioning-range__track span {
   position: absolute;
   top: 0;
-  height: 18px;
+  height: 14px;
   border-left: 1px solid var(--ink);
+}
+.positioning-range__values {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+}
+.positioning-range__values > div {
+  display: grid;
+  gap: 3px;
+}
+.positioning-range__values > div:nth-child(2) {
+  text-align: center;
+}
+.positioning-range__values > div:nth-child(3) {
+  text-align: right;
+}
+.positioning-range__values span {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.positioning-range__values strong {
+  font-family: var(--serif);
+  font-size: clamp(20px, 2vw, 24px);
+  font-weight: 400;
+  line-height: 1;
+  color: var(--ink);
 }
 .positioning-range__caption {
   margin-top: 8px;
@@ -754,6 +791,10 @@
 @media (max-width: 820px) {
   .positioning-card__body { padding: 24px 20px 20px; }
   .positioning-card__grid { grid-template-columns: 1fr; gap: 24px; }
+  .positioning-range__head {
+    display: grid;
+    gap: 4px;
+  }
   .positioning-profile__details { grid-template-columns: 1fr; }
   .positioning-form { grid-template-columns: 1fr; }
   .positioning-form__actions .cd-btn { width: 100%; justify-content: center; }

--- a/web/src/components/CoverageDashboard.tsx
+++ b/web/src/components/CoverageDashboard.tsx
@@ -67,7 +67,7 @@ type RecencyId = (typeof RECENCY_OPTIONS)[number]["id"];
 type SortKey = "name" | "state" | "enrollment" | "status" | "checked";
 type SortDir = "asc" | "desc";
 
-const ROW_HEIGHT = 56;
+const ROW_HEIGHT = 64;
 
 export function CoverageDashboard({ rows }: { rows: InstitutionCoverage[] }) {
   const router = useRouter();
@@ -348,121 +348,140 @@ export function CoverageDashboard({ rows }: { rows: InstitutionCoverage[] }) {
         SHOWING {filteredRows.length.toLocaleString()} OF {total.toLocaleString()} INSTITUTIONS
       </div>
 
-      {/* Sticky table header */}
       <div
-        role="row"
         style={{
-          display: "grid",
-          gridTemplateColumns: TABLE_COLUMNS,
-          alignItems: "baseline",
-          padding: "10px 0",
-          borderTop: "1px solid var(--rule-strong)",
-          borderBottom: "1px solid var(--rule-strong)",
-          fontFamily: "var(--mono)",
-          fontSize: 11,
-          letterSpacing: "0.06em",
-          textTransform: "uppercase",
-          color: "var(--ink-3)",
-          background: "var(--paper)",
+          overflowX: "auto",
+          WebkitOverflowScrolling: "touch",
         }}
-      >
-        <SortHeader label="School" col="name" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
-        <SortHeader label="State" col="state" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
-        <SortHeader
-          label="UGDS"
-          col="enrollment"
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onSort={handleSort}
-          align="right"
-        />
-        <SortHeader label="Status" col="status" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
-        <SortHeader label="Last checked" col="checked" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
-        <span>Action</span>
-      </div>
-
-      {/* Virtualized table body */}
-      <div
-        ref={parentRef}
-        style={{
-          height: 600,
-          overflowY: "auto",
-          borderBottom: "1px solid var(--rule-strong)",
-        }}
+        aria-label="Coverage table"
       >
         <div
           style={{
-            height: virtualizer.getTotalSize(),
-            position: "relative",
-            width: "100%",
+            minWidth: TABLE_MIN_WIDTH,
           }}
         >
-          {virtualizer.getVirtualItems().map((vi) => {
-            const r = filteredRows[vi.index];
-            return (
-              <div
-                key={r.school_id}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  transform: `translateY(${vi.start}px)`,
-                  height: ROW_HEIGHT,
-                  display: "grid",
-                  gridTemplateColumns: TABLE_COLUMNS,
-                  alignItems: "center",
-                  padding: "0 0",
-                  borderTop: vi.index === 0 ? "none" : "1px solid var(--rule)",
-                }}
-                role="row"
-              >
-                <Link
-                  href={`/schools/${r.school_id}`}
-                  style={{
-                    fontFamily: "var(--serif)",
-                    fontSize: 16,
-                    color: "var(--ink)",
-                    textDecoration: "none",
-                  }}
-                >
-                  {r.school_name}
-                </Link>
-                <span className="mono" style={{ fontSize: 12, color: "var(--ink-2)" }}>
-                  {r.state ?? "—"}
-                </span>
-                <span
-                  className="mono nums"
-                  style={{ fontSize: 13, color: "var(--ink-2)", textAlign: "right" }}
-                >
-                  {r.undergraduate_enrollment != null
-                    ? r.undergraduate_enrollment.toLocaleString()
-                    : "—"}
-                </span>
-                <CoverageBadge status={r.coverage_status} label={r.coverage_label} />
-                <span className="mono" style={{ fontSize: 12, color: "var(--ink-3)" }}>
-                  {formatChecked(r.last_checked_at)}
-                </span>
-                {r.can_submit_source ? (
-                  <Link
-                    href={`/schools/${r.school_id}#submit`}
-                    className="mono"
-                    style={{ fontSize: 12 }}
+          {/* Sticky table header */}
+          <div
+            role="row"
+            style={{
+              display: "grid",
+              gridTemplateColumns: TABLE_COLUMNS,
+              columnGap: TABLE_COLUMN_GAP,
+              alignItems: "baseline",
+              padding: "12px 0",
+              borderTop: "1px solid var(--rule-strong)",
+              borderBottom: "1px solid var(--rule-strong)",
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "var(--ink-3)",
+              background: "var(--paper)",
+            }}
+          >
+            <SortHeader label="School" col="name" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="State" col="state" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader
+              label="UGDS"
+              col="enrollment"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              align="right"
+            />
+            <SortHeader label="Status" col="status" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="Last checked" col="checked" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <span>Action</span>
+          </div>
+
+          {/* Virtualized table body */}
+          <div
+            ref={parentRef}
+            style={{
+              height: TABLE_VIEWPORT_HEIGHT,
+              overflowY: "auto",
+              borderBottom: "1px solid var(--rule-strong)",
+            }}
+          >
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
+                position: "relative",
+                width: "100%",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((vi) => {
+                const r = filteredRows[vi.index];
+                return (
+                  <div
+                    key={r.school_id}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      transform: `translateY(${vi.start}px)`,
+                      height: ROW_HEIGHT,
+                      display: "grid",
+                      gridTemplateColumns: TABLE_COLUMNS,
+                      columnGap: TABLE_COLUMN_GAP,
+                      alignItems: "center",
+                      padding: "0 0",
+                      borderTop: vi.index === 0 ? "none" : "1px solid var(--rule)",
+                    }}
+                    role="row"
                   >
-                    Send the link
-                  </Link>
-                ) : (
-                  <Link
-                    href={`/schools/${r.school_id}`}
-                    className="mono"
-                    style={{ fontSize: 12, color: "var(--ink-3)" }}
-                  >
-                    Open
-                  </Link>
-                )}
-              </div>
-            );
-          })}
+                    <Link
+                      href={`/schools/${r.school_id}`}
+                      style={{
+                        fontFamily: "var(--serif)",
+                        fontSize: 16,
+                        lineHeight: 1.25,
+                        color: "var(--ink)",
+                        textDecoration: "none",
+                      }}
+                    >
+                      {r.school_name}
+                    </Link>
+                    <span className="mono" style={{ fontSize: 12, color: "var(--ink-2)" }}>
+                      {r.state ?? "—"}
+                    </span>
+                    <span
+                      className="mono nums"
+                      style={{ fontSize: 13, color: "var(--ink-2)", textAlign: "right" }}
+                    >
+                      {r.undergraduate_enrollment != null
+                        ? r.undergraduate_enrollment.toLocaleString()
+                        : "—"}
+                    </span>
+                    <span style={{ minWidth: 0 }}>
+                      <CoverageBadge status={r.coverage_status} label={r.coverage_label} />
+                    </span>
+                    <span className="mono" style={{ fontSize: 12, color: "var(--ink-3)" }}>
+                      {formatChecked(r.last_checked_at)}
+                    </span>
+                    {r.can_submit_source ? (
+                      <Link
+                        href={`/schools/${r.school_id}#submit`}
+                        className="mono"
+                        style={{ fontSize: 12 }}
+                      >
+                        Send the link
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`/schools/${r.school_id}`}
+                        className="mono"
+                        style={{ fontSize: 12, color: "var(--ink-3)" }}
+                      >
+                        Open
+                      </Link>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
 
@@ -483,7 +502,10 @@ export function CoverageDashboard({ rows }: { rows: InstitutionCoverage[] }) {
   );
 }
 
-const TABLE_COLUMNS = "minmax(220px, 2fr) 56px 88px 220px 130px 110px";
+const TABLE_COLUMNS = "minmax(280px, 2fr) 64px 96px minmax(220px, 1fr) 140px 118px";
+const TABLE_COLUMN_GAP = 18;
+const TABLE_MIN_WIDTH = 1040;
+const TABLE_VIEWPORT_HEIGHT = ROW_HEIGHT * 10;
 
 const LABEL_BY_STATUS: Record<CoverageStatus, string> = {
   cds_available_current: "CDS available",

--- a/web/src/components/PositioningCard.tsx
+++ b/web/src/components/PositioningCard.tsx
@@ -18,10 +18,11 @@ function formatScore(value: number | null): string {
   return value == null ? "-" : value.toLocaleString();
 }
 
-function submitRateCaption(submitRate: number | null): string {
+function submitRateCaption(label: string, submitRate: number | null): string {
+  const testName = label.split(" ")[0] ?? "Test";
   return submitRate == null
     ? "SUBMIT RATE NOT REPORTED"
-    : `FROM THE ${formatPercent(submitRate)} OF ADMITS WHO SUBMITTED SCORES`;
+    : `${formatPercent(submitRate)} OF ADMITS SUBMITTED ${testName} SCORES`;
 }
 
 function RangeStrip({
@@ -40,23 +41,39 @@ function RangeStrip({
   year: string;
 }) {
   const hasRange = p25 != null && p50 != null && p75 != null;
+  const values = [
+    { label: "25th", value: p25 },
+    { label: "Median", value: p50 },
+    { label: "75th", value: p75 },
+  ];
+
   return (
     <div className="positioning-range">
       <div className="positioning-range__head">
         <span>{label}</span>
-        <span>
-          {formatScore(p25)} - {formatScore(p50)} - {formatScore(p75)}
-        </span>
+        <span>{hasRange ? "Middle 50% of score submitters" : "Not reported"}</span>
       </div>
-      <div className="positioning-range__track" aria-hidden="true">
-        <span style={{ left: "0%" }} />
-        <span style={{ left: "50%" }} />
-        <span style={{ left: "100%" }} />
-      </div>
+      {hasRange && (
+        <>
+          <div className="positioning-range__track" aria-hidden="true">
+            <span style={{ left: "0%" }} />
+            <span style={{ left: "50%" }} />
+            <span style={{ left: "100%" }} />
+          </div>
+          <div className="positioning-range__values" aria-label={`${label} percentile scores`}>
+            {values.map((item) => (
+              <div key={item.label}>
+                <span>{item.label}</span>
+                <strong>{formatScore(item.value)}</strong>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
       <div className="positioning-range__caption">
         {hasRange ? (
           <>
-            § {submitRateCaption(submitRate)} · {year} CDS ·{" "}
+            § {submitRateCaption(label, submitRate)} · {year} CDS ·{" "}
             <Link href="/methodology/positioning">METHOD →</Link>
           </>
         ) : (

--- a/web/tests/e2e/positioning-card.spec.ts
+++ b/web/tests/e2e/positioning-card.spec.ts
@@ -4,7 +4,8 @@ test("school page renders positioning card and persists profile locally", async 
   await page.goto("/schools/bowdoin");
   await expect(page.getByText("§ Academic profile")).toBeVisible();
   await expect(page.getByText("SAT composite").first()).toBeVisible();
-  await expect(page.getByText(/FROM THE .* OF ADMITS WHO SUBMITTED SCORES/).first()).toBeVisible();
+  await expect(page.getByText("Middle 50% of score submitters").first()).toBeVisible();
+  await expect(page.getByText(/OF ADMITS SUBMITTED SAT SCORES/).first()).toBeVisible();
 
   await page.getByRole("spinbutton", { name: "GPA" }).fill("3.85");
   await page.getByRole("spinbutton", { name: "SAT composite" }).fill("1500");


### PR DESCRIPTION
## Summary
- improve /coverage table spacing, mobile overflow behavior, and Methodology copy
- clarify Academic Profile SAT/ACT score ranges with explicit 25th / median / 75th labels
- make Vanderbilt-style ACT ranges readable when median and 75th percentile match

## Verification
- npm run typecheck
- npm run test -- positioning
- npm run build
- Playwright QA on /coverage and /schools/vanderbilt desktop/mobile
