### PR TITLE
Add Berkeley wait-list history chart

### DIFF
--- a/docs/recipes/waitlist-odds.md
+++ b/docs/recipes/waitlist-odds.md
@@ -46,6 +46,20 @@ The median is not the lesson by itself. The split matters:
 
 The practical answer is: hope is allowed, but planning on a wait-list admit is usually bad strategy. Treat it as an upside option while getting excited about the school that actually admitted you.
 
+The Berkeley history panel, inspired by a chart idea from [@neetu_arnold](https://x.com/neetu_arnold), is a hand-audited example from the nine Berkeley CDS files currently in the archive. The browser projection only exposes the two newest Berkeley wait-list rows, so the older values were read directly from archived source files:
+
+| CDS year | Offered | Accepted | Admitted | Success |
+| --- | ---: | ---: | ---: | ---: |
+| 2015-16 | 3,760 | 2,445 | 1,340 | 54.8% |
+| 2018-19 | 7,824 | 4,127 | 1,536 | 37.2% |
+| 2019-20 | 7,531 | 3,975 | 1,098 | 27.6% |
+| 2020-21 | 8,753 | 5,043 | 1,651 | 32.7% |
+| 2021-22 | 11,725 | 6,871 | 359 | 5.2% |
+| 2022-23 | 8,456 | 4,655 | 44 | 0.9% |
+| 2023-24 | 7,001 | 4,820 | 1,191 | 24.7% |
+| 2024-25 | 10,894 | 7,853 | 26 | 0.3% |
+| 2025-26 | 9,102 | 6,479 | 1 | 0.02% |
+
 ## How to reproduce
 
 The page is generated from public-facing browser rows:

--- a/web/src/components/WaitlistOddsExplorer.tsx
+++ b/web/src/components/WaitlistOddsExplorer.tsx
@@ -8,9 +8,11 @@ import {
   type WaitlistRecipeRow,
 } from "@/lib/waitlist-recipe-data";
 import {
+  BERKELEY_WAITLIST_HISTORY,
   WAITLIST_ANALYSIS_ROWS,
   WAITLIST_ANALYSIS_SUMMARY,
   WAITLIST_REPORTED_ANOMALY_ROWS,
+  type BerkeleyWaitlistHistoryRow,
   type WaitlistBucketKey,
   summarizeWaitlistBuckets,
 } from "@/lib/waitlist-recipe-analysis";
@@ -405,6 +407,185 @@ function CaseStudy({ row }: { row: WaitlistRecipeRow }) {
   );
 }
 
