### PR TITLE
feat: add admission visualization upgrades

### DIFF
--- a/docs/prd/023-admission-visualization-upgrades.md
+++ b/docs/prd/023-admission-visualization-upgrades.md
@@ -1,0 +1,623 @@
+# PRD 023: Admission visualization upgrades
+
+**Status:** Draft
+**Created:** 2026-05-11
+**Author:** Anthony + Codex
+**Related:** [PRD 016B](016B-admission-strategy-card.md), [PRD 020](020-accessible-cds-table-view.md), [PRD 021](021-ipeds-coverage-layer.md), [PRD 022](022-mcp-cli-readiness.md), [Admission strategy methodology](../../web/src/app/methodology/admission-strategy/page.tsx)
+
+---
+
+## Executive summary
+
+The current Admission Strategy card explains a school one year at a time:
+overall applicants, admits, enrolled students, Early Decision counts, residual
+non-ED estimates, yield, and wait-list activity.
+
+That is already more honest than a single headline admit rate, but the next
+version should make the admissions funnel easier to see.
+
+PRD 023 upgrades the school-page admission visuals with four layers:
+
+1. **Adjusted admission-flow view:** show how applicants become admits and how
+   the class is likely assembled, while keeping real counts in the labels. This
+   is Sankey-inspired, but the UI should not call it a Sankey unless widths are
+   globally proportional.
+2. **Wait-list view:** show wait-list offers, students accepting a spot, and
+   students admitted from the wait list as a small attrition visual.
+3. **Trend view:** when multi-year extracted data is available, show whether ED
+   share, residual admit rate, yield, and wait-list outcomes are changing.
+4. **Peer context:** compare each school against simple peer buckets, not a
+   hand-curated "peer list," so users can tell whether a metric is typical or
+   unusual for schools in the same rough admissions market.
+
+The first user-facing goal is clarity. A student or family should be able to
+look at Duke, Vanderbilt, or Goshen and understand the shape of admissions in
+under a minute: how much of the class is assembled early, how selective the
+remaining pool looks, whether the wait list is meaningful, and whether those
+signals are unusual relative to similar schools.
+
+## Product stance
+
+Move fast, keep the math visible, and let sparse data degrade cleanly.
+
+The current-year chart should ship first because the data already exists for
+schools where PRD 016B is populated. Trend and peer modules should appear only
+when the underlying data is strong enough to avoid false precision. The product
+should never promise a five-year trend when we only have one extracted year.
+
+This is not a prediction product. It is a public-data browser for understanding
+how a school builds a class.
+
+## Problem
+
+### 1. The current numbers are correct but cognitively expensive
+
+The Admission Strategy card now includes real counts and derived rates, but the
+reader still has to mentally convert those numbers into a model:
+
+- How many applicants were in ED versus all other rounds?
+- How much of the class was effectively committed through ED?
+- How different is the ED admit rate from the rest of the pool?
+- How much room was left after early admits?
+- Is the wait list a real path or mostly a hedge?
+
+A visual should do that work.
+
+### 2. Literal proportional charts become unreadable
+
+Admissions data often spans very different orders of magnitude:
+
+- tens of thousands of applicants;
+- thousands of admits;
+- hundreds or low thousands of enrolled students;
+- sometimes single-digit wait-list admits.
+
+A purely proportional Sankey can collapse the important paths into hairlines.
+The chart needs to be visually adjusted while being explicit that labels carry
+the exact counts.
+
+### 3. One-year data can overstate certainty
+
+ED share, yield, and wait-list admits can move year to year. A single year is
+still useful, but users should know whether a number is a pattern or a spike.
+
+The product should use trends when we have them and remain a current-year view
+when we do not.
+
+### 4. "High" needs context
+
+"ED fills 60% of the class" means something different at a highly selective
+private university than at a broad-access regional public institution. We do not
+need elaborate peer modeling in V1, but we do need simple context:
+
+- similar selectivity;
+- similar control type;
+- similar enrollment size;
+- same data year when possible.
+
+## Goals
+
+1. Replace the current admissions-round visual with an adjusted flow view that
+   keeps ED and all-other-round paths easy to compare without implying false
+   proportionality.
+2. Add a wait-list visual showing offers, accepted wait-list spots, and admits
+   from the wait list.
+3. Add trend visuals when at least three comparable years are available.
+4. Add peer-bucket context for the most important derived metrics.
+5. Preserve accessible tables for every charted value.
+6. Keep caveats concrete and close to the affected metric.
+7. Avoid hiding missing data behind decorative empty states.
+
+## Non-goals
+
+- No personalized admissions advice.
+- No probability prediction for an individual applicant.
+- No exact Regular Decision admit rate. We still publish the non-early residual
+  because CDS does not isolate RD.
+- No Early Action admit rate unless a future non-CDS source reliably supplies
+  the underlying counts.
+- No named peer-picker UI in V1.
+- No claim that a trend exists unless multiple comparable years are extracted.
+- No heavy dashboard surface on the school page.
+
+## User stories
+
+1. A student can open a school page and immediately see how much of the class is
+   shaped by Early Decision versus all other rounds.
+2. A parent can understand why the headline admit rate is not the same thing as
+   the likely non-ED pool.
+3. A counselor can see whether the wait list admitted many students, a few
+   students, or none at all.
+4. A journalist can cite the exact underlying counts from an accessible table.
+5. A developer can retrieve the same derived data through the public API once
+   the MCP/CLI layer grows to include admission strategy facts.
+
+## Product principles
+
+1. **Real counts first.** Every visual label uses the exact available count or a
+   clearly named derived estimate.
+2. **Adjusted visuals are allowed when labeled.** If the chart compresses scale
+   to remain readable, say so in chart copy and keep the table exact. Do not
+   use "Sankey" as the user-facing label unless one global scale is used.
+3. **Denominators must be visible.** "10%" is not enough; show "600 of 6,000"
+   where space allows.
+4. **Single-school first, context second.** The primary job is explaining this
+   school. Trends and peers should support that story, not become a separate
+   analytics product.
+5. **Sparse data should be honest.** Missing trend, peer, or wait-list data
+   should hide that module or show a small factual missing-data note.
+6. **Accessible by default.** Every chart has a semantic table equivalent and
+   does not rely on color alone.
+
+## V1 surface
+
+### 1. Adjusted admission-flow view
+
+Replace the current "Applicant paths" treatment with a two-lane flow:
+
+- **Early Decision**
+  - ED applicants
+  - ED admits
+  - likely ED class seats, using the assumption below
+- **All other rounds**
+  - remaining applicants
+  - remaining admits
+  - seats left after ED admits, using the assumption below
+
+The committed V1 shape is a **stage-normalized flow / Marimekko small-multiple**:
+
+- applicant widths compare ED applicants to non-ED applicants;
+- admit widths compare ED admits to non-ED admits;
+- class-seat widths compare likely ED seats to remaining seats.
+
+Each stage is internally proportional, but widths are not globally proportional
+from applicant stage to admit stage to class-seat stage. This avoids the
+hairline problem without pretending to be a true Sankey.
+
+Labels carry the real counts. A small note should say: "Each column is scaled
+within that stage. Labels show exact counts."
+
+Future option: a true Sankey can be explored later only if it uses one global
+scale, or a global square-root/log transform with an explicit caption. That is
+not the V1 implementation.
+
+#### ED class-seat assumption
+
+CDS does not report how many ED admits actually enrolled. Because ED is a
+binding admission plan, V1 uses this assumption:
+
+```text
+likely_ed_class_seats = min(ed_admitted, enrolled_first_year)
+seats_left_after_ed = enrolled_first_year - likely_ed_class_seats
+```
+
+The chart must name this assumption near the class-seat stage:
+"Class-seat estimate assumes ED admits enroll."
+
+This is good enough to explain class assembly, but it is still an estimate. Peer
+context should use "likely ED class share," not "ED class share," when this
+assumption is involved.
+
+#### Required metrics
+
+| Metric | Formula | Notes |
+|---|---:|---|
+| ED applicants | `ed_applicants` | CDS C.21 |
+| ED admits | `ed_admitted` | CDS C.21 |
+| ED admit rate | `ed_admitted / ed_applicants` | Hidden if denominator missing or zero |
+| All-other applicants | `c1_applicants - ed_applicants` | Labeled as residual, not RD |
+| All-other admits | `c1_admitted - ed_admitted` | Labeled as residual, not RD |
+| All-other residual admit rate | all-other admits / all-other applicants | Hidden if invalid |
+| ED share of admits | `ed_admitted / c1_admitted` | Exact from admits |
+| Likely ED class seats | `min(ed_admitted, enrolled_first_year)` | Assumes ED admits enroll |
+| Likely ED share of class | likely ED class seats / `enrolled_first_year` | Labeled as an estimate |
+| Seats left after ED | `enrolled_first_year - likely_ed_class_seats` | Labeled as an estimate |
+
+#### Design requirements
+
+- Put "Early Decision" and "All other rounds" outside the flow boxes so the
+  numeric columns align vertically.
+- Use the same column order in both lanes: applicants, admits, enrolled.
+- Keep exact counts in bold only where they are the main comparison.
+- Use the site palette. Suggested semantic pairing: early path = forest
+  `#3f5b3a`; other rounds = graphite or a tinted neutral. Do not introduce blue.
+- On mobile, stack the two lanes but keep the three stages in the same order.
+- For no-ED or open-admissions schools, collapse to a single "All applicants"
+  flow instead of rendering an empty ED lane.
+- Provide a table immediately below or via the existing accessible-table pattern
+  with all displayed values.
+
+### 2. Wait-list attrition view
+
+Add a compact visual for CDS C.2 wait-list data. This should be visually
+separate from the ED flow because wait-list dynamics are a different question:
+"Did the school actually use the wait list?"
+
+The recommended V1 visual is a three-stage attrition bar:
+
+1. students offered a place on the wait list;
+2. students accepting a wait-list spot;
+3. students admitted from the wait list.
+
+This is inspired by the recent wait-list coverage pattern that compares a large
+wait-list offer pool against a much smaller admitted-off-waitlist count. The
+CollegeData version should focus on the school currently being viewed, with
+peer context added nearby when available.
+
+#### Required metrics
+
+| Metric | Formula | User-facing label |
+|---|---:|---|
+| Wait-list offered | `wait_list_offered` | Offered a wait-list spot |
+| Wait-list accepted | `wait_list_accepted` | Accepted a wait-list spot |
+| Wait-list admitted | `wait_list_admitted` | Admitted from wait list |
+| Wait-list opt-in rate | `wait_list_accepted / wait_list_offered` | Joined the wait list |
+| Wait-list admit rate | `wait_list_admitted / wait_list_accepted` | Admitted after joining |
+| Wait-list offer rate | `wait_list_offered / c1_applicants` | Applicants offered wait list |
+| Wait-list admitted vs class size | `wait_list_admitted` alongside `enrolled_first_year` | Context, not the primary rate |
+
+#### Display rules
+
+- If the school reports a wait-list policy but no counts, show a small
+  "policy reported, counts unavailable" state.
+- If `wait_list_accepted > 0` and `wait_list_admitted = 0`, show the zero
+  explicitly. Do not hide the module.
+- If `wait_list_offered`, `wait_list_accepted`, or `wait_list_admitted` violate
+  basic monotonicity, show the values with a visible data-quality badge and link
+  to the source PDF. Suppress the visual only when the extraction is clearly
+  invalid, such as a hallucinated value, impossible order of magnitude, or source
+  mismatch.
+- Add an internal review flag for wait-list anomalies so these pages do not
+  become invisible repair work.
+- Always include a caution that wait-list outcomes are volatile year to year.
+
+### 3. Trend view, when we have it
+
+Add a trend strip below the current-year visual when at least three comparable
+years are available for a school. If only one or two comparable years exist,
+hide the trend strip for now.
+
+"Comparable" means:
+
+- same `school_id`;
+- same canonical field family populated for the metric being charted;
+- same template-family interpretation for the relevant fields;
+- no known schema-year change that alters the metric's meaning.
+
+The preferred trend view is:
+
+- a 100% stacked bar or area chart for estimated class composition:
+  ED seats versus all-other seats;
+- a small line chart for ED admit rate versus all-other residual admit rate;
+- a small line or dot chart for wait-list admit rate, when wait-list data is
+  available in the same years.
+
+#### Trend metrics
+
+| Metric | Minimum years | Chart |
+|---|---:|---|
+| Likely ED share of class | 3 | 100% stacked bar/area |
+| ED admit rate | 3 | Line |
+| All-other residual admit rate | 3 | Line |
+| Overall yield | 3 | Line or small stat trend |
+| Wait-list admit rate | 3 | Line or dots |
+| Wait-list admitted count | 3 | Bars |
+
+#### Data notes
+
+Trend data should use the same canonical schema mapping as current-year data.
+For V1, it is acceptable if trends are available only for schools with multiple
+clean modern CDS extractions. As older years become normalized, the same
+component can expand to five-year histories.
+
+If historical ED counts are missing but historical C.1 totals exist, do not
+render a partial ED trend. A broken trend is worse than no trend.
+
+### 4. Peer-bucket context
+
+Add simple comparative context for the school, using broad buckets rather than
+custom peers.
+
+V1 buckets:
+
+- `admit_rate_bucket`: under 5%, 5-10%, 10-20%, 20-40%, 40%+
+- `control`: public, private nonprofit, private for-profit when present
+- `undergrad_size_bucket`: under 2k, 2k-7k, 7k-15k, 15k+
+- `year_start`: same CDS year when possible, latest available otherwise
+
+Peer context should display as short contextual labels:
+
+- "High for private schools with 5-10% admit rates"
+- "Typical for schools in this selectivity band"
+- "Very low wait-list admit rate among similar schools"
+
+For V1, use percentiles and medians rather than ranking tables.
+
+#### Peer metrics
+
+| Metric | Peer statistic |
+|---|---|
+| Likely ED share of class | percentile and bucket median |
+| ED admit-rate multiple | percentile and bucket median |
+| All-other residual admit rate | percentile and bucket median |
+| Overall yield | percentile and bucket median |
+| Wait-list opt-in rate | percentile and bucket median |
+| Wait-list admit rate | percentile and bucket median |
+| Wait-list admitted count relative to class size | percentile and bucket median |
+
+#### Peer display rules
+
+- Require at least 30 schools with a non-null value for the specific metric. The
+  threshold is for statistical stability, not privacy.
+- Compute peer N per metric, not per bucket. A bucket with 30 schools but only
+  18 ED reporters should not show an ED peer label.
+- Use metric-family fallback rules:
+  - ED metrics: keep control type longer than size; broaden size first, then
+    control, then use admit-rate bucket only.
+  - Wait-list metrics: keep size longer than control; broaden control first,
+    then size, then use admit-rate bucket only.
+  - Yield and overall admit-rate metrics: broaden size first, then control.
+- If the broadened metric-specific bucket still has fewer than 30 schools, hide
+  peer labels for that metric.
+- Do not show precise percentile labels like "73rd percentile" on the primary
+  card. Use plain language: low, typical, high, unusually high.
+- The accessible table can expose the median, percentile, peer count, and bucket
+  definition.
+
+## Data model
+
+The current `school_browser_rows` surface already carries the current-year
+admission strategy fields. This PRD needs two additional derived surfaces:
+
+### `school_admission_strategy_years`
+
+One row per school per canonical year for charting trends.
+
+Suggested fields:
+
+| Field | Notes |
+|---|---|
+| `school_id` | canonical school slug |
+| `canonical_year` | e.g. `2024-25` |
+| `year_start` | numeric sort key |
+| `template_family` | schema/template compatibility key for trends |
+| `school_name` | display label |
+| `source_url` | CDS source URL |
+| `archive_url` | CollegeData archived document URL |
+| `applied` | C.1 applicants |
+| `admitted` | C.1 admitted |
+| `enrolled_first_year` | C.1 enrolled |
+| `yield_rate` | C.1 derived |
+| `ed_offered` | C.21 |
+| `ed_applicants` | C.21 |
+| `ed_admitted` | C.21 |
+| `wait_list_policy` | C.2 |
+| `wait_list_offered` | C.2 |
+| `wait_list_accepted` | C.2 |
+| `wait_list_admitted` | C.2 |
+| `wait_list_quality` | `ok`, `non_monotonic_reported`, `extraction_suspect`, `missing_counts` |
+| `admission_strategy_quality` | projection quality flag |
+
+### `admission_strategy_peer_buckets`
+
+Precomputed or queryable peer stats for current-year and latest-year views.
+
+Suggested fields:
+
+| Field | Notes |
+|---|---|
+| `year_start` | same-year when available |
+| `admit_rate_bucket` | broad selectivity band |
+| `control` | ownership/control type |
+| `undergrad_size_bucket` | size band |
+| `metric_key` | e.g. `likely_ed_share_of_class` |
+| `school_count` | comparison N for this metric, after null filtering |
+| `median_value` | bucket median |
+| `p25_value` | bucket p25 |
+| `p75_value` | bucket p75 |
+| `p90_value` | bucket p90 |
+
+The peer layer can start as an in-app derived query if that is faster. If the
+query becomes expensive, promote it to a materialized view.
+
+## API and MCP readiness
+
+PRD 022 introduces friendly school facts APIs, MCP tools, and CLI commands.
+Admission strategy visuals should use the same derived payload shape so the
+visual, API, MCP, and CLI surfaces do not drift.
+
+Future response shape:
+
+```json
+{
+  "category": "admissions",
+  "key": "admission_strategy",
+  "source": {
+    "layer": "cds",
+    "canonical_year": "2024-25",
+    "archive_url": "https://www.collegedata.fyi/schools/duke/2024-25"
+  },
+  "current_year": {
+    "ed": {
+      "applicants": 6201,
+      "admitted": 849,
+      "admit_rate": {
+        "value": 0.1369,
+        "display_value": "13.7%"
+      },
+      "likely_class_seats": {
+        "value": 849,
+        "display_value": "849"
+      }
+    },
+    "all_other_rounds": {
+      "applicants": 48232,
+      "admitted": 1901,
+      "residual_admit_rate": {
+        "value": 0.0394,
+        "display_value": "3.9%"
+      }
+    },
+    "wait_list": {
+      "offered": 3990,
+      "accepted": 2070,
+      "admitted": 86,
+      "wait_list_admit_rate_among_accepted": {
+        "value": 0.0415,
+        "display_value": "4.2%"
+      }
+    }
+  },
+  "trend": [],
+  "peer_context": []
+}
+```
+
+The first implementation can keep this internal to the frontend. Once PRD 022
+friendly endpoints exist, the same object should be exposed there.
+
+Precision rule: API payloads carry raw numeric values in `value`; UI and CLI
+surfaces use `display_value`. Percent displays round to one decimal place unless
+the value is below 1%, in which case two decimals are allowed.
+
+## UX placement
+
+On `/schools/[school_id]`, this belongs inside the existing Academic Profile /
+Admissions area near the current Admission Strategy card.
+
+Suggested order:
+
+1. headline admission facts;
+2. adjusted admission-flow view;
+3. wait-list attrition view;
+4. trend strip, if available;
+5. peer context labels;
+6. source and methodology links;
+7. accessible data table.
+
+On the archived CDS page `/schools/[school_id]/[year]`, show the same chart
+using only that year's source data. Do not show current-year peer labels or
+trend modules on archived pages in V1; mixing years there creates more confusion
+than context.
+
+## Accessibility
+
+Every visual must include:
+
+- semantic table with the same values;
+- chart title and short description;
+- visible source year;
+- no color-only encoding;
+- keyboard-accessible tooltip or disclosure for methodology notes;
+- mobile layout that does not require horizontal scrolling for the primary
+  chart.
+- at 390px width, all primary numeric labels are visible without truncation;
+  secondary details can move into a disclosure.
+
+Tooltips are acceptable for secondary details, but the primary takeaway must be
+visible without hover.
+
+## Copy guidelines
+
+Use plain, non-insider language.
+
+Preferred terms:
+
+- "Early Decision"
+- "All other rounds"
+- "Likely share of the entering class"
+- "Admitted from the wait list"
+- "Schools in a similar selectivity band"
+
+Avoid:
+
+- "residual" as the primary label, except in methodology copy;
+- "C.21" or "C.2" in user-facing chart headings;
+- "peer normalization";
+- "strategy score."
+
+## Implementation plan
+
+### Phase 1: Current-year adjusted flow
+
+- Rework the existing admission round visual into the adjusted two-lane flow.
+- Replace the current production visual in place. Do not run old and new charts
+  side by side except behind a short-lived local/dev flag.
+- Keep the current derived data contract where possible.
+- Add the accessible table using the CDS table-view pattern from PRD 020.
+- Verify on pinned `(school_id, canonical_year)` fixtures for Duke, Vanderbilt,
+  Goshen, and at least one school with no ED so tests do not drift with future
+  extraction updates.
+
+### Phase 2: Wait-list attrition
+
+- Add the three-stage wait-list visual.
+- Handle zero-admitted states explicitly.
+- Add the data-quality badge and internal review flag for non-monotonic
+  wait-list values.
+- Add derived wait-list rates to the frontend utility layer if not already
+  centralized.
+- Add source/methodology links back to CDS C.2 fields.
+
+### Phase 3: Trend data
+
+- Build or expose `school_admission_strategy_years`.
+- Render trend strip only when at least three comparable years are present.
+- Start with likely ED class share and wait-list admit rate; add yield and
+  all-other residual after the core chart works.
+
+### Phase 4: Peer buckets
+
+- Add simple bucket assignment.
+- Compute medians and percentiles for the core metrics.
+- Render short context labels on the school page.
+- Add detailed peer-bucket numbers to the accessible table, not the visual.
+
+### Phase 5: API alignment
+
+- Align the internal derived payload with PRD 022 school-facts output.
+- Add admission-strategy facts to the friendly API once that layer exists.
+- Document fields in public API docs.
+
+## Acceptance criteria
+
+1. Duke and Vanderbilt school pages make the ED versus all-other class model
+   clear without requiring the user to read the methodology page first.
+2. The adjusted flow labels use exact counts, include the stage-scaling note,
+   and link to methodology.
+3. Wait-list data shows all three counts and the wait-list admit rate among
+   students who accepted a wait-list spot.
+4. A school with `wait_list_admitted = 0` displays that zero clearly.
+5. Trend charts do not render unless at least three comparable years are
+   available.
+6. Peer context does not render unless the metric-specific comparison bucket has
+   at least 30 schools after fallback broadening.
+7. All charted values are available in an accessible table.
+8. Mobile layout remains readable at 390px width, with all primary numeric
+   labels visible without truncation.
+9. Playwright visual QA covers:
+   - pinned school-year with ED and wait-list data;
+   - pinned school-year with ED and no wait-list admits;
+   - pinned school-year with no ED;
+   - pinned school-year with missing historical data;
+   - pinned school-year with peer bucket too small.
+
+## Open questions
+
+1. Is "likely class seats" the right public label for the ED enrollment
+   assumption, or should the UI use "class seats if ED admits enroll"?
+2. Should wait-list peer context compare all schools, or only schools that
+   report a wait-list policy?
+3. Should trend view use a compact inline strip on the school page and a larger
+   version on a future compare page?
+4. Which school-year fixtures should be pinned for each visual state once the
+   first implementation data audit identifies stable examples?
+
+## First build recommendation
+
+Ship the current-year adjusted flow and wait-list attrition first. They solve
+the immediate comprehension problem and reuse data already in the product.
+
+Add trends as soon as `school_admission_strategy_years` has enough comparable
+rows. Add peer buckets after the chart copy is stable, because peer labels will
+amplify whatever terminology the primary visual uses.

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   fetchDocumentsBySchoolAndYear,
+  fetchAdmissionStrategyByDocumentId,
   fetchExtract,
   fetchScorecardByIpedsId,
 } from "@/lib/queries";
