### PR TITLE
Flag anomalous wait-list rates

### DIFF
--- a/docs/recipes/waitlist-odds.md
+++ b/docs/recipes/waitlist-odds.md
@@ -26,14 +26,16 @@ wait-list success rate = wait-listed students admitted / students accepting a wa
 
 That is the applicant-facing number. "Admitted divided by offered a spot" is also useful for understanding how much a school over-offers the list, but students usually make the decision after they have already accepted a spot.
 
+High-volume rows that report near-total wait-list admission are treated as data-quality caveats rather than odds estimates. Rows with at least 100 students accepting a wait-list spot and a reported success rate of at least 95% are preserved in the recipe but excluded from medians, bucket summaries, and the main chart. Some of these values appear verbatim in school PDFs; at least one inspected PDF leaves the accepted-count row blank and was over-filled by Tier 4 extraction. Exact duplicate school-year rows are collapsed before analysis, and the extremes table shows at most one row per school.
+
 ## What it shows
 
-The current generated dataset contains 191 complete school-year rows across 148 schools, plus 61 partial rows where the CDS projection reports only some wait-list values. Across complete rows:
+The current generated dataset contains 191 complete school-year rows across 148 schools, plus 61 partial rows where the CDS projection reports only some wait-list values. After collapsing duplicate school-year rows, six high-volume near-total rows are flagged as reported anomalies, leaving 180 school-year rows across 144 schools in the rate analysis. Across those analysis rows:
 
-- median success rate among accepted wait-list spots: 13.39%
-- weighted success rate: 23.32%
-- median "admitted / offered a spot" rate: 5.56%
-- rows under 2% success: 24
+- median success rate among accepted wait-list spots: 13.16%
+- weighted success rate: 21.51%
+- median "admitted / offered a spot" rate: 5.51%
+- rows under 2% success: 23
 
 The median is not the lesson by itself. The split matters:
 
@@ -67,8 +69,9 @@ wait_list_offered >= wait_list_accepted >= wait_list_admitted >= 0
 
 1. **This is CDS-reported, not counselor-rumor-reported.** When schools publish conflicting press figures or later updates, this recipe follows the Common Data Set projection.
 2. **Partial C2 rows are not rate rows.** Some PDFs expose offered and accepted counts but not admitted counts in the current projection. Those rows remain visible as caveats but do not enter medians.
-3. **One-year wait-list rates are volatile.** A school can admit hundreds one year and almost none the next. The chart is best read by bucket and by multi-year pattern, not as a guarantee for a single future class.
-4. **The accepted-wait-list denominator is applicant behavior.** Schools control how many spots they offer; students control whether they accept one. Both denominators are shown because they answer different questions.
+3. **Near-total high-volume admits are suspicious.** A school may publish them that way, but rows like IU Bloomington and UC Irvine can dominate the right edge of the chart while saying more about reporting quality than applicant odds.
+4. **One-year wait-list rates are volatile.** A school can admit hundreds one year and almost none the next. The chart is best read by bucket and by multi-year pattern, not as a guarantee for a single future class.
+5. **The accepted-wait-list denominator is applicant behavior.** Schools control how many spots they offer; students control whether they accept one. Both denominators are shown because they answer different questions.
 
 ## What else to try
 

--- a/web/src/app/recipes/waitlist-odds/page.tsx
+++ b/web/src/app/recipes/waitlist-odds/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { WaitlistOddsExplorer } from "@/components/WaitlistOddsExplorer";
-import { WAITLIST_RECIPE_SUMMARY } from "@/lib/waitlist-recipe-data";
+import { WAITLIST_ANALYSIS_SUMMARY } from "@/lib/waitlist-recipe-analysis";
 
 const WSJ_URL =
   "https://www.wsj.com/us-news/education/college-waitlists-national-decision-day-4cb7b5d8";
