### PR TITLE
Add Vercel interaction analytics

### DIFF
--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchSiteStats } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
 import { CopyButton } from "@/components/CopyButton";
+import { TrackedLink } from "@/components/TrackedLink";
 
 export const metadata: Metadata = {
   title: "API",
@@ -25,7 +26,14 @@ function CodeBlock({ children }: { children: string }) {
   return (
     <div className="relative mt-2">
       <div className="absolute right-2 top-2">
-        <CopyButton text={children} />
+        <CopyButton
+          text={children}
+          analyticsEvent="api_code_copied"
+          analyticsProperties={{
+            surface: "api_docs",
+            code_lines: children.split("\n").length,
+          }}
+        />
       </div>
       <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-gray-200 bg-gray-50 px-4 py-3 pr-16 text-xs leading-relaxed text-gray-800">
         <code>{children}</code>
@@ -1061,14 +1069,20 @@ function Resource({
         <code className="min-w-0 break-all text-sm font-semibold text-gray-900">
           GET /rest/v1/{name}
         </code>
-        <a
+        <TrackedLink
+          external
           href={`${BASE}/rest/v1/${name}?limit=1&apikey=${ANON_KEY}`}
           target="_blank"
           rel="noopener noreferrer"
           className={API_LINK_SMALL_CLASS}
+          analyticsEvent="api_resource_opened"
+          analyticsProperties={{
+            surface: "api_docs",
+            resource: name,
+          }}
         >
           try it →
-        </a>
+        </TrackedLink>
       </div>
       <p className="mt-2 text-sm leading-relaxed text-gray-700">
         {description}

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -45,13 +45,17 @@ export default function PrivacyPage() {
         <p>
           We use Vercel Analytics to understand anonymous, aggregate site
           usage: things like page views, referrers, browser type, device type,
-          and general location. This helps us see which pages are useful and
-          whether the site is performing reliably.
+          general location, and which site features are used, such as school
+          search, source links, downloads, copy buttons, and recipe controls.
+          This helps us see which pages are useful and whether the site is
+          performing reliably.
         </p>
 
         <p>
           Vercel Analytics does not give us a list of named visitors, and we do
-          not use it to build student profiles or sell audience data.
+          not send locally entered GPA, test scores, intended majors, search
+          terms, or share codes as analytics properties. We do not use analytics
+          to build student profiles or sell audience data.
         </p>
 
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>

--- a/web/src/app/recipes/acceptance-vs-yield/page.tsx
+++ b/web/src/app/recipes/acceptance-vs-yield/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { AcceptanceYieldChart } from "@/components/AcceptanceYieldChart";
+import { TrackedLink } from "@/components/TrackedLink";
 
 export const metadata: Metadata = {
   title: "Acceptance rate vs. yield",
@@ -263,16 +264,31 @@ export default function AcceptanceVsYieldPage() {
             fontSize: 13,
           }}
         >
-          <a
+          <TrackedLink
+            external
             href="https://github.com/bolewood/collegedata-fyi/blob/main/docs/recipes/acceptance-vs-yield.md"
             target="_blank"
             rel="noopener noreferrer"
+            analyticsEvent="recipe_writeup_opened"
+            analyticsProperties={{
+              surface: "recipe_detail",
+              recipe: "acceptance-vs-yield",
+            }}
           >
             Read the full write-up →
-          </a>
-          <a href="/recipes/acceptance-vs-yield-starter.xlsx">
+          </TrackedLink>
+          <TrackedLink
+            external
+            href="/recipes/acceptance-vs-yield-starter.xlsx"
+            analyticsEvent="download_clicked"
+            analyticsProperties={{
+              surface: "recipe_detail",
+              file_type: "xlsx",
+              item: "acceptance_vs_yield_starter",
+            }}
+          >
             Download XLSX starter
-          </a>
+          </TrackedLink>
         </div>
       </section>
     </div>

--- a/web/src/app/recipes/page.tsx
+++ b/web/src/app/recipes/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TrackedLink } from "@/components/TrackedLink";
 
 export const metadata: Metadata = {
   title: "Recipes",
@@ -114,9 +115,17 @@ export default function RecipesPage() {
                   margin: 0,
                 }}
               >
-                <Link href={r.demoPath} style={{ textDecoration: "none", color: "inherit" }}>
+                <TrackedLink
+                  href={r.demoPath}
+                  style={{ textDecoration: "none", color: "inherit" }}
+                  analyticsEvent="recipe_opened"
+                  analyticsProperties={{
+                    surface: "recipes_index_title",
+                    recipe: r.slug,
+                  }}
+                >
                   {r.title}
-                </Link>
+                </TrackedLink>
               </h2>
               <span className="mono" style={{ fontSize: 11, color: "var(--ink-3)", letterSpacing: "0.05em", whiteSpace: "nowrap" }}>
                 CDS {r.sections}
@@ -130,21 +139,47 @@ export default function RecipesPage() {
               {r.audience}
             </p>
             <div style={{ marginTop: 14, display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12 }}>
-              <Link href={r.demoPath} className="cd-btn" style={{ padding: "8px 14px", fontSize: 13 }}>
+              <TrackedLink
+                href={r.demoPath}
+                className="cd-btn"
+                style={{ padding: "8px 14px", fontSize: 13 }}
+                analyticsEvent="recipe_opened"
+                analyticsProperties={{
+                  surface: "recipes_index_button",
+                  recipe: r.slug,
+                }}
+              >
                 Open demo →
-              </Link>
-              <a
+              </TrackedLink>
+              <TrackedLink
+                external
                 href={r.writeupUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{ fontSize: 12 }}
+                analyticsEvent="recipe_writeup_opened"
+                analyticsProperties={{
+                  surface: "recipes_index",
+                  recipe: r.slug,
+                }}
               >
                 Read write-up
-              </a>
+              </TrackedLink>
               {r.extras?.map((x) => (
-                <a key={x.path} href={x.path} style={{ fontSize: 12 }}>
+                <TrackedLink
+                  key={x.path}
+                  external
+                  href={x.path}
+                  style={{ fontSize: 12 }}
+                  analyticsEvent="download_clicked"
+                  analyticsProperties={{
+                    surface: "recipes_index",
+                    file_type: x.path.split(".").pop() ?? "file",
+                    item: x.label,
+                  }}
+                >
                   {x.label}
-                </a>
+                </TrackedLink>
               ))}
             </div>
           </article>

--- a/web/src/app/recipes/test-optional-tracker/page.tsx
+++ b/web/src/app/recipes/test-optional-tracker/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { TestOptionalChart } from "@/components/TestOptionalChart";
+import { TrackedLink } from "@/components/TrackedLink";
 
 export const metadata: Metadata = {
   title: "Test-optional tracker",
@@ -249,13 +250,19 @@ export default function TestOptionalTrackerPage() {
             fontSize: 13,
           }}
         >
-          <a
+          <TrackedLink
+            external
             href="https://github.com/bolewood/collegedata-fyi/blob/main/docs/recipes/test-optional-tracker.md"
             target="_blank"
             rel="noopener noreferrer"
+            analyticsEvent="recipe_writeup_opened"
+            analyticsProperties={{
+              surface: "recipe_detail",
+              recipe: "test-optional-tracker",
+            }}
           >
             Read the full write-up →
-          </a>
+          </TrackedLink>
         </div>
       </section>
     </div>

--- a/web/src/app/recipes/waitlist-odds/page.tsx
+++ b/web/src/app/recipes/waitlist-odds/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { WaitlistOddsExplorer } from "@/components/WaitlistOddsExplorer";
+import { TrackedLink } from "@/components/TrackedLink";
 import { WAITLIST_ANALYSIS_SUMMARY } from "@/lib/waitlist-recipe-analysis";
 
 const WSJ_URL =
@@ -66,9 +67,20 @@ export default function WaitlistOddsPage() {
             }}
           >
             Inspired by Roshan Fernandez&apos;s{" "}
-            <a href={WSJ_URL} target="_blank" rel="noopener noreferrer">
+            <TrackedLink
+              external
+              href={WSJ_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              analyticsEvent="recipe_inspiration_opened"
+              analyticsProperties={{
+                surface: "recipe_hero",
+                recipe: "waitlist-odds",
+                source: "wsj",
+              }}
+            >
               May 10, 2026 Wall Street Journal story
-            </a>{" "}
+            </TrackedLink>{" "}
             on ballooning college wait lists, this recipe ignores anecdotes and
             looks across every complete C2 wait-list row currently visible in
             the collegedata.fyi CDS corpus, with high-volume near-total admit
@@ -152,16 +164,33 @@ export default function WaitlistOddsPage() {
 {`curl 'https://api.collegedata.fyi/rest/v1/school_browser_rows?select=school_id,school_name,canonical_year,acceptance_rate,wait_list_policy,wait_list_offered,wait_list_accepted,wait_list_admitted&wait_list_offered=not.is.null'`}
         </pre>
         <div style={{ display: "flex", gap: 16, flexWrap: "wrap", fontSize: 13, marginTop: 14 }}>
-          <a
+          <TrackedLink
+            external
             href="https://github.com/bolewood/collegedata-fyi/blob/main/docs/recipes/waitlist-odds.md"
             target="_blank"
             rel="noopener noreferrer"
+            analyticsEvent="recipe_writeup_opened"
+            analyticsProperties={{
+              surface: "recipe_detail",
+              recipe: "waitlist-odds",
+            }}
           >
             Read the methodology →
-          </a>
-          <a href={WSJ_URL} target="_blank" rel="noopener noreferrer">
+          </TrackedLink>
+          <TrackedLink
+            external
+            href={WSJ_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            analyticsEvent="recipe_inspiration_opened"
+            analyticsProperties={{
+              surface: "recipe_detail",
+              recipe: "waitlist-odds",
+              source: "wsj",
+            }}
+          >
             WSJ inspiration →
-          </a>
+          </TrackedLink>
         </div>
       </section>
     </div>

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,13 +1,25 @@
 "use client";
 
 import { useState } from "react";
+import { type AnalyticsProperties, trackEvent } from "@/lib/analytics";
 
-export function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
+export function CopyButton({
+  text,
+  label = "Copy",
+  analyticsEvent = "copy_clicked",
+  analyticsProperties,
+}: {
+  text: string;
+  label?: string;
+  analyticsEvent?: string;
+  analyticsProperties?: AnalyticsProperties;
+}) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {
     try {
       await navigator.clipboard.writeText(text);
+      trackEvent(analyticsEvent, analyticsProperties);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1600);
     } catch {

--- a/web/src/components/DocumentCard.tsx
+++ b/web/src/components/DocumentCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import {
   formatBadgeLabel,
@@ -5,6 +7,7 @@ import {
   storageUrl,
   dataQualityLabel,
 } from "@/lib/format";
+import { trackSourceOpened, trackEvent } from "@/lib/analytics";
 import type { ManifestRow } from "@/lib/types";
 
 // Map an extraction status to a chip variant. Only the success state gets
@@ -112,16 +115,51 @@ export function DocumentCard({
 
       <div className="document-card-row__actions">
         {canLink && (
-          <Link href={`/schools/${doc.school_id}/${doc.canonical_year}`}>
+          <Link
+            href={`/schools/${doc.school_id}/${doc.canonical_year}`}
+            onClick={() =>
+              trackEvent("school_document_fields_opened", {
+                school_id: doc.school_id,
+                cds_year: doc.canonical_year,
+                source_format: doc.source_format,
+              })
+            }
+          >
             View fields →
           </Link>
         )}
         {pdfUrl ? (
-          <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            href={pdfUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              trackSourceOpened({
+                surface: "school_documents",
+                schoolId: doc.school_id,
+                cdsYear: doc.canonical_year ?? doc.cds_year,
+                sourceFormat: doc.source_format,
+                action: "download",
+              })
+            }
+          >
             {downloadLabel(doc.source_format)}
           </a>
         ) : sourceUrl ? (
-          <a href={sourceUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              trackSourceOpened({
+                surface: "school_documents",
+                schoolId: doc.school_id,
+                cdsYear: doc.canonical_year ?? doc.cds_year,
+                sourceFormat: doc.source_format,
+                action: "view_source",
+              })
+            }
+          >
             View source →
           </a>
         ) : null}

--- a/web/src/components/HeaderSchoolSearch.tsx
+++ b/web/src/components/HeaderSchoolSearch.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
+import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
 
 const DEBOUNCE_MS = 180;
@@ -55,7 +56,17 @@ export function HeaderSchoolSearch() {
     return () => clearTimeout(timer);
   }, [query]);
 
-  function handleSelect(schoolId: string) {
+  function handleSelect(schoolId: string, inputMethod: "keyboard" | "mouse") {
+    const selected = results.find((result) => result.school_id === schoolId);
+    trackSchoolSearchSelected({
+      surface: "header",
+      schoolId,
+      coverageStatus: selected?.coverage_status,
+      latestCdsYear: selected?.latest_available_cds_year,
+      queryLength: query.trim().length,
+      resultCount: results.length,
+      inputMethod,
+    });
     setIsOpen(false);
     setQuery("");
     setResults([]);
@@ -72,7 +83,7 @@ export function HeaderSchoolSearch() {
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      handleSelect(results[selectedIndex].school_id);
+      handleSelect(results[selectedIndex].school_id, "keyboard");
     } else if (e.key === "Escape") {
       setIsOpen(false);
     }
@@ -109,7 +120,7 @@ export function HeaderSchoolSearch() {
               key={result.school_id}
               className="cd-header-search__result"
               data-active={index === selectedIndex ? "true" : "false"}
-              onMouseDown={() => handleSelect(result.school_id)}
+              onMouseDown={() => handleSelect(result.school_id, "mouse")}
             >
               <span className="cd-header-search__school">
                 <span className="cd-header-search__name">{result.school_name}</span>

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { track } from "@vercel/analytics";
+import { trackDownload, trackEvent } from "@/lib/analytics";
 import {
   DEFAULT_MATCH_FILTERS,
   groupRankedSchools,
@@ -137,11 +137,13 @@ export function MatchListBuilder({
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
     setProfile(next);
     setCopied(false);
-    try {
-      track("match_profile_entered");
-    } catch {
-      // Analytics must not block local profile entry.
-    }
+    trackEvent("match_profile_entered", {
+      has_gpa: next.gpa != null,
+      has_sat: next.sat != null,
+      has_act: next.act != null,
+      has_state: next.state != null,
+      has_major: next.intendedMajor != null,
+    });
   }
 
   function onFilterChange(event: React.ChangeEvent<HTMLFormElement>) {
@@ -161,6 +163,7 @@ export function MatchListBuilder({
     if (!shareHref) return;
     try {
       await navigator.clipboard.writeText(shareHref);
+      trackEvent("match_share_copied", { ranked_count: ranked.length });
       setCopied(true);
       return;
     } catch {
@@ -173,6 +176,7 @@ export function MatchListBuilder({
       textarea.select();
       const ok = document.execCommand("copy");
       textarea.remove();
+      if (ok) trackEvent("match_share_copied", { ranked_count: ranked.length });
       setCopied(ok);
     }
   }
@@ -284,12 +288,27 @@ export function MatchListBuilder({
           <button
             className="cd-btn cd-btn--ghost"
             type="button"
-            onClick={() => downloadCsv("collegedata-match-list.csv", rankedSchoolsCsv(ranked))}
+            onClick={() => {
+              downloadCsv("collegedata-match-list.csv", rankedSchoolsCsv(ranked));
+              trackDownload({
+                surface: "match_builder",
+                fileType: "csv",
+                item: "ranked_match_list",
+                rowCount: ranked.length,
+              });
+            }}
             disabled={ranked.length === 0}
           >
             Export CSV
           </button>
-          <button className="cd-btn cd-btn--ghost" type="button" onClick={() => window.print()}>
+          <button
+            className="cd-btn cd-btn--ghost"
+            type="button"
+            onClick={() => {
+              trackEvent("match_print_clicked", { ranked_count: ranked.length });
+              window.print();
+            }}
+          >
             Print
           </button>
           <button className="cd-btn cd-btn--ghost" type="button" onClick={copyShareLink} disabled={!shareHref}>

--- a/web/src/components/PositioningCardProfile.tsx
+++ b/web/src/components/PositioningCardProfile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { track } from "@vercel/analytics";
+import { trackEvent } from "@/lib/analytics";
 import {
   scorePosition,
   tierLabel,
@@ -101,15 +101,21 @@ export function PositioningCardProfile({ school }: { school: SchoolAcademicProfi
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
     setProfile(next);
     setEditing(false);
-    try {
-      track("positioning_profile_entered");
-    } catch {
-      // Analytics must never block the local-only profile interaction.
-    }
+    trackEvent("positioning_profile_entered", {
+      school_id: school.schoolId,
+      cds_year: school.cdsYear,
+      has_gpa: next.gpa != null,
+      has_sat: next.sat != null,
+      has_act: next.act != null,
+    });
   }
 
   function clearProfile() {
     window.localStorage.removeItem(STORAGE_KEY);
+    trackEvent("positioning_profile_cleared", {
+      school_id: school.schoolId,
+      cds_year: school.cdsYear,
+    });
     setProfile(null);
     setEditing(true);
   }

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -11,6 +11,7 @@ import {
   type BrowserSearchMetadata,
   type BrowserSort,
 } from "@/lib/browser-search";
+import { trackDownload, trackEvent, trackSourceOpened } from "@/lib/analytics";
 import { formatBadgeLabel, formatCurrency, formatPercent } from "@/lib/format";
 
 type FilterState = {
@@ -227,6 +228,12 @@ export function SchoolBrowser() {
         page_size: 500,
       });
       downloadCsv(response.rows);
+      trackDownload({
+        surface: "school_browser",
+        fileType: "csv",
+        item: "browser_export",
+        rowCount: response.rows.length,
+      });
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -301,6 +308,10 @@ export function SchoolBrowser() {
               onChange={(e) => {
                 setPage(1);
                 setSortIndex(Number(e.target.value));
+                trackEvent("browser_sort_changed", {
+                  sort: SORT_OPTIONS[Number(e.target.value)]?.sort.field,
+                  direction: SORT_OPTIONS[Number(e.target.value)]?.sort.direction,
+                });
               }}
               style={inputStyle(220)}
             >
@@ -318,6 +329,7 @@ export function SchoolBrowser() {
               onClick={() => {
                 setPage(1);
                 setFilters({ undergradMin: "", acceptanceMax: "", yieldMin: "", netPriceMax: "", retentionMin: "" });
+                trackEvent("browser_filters_reset");
               }}
             >
               Reset
@@ -384,7 +396,17 @@ export function SchoolBrowser() {
             {rows.map((row) => (
               <tr key={row.document_id} className="rule">
                 <td style={{ padding: "12px 10px 12px 0" }}>
-                  <Link href={`/schools/${row.school_id}`} style={{ fontFamily: "var(--serif)", fontSize: 18 }}>
+                  <Link
+                    href={`/schools/${row.school_id}`}
+                    style={{ fontFamily: "var(--serif)", fontSize: 18 }}
+                    onClick={() =>
+                      trackEvent("browser_school_opened", {
+                        surface: "table",
+                        school_id: row.school_id,
+                        cds_year: row.canonical_year,
+                      })
+                    }
+                  >
                     {row.school_name}
                   </Link>
                   {row.sub_institutional && (
@@ -415,6 +437,15 @@ export function SchoolBrowser() {
                     rel="noopener noreferrer"
                     className="cd-chip"
                     data-testid="browser-source-link"
+                    onClick={() =>
+                      trackSourceOpened({
+                        surface: "school_browser_table",
+                        schoolId: row.school_id,
+                        cdsYear: row.canonical_year,
+                        sourceFormat: row.source_format,
+                        action: "open_archive",
+                      })
+                    }
                   >
                     {formatBadgeLabel(row.source_format)}
                   </a>
@@ -451,7 +482,14 @@ export function SchoolBrowser() {
             type="button"
             className="cd-btn cd-btn--ghost"
             disabled={page <= 1 || loading}
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            onClick={() => {
+              trackEvent("browser_page_changed", {
+                direction: "previous",
+                current_page: page,
+                total_pages: totalPages,
+              });
+              setPage((p) => Math.max(1, p - 1));
+            }}
           >
             Previous
           </button>
@@ -459,7 +497,14 @@ export function SchoolBrowser() {
             type="button"
             className="cd-btn cd-btn--ghost"
             disabled={page >= totalPages || loading}
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            onClick={() => {
+              trackEvent("browser_page_changed", {
+                direction: "next",
+                current_page: page,
+                total_pages: totalPages,
+              });
+              setPage((p) => Math.min(totalPages, p + 1));
+            }}
           >
             Next
           </button>
@@ -503,7 +548,17 @@ function BrowserResultCard({ row }: { row: BrowserRow }) {
     <article className="cd-card" style={{ padding: 14 }}>
       <div style={{ display: "flex", gap: 10, alignItems: "flex-start", justifyContent: "space-between" }}>
         <div style={{ minWidth: 0 }}>
-          <Link href={`/schools/${row.school_id}`} style={{ fontFamily: "var(--serif)", fontSize: 19, lineHeight: 1.15 }}>
+          <Link
+            href={`/schools/${row.school_id}`}
+            style={{ fontFamily: "var(--serif)", fontSize: 19, lineHeight: 1.15 }}
+            onClick={() =>
+              trackEvent("browser_school_opened", {
+                surface: "card",
+                school_id: row.school_id,
+                cds_year: row.canonical_year,
+              })
+            }
+          >
             {row.school_name}
           </Link>
           {row.sub_institutional && (
@@ -539,6 +594,15 @@ function BrowserResultCard({ row }: { row: BrowserRow }) {
           rel="noopener noreferrer"
           className="cd-chip"
           data-testid="browser-source-link"
+          onClick={() =>
+            trackSourceOpened({
+              surface: "school_browser_card",
+              schoolId: row.school_id,
+              cdsYear: row.canonical_year,
+              sourceFormat: row.source_format,
+              action: "open_archive",
+            })
+          }
         >
           {formatBadgeLabel(row.source_format)} source
         </a>

--- a/web/src/components/SchoolListItem.tsx
+++ b/web/src/components/SchoolListItem.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { trackEvent, trackSourceOpened } from "@/lib/analytics";
 import { academicFitLabel, admissionsOutlookLabel, type Caveat } from "@/lib/positioning";
 import type { RankedMatchSchool } from "@/lib/list-builder";
 
@@ -46,7 +49,19 @@ export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
     <article className="match-school-row rule">
       <div className="match-school-row__identity">
         <div className="match-school-row__name">
-          <Link href={school.schoolUrl}>{school.schoolName}</Link>
+          <Link
+            href={school.schoolUrl}
+            onClick={() =>
+              trackEvent("match_school_opened", {
+                school_id: school.schoolId,
+                cds_year: school.cdsYear,
+                academic_fit: school.result.academicFit,
+                admissions_outlook: school.result.admissionsOutlook,
+              })
+            }
+          >
+            {school.schoolName}
+          </Link>
         </div>
         <div className="match-school-row__meta mono">
           {school.state ?? "state n/a"} · {school.cdsYear} CDS · admit {formatPercent(school.acceptanceRate)}
@@ -87,7 +102,20 @@ export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
           </span>
         ))}
         {school.archiveUrl ? (
-          <a href={school.archiveUrl} target="_blank" rel="noopener noreferrer" className="match-source-link mono">
+          <a
+            href={school.archiveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="match-source-link mono"
+            onClick={() =>
+              trackSourceOpened({
+                surface: "match_builder",
+                schoolId: school.schoolId,
+                cdsYear: school.cdsYear,
+                action: "open_archive",
+              })
+            }
+          >
             source
           </a>
         ) : null}

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
+import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
 
 // PRD 015 M4 — server-backed autocomplete over institution_cds_coverage.
@@ -69,7 +70,17 @@ export function SchoolSearch() {
     return () => clearTimeout(timer);
   }, [query]);
 
-  function handleSelect(schoolId: string) {
+  function handleSelect(schoolId: string, inputMethod: "keyboard" | "mouse") {
+    const selected = results.find((result) => result.school_id === schoolId);
+    trackSchoolSearchSelected({
+      surface: "home",
+      schoolId,
+      coverageStatus: selected?.coverage_status,
+      latestCdsYear: selected?.latest_available_cds_year,
+      queryLength: query.trim().length,
+      resultCount: results.length,
+      inputMethod,
+    });
     setIsOpen(false);
     setQuery("");
     setResults([]);
@@ -86,7 +97,7 @@ export function SchoolSearch() {
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      handleSelect(results[selectedIndex].school_id);
+      handleSelect(results[selectedIndex].school_id, "keyboard");
     } else if (e.key === "Escape") {
       setIsOpen(false);
     }
@@ -147,7 +158,7 @@ export function SchoolSearch() {
           {results.map((r, i) => (
             <li
               key={r.school_id}
-              onMouseDown={() => handleSelect(r.school_id)}
+              onMouseDown={() => handleSelect(r.school_id, "mouse")}
               style={{
                 display: "grid",
                 gridTemplateColumns: "1fr auto",

--- a/web/src/components/TestOptionalChart.tsx
+++ b/web/src/components/TestOptionalChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { trackEvent } from "@/lib/analytics";
 
 type Point = { year: string; sat: number; act: number | null };
 type Series = {
@@ -390,7 +391,14 @@ export function TestOptionalChart() {
             <button
               key={s.id}
               type="button"
-              onClick={() => toggle(s.id)}
+              onClick={() => {
+                trackEvent("recipe_chart_series_toggled", {
+                  recipe: "test-optional-tracker",
+                  series: s.id,
+                  next_visible: hidden.has(s.id),
+                });
+                toggle(s.id);
+              }}
               aria-pressed={!off}
               style={{
                 display: "inline-flex",

--- a/web/src/components/TrackedLink.tsx
+++ b/web/src/components/TrackedLink.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps, MouseEvent } from "react";
+import { type AnalyticsProperties, trackEvent } from "@/lib/analytics";
+
+type LinkProps = ComponentProps<typeof Link>;
+type AnchorProps = ComponentProps<"a">;
+
+type TrackedInternalLinkProps = LinkProps & {
+  analyticsEvent: string;
+  analyticsProperties?: AnalyticsProperties;
+  external?: false;
+};
+
+type TrackedExternalLinkProps = AnchorProps & {
+  analyticsEvent: string;
+  analyticsProperties?: AnalyticsProperties;
+  external: true;
+};
+
+type TrackedLinkProps = TrackedInternalLinkProps | TrackedExternalLinkProps;
+
+export function TrackedLink(props: TrackedLinkProps) {
+  const { analyticsEvent, analyticsProperties, onClick } = props;
+
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    trackEvent(analyticsEvent, analyticsProperties);
+    onClick?.(event);
+  }
+
+  if (props.external) {
+    const { analyticsEvent: _event, analyticsProperties: _properties, external: _external, ...anchorProps } = props;
+    return <a {...anchorProps} onClick={handleClick} />;
+  }
+
+  const { analyticsEvent: _event, analyticsProperties: _properties, external: _external, ...linkProps } = props;
+  return <Link {...linkProps} onClick={handleClick} />;
+}

--- a/web/src/components/WaitlistOddsExplorer.tsx
+++ b/web/src/components/WaitlistOddsExplorer.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { trackEvent, trackSourceOpened } from "@/lib/analytics";
 import {
   WAITLIST_CASES,
   type WaitlistBucketSummary,
@@ -559,7 +560,20 @@ function BerkeleyHistoryChart() {
               {years.map((row) => (
                 <tr key={row.year}>
                   <td style={{ padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                    <a href={row.archiveUrl}>{row.year}</a>
+                    <a
+                      href={row.archiveUrl}
+                      onClick={() =>
+                        trackSourceOpened({
+                          surface: "berkeley_waitlist_history",
+                          schoolId: "uc-berkeley",
+                          cdsYear: row.year,
+                          sourceFormat: row.sourceKind,
+                          action: "open_archive",
+                        })
+                      }
+                    >
+                      {row.year}
+                    </a>
                     <span className="mono" style={{ color: "var(--ink-3)", fontSize: 10.5, marginLeft: 8 }}>
                       {row.sourceKind.toUpperCase()}
                     </span>
@@ -671,7 +685,13 @@ export function WaitlistOddsExplorer() {
               type="button"
               className={`cd-btn ${bucketKey === key ? "" : "cd-btn--ghost"}`}
               style={{ padding: "8px 12px", fontSize: 13 }}
-              onClick={() => setBucketKey(key)}
+              onClick={() => {
+                trackEvent("recipe_bucket_changed", {
+                  recipe: "waitlist-odds",
+                  bucket: key,
+                });
+                setBucketKey(key);
+              }}
             >
               {BUCKET_LABELS[key]}
             </button>
@@ -791,7 +811,13 @@ export function WaitlistOddsExplorer() {
               type="button"
               className={`cd-btn ${tableMode === "lowest" ? "" : "cd-btn--ghost"}`}
               style={{ padding: "8px 12px", fontSize: 13 }}
-              onClick={() => setTableMode("lowest")}
+              onClick={() => {
+                trackEvent("recipe_extremes_table_changed", {
+                  recipe: "waitlist-odds",
+                  mode: "lowest",
+                });
+                setTableMode("lowest");
+              }}
             >
               Lowest odds
             </button>
@@ -799,7 +825,13 @@ export function WaitlistOddsExplorer() {
               type="button"
               className={`cd-btn ${tableMode === "largest" ? "" : "cd-btn--ghost"}`}
               style={{ padding: "8px 12px", fontSize: 13 }}
-              onClick={() => setTableMode("largest")}
+              onClick={() => {
+                trackEvent("recipe_extremes_table_changed", {
+                  recipe: "waitlist-odds",
+                  mode: "largest",
+                });
+                setTableMode("largest");
+              }}
             >
               Largest lists
             </button>

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+
+type AnalyticsValue = string | number | boolean | null | undefined;
+export type AnalyticsProperties = Record<string, AnalyticsValue>;
+
+export function trackEvent(name: string, properties?: AnalyticsProperties) {
+  try {
+    track(name, properties);
+  } catch {
+    // Analytics should never block navigation, local storage, copy, or downloads.
+  }
+}
+
+export function trackSchoolSearchSelected(properties: {
+  surface: "home" | "header";
+  schoolId: string;
+  coverageStatus?: string | null;
+  latestCdsYear?: string | null;
+  queryLength: number;
+  resultCount: number;
+  inputMethod: "keyboard" | "mouse";
+}) {
+  trackEvent("school_search_selected", {
+    surface: properties.surface,
+    school_id: properties.schoolId,
+    coverage_status: properties.coverageStatus,
+    latest_cds_year: properties.latestCdsYear,
+    query_length: properties.queryLength,
+    result_count: properties.resultCount,
+    input_method: properties.inputMethod,
+  });
+}
+
+export function trackSourceOpened(properties: {
+  surface: string;
+  schoolId?: string | null;
+  cdsYear?: string | null;
+  sourceFormat?: string | null;
+  action?: "download" | "view_source" | "open_archive";
+}) {
+  trackEvent("source_opened", {
+    surface: properties.surface,
+    school_id: properties.schoolId,
+    cds_year: properties.cdsYear,
+    source_format: properties.sourceFormat,
+    action: properties.action ?? "open_archive",
+  });
+}
+
+export function trackDownload(properties: {
+  surface: string;
+  fileType: string;
+  item?: string | null;
+  rowCount?: number | null;
+}) {
+  trackEvent("download_clicked", {
+    surface: properties.surface,
+    file_type: properties.fileType,
+    item: properties.item,
+    row_count: properties.rowCount,
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a shared Vercel Analytics helper and tracked link wrapper
- instrument school search, source/document opens, CSV/XLSX downloads, API copy/try-it actions, recipe controls, browser controls, match list actions, and positioning profile actions
- update privacy copy to disclose anonymous aggregate feature analytics and clarify that GPA/test scores/search terms/share codes are not sent as analytics properties

## Verification
- npm run typecheck
- npm run build
- npm test
- local production smoke across /, /api, /recipes, /recipes/waitlist-odds, /browse, /match, and /privacy