+const HISTORY_W = 980;
+const HISTORY_H = 360;
+const HISTORY_M = { l: 64, r: 28, t: 28, b: 54 };
+const HISTORY_IW = HISTORY_W - HISTORY_M.l - HISTORY_M.r;
+const HISTORY_IH = HISTORY_H - HISTORY_M.t - HISTORY_M.b;
+const HISTORY_RATE_MAX = 0.6;
+
+function BerkeleyHistoryChart() {
+  const years = BERKELEY_WAITLIST_HISTORY;
+  const minYear = Math.min(...years.map((row) => row.yearStart));
+  const maxYear = Math.max(...years.map((row) => row.yearStart));
+  const x = (row: BerkeleyWaitlistHistoryRow) =>
+    HISTORY_M.l + ((row.yearStart - minYear) / (maxYear - minYear)) * HISTORY_IW;
+  const y = (rate: number) =>
+    HISTORY_M.t + (1 - Math.min(rate, HISTORY_RATE_MAX) / HISTORY_RATE_MAX) * HISTORY_IH;
+  const points = years.map((row) => `${x(row)},${y(row.waitListSuccessRate)}`).join(" ");
+  const yTicks = [0, 0.1, 0.25, 0.5];
+
+  return (
+    <section style={{ marginTop: 44 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "220px 1fr",
+          gap: 36,
+        }}
+        className="cd-recipe-guide"
+      >
+        <div>
+          <div className="meta">§ Berkeley over time</div>
+          <div className="serif" style={{ color: "var(--ink-2)", fontSize: 21, fontStyle: "italic", lineHeight: 1.25, marginTop: 8 }}>
+            Nine CDS files,
+            <br />
+            one sharp cliff.
+          </div>
+        </div>
+        <p style={{ color: "var(--ink-2)", fontSize: 16, lineHeight: 1.65, margin: 0 }}>
+          Berkeley is the clearest example of why one wait-list year should not become a rule.
+          The archive has nine Berkeley CDS files with wait-list C2 counts. The success rate was
+          routinely above 25% in older files, then fell below 1% in 2022-23, 2024-25, and 2025-26.
+          Chart idea credited to <a href="https://x.com/neetu_arnold">@neetu_arnold</a>.
+        </p>
+      </div>
+
+      <div className="cd-card" style={{ marginTop: 16, padding: 24 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 12,
+            flexWrap: "wrap",
+            marginBottom: 10,
+          }}
+        >
+          <div className="meta">Fig. 2 · Berkeley wait-list success rate</div>
+          <div className="mono" style={{ color: "var(--ink-3)", fontSize: 11 }}>
+            ADMITTED FROM WAIT LIST / ACCEPTED WAIT-LIST SPOTS
+          </div>
+        </div>
+        <div style={{ overflowX: "auto" }}>
+          <svg
+            width={HISTORY_W}
+            height={HISTORY_H}
+            viewBox={`0 0 ${HISTORY_W} ${HISTORY_H}`}
+            style={{ display: "block", height: "auto", maxWidth: "100%", minWidth: 720 }}
+            role="img"
+            aria-label="Line chart of Berkeley wait-list success rate across nine CDS files"
+          >
+            {yTicks.map((tick) => (
+              <g key={tick}>
+                <line
+                  x1={HISTORY_M.l}
+                  x2={HISTORY_W - HISTORY_M.r}
+                  y1={y(tick)}
+                  y2={y(tick)}
+                  stroke="var(--chart-grid)"
+                />
+                <text
+                  x={HISTORY_M.l - 12}
+                  y={y(tick) + 4}
+                  textAnchor="end"
+                  fontFamily="var(--mono)"
+                  fontSize="11"
+                  fill="var(--chart-axis)"
+                >
+                  {formatPct(tick, 0)}
+                </text>
+              </g>
+            ))}
+            <polyline
+              points={points}
+              fill="none"
+              stroke="var(--forest)"
+              strokeWidth="2.5"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+            {years.map((row) => (
+              <g key={row.year}>
+                <line
+                  x1={x(row)}
+                  x2={x(row)}
+                  y1={HISTORY_M.t}
+                  y2={HISTORY_H - HISTORY_M.b}
+                  stroke="var(--rule)"
+                  strokeDasharray="2 5"
+                />
+                <circle
+                  cx={x(row)}
+                  cy={y(row.waitListSuccessRate)}
+                  r={row.waitListSuccessRate < 0.01 ? 5 : 4}
+                  fill={row.waitListSuccessRate < 0.01 ? "var(--brick)" : "var(--forest)"}
+                  stroke="var(--paper)"
+                  strokeWidth="1.5"
+                />
+                <text
+                  x={x(row)}
+                  y={HISTORY_H - 22}
+                  textAnchor="middle"
+                  fontFamily="var(--mono)"
+                  fontSize="10.5"
+                  fill="var(--chart-axis)"
+                >
+                  {row.year.slice(2)}
+                </text>
+              </g>
+            ))}
+            <line
+              x1={HISTORY_M.l}
+              x2={HISTORY_W - HISTORY_M.r}
+              y1={HISTORY_H - HISTORY_M.b}
+              y2={HISTORY_H - HISTORY_M.b}
+              stroke="var(--ink)"
+            />
+          </svg>
+        </div>
+        <div style={{ borderTop: "1px solid var(--rule)", marginTop: 14, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <thead>
+              <tr className="mono" style={{ color: "var(--ink-3)", fontSize: 10.5, letterSpacing: "0.06em" }}>
+                <th style={{ textAlign: "left", padding: "12px 14px", borderBottom: "1px solid var(--rule)" }}>CDS year</th>
+                <th style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px solid var(--rule)" }}>Offered</th>
+                <th style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px solid var(--rule)" }}>Accepted</th>
+                <th style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px solid var(--rule)" }}>Admitted</th>
+                <th style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px solid var(--rule)" }}>Success</th>
+              </tr>
+            </thead>
+            <tbody>
+              {years.map((row) => (
+                <tr key={row.year}>
+                  <td style={{ padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
+                    <a href={row.archiveUrl}>{row.year}</a>
+                    <span className="mono" style={{ color: "var(--ink-3)", fontSize: 10.5, marginLeft: 8 }}>
+                      {row.sourceKind.toUpperCase()}
+                    </span>
+                  </td>
+                  <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
+                    {formatNumber(row.waitListOffered)}
+                  </td>
+                  <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
+                    {formatNumber(row.waitListAccepted)}
+                  </td>
+                  <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
+                    {formatNumber(row.waitListAdmitted)}
+                  </td>
+                  <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
+                    {formatSuccessPct(row.waitListSuccessRate)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function oneExtremeRowPerSchool(
   rows: readonly WaitlistRecipeRow[],
   tableMode: "lowest" | "largest",
@@ -545,6 +726,8 @@ export function WaitlistOddsExplorer() {
           </div>
         </div>
       </section>
+
+      <BerkeleyHistoryChart />
 
       <section
         style={{

--- a/web/src/lib/waitlist-recipe-analysis.ts
+++ b/web/src/lib/waitlist-recipe-analysis.ts
@@ -8,6 +8,17 @@ import {
 
 export type WaitlistBucketKey = "selectivity" | "control" | "size" | "carnegie";
 
+export type BerkeleyWaitlistHistoryRow = {
+  year: string;
+  yearStart: number;
+  waitListOffered: number;
+  waitListAccepted: number;
+  waitListAdmitted: number;
+  waitListSuccessRate: number;
+  sourceKind: "pdf" | "xlsx";
+  archiveUrl: string;
+};
+
 export type WaitlistAnalysisSummary = {
   allVisibleRows: number;
   completeRows: number;
@@ -25,6 +36,99 @@ export type WaitlistAnalysisSummary = {
 
 const WAITLIST_REPORTED_ANOMALY_RATE = 0.95;
 const WAITLIST_REPORTED_ANOMALY_ACCEPTED = 100;
+
+export const BERKELEY_WAITLIST_HISTORY: readonly BerkeleyWaitlistHistoryRow[] = [
+  {
+    year: "2015-16",
+    yearStart: 2015,
+    waitListOffered: 3760,
+    waitListAccepted: 2445,
+    waitListAdmitted: 1340,
+    waitListSuccessRate: 1340 / 2445,
+    sourceKind: "pdf",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2015-16",
+  },
+  {
+    year: "2018-19",
+    yearStart: 2018,
+    waitListOffered: 7824,
+    waitListAccepted: 4127,
+    waitListAdmitted: 1536,
+    waitListSuccessRate: 1536 / 4127,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2018-19",
+  },
+  {
+    year: "2019-20",
+    yearStart: 2019,
+    waitListOffered: 7531,
+    waitListAccepted: 3975,
+    waitListAdmitted: 1098,
+    waitListSuccessRate: 1098 / 3975,
+    sourceKind: "pdf",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2019-20",
+  },
+  {
+    year: "2020-21",
+    yearStart: 2020,
+    waitListOffered: 8753,
+    waitListAccepted: 5043,
+    waitListAdmitted: 1651,
+    waitListSuccessRate: 1651 / 5043,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2020-21",
+  },
+  {
+    year: "2021-22",
+    yearStart: 2021,
+    waitListOffered: 11725,
+    waitListAccepted: 6871,
+    waitListAdmitted: 359,
+    waitListSuccessRate: 359 / 6871,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2021-22",
+  },
+  {
+    year: "2022-23",
+    yearStart: 2022,
+    waitListOffered: 8456,
+    waitListAccepted: 4655,
+    waitListAdmitted: 44,
+    waitListSuccessRate: 44 / 4655,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2022-23",
+  },
+  {
+    year: "2023-24",
+    yearStart: 2023,
+    waitListOffered: 7001,
+    waitListAccepted: 4820,
+    waitListAdmitted: 1191,
+    waitListSuccessRate: 1191 / 4820,
+    sourceKind: "pdf",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2023-24",
+  },
+  {
+    year: "2024-25",
+    yearStart: 2024,
+    waitListOffered: 10894,
+    waitListAccepted: 7853,
+    waitListAdmitted: 26,
+    waitListSuccessRate: 26 / 7853,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2024-25",
+  },
+  {
+    year: "2025-26",
+    yearStart: 2025,
+    waitListOffered: 9102,
+    waitListAccepted: 6479,
+    waitListAdmitted: 1,
+    waitListSuccessRate: 1 / 6479,
+    sourceKind: "xlsx",
+    archiveUrl: "https://www.collegedata.fyi/schools/uc-berkeley/2025-26",
+  },
+];
 
 function median(values: readonly number[]): number | null {
   if (values.length === 0) return null;


### PR DESCRIPTION
## Summary
- add a Berkeley nine-file wait-list history panel to the wait-list recipe
- plot Berkeley wait-list success rate across archived CDS years
- include the source C2 counts table for offered, accepted, admitted, and success rate
- credit @neetu_arnold for the chart idea
- document the hand-audited Berkeley values in the recipe methodology

## Notes
- school_browser_rows only projects Berkeley wait-list rows for 2024-25 and 2025-26
- older Berkeley values were read directly from archived source PDFs/XLSX files

## Verification
- npm run build
- npm run typecheck