@@ -71,7 +71,8 @@ export default function WaitlistOddsPage() {
             </a>{" "}
             on ballooning college wait lists, this recipe ignores anecdotes and
             looks across every complete C2 wait-list row currently visible in
-            the collegedata.fyi CDS corpus.
+            the collegedata.fyi CDS corpus, with high-volume near-total admit
+            rows treated as data-quality caveats.
           </p>
         </div>
         <div
@@ -117,13 +118,14 @@ export default function WaitlistOddsPage() {
             className="serif nums"
             style={{ fontSize: 40, lineHeight: 1, marginTop: 8 }}
           >
-            {WAITLIST_RECIPE_SUMMARY.latestCompleteSchools}
+            {WAITLIST_ANALYSIS_SUMMARY.latestCompleteSchools}
           </div>
           <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "8px 0 0" }}>
-            schools with complete wait-list counts, across{" "}
-            {WAITLIST_RECIPE_SUMMARY.completeRows} complete school-year rows.
-            Another {WAITLIST_RECIPE_SUMMARY.partialRows} rows report only part
-            of C2 and are shown as caveats.
+            schools in the rate analysis, across{" "}
+            {WAITLIST_ANALYSIS_SUMMARY.analysisRows} school-year rows. Another{" "}
+            {WAITLIST_ANALYSIS_SUMMARY.partialRows} rows report only part of C2,
+            and {WAITLIST_ANALYSIS_SUMMARY.reportedAnomalyRows} high-volume
+            near-total admit rows are shown as caveats.
           </p>
         </div>
       </section>

--- a/web/src/components/WaitlistOddsExplorer.tsx
+++ b/web/src/components/WaitlistOddsExplorer.tsx
@@ -3,17 +3,19 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import {
-  WAITLIST_BUCKETS,
   WAITLIST_CASES,
-  WAITLIST_RECIPE_SUMMARY,
-  WAITLIST_ROWS,
   type WaitlistBucketSummary,
   type WaitlistRecipeRow,
 } from "@/lib/waitlist-recipe-data";
+import {
+  WAITLIST_ANALYSIS_ROWS,
+  WAITLIST_ANALYSIS_SUMMARY,
+  WAITLIST_REPORTED_ANOMALY_ROWS,
+  type WaitlistBucketKey,
+  summarizeWaitlistBuckets,
+} from "@/lib/waitlist-recipe-analysis";
 
