### PR TITLE
Bump Tier 4 producer for admissions re-clean

### DIFF
--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.10"
+PRODUCER_VERSION = "0.3.11"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35


### PR DESCRIPTION
## Summary
- Bump `tier4_docling` producer version to `0.3.11` so the admissions cleaner fix writes fresh canonical artifacts during the targeted redrain.

## Verification
- `PYTHONPATH=tools/extraction_worker python3 -m unittest discover -s tools/extraction_worker -p 'test_tier4_cleaner*.py'`