### PR TITLE
Fix compact CDS admissions extraction

### DIFF
--- a/tools/data_quality/audit_reclean_candidates.py
+++ b/tools/data_quality/audit_reclean_candidates.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Find Tier 4 artifacts that likely need a deterministic re-clean.
+
+This targets cleaner misses where the stored Docling markdown contains an
+answerable CDS subsection, but the canonical values and browser projection are
+missing the corresponding fields. It is intentionally conservative: it emits a
+worklist for re-clean/redrain, not a migration by itself.
+
+Usage:
+    python tools/data_quality/audit_reclean_candidates.py --env .env.local
+    python tools/data_quality/audit_reclean_candidates.py --school boston-university
+    python tools/data_quality/audit_reclean_candidates.py --output .context/reclean-candidates.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from supabase import create_client
+
+
+PUBLIC_SUPABASE_URL = "https://isduwmygvmdozhpvzaix.supabase.co"
+
+ED_FIELDS = ("C.2101", "C.2110", "C.2111", "C.2201")
+ADMISSION_POLICY_FIELDS = (
+    "C.1301",
+    "C.1302",
+    "C.1304",
+    "C.1305",
+    "C.1401",
+    "C.1402",
+    "C.1403",
+    "C.1501",
+    "C.1604",
+    "C.1605",
+    "C.1606",
+    "C.1701",
+    "C.1702",
+    "C.1703",
+    "C.1709",
+    "C.1710",
+    "C.1711",
+    "C.1801",
+    "C.1901",
+)
+
+
+@dataclass
+class Candidate:
+    category: str
+    confidence: str
+    reason: str
+    document_id: str
+    school_id: str
+    school_name: str
+    canonical_year: str
+    applied: int | None
+    producer_version: str
+    artifact_id: str
+    artifact_created_at: str
+    browser_ed_offered: bool | None
+    browser_ed_applicants: int | None
+    browser_ed_admitted: int | None
+    inferred_ed_offered: bool | None
+    inferred_ed_applicants: int | None
+    inferred_ed_admitted: int | None
+    missing_fields: list[str]
+    present_fields: list[str]
+
+
+def load_env(path: Path | None) -> None:
+    if not path or not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key.strip(), value)
+
+
+def make_client(env_path: Path | None) -> Any:
+    load_env(env_path)
+    url = (
+        os.environ.get("SUPABASE_URL")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+        or PUBLIC_SUPABASE_URL
+    )
+    key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("SUPABASE_ANON_KEY")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    )
+    if not key:
+        raise SystemExit(
+            "Missing SUPABASE_ANON_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY, or SUPABASE_SERVICE_ROLE_KEY"
+        )
+    return create_client(url, key)
+
+
+def fetch_all(query: Any, page_size: int = 1000) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        batch: list[dict[str, Any]] = []
+        for attempt in range(4):
+            try:
+                batch = query.range(offset, offset + page_size - 1).execute().data or []
+                break
+            except Exception:
+                if attempt == 3:
+                    raise
+                time.sleep(2**attempt)
+        rows.extend(batch)
+        if len(batch) < page_size:
+            return rows
+        offset += page_size
+
+
+def fetch_browser_rows(
+    client: Any,
+    *,
+    school: str | None,
+    min_year_start: int,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    select_cols = (
+        "document_id,school_id,school_name,canonical_year,year_start,producer,"
+        "applied,admitted,ed_offered,ed_applicants,ed_admitted,ed_has_second_deadline,"
+        "ea_offered,ea_restrictive"
+    )
+    query = (
+        client.table("school_browser_rows")
+        .select(select_cols)
+        .gte("year_start", min_year_start)
+        .is_("sub_institutional", "null")
+        .order("year_start", desc=True)
+        .order("school_id", desc=False)
+    )
+    if school:
+        query = query.eq("school_id", school)
+    rows = fetch_all(query)
+    rows = [row for row in rows if row.get("producer") == "tier4_docling"]
+    return rows[:limit] if limit else rows
+
+
+def latest_canonical_artifacts(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for row in sorted(rows, key=lambda item: str(item.get("created_at") or ""), reverse=True):
+        doc_id = str(row.get("document_id") or "")
+        if doc_id and doc_id not in latest:
+            latest[doc_id] = row
+    return latest
+
+
+def fetch_artifacts(client: Any, document_ids: list[str]) -> dict[str, dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    select_cols = "id,document_id,kind,producer,producer_version,schema_version,created_at,notes"
+    for start in range(0, len(document_ids), 25):
+        chunk = document_ids[start : start + 25]
+        for attempt in range(4):
+            try:
+                batch = (
+                    client.table("cds_artifacts")
+                    .select(select_cols)
+                    .eq("kind", "canonical")
+                    .eq("producer", "tier4_docling")
+                    .in_("document_id", chunk)
+                    .execute()
+                    .data
+                    or []
+                )
+                rows.extend(batch)
+                break
+            except Exception:
+                if attempt == 3:
+                    raise
+                time.sleep(2**attempt)
+    return latest_canonical_artifacts(rows)
+
+
+def int_or_none(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value).replace(",", ""))
+    except ValueError:
+        return None
+
+
+def field_value(record: Any) -> Any:
+    if isinstance(record, dict) and "value" in record:
+        return record["value"]
+    return record
+
+
+def normalized_values(notes: dict[str, Any]) -> dict[str, Any]:
+    raw = notes.get("values") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): field_value(value) for key, value in raw.items()}
+
+
+def section_between(text: str, start_re: str, end_re: str) -> str:
+    start = re.search(start_re, text, re.IGNORECASE)
+    if not start:
+        return ""
+    end = re.search(end_re, text[start.end() :], re.IGNORECASE)
+    end_idx = start.end() + end.start() if end else len(text)
+    return text[start.end() : end_idx]
+
+
+def nonempty_lines(text: str) -> list[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def leading_yes_no(section: str) -> bool | None:
+    lines = nonempty_lines(section)
+    for line in lines[:8]:
+        normalized = re.sub(r"\s+", "", line).lower()
+        if normalized == "yes":
+            return True
+        if normalized in {"no", "n/a", "na"}:
+            return False
+    return None
+
+
+def extract_count_pair(section: str) -> tuple[int, int] | None:
+    compact = re.sub(r"\s+", " ", section)
+    labeled_apps = re.search(
+        r"Number of early decision applications received.*?(\d[\d,]{2,})",
+        compact,
+        re.IGNORECASE,
+    )
+    labeled_admitted = re.search(
+        r"Number of applicants admitted under early decision plan.*?(\d[\d,]{2,})",
+        compact,
+        re.IGNORECASE,
+    )
+    if labeled_apps and labeled_admitted:
+        pair = int(labeled_apps.group(1).replace(",", "")), int(
+            labeled_admitted.group(1).replace(",", "")
+        )
+        return pair if pair[1] < pair[0] else None
+
+    before_details = re.split(
+        r"Please provide significant details|C22\.?\s+Early action",
+        section,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    values: list[int] = []
+    for match in re.finditer(r"\b\d{1,3}(?:,\d{3})+\b|\b\d{3,6}\b", before_details):
+        value = int(match.group(0).replace(",", ""))
+        if 1900 <= value <= 2099:
+            continue
+        if value < 100:
+            continue
+        values.append(value)
+    if len(values) >= 2:
+        pair = values[0], values[1]
+        return pair if pair[1] < pair[0] else None
+    return None
+
+
+def classify_ed(row: dict[str, Any], artifact: dict[str, Any], values: dict[str, Any]) -> Candidate | None:
+    notes = artifact.get("notes") or {}
+    markdown = str(notes.get("markdown") or "")
+    c21 = section_between(
+        markdown,
+        r"(?:^|\n)\s*(?:#+\s*)?C21\.?\s+Early Decision",
+        r"(?:^|\n)\s*(?:#+\s*)?C22\.?\s+Early action",
+    )
+    if not c21:
+        return None
+
+    inferred_offered = leading_yes_no(c21)
+    count_pair = extract_count_pair(c21)
+    browser_apps = int_or_none(row.get("ed_applicants"))
+    browser_admitted = int_or_none(row.get("ed_admitted"))
+    browser_offered = row.get("ed_offered") if isinstance(row.get("ed_offered"), bool) else None
+    artifact_apps = int_or_none(values.get("C.2110"))
+    artifact_admitted = int_or_none(values.get("C.2111"))
+
+    if (
+        inferred_offered is not True
+        or count_pair is None
+        or (browser_apps is not None and browser_admitted is not None)
+        or (artifact_apps is not None and artifact_admitted is not None)
+    ):
+        return None
+
+    missing = [
+        field
+        for field in ("C.2101", "C.2110", "C.2111")
+        if values.get(field) in (None, "")
+    ]
+    if browser_offered is not True:
+        missing.append("browser.ed_offered")
+    if browser_apps is None:
+        missing.append("browser.ed_applicants")
+    if browser_admitted is None:
+        missing.append("browser.ed_admitted")
+
+    return Candidate(
+        category="early_decision_counts",
+        confidence="high",
+        reason="C21 block has ED=Yes and a two-number applicant/admit pair, but canonical/browser ED counts are missing",
+        document_id=str(row["document_id"]),
+        school_id=str(row["school_id"]),
+        school_name=str(row.get("school_name") or ""),
+        canonical_year=str(row.get("canonical_year") or ""),
+        applied=int_or_none(row.get("applied")),
+        producer_version=str(artifact.get("producer_version") or ""),
+        artifact_id=str(artifact.get("id") or ""),
+        artifact_created_at=str(artifact.get("created_at") or ""),
+        browser_ed_offered=browser_offered,
+        browser_ed_applicants=browser_apps,
+        browser_ed_admitted=browser_admitted,
+        inferred_ed_offered=inferred_offered,
+        inferred_ed_applicants=count_pair[0],
+        inferred_ed_admitted=count_pair[1],
+        missing_fields=missing,
+        present_fields=sorted(field for field in ED_FIELDS if values.get(field) not in (None, "")),
+    )
+
+
+def classify_admission_policy(
+    row: dict[str, Any], artifact: dict[str, Any], values: dict[str, Any]
+) -> Candidate | None:
+    notes = artifact.get("notes") or {}
+    markdown = str(notes.get("markdown") or "")
+    compact_signature = all(
+        re.search(pattern, markdown, re.IGNORECASE)
+        for pattern in (
+            r"C13\.?\s+Application Fee",
+            r"C14\.?\s+Application closing date",
+            r"C15\.?\s+Are first-time",
+            r"C16\.?\s+Notification to applicants",
+            r"C17\.?\s+Reply policy",
+        )
+    )
+    if not compact_signature:
+        return None
+    present = sorted(field for field in ADMISSION_POLICY_FIELDS if values.get(field) not in (None, ""))
+    missing = [field for field in ADMISSION_POLICY_FIELDS if field not in present]
+    if len(missing) < 8:
+        return None
+
+    return Candidate(
+        category="compact_admission_policy_section",
+        confidence="medium",
+        reason="C13-C17 compact section headings are present in markdown, but many deterministic policy fields are absent",
+        document_id=str(row["document_id"]),
+        school_id=str(row["school_id"]),
+        school_name=str(row.get("school_name") or ""),
+        canonical_year=str(row.get("canonical_year") or ""),
+        applied=int_or_none(row.get("applied")),
+        producer_version=str(artifact.get("producer_version") or ""),
+        artifact_id=str(artifact.get("id") or ""),
+        artifact_created_at=str(artifact.get("created_at") or ""),
+        browser_ed_offered=row.get("ed_offered") if isinstance(row.get("ed_offered"), bool) else None,
+        browser_ed_applicants=int_or_none(row.get("ed_applicants")),
+        browser_ed_admitted=int_or_none(row.get("ed_admitted")),
+        inferred_ed_offered=None,
+        inferred_ed_applicants=None,
+        inferred_ed_admitted=None,
+        missing_fields=missing,
+        present_fields=present,
+    )
+
+
+def build_report(rows: list[dict[str, Any]], artifacts: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    candidates_by_key: dict[tuple[str, str], Candidate] = {}
+    for row in rows:
+        artifact = artifacts.get(str(row["document_id"]))
+        if not artifact:
+            continue
+        notes = artifact.get("notes") or {}
+        if not isinstance(notes, dict):
+            continue
+        values = normalized_values(notes)
+        for candidate in (
+            classify_ed(row, artifact, values),
+            classify_admission_policy(row, artifact, values),
+        ):
+            if candidate:
+                candidates_by_key[(candidate.document_id, candidate.category)] = candidate
+
+    candidates = list(candidates_by_key.values())
+    candidates.sort(
+        key=lambda item: (
+            {"high": 0, "medium": 1, "low": 2}.get(item.confidence, 9),
+            item.category,
+            -(item.applied or 0),
+            item.school_id,
+            item.canonical_year,
+        )
+    )
+    category_counts = Counter(candidate.category for candidate in candidates)
+    confidence_counts = Counter(candidate.confidence for candidate in candidates)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "school_browser_rows + latest canonical tier4_docling artifacts",
+        "rows_scanned": len(rows),
+        "artifacts_scanned": len(artifacts),
+        "candidate_count": len(candidates),
+        "category_counts": dict(sorted(category_counts.items())),
+        "confidence_counts": dict(sorted(confidence_counts.items())),
+        "candidates": [asdict(candidate) for candidate in candidates],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
+    parser.add_argument("--env", type=Path, default=Path(".env.local"))
+    parser.add_argument("--school", help="Restrict to one school_id")
+    parser.add_argument("--min-year-start", type=int, default=2024)
+    parser.add_argument("--limit", type=int, help="Limit browser rows before artifact fetch")
+    parser.add_argument("--output", type=Path, default=Path(".context/reclean-candidates.json"))
+    parser.add_argument("--json", action="store_true", help="Print full JSON report")
+    args = parser.parse_args()
+
+    client = make_client(args.env)
+    rows = fetch_browser_rows(
+        client,
+        school=args.school,
+        min_year_start=args.min_year_start,
+        limit=args.limit,
+    )
+    artifacts = fetch_artifacts(client, [str(row["document_id"]) for row in rows])
+    report = build_report(rows, artifacts)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    summary = {
+        key: report[key]
+        for key in (
+            "generated_at",
+            "rows_scanned",
+            "artifacts_scanned",
+            "candidate_count",
+            "category_counts",
+            "confidence_counts",
+        )
+    }
+    print(json.dumps(report if args.json else summary, indent=2, sort_keys=True))
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/extraction_worker/test_tier4_cleaner_c12.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c12.py
@@ -61,6 +61,21 @@ C12 Average high school GPA of all degree-seeking, first-time, first-year
         self.assertEqual(values["C.1201"]["value"], "3.27")
         self.assertEqual(values["C.1202"]["value"], "99")
 
+    def test_c12_handles_bu_split_layout_value_after_truncated_label(self):
+        supplemental = """
+C12. Average high school GPA of all degree-seeking, first-time, first-year students who submitted GPA
+
+Average high school GPA of all degree-seeking, first-time,             3.86
+Percent of total first-time, first-year students who submitted        100%
+
+C13. Application Fee
+"""
+
+        values = clean("", supplemental_text=supplemental)
+
+        self.assertEqual(values["C.1201"]["value"], "3.86")
+        self.assertEqual(values["C.1202"]["value"], "100")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_cleaner_c13_c19.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c13_c19.py
@@ -89,6 +89,85 @@ C20              Common Application: Question removed from CDS.
         self.assertEqual(values["C.1802"]["value"], "1 year")
         self.assertEqual(values["C.1901"]["value"], "No")
 
+    def test_c13_c19_bu_dotted_headings_and_inline_values(self):
+        supplemental = """
+C13. Application Fee
+
+Does your institution have an application fee?                         Ye s
+Amount of application fee:                                             $80
+Can it be waived for applicants with financial need?                   Yes
+Same fee                      X
+Free
+Reduced
+Can on-line application fee be waived for applicants with              Ye s
+
+C14. Application closing date
+
+Does your institution have an application closing date?               Yes
+Application closing date (fall)                                  January 5, for all
+                                                                   admissions
+Priority Date                                                    December 1, for
+                                                                   Presidential
+
+C15. Are first-time, first-year students accepted for terms other than the fall?
+
+Are first-time, first-year students accepted for terms other       Yes, in most
+than the fall?                                                      programs
+
+C16. Notification to applicants of admission decision sent (fill in one only)
+
+On a rolling basis beginning (date):
+By (date):                                       April 1
+Other:
+
+C17. Reply policy for admitted applicants (fill in one only)
+
+Must reply by (date):                            May 1
+No set date
+Must reply by May 1st or within
+Other:
+Deadline for housing deposit (MMDD):             May 1
+Amount of housing deposit:                       $650
+Refundable if student does not enroll?            No
+
+C18. Deferred admission
+
+Does your institution allow students to postpone enrollment after admission?       Yes
+If yes, maximum period of postponement: Deferred admission is allowed with a maximum postponement of one year (freshmen only).
+
+C19. Early admission of high school students
+                                                                                       No
+Does your institution allow high school students to enroll as full-time, first-time,
+
+C20. Common Application: Question removed from CDS.
+"""
+
+        values = clean("", supplemental_text=supplemental)
+
+        self.assertEqual(values["C.1301"]["value"], "Yes")
+        self.assertEqual(values["C.1302"]["value"], "80")
+        self.assertEqual(values["C.1303"]["value"], "Yes")
+        self.assertEqual(values["C.1304"]["value"], "X")
+        self.assertEqual(values["C.1305"]["value"], "Yes")
+        self.assertEqual(values["C.1401"]["value"], "Yes")
+        self.assertEqual(values["C.1402"]["value"], "1")
+        self.assertEqual(values["C.1403"]["value"], "5")
+        self.assertEqual(values["C.1404"]["value"], "12")
+        self.assertEqual(values["C.1405"]["value"], "1")
+        self.assertEqual(values["C.1501"]["value"], "Yes")
+        self.assertEqual(values["C.1604"]["value"], "X")
+        self.assertEqual(values["C.1605"]["value"], "4")
+        self.assertEqual(values["C.1606"]["value"], "1")
+        self.assertEqual(values["C.1701"]["value"], "X")
+        self.assertEqual(values["C.1702"]["value"], "5")
+        self.assertEqual(values["C.1703"]["value"], "1")
+        self.assertEqual(values["C.1709"]["value"], "5")
+        self.assertEqual(values["C.1710"]["value"], "1")
+        self.assertEqual(values["C.1711"]["value"], "650")
+        self.assertEqual(values["C.1801"]["value"], "Yes")
+        self.assertEqual(values["C.1802"]["value"], "Deferred admission is allowed with a maximum postponement of one year (freshmen only).")
+        self.assertEqual(values["C.1901"]["value"], "No")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_cleaner_c21_c22.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c21_c22.py
@@ -196,6 +196,49 @@ Yes
         self.assertEqual(values["C.2110"]["value"], "124")
         self.assertEqual(values["C.2111"]["value"], "77")
 
+    def test_c21_2025_26_dotted_heading_value_only_counts(self):
+        markdown = """
+## C21. Early Decision
+
+Yes
+
+November 1
+
+December 15
+
+January 5
+
+February 15
+
+## For the Fall 2025 entering class:
+
+6,907
+
+2,165
+
+Please provide significant details about your early decision plan:
+
+Only available for high school seniors applying for September admission.
+
+If admitted, students must send in the required enrollment deposit by January 9 for Early Decision and by February 15 for Early Decision 2.
+
+## C22. Early action
+
+No
+
+If 'yes,' please complete the following: Do you have a nonbinding early action plan whereby
+"""
+
+        values = clean(
+            markdown,
+            schema=SchemaIndex(Path("schemas/cds_schema_2025_26.json")),
+        )
+
+        self.assertEqual(values["C.2101"]["value"], "Yes")
+        self.assertEqual(values["C.2110"]["value"], "6907")
+        self.assertEqual(values["C.2111"]["value"], "2165")
+        self.assertEqual(values["C.2201"]["value"], "No")
+
     def test_c21_docling_vertical_yes_no_checkmark_means_no(self):
         markdown = """
 ## C21 Early Decision

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -3075,6 +3075,10 @@ def _split_month_day(value: str) -> tuple[str, str] | None:
         month = _MONTHS.get(match.group(1).lower())
         if month:
             return month, match.group(2)
+    if match := re.fullmatch(r"([A-Za-z]{3,9})\s+(\d{1,2})(?:,.*)?", value):
+        month = _month_number(match.group(1))
+        if month:
+            return month, match.group(2)
     return None
 
 
@@ -3100,11 +3104,26 @@ def _extract_number_after_label(text: str, label_re: str) -> str | None:
 def _extract_date_after_label(text: str, label_re: str) -> str | None:
     compact = _compact_block_text(text)
     match = re.search(
-        rf"{label_re}\s*:?\s*((?:\d{{1,2}}/[0-9]{{1,2}})|(?:\d{{1,2}}-[A-Za-z]{{3,4}})|(?:[A-Za-z]{{3,4}}-\d{{1,2}}))",
+        rf"{label_re}\s*:?\s*((?:\d{{1,2}}/[0-9]{{1,2}})|(?:\d{{1,2}}-[A-Za-z]{{3,4}})|(?:[A-Za-z]{{3,9}}-\d{{1,2}})|(?:[A-Za-z]{{3,9}}\s+\d{{1,2}}(?:,\s*[^|]+)?))",
         compact,
         re.IGNORECASE,
     )
     return match.group(1) if match else None
+
+
+def _extract_inline_yes_no_after_label(text: str, label_re: str) -> str | None:
+    compact = _compact_block_text(text)
+    compact = re.sub(r"\bY\s*e\s*s\b", "Yes", compact, flags=re.IGNORECASE)
+    compact = re.sub(r"\bN\s*o\b", "No", compact, flags=re.IGNORECASE)
+    match = re.search(
+        rf"{label_re}\s*:?\s*(Yes|No|N/A|NA)\b",
+        compact,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    value = match.group(1).lower()
+    return "No" if value in ("n/a", "na") else value.capitalize()
 
 
 def _month_number(value: str) -> str | None:
@@ -3132,6 +3151,25 @@ def _extract_c21_layout_date_pairs(text: str) -> list[tuple[str, str]]:
         if len(dates) >= 2:
             pairs.append((dates[0], dates[1]))
     return pairs
+
+
+def _extract_c21_layout_month_day_values(text: str) -> list[tuple[str, str]]:
+    values: list[tuple[str, str]] = []
+    date_block = re.split(
+        r"For the Fall|Number of early decision|Please provide",
+        text,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    for line in date_block.splitlines():
+        match = re.fullmatch(r"\s*([A-Za-z]{3,9})\s+(\d{1,2})\s*", line)
+        if not match:
+            continue
+        month = _month_number(match.group(1))
+        day = match.group(2)
+        if month:
+            values.append((month, day))
+    return values
 
 
 def _extract_c21_layout_count_pair(text: str) -> tuple[str, str] | None:
@@ -3706,6 +3744,18 @@ def resolve_c12_gpa_summary(
         out["C.1201"] = {"value": match.group(1), "source": "tier4_cleaner"}
     elif match := re.search(r"\b([0-4]\.\d{1,2})\s*Average high school GPA", c12, re.IGNORECASE):
         out["C.1201"] = {"value": match.group(1), "source": "tier4_cleaner"}
+    elif match := re.search(
+        r"^.*Average high school GPA.*?\b([0-4](?:\.\d{1,2})?)\s*$",
+        c12,
+        re.IGNORECASE | re.MULTILINE,
+    ):
+        out["C.1201"] = {"value": match.group(1), "source": "tier4_cleaner"}
+    elif match := re.search(
+        r"Average high school GPA of all degree-seeking,\s*first-time,\s*first-year students who submitted(?: high school)?(?: GPA)?\s*:?\s*([0-4](?:\.\d{1,2})?)\b",
+        _compact_block_text(c12),
+        re.IGNORECASE,
+    ):
+        out["C.1201"] = {"value": match.group(1), "source": "tier4_cleaner"}
 
     pct_anchor = re.search(
         r"Percent of total first-time,\s*first-year students who submitted high",
@@ -3715,6 +3765,13 @@ def resolve_c12_gpa_summary(
     if pct_anchor:
         window = c12[pct_anchor.end(): pct_anchor.end() + 250]
         if match := re.search(r"\b(\d+(?:\.\d+)?)\s*%", window):
+            out["C.1202"] = {"value": match.group(1), "source": "tier4_cleaner"}
+    if "C.1202" not in out:
+        if match := re.search(
+            r"Percent of total first-time,\s*first-year students who submitted(?: high school)?(?: GPA)?\s*:?\s*(\d+(?:\.\d+)?)\s*%",
+            _compact_block_text(c12),
+            re.IGNORECASE,
+        ):
             out["C.1202"] = {"value": match.group(1), "source": "tier4_cleaner"}
 
     return out
@@ -3726,7 +3783,7 @@ def resolve_c13_application_fee(
     tables: list[dict], markdown: str, schema: SchemaIndex
 ) -> dict[str, dict]:
     out: dict[str, dict] = {}
-    c13 = _section_between(markdown, r"C13\s+Application Fee", r"C14\b")
+    c13 = _section_between(markdown, r"C13\.?\s+Application Fee", r"C14\.?\b")
     if not c13:
         c13 = ""
     else:
@@ -3734,8 +3791,25 @@ def resolve_c13_application_fee(
             c13,
             r"Does your institution have an application fee\?",
         )
+        if not value:
+            value = _extract_inline_yes_no_after_label(
+                c13,
+                r"Does your institution have an application fee\?",
+            )
         if value:
             out["C.1301"] = {"value": value, "source": "tier4_cleaner"}
+        if match := re.search(
+            r"Amount of application fee:\s*\$?\s*(\d[\d,]*)",
+            _compact_block_text(c13),
+            re.IGNORECASE,
+        ):
+            out["C.1302"] = {"value": match.group(1).replace(",", ""), "source": "tier4_cleaner"}
+        value = _extract_inline_yes_no_after_label(
+            c13,
+            r"Can it be waived for applicants with financial need\?",
+        )
+        if value:
+            out["C.1303"] = {"value": value, "source": "tier4_cleaner"}
 
     # C13 continues across the page break in Farmingdale. The first
     # continuation row loses its Yes/No header in layout text; the visual x is
@@ -3746,42 +3820,64 @@ def resolve_c13_application_fee(
 
     if re.search(r"(?:^|\n)\s*(?:-\s*\[\s*\]\s*)?x\s+Same fee\b", markdown, re.IGNORECASE):
         out["C.1304"] = {"value": "X", "source": "tier4_cleaner"}
+    if re.search(r"\bSame fee\b\s*(?:\|\s*)?[xX]\b", c13, re.IGNORECASE):
+        out["C.1304"] = {"value": "X", "source": "tier4_cleaner"}
 
     c1305 = _extract_yes_no_by_layout(
         markdown,
         r"Can on-line application fee be waived for applicants",
     )
+    if not c1305:
+        c1305 = _extract_inline_yes_no_after_label(
+            c13,
+            r"Can on-line application fee be waived for applicants(?: with(?: financial need)?)?",
+        )
     if c1305:
         out["C.1305"] = {"value": c1305, "source": "tier4_cleaner"}
 
+    c14 = _section_between(markdown, r"C14\.?\s+Application closing date", r"C15\.?\b")
     c1401 = _extract_yes_no_by_layout(
-        markdown,
+        c14 or markdown,
         r"Does your institution have an application closing date\?",
     )
+    if not c1401:
+        c1401 = _extract_inline_yes_no_after_label(
+            c14 or markdown,
+            r"Does your institution have an application closing date\?",
+        )
     if c1401:
         out["C.1401"] = {"value": c1401, "source": "tier4_cleaner"}
-    if match := re.search(r"Application closing date \(fall\)\s+(\d{1,2}/\d{1,2})", markdown, re.IGNORECASE):
-        month_day = _split_month_day(match.group(1))
+    closing = _extract_date_after_label(c14 or markdown, r"Application closing date \(fall\)")
+    if closing:
+        month_day = _split_month_day(closing)
         if month_day:
             out["C.1402"] = {"value": month_day[0], "source": "tier4_cleaner"}
             out["C.1403"] = {"value": month_day[1], "source": "tier4_cleaner"}
-    if match := re.search(r"Priority Date\s+(\d{1,2}/\d{1,2})", markdown, re.IGNORECASE):
-        month_day = _split_month_day(match.group(1))
+    priority = _extract_date_after_label(c14 or markdown, r"Priority Date")
+    if priority:
+        month_day = _split_month_day(priority)
         if month_day:
             out["C.1404"] = {"value": month_day[0], "source": "tier4_cleaner"}
             out["C.1405"] = {"value": month_day[1], "source": "tier4_cleaner"}
 
-    c15 = _section_between(markdown, r"C15\b", r"C16\b")
+    c15 = _section_between(markdown, r"C15\.?\b", r"C16\.?\b")
     c1501 = _extract_yes_no_by_layout(
         c15,
         r"Are first-time,\s*first-year students accepted for terms other than",
     )
     if not c1501 and re.search(r"\bx\s*Are first-time,\s*first-year students accepted for terms other than", c15, re.IGNORECASE):
         c1501 = "Yes"
+    if not c1501:
+        c1501 = _extract_inline_yes_no_after_label(
+            c15,
+            r"Are first-time,\s*first-year students accepted for terms other than the fall\?",
+        )
+    if not c1501 and re.search(r"\bYes\b", c15, re.IGNORECASE):
+        c1501 = "Yes"
     if c1501:
         out["C.1501"] = {"value": c1501, "source": "tier4_cleaner"}
 
-    c16 = _section_between(markdown, r"C16\b", r"C17\b")
+    c16 = _section_between(markdown, r"C16\.?\b", r"C17\.?\b")
     if re.search(r"(?:^|\n)\s*(?:-\s*\[\s*\]\s*)?x\s+On a rolling basis beginning\b", c16, re.IGNORECASE):
         out["C.1601"] = {"value": "X", "source": "tier4_cleaner"}
         if match := re.search(r"On a rolling basis beginning\s+(\d{1,2}-[A-Za-z]{3,4}|[A-Za-z]{3,4}-\d{1,2})", c16, re.IGNORECASE):
@@ -3789,18 +3885,40 @@ def resolve_c13_application_fee(
             if month_day:
                 out["C.1602"] = {"value": month_day[0], "source": "tier4_cleaner"}
                 out["C.1603"] = {"value": month_day[1], "source": "tier4_cleaner"}
+    by_date = _extract_date_after_label(c16, r"By \(date\)")
+    if by_date:
+        month_day = _split_month_day(by_date)
+        if month_day:
+            out["C.1604"] = {"value": "X", "source": "tier4_cleaner"}
+            out["C.1605"] = {"value": month_day[0], "source": "tier4_cleaner"}
+            out["C.1606"] = {"value": month_day[1], "source": "tier4_cleaner"}
 
-    c17 = _section_between(markdown, r"C17\b", r"C18\b")
+    c17 = _section_between(markdown, r"C17\.?\b", r"C18\.?\b")
+    reply_by = _extract_date_after_label(c17, r"Must reply by \(date\)")
+    if reply_by:
+        month_day = _split_month_day(reply_by)
+        if month_day:
+            out["C.1701"] = {"value": "X", "source": "tier4_cleaner"}
+            out["C.1702"] = {"value": month_day[0], "source": "tier4_cleaner"}
+            out["C.1703"] = {"value": month_day[1], "source": "tier4_cleaner"}
     if re.search(r"(?:^|\n)\s*(?:-\s*\[\s*\]\s*)?x\s+Must reply by May 1st or within\b", c17, re.IGNORECASE):
         if match := re.search(r"Must reply by May 1st or within\s+(\d+)\s+weeks", c17, re.IGNORECASE | re.DOTALL):
             out["C.1705"] = {"value": match.group(1), "source": "tier4_cleaner"}
-    if match := re.search(r"Deadline for housing deposit \(MMD\w*\s+(\d{1,2}-[A-Za-z]{3,4}|[A-Za-z]{3,4}-\d{1,2})", c17, re.IGNORECASE):
-        month_day = _split_month_day(match.group(1))
+    housing_deadline = _extract_date_after_label(c17, r"Deadline for housing deposit \(MMD\w*\)")
+    if not housing_deadline:
+        match = re.search(
+            r"Deadline for housing deposit \(MMD\w*\s+(\d{1,2}-[A-Za-z]{3,9}|[A-Za-z]{3,9}-\d{1,2}|[A-Za-z]{3,9}\s+\d{1,2}|\d{1,2}/\d{1,2})",
+            c17,
+            re.IGNORECASE,
+        )
+        housing_deadline = match.group(1) if match else None
+    if housing_deadline:
+        month_day = _split_month_day(housing_deadline)
         if month_day:
             out["C.1709"] = {"value": month_day[0], "source": "tier4_cleaner"}
             out["C.1710"] = {"value": month_day[1], "source": "tier4_cleaner"}
     if match := re.search(
-        r"Amount of housing deposit:\s+(?:(?:\d{1,2}-[A-Za-z]{3,4}|[A-Za-z]{3,4}-\d{1,2})\s+)?(\d+)",
+        r"Amount of housing deposit:\s+(?:(?:\d{1,2}-[A-Za-z]{3,9}|[A-Za-z]{3,9}-\d{1,2}|[A-Za-z]{3,9}\s+\d{1,2})\s+)?\$?\s*(\d+)",
         c17,
         re.IGNORECASE,
     ):
@@ -3808,11 +3926,16 @@ def resolve_c13_application_fee(
     if re.search(r"(?:^|\n)\s*(?:-\s*\[\s*\]\s*)?x\s+Yes,\s*in full\b", c17, re.IGNORECASE):
         out["C.1712"] = {"value": "X", "source": "tier4_cleaner"}
 
-    c18 = _section_between(markdown, r"C18\b", r"C19\b")
+    c18 = _section_between(markdown, r"C18\.?\b", r"C19\.?\b")
     c1801 = _extract_yes_no_by_layout(
         c18,
         r"Does your institution allow students to postpone enrollment after",
     )
+    if not c1801:
+        c1801 = _extract_inline_yes_no_after_label(
+            c18,
+            r"Does your institution allow students to postpone enrollment after admission\?",
+        )
     if c1801:
         out["C.1801"] = {"value": c1801, "source": "tier4_cleaner"}
     if match := re.search(r"maximum period of postponement:\s+(.+?)\s*(?:\n|$)", c18, re.IGNORECASE):
@@ -3820,16 +3943,18 @@ def resolve_c13_application_fee(
         if text:
             out["C.1802"] = {"value": text, "source": "tier4_cleaner"}
 
-    c19 = _section_between(markdown, r"C19\b", r"C20\b")
+    c19 = _section_between(markdown, r"C19\.?\b", r"C20\.?\b")
     c1901 = _extract_yes_no_by_layout(
         c19,
         r"one year or more before high school",
     )
+    if not c1901:
+        c1901 = _extract_leading_yes_no(c19)
     if c1901:
         out["C.1901"] = {"value": c1901, "source": "tier4_cleaner"}
 
-    c21_start_re = r"(?:^|\n)\s*(?:[-*]\s*)?(?:##\s*)?C21\s+Early Decision"
-    c22_start_re = r"(?:^|\n)\s*(?:[-*]\s*)?(?:##\s*)?C22\s+Early action"
+    c21_start_re = r"(?:^|\n)\s*(?:[-*]\s*)?(?:##\s*)?C21\.?\s+Early Decision"
+    c22_start_re = r"(?:^|\n)\s*(?:[-*]\s*)?(?:##\s*)?C22\.?\s+Early action"
 
     c2101 = _extract_yes_no_block_by_layout(markdown, c21_start_re, c22_start_re)
     if c2101:
@@ -3894,6 +4019,15 @@ def resolve_c13_application_fee(
         else:
             layout_date_pairs = _extract_c21_layout_date_pairs(c21)
             layout_other_pair = layout_date_pairs[1] if len(layout_date_pairs) > 1 else None
+            layout_month_day_values = _extract_c21_layout_month_day_values(c21)
+            layout_month_day_by_qn = {
+                "C.2106": layout_month_day_values[2]
+                if len(layout_month_day_values) > 2
+                else None,
+                "C.2108": layout_month_day_values[3]
+                if len(layout_month_day_values) > 3
+                else None,
+            }
             for label, month_qn, day_qn in [
                 (
                     r"Other early decision plan closing date",
@@ -3922,6 +4056,8 @@ def resolve_c13_application_fee(
                     month_day = (month, day) if month and day else None
                 if not month_day and layout_other_pair and month_qn == "C.2106":
                     month_day = _split_month_day(layout_other_pair[0])
+                if not month_day and layout_month_day_by_qn[month_qn]:
+                    month_day = layout_month_day_by_qn[month_qn]
                 if month_day:
                     out[month_qn] = {"value": month_day[0], "source": "tier4_cleaner"}
                     out[day_qn] = {"value": month_day[1], "source": "tier4_cleaner"}
@@ -3939,6 +4075,17 @@ def resolve_c13_application_fee(
     c22_prompt_answers = _extract_yes_or_no_prompt_answers(c22) if c22 else []
     if not c2201 and c22_prompt_answers:
         c2201 = c22_prompt_answers[0]
+    if not c2201 and c22:
+        c22_lines = _nonempty_lines(c22)
+        if (
+            c22_lines
+            and c22_lines[0].strip().lower() in ("yes", "no", "n/a", "na")
+            and not (
+                len(c22_lines) > 1
+                and c22_lines[1].strip().lower() in ("yes", "no", "n/a", "na")
+            )
+        ):
+            c2201 = _extract_leading_yes_no(c22)
     if c2201:
         out["C.2201"] = {"value": c2201, "source": "tier4_cleaner"}
 


### PR DESCRIPTION
## Summary
- Fix Tier 4 cleaner anchors for dotted CDS headings like `C21. Early Decision`.
- Recover BU-style compact/value-only C12-C22 admissions fields, including ED counts and C13-C19 policy fields.
- Add a data-quality scanner for re-clean candidates across canonical Tier 4 artifacts.

## Verification
- `PYTHONPATH=tools/extraction_worker python3 -m unittest discover -s tools/extraction_worker -p 'test_tier4_cleaner*.py'`
- `python3 -m py_compile tools/data_quality/audit_reclean_candidates.py`

## Data QA
- BU 2025-26 local re-clean adds 31 fields with 0 changed and 0 removed.
- Corpus scanner found 1 high-confidence ED miss and 227 medium-confidence compact admission-policy re-clean candidates.