-type BucketKey = "selectivity" | "control" | "size" | "carnegie";
-
-const BUCKET_LABELS: Record<BucketKey, string> = {
+const BUCKET_LABELS: Record<WaitlistBucketKey, string> = {
   selectivity: "Admit-rate band",
   control: "Control",
   size: "Undergrad size",
@@ -72,12 +74,13 @@ function rowMedian(summary: WaitlistBucketSummary): number {
 function Chart({
   bucketKey,
   rows,
+  summaries,
 }: {
-  bucketKey: BucketKey;
+  bucketKey: WaitlistBucketKey;
   rows: readonly WaitlistRecipeRow[];
+  summaries: readonly WaitlistBucketSummary[];
 }) {
   const [hover, setHover] = useState<WaitlistRecipeRow | null>(null);
-  const summaries = WAITLIST_BUCKETS[bucketKey];
   const bucketIndex = new Map<string, number>(summaries.map((bucket, index) => [bucket.label, index]));
   const rowH = (H - M.t - M.b) / summaries.length;
   const yCenter = (index: number) => M.t + rowH * index + rowH / 2;
@@ -251,7 +254,9 @@ function Chart({
         <span><span style={{ color: "var(--brick)" }}>■</span> under 2%</span>
         <span><span style={{ color: "var(--ochre)" }}>■</span> 2-10%</span>
         <span><span style={{ color: "var(--forest)" }}>■</span> 10%+</span>
-        <span style={{ marginLeft: "auto" }}>Vertical forest ticks mark each bucket median.</span>
+        <span style={{ marginLeft: "auto" }}>
+          Vertical forest ticks mark each bucket median; reported anomalous rows are excluded.
+        </span>
       </div>
 
       {hover && (
@@ -292,7 +297,11 @@ function Chart({
   );
 }
 
-function BucketTable({ bucketKey }: { bucketKey: BucketKey }) {
+function BucketTable({
+  summaries,
+}: {
+  summaries: readonly WaitlistBucketSummary[];
+}) {
   return (
     <div className="cd-card" style={{ overflowX: "auto" }}>
       <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
@@ -319,7 +328,7 @@ function BucketTable({ bucketKey }: { bucketKey: BucketKey }) {
           </tr>
         </thead>
         <tbody>
-          {WAITLIST_BUCKETS[bucketKey].map((bucket) => (
+          {summaries.map((bucket) => (
             <tr key={bucket.label}>
               <td style={{ padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
                 {bucket.label}
@@ -396,23 +405,56 @@ function CaseStudy({ row }: { row: WaitlistRecipeRow }) {
   );
 }
 
+function oneExtremeRowPerSchool(
+  rows: readonly WaitlistRecipeRow[],
+  tableMode: "lowest" | "largest",
+): WaitlistRecipeRow[] {
+  const bySchool = new Map<string, WaitlistRecipeRow>();
+  for (const row of rows) {
+    const existing = bySchool.get(row.schoolId);
+    if (!existing) {
+      bySchool.set(row.schoolId, row);
+      continue;
+    }
+
+    if (tableMode === "largest") {
+      const existingAccepted = existing.waitListAccepted ?? 0;
+      const rowAccepted = row.waitListAccepted ?? 0;
+      if (
+        rowAccepted > existingAccepted ||
+        (rowAccepted === existingAccepted && row.yearStart > existing.yearStart)
+      ) {
+        bySchool.set(row.schoolId, row);
+      }
+      continue;
+    }
+
+    const existingRate = existing.waitListSuccessRate ?? Number.POSITIVE_INFINITY;
+    const rowRate = row.waitListSuccessRate ?? Number.POSITIVE_INFINITY;
+    if (rowRate < existingRate || (rowRate === existingRate && row.yearStart > existing.yearStart)) {
+      bySchool.set(row.schoolId, row);
+    }
+  }
+  return [...bySchool.values()];
+}
+
 export function WaitlistOddsExplorer() {
-  const [bucketKey, setBucketKey] = useState<BucketKey>("selectivity");
+  const [bucketKey, setBucketKey] = useState<WaitlistBucketKey>("selectivity");
   const [tableMode, setTableMode] = useState<"lowest" | "largest">("lowest");
 
-  const completeRows = useMemo(
-    () => WAITLIST_ROWS.filter((row) => row.complete && row.waitListAccepted && row.waitListAccepted > 0),
-    [],
+  const bucketSummaries = useMemo(
+    () => summarizeWaitlistBuckets(WAITLIST_ANALYSIS_ROWS, bucketKey),
+    [bucketKey],
   );
   const rankedRows = useMemo(() => {
-    const rows = [...completeRows];
+    const rows = oneExtremeRowPerSchool(WAITLIST_ANALYSIS_ROWS, tableMode);
     if (tableMode === "largest") {
       rows.sort((a, b) => (b.waitListAccepted ?? 0) - (a.waitListAccepted ?? 0));
     } else {
       rows.sort((a, b) => (a.waitListSuccessRate ?? 0) - (b.waitListSuccessRate ?? 0));
     }
     return rows.slice(0, 15);
-  }, [completeRows, tableMode]);
+  }, [tableMode]);
 
   return (
     <>
@@ -426,10 +468,10 @@ export function WaitlistOddsExplorer() {
         className="waitlist-recipe-stats"
       >
         {[
-          ["Complete CDS rows", WAITLIST_RECIPE_SUMMARY.completeRows.toLocaleString("en-US")],
-          ["Median success", formatPct(WAITLIST_RECIPE_SUMMARY.medianSuccessRate)],
-          ["Weighted success", formatPct(WAITLIST_RECIPE_SUMMARY.weightedSuccessRate)],
-          ["Under 2%", `${WAITLIST_RECIPE_SUMMARY.zeroishRows} rows`],
+          ["Analysis rows", WAITLIST_ANALYSIS_SUMMARY.analysisRows.toLocaleString("en-US")],
+          ["Median success", formatPct(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)],
+          ["Weighted success", formatPct(WAITLIST_ANALYSIS_SUMMARY.weightedSuccessRate)],
+          ["Flagged rows", WAITLIST_ANALYSIS_SUMMARY.reportedAnomalyRows.toLocaleString("en-US")],
         ].map(([label, value]) => (
           <div key={label} className="cd-card" style={{ padding: 16 }}>
             <div className="meta">{label}</div>
@@ -442,7 +484,7 @@ export function WaitlistOddsExplorer() {
 
       <section style={{ marginTop: 28 }}>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
-          {(Object.keys(BUCKET_LABELS) as BucketKey[]).map((key) => (
+          {(Object.keys(BUCKET_LABELS) as WaitlistBucketKey[]).map((key) => (
             <button
               key={key}
               type="button"
@@ -454,7 +496,54 @@ export function WaitlistOddsExplorer() {
             </button>
           ))}
         </div>
-        <Chart bucketKey={bucketKey} rows={completeRows} />
+        <Chart bucketKey={bucketKey} rows={WAITLIST_ANALYSIS_ROWS} summaries={bucketSummaries} />
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <div className="cd-card" style={{ padding: 18 }}>
+          <div className="meta">§ Reported-data caveat</div>
+          <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.6, margin: "8px 0 0" }}>
+            {WAITLIST_ANALYSIS_SUMMARY.reportedAnomalyRows} high-volume rows report that at least 95%
+            of students who accepted a wait-list spot were admitted. Some of those values appear
+            verbatim in the source PDFs, and at least one row has a blank accepted-count cell that the
+            extractor filled from the admitted-count row. They are preserved below as source-reported
+            anomalies, but excluded from medians, bucket summaries, and the main chart.
+          </p>
+          <div style={{ overflowX: "auto", marginTop: 12 }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+              <thead>
+                <tr className="mono" style={{ color: "var(--ink-3)", fontSize: 10.5, letterSpacing: "0.06em" }}>
+                  <th style={{ textAlign: "left", padding: "10px 0", borderBottom: "1px solid var(--rule)" }}>School</th>
+                  <th style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px solid var(--rule)" }}>Year</th>
+                  <th style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px solid var(--rule)" }}>Accepted</th>
+                  <th style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px solid var(--rule)" }}>Admitted</th>
+                  <th style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px solid var(--rule)" }}>Reported rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {WAITLIST_REPORTED_ANOMALY_ROWS.map((row) => (
+                  <tr key={row.documentId}>
+                    <td style={{ padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
+                      <Link href={row.schoolUrl}>{row.schoolName}</Link>
+                    </td>
+                    <td className="nums" style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
+                      {row.year}
+                    </td>
+                    <td className="nums" style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
+                      {formatNumber(row.waitListAccepted)}
+                    </td>
+                    <td className="nums" style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
+                      {formatNumber(row.waitListAdmitted)}
+                    </td>
+                    <td className="nums" style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
+                      {formatPct(row.waitListSuccessRate)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
       </section>
 
       <section
@@ -476,17 +565,18 @@ export function WaitlistOddsExplorer() {
         </div>
         <p style={{ color: "var(--ink-2)", fontSize: 16, lineHeight: 1.65, margin: 0 }}>
           Across complete CDS wait-list rows in the current corpus, the median school admits{" "}
-          {formatPct(WAITLIST_RECIPE_SUMMARY.medianSuccessRate)} of students who accept a spot.
+          {formatPct(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)} of students who accept a spot.
           That sounds meaningful until you split the schools: the most selective buckets cluster
-          around low single digits, and {WAITLIST_RECIPE_SUMMARY.zeroishRows} complete rows are
+          around low single digits, and {WAITLIST_ANALYSIS_SUMMARY.zeroishRows} complete rows are
           effectively closed doors under 2%. Higher rates exist, but they are concentrated at less
-          selective schools and in years where the enrollment model missed badly.
+          selective schools and in years where the enrollment model missed badly. Reported near-total
+          wait-list admit rows are treated as data-quality caveats rather than odds estimates.
         </p>
       </section>
 
       <section style={{ marginTop: 44 }}>
         <div className="meta" style={{ marginBottom: 10 }}>§ Bucket table</div>
-        <BucketTable bucketKey={bucketKey} />
+        <BucketTable summaries={bucketSummaries} />
       </section>
 
       <section style={{ marginTop: 44 }}>

--- a/web/src/lib/waitlist-recipe-analysis.ts
+++ b/web/src/lib/waitlist-recipe-analysis.ts
@@ -1,0 +1,142 @@
+import {
+  WAITLIST_BUCKETS,
+  WAITLIST_RECIPE_SUMMARY,
+  WAITLIST_ROWS,
+  type WaitlistBucketSummary,
+  type WaitlistRecipeRow,
+} from "@/lib/waitlist-recipe-data";
+
+export type WaitlistBucketKey = "selectivity" | "control" | "size" | "carnegie";
+
+export type WaitlistAnalysisSummary = {
+  allVisibleRows: number;
+  completeRows: number;
+  analysisRows: number;
+  analysisSchools: number;
+  latestCompleteSchools: number;
+  partialRows: number;
+  reportedAnomalyRows: number;
+  medianSuccessRate: number | null;
+  weightedSuccessRate: number | null;
+  medianOfferSuccessRate: number | null;
+  zeroishRows: number;
+  zeroishShare: number;
+};
+
+const WAITLIST_REPORTED_ANOMALY_RATE = 0.95;
+const WAITLIST_REPORTED_ANOMALY_ACCEPTED = 100;
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function round4(value: number | null): number | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return Math.round(value * 10000) / 10000;
+}
+
+export function isLikelyWaitlistReportingAnomaly(row: WaitlistRecipeRow): boolean {
+  return Boolean(
+    row.complete &&
+      row.waitListAccepted != null &&
+      row.waitListAccepted >= WAITLIST_REPORTED_ANOMALY_ACCEPTED &&
+      row.waitListSuccessRate != null &&
+      row.waitListSuccessRate >= WAITLIST_REPORTED_ANOMALY_RATE,
+  );
+}
+
+function uniqueBy<T>(items: readonly T[], keyFor: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const item of items) {
+    const key = keyFor(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(item);
+  }
+  return unique;
+}
+
+const COMPLETE_SCHOOL_YEAR_ROWS = uniqueBy(
+  WAITLIST_ROWS.filter(
+    (row) => row.complete && row.waitListAccepted != null && row.waitListAccepted > 0,
+  ),
+  (row) => `${row.schoolId}:${row.year}`,
+);
+
+export const WAITLIST_REPORTED_ANOMALY_ROWS = COMPLETE_SCHOOL_YEAR_ROWS.filter(
+  isLikelyWaitlistReportingAnomaly,
+);
+
+export const WAITLIST_ANALYSIS_ROWS = COMPLETE_SCHOOL_YEAR_ROWS.filter(
+  (row) => !isLikelyWaitlistReportingAnomaly(row),
+);
+
+function summarizeRows(rows: readonly WaitlistRecipeRow[]): Omit<
+  WaitlistAnalysisSummary,
+  "allVisibleRows" | "completeRows" | "analysisRows" | "analysisSchools" | "latestCompleteSchools" | "partialRows" | "reportedAnomalyRows"
+> {
+  const successRates = rows
+    .map((row) => row.waitListSuccessRate)
+    .filter((value): value is number => value != null && Number.isFinite(value));
+  const offerSuccessRates = rows
+    .map((row) => row.waitListOfferSuccessRate)
+    .filter((value): value is number => value != null && Number.isFinite(value));
+  const accepted = rows.reduce((sum, row) => sum + (row.waitListAccepted ?? 0), 0);
+  const admitted = rows.reduce((sum, row) => sum + (row.waitListAdmitted ?? 0), 0);
+  const zeroishRows = rows.filter(
+    (row) => row.waitListSuccessRate != null && row.waitListSuccessRate < 0.02,
+  ).length;
+
+  return {
+    medianSuccessRate: round4(median(successRates)),
+    weightedSuccessRate: accepted > 0 ? round4(admitted / accepted) : null,
+    medianOfferSuccessRate: round4(median(offerSuccessRates)),
+    zeroishRows,
+    zeroishShare: rows.length > 0 ? round4(zeroishRows / rows.length) ?? 0 : 0,
+  };
+}
+
+export const WAITLIST_ANALYSIS_SUMMARY: WaitlistAnalysisSummary = {
+  allVisibleRows: WAITLIST_RECIPE_SUMMARY.allVisibleRows,
+  completeRows: WAITLIST_RECIPE_SUMMARY.completeRows,
+  analysisRows: WAITLIST_ANALYSIS_ROWS.length,
+  analysisSchools: new Set(WAITLIST_ANALYSIS_ROWS.map((row) => row.schoolId)).size,
+  latestCompleteSchools: new Set(WAITLIST_ANALYSIS_ROWS.map((row) => row.schoolId)).size,
+  partialRows: WAITLIST_RECIPE_SUMMARY.partialRows,
+  reportedAnomalyRows: WAITLIST_REPORTED_ANOMALY_ROWS.length,
+  ...summarizeRows(WAITLIST_ANALYSIS_ROWS),
+};
+
+export function summarizeWaitlistBuckets(
+  rows: readonly WaitlistRecipeRow[],
+  bucketKey: WaitlistBucketKey,
+): WaitlistBucketSummary[] {
+  const labels = WAITLIST_BUCKETS[bucketKey].map((bucket) => bucket.label);
+
+  return labels.map((label) => {
+    const bucketRows = rows.filter((row) => row[bucketKey] === label);
+    const accepted = bucketRows.reduce((sum, row) => sum + (row.waitListAccepted ?? 0), 0);
+    const admitted = bucketRows.reduce((sum, row) => sum + (row.waitListAdmitted ?? 0), 0);
+    const bucketSummary = summarizeRows(bucketRows);
+
+    return {
+      label,
+      rows: bucketRows.length,
+      schools: new Set(bucketRows.map((row) => row.schoolId)).size,
+      medianSuccessRate: bucketSummary.medianSuccessRate,
+      weightedSuccessRate: accepted > 0 ? round4(admitted / accepted) : null,
+      medianOfferSuccessRate: bucketSummary.medianOfferSuccessRate,
+      zeroishShare: bucketSummary.zeroishShare,
+      medianAccepted:
+        median(
+          bucketRows
+            .map((row) => row.waitListAccepted)
+            .filter((value): value is number => value != null && Number.isFinite(value)),
+        ) ?? 0,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- exclude high-volume near-total wait-list admit rows from the recipe analysis set
- collapse exact duplicate school-year rows before computing medians
- show at most one row per school in the extremes table, so Berkeley does not appear for both 2025-26 and 2024-25
- show anomalous rows in a reported-data caveat table instead of plotting them as clean 100% odds
- document the anomaly/dedupe rules and update the wait-list recipe statistics

## Findings
- UC Irvine and IU Bloomington report near-100% values in their source PDFs
- Case Western 2025-26 leaves the accepted-count row blank, but Tier 4 over-filled it from the admitted-count row
- five exact duplicate school/year groups were present in the recipe data and are now collapsed for analysis

## Verification
- npm run typecheck
- npm run build
- local production smoke: /recipes/waitlist-odds shows 180 analysis rows, 6 flagged rows, and only one Berkeley row in the extremes table