@@ -14,6 +15,7 @@ import { FieldsView } from "@/components/FieldsView";
 import { MarkdownView } from "@/components/MarkdownView";
 import { OutcomesBand } from "@/components/OutcomesBand";
 import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
+import { AdmissionStrategyCard } from "@/components/AdmissionStrategyCard";
 
 export const revalidate = 3600;
 
@@ -156,6 +158,9 @@ async function DocumentVariant({
   }
 
   const hasValues = Object.keys(values).length > 0;
+  const admissionStrategy = doc.document_id
+    ? await fetchAdmissionStrategyByDocumentId(doc.document_id)
+    : null;
 
   return (
     <div className="mt-8">
@@ -189,8 +194,15 @@ async function DocumentVariant({
       {/* Key stats */}
       {hasValues && (
         <div className="mt-4">
-          <KeyStats values={values} />
+          <KeyStats schemaVersion={schemaVersion ?? doc.cds_year ?? undefined} values={values} />
         </div>
+      )}
+
+      {admissionStrategy && (
+        <AdmissionStrategyCard
+          school={admissionStrategy}
+          sourceHref={pdfUrl ?? admissionStrategy.archiveUrl}
+        />
       )}
 
       {/* Federal outcomes — Scorecard data. Only render under the first

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -930,6 +930,92 @@
   padding-top: 22px;
   border-top: 1px solid var(--rule);
 }
+.admission-strategy-flow__scale-note {
+  font-family: var(--mono);
+  font-size: 10.5px !important;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.admission-strategy-flow-matrix {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+.admission-strategy-flow-matrix__head,
+.admission-strategy-flow-lane {
+  display: grid;
+  grid-template-columns: minmax(116px, 0.24fr) repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  align-items: stretch;
+}
+.admission-strategy-flow-matrix__head {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+.admission-strategy-flow-lane__label {
+  display: flex;
+  align-items: center;
+  padding-top: 2px;
+}
+.admission-strategy-flow-lane__cells {
+  display: contents;
+}
+.admission-strategy-flow-cell {
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid var(--rule);
+  background: color-mix(in srgb, var(--paper) 82%, white);
+}
+.admission-strategy-flow-cell__stage {
+  display: none;
+}
+.admission-strategy-flow-cell strong,
+.admission-strategy-flow-cell span {
+  display: block;
+}
+.admission-strategy-flow-cell strong {
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: clamp(22px, 2.4vw, 30px);
+  font-weight: 400;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.admission-strategy-flow-cell > span:not(.admission-strategy-flow-cell__stage) {
+  margin-top: 5px;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.admission-strategy-flow-cell__track {
+  height: 7px;
+  margin-top: 10px;
+  background: var(--paper-3);
+}
+.admission-strategy-flow-cell__bar {
+  display: block;
+  min-width: 0;
+  height: 100%;
+}
+.admission-strategy-flow-cell__bar--ed {
+  background: var(--forest);
+}
+.admission-strategy-flow-cell__bar--other {
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in srgb, var(--forest) 18%, var(--paper)),
+    color-mix(in srgb, var(--forest) 18%, var(--paper)) 6px,
+    var(--paper) 6px,
+    var(--paper) 12px
+  );
+}
+.admission-strategy-flow-cell__bar--single {
+  background: var(--ink);
+}
 .admission-strategy-flow-grid {
   display: grid;
   gap: 12px;
@@ -1010,6 +1096,16 @@
   border-top: 1px solid var(--rule);
   padding-top: 14px;
 }
+.admission-strategy-panel--wide {
+  grid-column: 1 / -1;
+}
+.admission-strategy-panel__head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
 .admission-strategy-panel--accent {
   border-top-color: var(--forest);
 }
@@ -1037,6 +1133,93 @@
   letter-spacing: 0;
   text-transform: none;
 }
+.admission-strategy-wait {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.admission-strategy-wait-stage {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.34fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+.admission-strategy-wait-stage span {
+  display: block;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.admission-strategy-wait-stage strong {
+  display: block;
+  margin-top: 3px;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 27px;
+  font-weight: 400;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.admission-strategy-wait-stage__track {
+  height: 18px;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+.admission-strategy-wait-stage__track i {
+  display: block;
+  min-width: 0;
+  height: 100%;
+  background: var(--forest);
+}
+.admission-strategy-zero-note {
+  color: var(--ink) !important;
+  font-weight: 600;
+}
+.admission-strategy-caution {
+  color: var(--ink-3) !important;
+  font-size: 12.5px !important;
+}
+.admission-strategy-data {
+  margin-top: 12px;
+  border-top: 1px dashed var(--rule);
+  padding-top: 10px;
+}
+.admission-strategy-data summary {
+  cursor: pointer;
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.admission-strategy-data__wrap {
+  overflow-x: auto;
+  margin-top: 10px;
+}
+.admission-strategy-data table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+.admission-strategy-data th,
+.admission-strategy-data td {
+  border-top: 1px solid var(--rule);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+.admission-strategy-data th {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
 .admission-strategy-card__source {
   margin-top: 26px;
   padding-top: 14px;
@@ -1060,6 +1243,38 @@
   .admission-strategy-flow-row__cells {
     grid-template-columns: 1fr;
   }
+  .admission-strategy-flow-matrix__head {
+    display: none;
+  }
+  .admission-strategy-flow-lane {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .admission-strategy-flow-lane:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+  .admission-strategy-flow-lane__cells {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+  .admission-strategy-flow-cell__stage {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--ink-3);
+    font-family: var(--mono);
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
+    line-height: 1.3;
+    text-transform: uppercase;
+  }
+  .admission-strategy-wait-stage {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
   .admission-strategy-flow-row__label {
     padding-top: 0;
   }
@@ -1067,6 +1282,9 @@
 }
 @media (max-width: 560px) {
   .admission-strategy-insights { grid-template-columns: 1fr; }
+  .admission-strategy-flow-lane__cells {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Merit profile card. H-section financial-aid facts sit beside Scorecard

--- a/web/src/components/AdmissionStrategyCard.tsx
+++ b/web/src/components/AdmissionStrategyCard.tsx
@@ -34,6 +34,11 @@ function maybeMultiple(value: number | null): string {
   return value == null || !Number.isFinite(value) ? "n/a" : `${value.toFixed(1)}x`;
 }
 
+function shareOf(value: number | null, total: number): number {
+  if (value == null || value <= 0 || total <= 0) return 0;
+  return Math.max(0, Math.min(100, (value / total) * 100));
+}
+
 function important(value: string | null): boolean {
   return value === "Important" || value === "Very Important";
 }
@@ -56,38 +61,287 @@ function InsightBlock({
   );
 }
 
-function FlowRow({
-  admitRate,
-  admitted,
-  applicants,
-  enrolled,
-  label,
-  yieldLabel,
-}: {
-  admitRate: number | null;
-  admitted: number | null;
-  applicants: number | null;
-  enrolled: number | null;
+type FlowLane = {
   label: string;
+  tone: "ed" | "other" | "single";
+  applicants: number | null;
+  admitted: number | null;
+  enrolled: number | null;
+  admitRate: number | null;
   yieldLabel: string;
+};
+
+function FlowCell({
+  label,
+  value,
+  width,
+  rate,
+  tone,
+}: {
+  label: string;
+  value: number | null;
+  width: number;
+  rate: string;
+  tone: FlowLane["tone"];
+}) {
+  const cssWidth = `${width}%`;
+  return (
+    <div className="admission-strategy-flow-cell">
+      <span className="admission-strategy-flow-cell__stage">{label}</span>
+      <strong>{maybeCount(value)}</strong>
+      <span>{rate}</span>
+      <div className="admission-strategy-flow-cell__track" aria-hidden="true">
+        <i
+          className={`admission-strategy-flow-cell__bar admission-strategy-flow-cell__bar--${tone}`}
+          style={{ width: cssWidth }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AdjustedFlow({
+  description,
+  lanes,
+  titleId,
+}: {
+  description: string;
+  lanes: FlowLane[];
+  titleId: string;
+}) {
+  const applicantTotal = lanes.reduce((sum, lane) => sum + (lane.applicants ?? 0), 0);
+  const admittedTotal = lanes.reduce((sum, lane) => sum + (lane.admitted ?? 0), 0);
+  const enrolledTotal = lanes.reduce((sum, lane) => sum + (lane.enrolled ?? 0), 0);
+
+  return (
+    <div className="admission-strategy-flow" aria-labelledby={titleId}>
+      <div>
+        <div id={titleId} className="meta">
+          § Adjusted admission flow
+        </div>
+        <p>{description}</p>
+        <p className="admission-strategy-flow__scale-note">
+          Each column is scaled within that stage. Labels show exact counts.
+        </p>
+      </div>
+      <div className="admission-strategy-flow-matrix">
+        <div className="admission-strategy-flow-matrix__head" aria-hidden="true">
+          <span />
+          <span>Applicants</span>
+          <span>Admits</span>
+          <span>Class seats</span>
+        </div>
+        {lanes.map((lane) => (
+          <div className="admission-strategy-flow-lane" key={lane.label}>
+            <div className="admission-strategy-flow-lane__label meta">{lane.label}</div>
+            <div className="admission-strategy-flow-lane__cells">
+              <FlowCell
+                label="Applicants"
+                value={lane.applicants}
+                width={shareOf(lane.applicants, applicantTotal)}
+                rate="reported count"
+                tone={lane.tone}
+              />
+              <FlowCell
+                label="Admits"
+                value={lane.admitted}
+                width={shareOf(lane.admitted, admittedTotal)}
+                rate={maybePct(lane.admitRate)}
+                tone={lane.tone}
+              />
+              <FlowCell
+                label="Class seats"
+                value={lane.enrolled}
+                width={shareOf(lane.enrolled, enrolledTotal)}
+                rate={lane.yieldLabel}
+                tone={lane.tone}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DataTable({
+  rows,
+}: {
+  rows: Array<{
+    label: string;
+    applicants: string;
+    admitted: string;
+    admitRate: string;
+    enrolled: string;
+    note: string;
+  }>;
 }) {
   return (
-    <div className="admission-strategy-flow-row">
-      <div className="admission-strategy-flow-row__label meta">{label}</div>
-      <div className="admission-strategy-flow-row__cells">
-        <div>
-          <strong>{maybeCount(applicants)}</strong>
-          <small>applicants</small>
-        </div>
-        <div>
-          <strong>{maybeCount(admitted)}</strong>
-          <small>admitted · {maybePct(admitRate)}</small>
-        </div>
-        <div>
-          <strong>{maybeCount(enrolled)}</strong>
-          <small>{yieldLabel}</small>
-        </div>
+    <details className="admission-strategy-data">
+      <summary>Exact admission data</summary>
+      <div className="admission-strategy-data__wrap">
+        <table>
+          <caption className="sr-only">Admission flow data</caption>
+          <thead>
+            <tr>
+              <th>Path</th>
+              <th>Applicants</th>
+              <th>Admitted</th>
+              <th>Admit rate</th>
+              <th>Class seats</th>
+              <th>Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <td>{row.label}</td>
+                <td>{row.applicants}</td>
+                <td>{row.admitted}</td>
+                <td>{row.admitRate}</td>
+                <td>{row.enrolled}</td>
+                <td>{row.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
+    </details>
+  );
+}
+
+function WaitListStage({
+  label,
+  value,
+  width,
+}: {
+  label: string;
+  value: number | null;
+  width: number;
+}) {
+  return (
+    <div className="admission-strategy-wait-stage">
+      <div>
+        <span>{label}</span>
+        <strong>{maybeCount(value)}</strong>
+      </div>
+      <div className="admission-strategy-wait-stage__track" aria-hidden="true">
+        <i style={{ width: `${width}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function WaitListView({
+  accepted,
+  admitted,
+  anomalous,
+  offerRate,
+  offered,
+  optInRate,
+  admitRate,
+  policyMissingCounts,
+  sourceHref,
+}: {
+  accepted: number | null;
+  admitted: number | null;
+  anomalous: boolean;
+  offerRate: number | null;
+  offered: number | null;
+  optInRate: number | null;
+  admitRate: number | null;
+  policyMissingCounts: boolean;
+  sourceHref: string | null;
+}) {
+  const max = Math.max(offered ?? 0, accepted ?? 0, admitted ?? 0);
+
+  return (
+    <div className="admission-strategy-panel admission-strategy-panel--wide">
+      <div className="admission-strategy-panel__head">
+        <div className="meta">§ Wait list attrition</div>
+        {anomalous && <span className="cd-chip cd-chip--brick">Review flagged</span>}
+      </div>
+      {policyMissingCounts ? (
+        <p>Wait-list policy reported, counts unavailable.</p>
+      ) : (
+        <>
+          <div className="admission-strategy-wait" role="img" aria-label={`Wait-list flow: ${maybeCount(offered)} offered a place, ${maybeCount(accepted)} accepted a place, ${maybeCount(admitted)} admitted from the wait list.`}>
+            <WaitListStage
+              label="Offered a spot"
+              value={offered}
+              width={shareOf(offered, max)}
+            />
+            <WaitListStage
+              label="Accepted a spot"
+              value={accepted}
+              width={shareOf(accepted, max)}
+            />
+            <WaitListStage
+              label="Admitted from wait list"
+              value={admitted}
+              width={shareOf(admitted, max)}
+            />
+          </div>
+          <p>
+            {anomalous
+              ? "The reported wait-list counts do not follow the usual offered to accepted to admitted order, so rates are withheld pending review."
+              : `${maybePct(optInRate)} joined after being offered a spot. ${maybePct(admitRate)} of students who joined were admitted.`}
+            {offerRate != null ? ` ${maybePct(offerRate)} of applicants were offered the wait list.` : ""}
+          </p>
+          {admitted === 0 && (
+            <p className="admission-strategy-zero-note">
+              Zero students were reported as admitted from the wait list.
+            </p>
+          )}
+          <details className="admission-strategy-data">
+            <summary>Exact wait-list data</summary>
+            <div className="admission-strategy-data__wrap">
+              <table>
+                <caption className="sr-only">Wait-list data</caption>
+                <thead>
+                  <tr>
+                    <th>Metric</th>
+                    <th>Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Offered a wait-list spot</td>
+                    <td>{maybeCount(offered)}</td>
+                  </tr>
+                  <tr>
+                    <td>Accepted a wait-list spot</td>
+                    <td>{maybeCount(accepted)}</td>
+                  </tr>
+                  <tr>
+                    <td>Admitted from wait list</td>
+                    <td>{maybeCount(admitted)}</td>
+                  </tr>
+                  <tr>
+                    <td>Joined after being offered</td>
+                    <td>{maybePct(optInRate)}</td>
+                  </tr>
+                  <tr>
+                    <td>Admitted after joining</td>
+                    <td>{maybePct(admitRate)}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </details>
+        </>
+      )}
+      <p className="admission-strategy-caution">
+        Wait-list outcomes can change sharply year to year.
+        {anomalous && sourceHref ? (
+          <>
+            {" "}
+            <a href={sourceHref} target="_blank" rel="noopener noreferrer">
+              Check the source.
+            </a>
+          </>
+        ) : null}
+      </p>
     </div>
   );
 }
@@ -154,26 +408,12 @@ export function AdmissionStrategyCard({
   ];
 
   const showEdSuppressed = school.quality === "ed_math_inconsistent";
-  const showWaitListSuppressed = school.quality === "wait_list_math_inconsistent";
   const showWaitList =
-    !showWaitListSuppressed &&
     (school.waitListPolicy === true ||
-      (school.waitListOffered != null &&
-        school.waitListAccepted != null &&
-        school.waitListAdmitted != null)) &&
-    (school.waitListOffered != null ||
-      school.waitListAccepted != null ||
-      school.waitListAdmitted != null ||
-      derived.waitListConditionalAdmitRate != null);
+      derived.waitListHasAnyCount ||
+      derived.waitListCountsMissing);
   const showAppFee = school.appFeeAmount != null || school.appFeeWaiverOffered != null;
-  const hasClassModel =
-    derived.edAdmitRate != null &&
-    derived.edShareOfClass != null &&
-    derived.estimatedNonEarlyEnrolled != null;
-  const edWidth = derived.edShareOfClass == null
-    ? 0
-    : Math.max(0, Math.min(100, derived.edShareOfClass * 100));
-  const nonEarlyWidth = 100 - edWidth;
+  const showFlow = derived.hasEdFlow || derived.hasSingleApplicantFlow;
   const edClassShareNote =
     school.enrolledFirstYear != null && school.edAdmitted != null
       ? `${maybeCount(school.edAdmitted)} ED admits / ${maybeCount(school.enrolledFirstYear)} enrolled first-years`
@@ -182,14 +422,69 @@ export function AdmissionStrategyCard({
     school.enrolledFirstYear != null
       ? `of ${maybeCount(school.enrolledFirstYear)} enrolled first-year seats`
       : "after binding-ED assumption";
+  const flowLanes: FlowLane[] = derived.hasEdFlow
+    ? [
+        {
+          label: "Early Decision",
+          tone: "ed",
+          applicants: school.edApplicants,
+          admitted: school.edAdmitted,
+          admitRate: derived.edAdmitRate,
+          enrolled: derived.estimatedEdEnrolled,
+          yieldLabel: "assumes ED admits enroll",
+        },
+        {
+          label: "All other rounds",
+          tone: "other",
+          applicants: derived.nonEarlyApplicants,
+          admitted: derived.nonEarlyAdmitted,
+          admitRate: derived.nonEarlyResidualAdmitRate,
+          enrolled: derived.estimatedNonEarlyEnrolled,
+          yieldLabel: `${maybePct(derived.nonEarlyYield)} estimated yield`,
+        },
+      ]
+    : derived.hasSingleApplicantFlow
+      ? [
+          {
+            label: "All applicants",
+            tone: "single",
+            applicants: school.applied,
+            admitted: school.admitted,
+            admitRate: school.acceptanceRate,
+            enrolled: school.enrolledFirstYear,
+            yieldLabel: `${maybePct(school.yieldRate)} yield`,
+          },
+        ]
+      : [];
+  const flowDescription = derived.hasEdFlow
+    ? "Applicants, admits, and class seats use separate stage scales so Early Decision and all other rounds stay readable."
+    : "This school does not report an Early Decision lane, so the flow collapses to the school-reported applicant, admit, and enrolled totals.";
+  const flowDataRows = flowLanes.map((lane) => ({
+    label: lane.label,
+    applicants: maybeCount(lane.applicants),
+    admitted: maybeCount(lane.admitted),
+    admitRate: maybePct(lane.admitRate),
+    enrolled: maybeCount(lane.enrolled),
+    note:
+      lane.tone === "ed"
+        ? "Likely class seats assume ED admits enroll."
+        : lane.tone === "other"
+          ? "All other rounds are residual CDS totals, not exact Regular Decision."
+      : "School-reported totals.",
+  }));
+  const sectionId = `admission-strategy-${school.schoolId}-${school.cdsYear
+    .replace(/[^a-z0-9]+/gi, "-")
+    .toLowerCase()}`;
+  const titleId = `${sectionId}-title`;
+  const flowTitleId = `${sectionId}-flow-title`;
 
   return (
-    <section className="admission-strategy-card rule-2" aria-labelledby="admission-strategy-title">
+    <section className="admission-strategy-card rule-2" aria-labelledby={titleId}>
       <div className="meta">§ Admission rounds</div>
       <div className="admission-strategy-card__body cd-card cd-card--cut">
         <div className="admission-strategy-card__head">
           <div>
-            <h2 id="admission-strategy-title" className="serif admission-strategy-card__title">
+            <h2 id={titleId} className="serif admission-strategy-card__title">
               How the class gets assembled.
             </h2>
             <RoundLine school={school} />
@@ -202,137 +497,60 @@ export function AdmissionStrategyCard({
           </div>
         )}
 
-        {derived.edAdmitRate != null && (
+        {(showFlow || derived.edAdmitRate != null) && (
           <div className="admission-strategy-model">
-            <div className="admission-strategy-insights">
-              {derived.edShareOfClass != null && (
-                <InsightBlock
-                  label="Estimated ED share of class"
-                  value={pct(derived.edShareOfClass)}
-                  note={edClassShareNote}
-                />
-              )}
-              {derived.edAdmitRateMultiple != null && (
-                <InsightBlock
-                  label="ED admit-rate multiple"
-                  value={maybeMultiple(derived.edAdmitRateMultiple)}
-                  note={`${pct(derived.edAdmitRate)} ED vs ${pct(derived.nonEarlyResidualAdmitRate)} estimated non-ED`}
-                />
-              )}
-              {derived.estimatedNonEarlyEnrolled != null && (
-                <InsightBlock
-                  label="Seats left outside ED"
-                  value={maybeCount(derived.estimatedNonEarlyEnrolled)}
-                  note={remainingSeatNote}
-                />
-              )}
-              {derived.nonEarlyResidualAdmitRate != null && (
-                <InsightBlock
-                  label="Estimated non-ED admit rate"
-                  value={pct(derived.nonEarlyResidualAdmitRate)}
-                  note={`${maybeCount(derived.nonEarlyAdmitted)} admitted from ${maybeCount(derived.nonEarlyApplicants)} applicants`}
-                />
-              )}
-            </div>
-
-            {hasClassModel && derived.estimatedEdEnrolled != null && (
-              <div className="admission-strategy-class-model">
-                <div>
-                  <div className="meta">§ Enrolled class model</div>
-                  <p>
-                    Start with the real enrolled class. If binding ED admits enroll,{" "}
-                    <strong>{maybeCount(derived.estimatedEdEnrolled)}</strong> of{" "}
-                    <strong> {maybeCount(school.enrolledFirstYear)}</strong> first-year
-                    seats are already spoken for before the remaining admission rounds
-                    fill the class.
-                  </p>
-                </div>
-                <div
-                  className="admission-strategy-seatbar"
-                  role="img"
-                  aria-label={`${maybeCount(derived.estimatedEdEnrolled)} enrolled seats are estimated Early Decision seats; ${maybeCount(derived.estimatedNonEarlyEnrolled)} are estimated seats outside Early Decision.`}
-                >
-                  <span
-                    className="admission-strategy-seatbar__ed"
-                    style={{ width: `${edWidth}%` }}
-                  >
-                    ED {maybeCount(derived.estimatedEdEnrolled)}
-                  </span>
-                  <span
-                    className="admission-strategy-seatbar__regular"
-                    style={{ width: `${nonEarlyWidth}%` }}
-                  >
-                    Non-ED {maybeCount(derived.estimatedNonEarlyEnrolled)}
-                  </span>
-                </div>
+            {derived.edAdmitRate != null && (
+              <div className="admission-strategy-insights">
+                {derived.edShareOfClass != null && (
+                  <InsightBlock
+                    label="Likely ED share of class"
+                    value={pct(derived.edShareOfClass)}
+                    note={edClassShareNote}
+                  />
+                )}
+                {derived.edAdmitRateMultiple != null && (
+                  <InsightBlock
+                    label="ED admit-rate multiple"
+                    value={maybeMultiple(derived.edAdmitRateMultiple)}
+                    note={`${pct(derived.edAdmitRate)} ED vs ${pct(derived.nonEarlyResidualAdmitRate)} all other rounds`}
+                  />
+                )}
+                {derived.estimatedNonEarlyEnrolled != null && (
+                  <InsightBlock
+                    label="Seats left after ED"
+                    value={maybeCount(derived.estimatedNonEarlyEnrolled)}
+                    note={remainingSeatNote}
+                  />
+                )}
+                {derived.nonEarlyResidualAdmitRate != null && (
+                  <InsightBlock
+                    label="All-other admit rate"
+                    value={pct(derived.nonEarlyResidualAdmitRate)}
+                    note={`${maybeCount(derived.nonEarlyAdmitted)} admitted from ${maybeCount(derived.nonEarlyApplicants)} applicants`}
+                  />
+                )}
               </div>
             )}
 
-            <div className="admission-strategy-flow" aria-labelledby="admission-strategy-flow-title">
-              <div>
-                <div id="admission-strategy-flow-title" className="meta">
-                  § Applicant paths
-                </div>
-                <p>
-                  Same class, different denominators: applicant pool, admitted pool,
-                  then enrolled seats.
-                </p>
-              </div>
-              <div className="admission-strategy-flow-grid">
-                <FlowRow
-                  label="Early Decision"
-                  applicants={school.edApplicants}
-                  admitted={school.edAdmitted}
-                  admitRate={derived.edAdmitRate}
-                  enrolled={derived.estimatedEdEnrolled}
-                  yieldLabel="assumed enrolled"
+            {showFlow && (
+              <>
+                <AdjustedFlow
+                  description={flowDescription}
+                  lanes={flowLanes}
+                  titleId={flowTitleId}
                 />
-                <FlowRow
-                  label="All other rounds"
-                  applicants={derived.nonEarlyApplicants}
-                  admitted={derived.nonEarlyAdmitted}
-                  admitRate={derived.nonEarlyResidualAdmitRate}
-                  enrolled={derived.estimatedNonEarlyEnrolled}
-                  yieldLabel={`${maybePct(derived.nonEarlyYield)} estimated yield`}
-                />
-              </div>
-              <table className="sr-only">
-                <caption>Admission rounds model</caption>
-                <thead>
-                  <tr>
-                    <th>Path</th>
-                    <th>Applicants</th>
-                    <th>Admitted</th>
-                    <th>Admit rate</th>
-                    <th>Estimated enrolled</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Early Decision</td>
-                    <td>{maybeCount(school.edApplicants)}</td>
-                    <td>{maybeCount(school.edAdmitted)}</td>
-                    <td>{pct(derived.edAdmitRate)}</td>
-                    <td>{maybeCount(derived.estimatedEdEnrolled)}</td>
-                  </tr>
-                  <tr>
-                    <td>All other rounds</td>
-                    <td>{maybeCount(derived.nonEarlyApplicants)}</td>
-                    <td>{maybeCount(derived.nonEarlyAdmitted)}</td>
-                    <td>{pct(derived.nonEarlyResidualAdmitRate)}</td>
-                    <td>{maybeCount(derived.estimatedNonEarlyEnrolled)}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+                <DataTable rows={flowDataRows} />
+              </>
+            )}
 
             <div className="admission-strategy-model-notes">
-              <div className="admission-strategy-caveat">
-                <strong>Binding ED assumption.</strong> The class-share model uses
-                ED admits as estimated enrolled ED seats. CDS does not report
-                confirmed ED enrollment, so this is a practical proxy rather than
-                a separate school-reported count.
-              </div>
+              {derived.hasEdFlow && (
+                <div className="admission-strategy-caveat">
+                  <strong>Class-seat estimate assumes ED admits enroll.</strong> CDS
+                  does not report confirmed ED enrollment, so likely ED class seats
+                  are calculated as the smaller of ED admits and enrolled first-years.
+                </div>
+              )}
               {school.yieldRate != null && (
                 <div className="admission-strategy-caveat">
                   <strong>Overall yield: {pct(school.yieldRate)}.</strong> Published
@@ -340,39 +558,30 @@ export function AdmissionStrategyCard({
                   admitted pool.
                 </div>
               )}
-              <div className="admission-strategy-caveat">
-                <strong>Read the ED rate carefully.</strong> Published ED rates can
-                include recruited athletes, legacy applicants, and institutional-priority
-                applicants. The general-pool ED rate can be lower.
-              </div>
+              {derived.edAdmitRate != null && (
+                <div className="admission-strategy-caveat">
+                  <strong>Read the ED rate carefully.</strong> Published ED rates can
+                  include recruited athletes, legacy applicants, and institutional-priority
+                  applicants. The general-pool ED rate can be lower.
+                </div>
+              )}
             </div>
           </div>
         )}
 
         <div className="admission-strategy-grid">
           {showWaitList && (
-            <div className="admission-strategy-panel">
-              <div className="meta">§ Wait list</div>
-              <div className="admission-strategy-counts mono">
-                <span>Offered {maybeCount(school.waitListOffered)}</span>
-                <span>Accepted {maybeCount(school.waitListAccepted)}</span>
-                <span>Admitted {maybeCount(school.waitListAdmitted)}</span>
-              </div>
-              <p>
-                {derived.waitListOfferRate != null
-                  ? `${pct(derived.waitListOfferRate)} of applicants were offered the wait list. `
-                  : ""}
-                {derived.waitListConditionalAdmitRate != null
-                  ? `${pct(derived.waitListConditionalAdmitRate)} of students who accepted a wait-list spot were admitted.`
-                  : "Wait-list counts are reported, but the conditional admit rate is not computable."}
-              </p>
-            </div>
-          )}
-
-          {showWaitListSuppressed && (
-            <div className="admission-strategy-note admission-strategy-note--warn">
-              Wait-list counts for this school could not be reconciled and have been omitted.
-            </div>
+            <WaitListView
+              accepted={school.waitListAccepted}
+              admitted={school.waitListAdmitted}
+              anomalous={derived.waitListCountsAnomalous}
+              offerRate={derived.waitListOfferRate}
+              offered={school.waitListOffered}
+              optInRate={derived.waitListOptInRate}
+              admitRate={derived.waitListConditionalAdmitRate}
+              policyMissingCounts={derived.waitListCountsMissing}
+              sourceHref={sourceHref}
+            />
           )}
 
           <FactorsBlock factors={factors} />

--- a/web/src/components/KeyStats.tsx
+++ b/web/src/components/KeyStats.tsx
@@ -33,13 +33,47 @@ function sumFields(
   return found ? total : null;
 }
 
-export function KeyStats({ values }: { values: Record<string, FieldValue> }) {
+function c1TotalsForSchema(schemaVersion: string | undefined): {
+  applied: string[];
+  admitted: string[];
+  enrolled: string[];
+} {
+  if (schemaVersion === "2024-25") {
+    return {
+      applied: ["C.117"],
+      admitted: ["C.118"],
+      enrolled: ["C.119"],
+    };
+  }
+
+  if (schemaVersion === "2025-26") {
+    return {
+      applied: ["C.116"],
+      admitted: ["C.117"],
+      enrolled: ["C.118"],
+    };
+  }
+
+  return {
+    applied: ["C.101", "C.102", "C.103"],
+    admitted: ["C.104", "C.105", "C.106"],
+    enrolled: ["C.107", "C.108", "C.109"],
+  };
+}
+
+export function KeyStats({
+  schemaVersion,
+  values,
+}: {
+  schemaVersion?: string;
+  values: Record<string, FieldValue>;
+}) {
   const stats: { label: string; value: string }[] = [];
 
-  // Admissions funnel: sum across male + female + unknown
-  const totalApplied = sumFields(values, "C.101", "C.102", "C.103");
-  const totalAdmitted = sumFields(values, "C.104", "C.105", "C.106");
-  const totalEnrolled = sumFields(values, "C.107", "C.108", "C.109");
+  const c1Totals = c1TotalsForSchema(schemaVersion);
+  const totalApplied = sumFields(values, ...c1Totals.applied);
+  const totalAdmitted = sumFields(values, ...c1Totals.admitted);
+  const totalEnrolled = sumFields(values, ...c1Totals.enrolled);
 
   // Acceptance rate
   if (totalApplied && totalAdmitted && totalApplied > 0) {

--- a/web/src/lib/admission-strategy.test.ts
+++ b/web/src/lib/admission-strategy.test.ts
@@ -49,9 +49,14 @@ describe("computeAdmissionStrategy", () => {
     expect(result.nonEarlyAdmitted).toBe(60);
     expect(result.nonEarlyYield).toBeCloseTo(0.1667, 4);
     expect(result.edAdmitRateMultiple).toBeCloseTo(2.6667, 4);
+    expect(result.hasEdFlow).toBe(true);
+    expect(result.hasSingleApplicantFlow).toBe(false);
     expect(result.hasHighEdShare).toBe(true);
     expect(result.waitListOfferRate).toBe(0.3);
+    expect(result.waitListOptInRate).toBe(0.5);
     expect(result.waitListConditionalAdmitRate).toBe(0.2);
+    expect(result.waitListHasCounts).toBe(true);
+    expect(result.waitListCountsAnomalous).toBe(false);
     expect(result.hasRenderableContent).toBe(true);
   });
 
@@ -66,7 +71,22 @@ describe("computeAdmissionStrategy", () => {
     expect(result.edAdmitRate).toBeNull();
     expect(result.nonEarlyResidualAdmitRate).toBeNull();
     expect(result.edShareOfAdmitted).toBeNull();
+    expect(result.hasEdFlow).toBe(false);
     expect(result.hasRenderableContent).toBe(true);
+  });
+
+  it("suppresses impossible ED counts even when the quality flag is missing", () => {
+    const result = computeAdmissionStrategy({
+      ...base,
+      edOffered: true,
+      edApplicants: 40,
+      edAdmitted: 41,
+      quality: "ok",
+    });
+
+    expect(result.edAdmitRate).toBeNull();
+    expect(result.hasEdFlow).toBe(false);
+    expect(result.hasSingleApplicantFlow).toBe(true);
   });
 
   it("treats valid ED counts as an offered ED round", () => {
@@ -99,7 +119,46 @@ describe("computeAdmissionStrategy", () => {
     });
 
     expect(result.waitListOfferRate).toBe(0.2);
+    expect(result.waitListOptInRate).toBe(0.5);
     expect(result.waitListConditionalAdmitRate).toBe(0.1);
+    expect(result.hasRenderableContent).toBe(true);
+  });
+
+  it("renders no-ED schools as a single applicant flow when totals exist", () => {
+    const result = computeAdmissionStrategy({
+      ...base,
+      edOffered: false,
+      edApplicants: null,
+      edAdmitted: null,
+    });
+
+    expect(result.hasEdFlow).toBe(false);
+    expect(result.hasSingleApplicantFlow).toBe(true);
+    expect(result.edAdmitRate).toBeNull();
+  });
+
+  it("keeps anomalous wait-list counts visible but does not compute invalid rates", () => {
+    const result = computeAdmissionStrategy({
+      ...base,
+      quality: "wait_list_math_inconsistent",
+      waitListOffered: 100,
+      waitListAccepted: 120,
+      waitListAdmitted: 10,
+      edOffered: false,
+      edApplicants: null,
+      edAdmitted: null,
+      yieldRate: null,
+      firstGenFactor: null,
+      demonstratedInterestFactor: null,
+      appFeeAmount: null,
+      appFeeWaiverOffered: null,
+    });
+
+    expect(result.waitListHasCounts).toBe(true);
+    expect(result.waitListCountsAnomalous).toBe(true);
+    expect(result.waitListOfferRate).toBeNull();
+    expect(result.waitListOptInRate).toBeNull();
+    expect(result.waitListConditionalAdmitRate).toBeNull();
     expect(result.hasRenderableContent).toBe(true);
   });
 

--- a/web/src/lib/admission-strategy.ts
+++ b/web/src/lib/admission-strategy.ts
@@ -43,6 +43,8 @@ export type AdmissionStrategySchool = {
 };
 
 export type AdmissionStrategyDerived = {
+  hasEdFlow: boolean;
+  hasSingleApplicantFlow: boolean;
   edAdmitRate: number | null;
   nonEarlyResidualAdmitRate: number | null;
   edShareOfAdmitted: number | null;
@@ -54,7 +56,12 @@ export type AdmissionStrategyDerived = {
   nonEarlyAdmitted: number | null;
   nonEarlyYield: number | null;
   waitListOfferRate: number | null;
+  waitListOptInRate: number | null;
   waitListConditionalAdmitRate: number | null;
+  waitListHasCounts: boolean;
+  waitListHasAnyCount: boolean;
+  waitListCountsAnomalous: boolean;
+  waitListCountsMissing: boolean;
   hasHighEdShare: boolean;
   hasRenderableContent: boolean;
 };
@@ -67,6 +74,10 @@ function safeRate(numerator: number | null, denominator: number | null): number 
   if (numerator == null || denominator == null || denominator <= 0) return null;
   if (numerator < 0) return null;
   return numerator / denominator;
+}
+
+function safeNonNegative(value: number | null): number | null {
+  return value == null || value < 0 ? null : value;
 }
 
 function important(value: string | null): boolean {
@@ -89,7 +100,8 @@ export function computeAdmissionStrategy(
         school.edAdmitted <= school.edApplicants)) &&
     school.edApplicants != null &&
     school.edApplicants > 0 &&
-    school.edAdmitted != null;
+    school.edAdmitted != null &&
+    school.edAdmitted <= school.edApplicants;
 
   const edAdmitRate = edCountsValid
     ? safeRate(school.edAdmitted, school.edApplicants)
@@ -112,11 +124,11 @@ export function computeAdmissionStrategy(
       : null;
   const nonEarlyApplicants =
     edCountsValid && school.applied != null
-      ? school.applied - school.edApplicants!
+      ? safeNonNegative(school.applied - school.edApplicants!)
       : null;
   const nonEarlyAdmitted =
     edCountsValid && school.admitted != null
-      ? school.admitted - school.edAdmitted!
+      ? safeNonNegative(school.admitted - school.edAdmitted!)
       : null;
   const estimatedEdEnrolled =
     edCountsValid && school.enrolledFirstYear != null
@@ -141,18 +153,34 @@ export function computeAdmissionStrategy(
       ? edAdmitRate / nonEarlyResidualAdmitRate
       : null;
 
-  const waitListValid =
-    school.quality !== "wait_list_math_inconsistent" &&
-    (school.waitListPolicy === true ||
-      (school.waitListOffered != null &&
-        school.waitListAccepted != null &&
-        school.waitListAdmitted != null &&
-        school.waitListAccepted <= school.waitListOffered &&
-        school.waitListAdmitted <= school.waitListAccepted));
-  const waitListOfferRate = waitListValid
+  const waitListHasAnyCount =
+    school.waitListOffered != null ||
+    school.waitListAccepted != null ||
+    school.waitListAdmitted != null;
+  const waitListHasCounts =
+    school.waitListOffered != null &&
+    school.waitListAccepted != null &&
+    school.waitListAdmitted != null;
+  const waitListCountsAnomalous =
+    school.quality === "wait_list_math_inconsistent" ||
+    (school.waitListOffered != null &&
+      school.waitListAccepted != null &&
+      school.waitListAccepted > school.waitListOffered) ||
+    (school.waitListAccepted != null &&
+      school.waitListAdmitted != null &&
+      school.waitListAdmitted > school.waitListAccepted);
+  const waitListCountsMissing =
+    school.waitListPolicy === true && !waitListHasCounts;
+  const waitListCanCompute =
+    (school.waitListPolicy === true || waitListHasCounts) &&
+    !waitListCountsAnomalous;
+  const waitListOfferRate = waitListCanCompute
     ? safeRate(school.waitListOffered, school.applied)
     : null;
-  const waitListConditionalAdmitRate = waitListValid
+  const waitListOptInRate = waitListCanCompute
+    ? safeRate(school.waitListAccepted, school.waitListOffered)
+    : null;
+  const waitListConditionalAdmitRate = waitListCanCompute
     ? safeRate(school.waitListAdmitted, school.waitListAccepted)
     : null;
 
@@ -166,15 +194,29 @@ export function computeAdmissionStrategy(
 
   const hasRenderableContent =
     !HIDDEN_DOCUMENT_FLAGS.has(school.dataQualityFlag ?? "") &&
-    school.quality !== "insufficient_data" &&
+      school.quality !== "insufficient_data" &&
     (edAdmitRate != null ||
       school.yieldRate != null ||
       waitListOfferRate != null ||
       waitListConditionalAdmitRate != null ||
+      waitListHasAnyCount ||
+      waitListCountsMissing ||
       hasFactorSignal ||
       school.eaOffered === true);
 
   return {
+    hasEdFlow:
+      edCountsValid &&
+      school.applied != null &&
+      school.admitted != null &&
+      school.enrolledFirstYear != null &&
+      nonEarlyApplicants != null &&
+      nonEarlyAdmitted != null,
+    hasSingleApplicantFlow:
+      !edCountsValid &&
+      school.applied != null &&
+      school.admitted != null &&
+      school.enrolledFirstYear != null,
     edAdmitRate,
     nonEarlyResidualAdmitRate,
     edShareOfAdmitted,
@@ -186,7 +228,12 @@ export function computeAdmissionStrategy(
     nonEarlyAdmitted,
     nonEarlyYield,
     waitListOfferRate,
+    waitListOptInRate,
     waitListConditionalAdmitRate,
+    waitListHasCounts,
+    waitListHasAnyCount,
+    waitListCountsAnomalous,
+    waitListCountsMissing,
     hasHighEdShare:
       edShareOfAdmitted != null && edShareOfAdmitted >= HIGH_ED_SHARE_THRESHOLD,
     hasRenderableContent,

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -53,6 +53,9 @@ export type BrowserAdmissionStrategyRow = AdmissionStrategySchool & {
   yearStart: number | null;
 };
 
+const ADMISSION_STRATEGY_SELECT =
+  "document_id, school_id, school_name, canonical_year, year_start, archive_url, data_quality_flag, applied, admitted, enrolled_first_year, acceptance_rate, yield_rate, ed_offered, ed_applicants, ed_admitted, ed_has_second_deadline, ea_offered, ea_restrictive, wait_list_policy, wait_list_offered, wait_list_accepted, wait_list_admitted, c711_first_gen_factor, c712_legacy_factor, c713_geography_factor, c714_state_residency_factor, c718_demonstrated_interest_factor, app_fee_amount, app_fee_waiver_offered, admission_strategy_card_quality";
+
 type DirectoryContextRow = {
   school_id: string | null;
   state: string | null;
@@ -74,6 +77,41 @@ type GpaContextRow = {
 
 function sha256Text(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function mapAdmissionStrategyRow(data: any): BrowserAdmissionStrategyRow {
+  return {
+    documentId: String(data.document_id),
+    schoolId: String(data.school_id),
+    schoolName: String(data.school_name),
+    cdsYear: String(data.canonical_year),
+    yearStart: numberOrNull(data.year_start),
+    archiveUrl: data.archive_url ?? null,
+    dataQualityFlag: data.data_quality_flag ?? null,
+    applied: numberOrNull(data.applied),
+    admitted: numberOrNull(data.admitted),
+    enrolledFirstYear: numberOrNull(data.enrolled_first_year),
+    acceptanceRate: normalizeRate(data.acceptance_rate),
+    yieldRate: normalizeRate(data.yield_rate),
+    edOffered: data.ed_offered ?? null,
+    edApplicants: numberOrNull(data.ed_applicants),
+    edAdmitted: numberOrNull(data.ed_admitted),
+    edHasSecondDeadline: data.ed_has_second_deadline ?? null,
+    eaOffered: data.ea_offered ?? null,
+    eaRestrictive: data.ea_restrictive ?? null,
+    waitListPolicy: data.wait_list_policy ?? null,
+    waitListOffered: numberOrNull(data.wait_list_offered),
+    waitListAccepted: numberOrNull(data.wait_list_accepted),
+    waitListAdmitted: numberOrNull(data.wait_list_admitted),
+    firstGenFactor: data.c711_first_gen_factor ?? null,
+    legacyFactor: data.c712_legacy_factor ?? null,
+    geographyFactor: data.c713_geography_factor ?? null,
+    stateResidencyFactor: data.c714_state_residency_factor ?? null,
+    demonstratedInterestFactor: data.c718_demonstrated_interest_factor ?? null,
+    appFeeAmount: numberOrNull(data.app_fee_amount),
+    appFeeWaiverOffered: data.app_fee_waiver_offered ?? null,
+    quality: (data.admission_strategy_card_quality ?? null) as AdmissionStrategyQuality | null,
+  };
 }
 
 function fallbackMatchesCanonical(
@@ -668,9 +706,7 @@ export const fetchAdmissionStrategyBySchoolId = cache(
     try {
       const { data, error } = await (supabase as unknown as UntypedSupabase)
         .from("school_browser_rows")
-        .select(
-          "document_id, school_id, school_name, canonical_year, year_start, archive_url, data_quality_flag, applied, admitted, enrolled_first_year, acceptance_rate, yield_rate, ed_offered, ed_applicants, ed_admitted, ed_has_second_deadline, ea_offered, ea_restrictive, wait_list_policy, wait_list_offered, wait_list_accepted, wait_list_admitted, c711_first_gen_factor, c712_legacy_factor, c713_geography_factor, c714_state_residency_factor, c718_demonstrated_interest_factor, app_fee_amount, app_fee_waiver_offered, admission_strategy_card_quality",
-        )
+        .select(ADMISSION_STRATEGY_SELECT)
         .eq("school_id", schoolId)
         .gte("year_start", 2024)
         .is("sub_institutional", null)
@@ -683,40 +719,33 @@ export const fetchAdmissionStrategyBySchoolId = cache(
         return null;
       }
 
-      return {
-        documentId: String(data.document_id),
-        schoolId: String(data.school_id),
-        schoolName: String(data.school_name),
-        cdsYear: String(data.canonical_year),
-        yearStart: numberOrNull(data.year_start),
-        archiveUrl: data.archive_url ?? null,
-        dataQualityFlag: data.data_quality_flag ?? null,
-        applied: numberOrNull(data.applied),
-        admitted: numberOrNull(data.admitted),
-        enrolledFirstYear: numberOrNull(data.enrolled_first_year),
-        acceptanceRate: normalizeRate(data.acceptance_rate),
-        yieldRate: normalizeRate(data.yield_rate),
-        edOffered: data.ed_offered ?? null,
-        edApplicants: numberOrNull(data.ed_applicants),
-        edAdmitted: numberOrNull(data.ed_admitted),
-        edHasSecondDeadline: data.ed_has_second_deadline ?? null,
-        eaOffered: data.ea_offered ?? null,
-        eaRestrictive: data.ea_restrictive ?? null,
-        waitListPolicy: data.wait_list_policy ?? null,
-        waitListOffered: numberOrNull(data.wait_list_offered),
-        waitListAccepted: numberOrNull(data.wait_list_accepted),
-        waitListAdmitted: numberOrNull(data.wait_list_admitted),
-        firstGenFactor: data.c711_first_gen_factor ?? null,
-        legacyFactor: data.c712_legacy_factor ?? null,
-        geographyFactor: data.c713_geography_factor ?? null,
-        stateResidencyFactor: data.c714_state_residency_factor ?? null,
-        demonstratedInterestFactor: data.c718_demonstrated_interest_factor ?? null,
-        appFeeAmount: numberOrNull(data.app_fee_amount),
-        appFeeWaiverOffered: data.app_fee_waiver_offered ?? null,
-        quality: (data.admission_strategy_card_quality ?? null) as AdmissionStrategyQuality | null,
-      };
+      return mapAdmissionStrategyRow(data);
     } catch (error) {
       console.warn(`fetchAdmissionStrategyBySchoolId: ${String(error)}`);
+      return null;
+    }
+  },
+);
+
+export const fetchAdmissionStrategyByDocumentId = cache(
+  async function fetchAdmissionStrategyByDocumentId(
+    documentId: string,
+  ): Promise<BrowserAdmissionStrategyRow | null> {
+    try {
+      const { data, error } = await (supabase as unknown as UntypedSupabase)
+        .from("school_browser_rows")
+        .select(ADMISSION_STRATEGY_SELECT)
+        .eq("document_id", documentId)
+        .maybeSingle();
+
+      if (error || !data) {
+        if (error) console.warn(`fetchAdmissionStrategyByDocumentId: ${error.message}`);
+        return null;
+      }
+
+      return mapAdmissionStrategyRow(data);
+    } catch (error) {
+      console.warn(`fetchAdmissionStrategyByDocumentId: ${String(error)}`);
       return null;
     }
   },


### PR DESCRIPTION
## Summary

- add PRD 023 for admission visualization upgrades
- replace the admission strategy card path table with a stage-normalized admission flow and exact data disclosure table
- add wait-list attrition states, archived-year admission cards, and schema-aware C.1 totals for archived KeyStats

## Verification

- `npm exec -- next build --webpack`
- `npm --prefix web run typecheck`
- `PLAYWRIGHT_BASE_URL=http://localhost:3011 npm --prefix web run test:smoke` (17 passed, 1 skipped)
- `git diff --check`

## Notes

- Local `npm --prefix web run test -- admission-strategy` is blocked by the macOS rolldown native binding code-signature failure in this workspace. The PR includes focused admission-strategy regression tests, and the production build/typecheck/smoke path is green.
- No root `VERSION` or `CHANGELOG.md` exists in this repo, so this ship does not include version/changelog bookkeeping.
