### PR TITLE
fix(extraction): heal stuck extraction_pending + harden the daily drain

### DIFF
--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -37,6 +37,10 @@ on:
         description: "Optional minimum CDS start year for targeted fresh-file drains, e.g. 2025."
         required: false
         default: ""
+      deadline_minutes:
+        description: "Wall-clock budget; the worker stops the drain gracefully before this many minutes so the job is never hard-killed (which reports as cancelled and loses progress). Must be below timeout-minutes."
+        required: false
+        default: "100"
   schedule:
     # Small daily pending-row drain. Full corpus drains belong on manual
     # operator machines or a self-hosted runner, not regular hosted CI.
@@ -59,7 +63,13 @@ jobs:
   drain-pending:
     name: Drain pending extraction rows
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Headroom over the worker's --deadline-minutes budget (default 100). The
+    # worker stops itself gracefully before the budget; this hard cap only
+    # fires if something hangs. Previously 60, which routinely hard-killed the
+    # daily drain mid-batch and reported it as "cancelled" — 20 consecutive
+    # cancelled runs (2026-05-12..05-31) stranded ~150 already-extracted docs
+    # in extraction_pending. See --reconcile-pending below.
+    timeout-minutes: 120
     env:
       INPUT_LIMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.limit || '25' }}
       INPUT_SCHOOL: ${{ github.event_name == 'workflow_dispatch' && inputs.school || '' }}
@@ -69,6 +79,7 @@ jobs:
       INPUT_SEED_PROJECTION_METADATA: ${{ github.event_name != 'workflow_dispatch' || inputs.seed_projection_metadata }}
       INPUT_LOW_FIELD_THRESHOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.low_field_threshold || '25' }}
       INPUT_MIN_YEAR_START: ${{ github.event_name == 'workflow_dispatch' && inputs.min_year_start || '' }}
+      INPUT_DEADLINE_MINUTES: ${{ github.event_name == 'workflow_dispatch' && inputs.deadline_minutes || '100' }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
@@ -109,6 +120,10 @@ jobs:
             echo "min_year_start must be an integer when provided" >&2
             exit 2
           fi
+          if [[ -n "${INPUT_DEADLINE_MINUTES}" ]] && ! [[ "${INPUT_DEADLINE_MINUTES}" =~ ^[0-9]+$ ]]; then
+            echo "deadline_minutes must be an integer when provided" >&2
+            exit 2
+          fi
 
           mkdir -p ops-summary
           {
@@ -146,9 +161,13 @@ jobs:
           args=(
             --env .env.ops
             --limit "${INPUT_LIMIT}"
+            --reconcile-pending
             --summary-json ops-summary/summary.json
             --low-field-threshold "${INPUT_LOW_FIELD_THRESHOLD}"
           )
+          if [[ -n "${INPUT_DEADLINE_MINUTES}" ]]; then
+            args+=(--deadline-minutes "${INPUT_DEADLINE_MINUTES}")
+          fi
           if [[ "${INPUT_SEED_PROJECTION_METADATA}" == "true" ]]; then
             args+=(--seed-projection-metadata)
           fi

--- a/docs/prd/024-share-button.md
+++ b/docs/prd/024-share-button.md
@@ -1,0 +1,418 @@
+# PRD 024: Share button
+
+**Status:** Draft
+**Created:** 2026-05-21
+**Author:** Anthony + Codex
+**Related:** [PRD 002](002-frontend.md), [PRD 013](013-analytics-and-abuse-signal.md), [PRD 015](015-institution-directory-and-cds-coverage.md), [PRD 017](017-match-list-builder.md), [PRD 020](020-accessible-cds-table-view.md), [PRD 023](023-admission-visualization-upgrades.md)
+
+---
+
+## Context
+
+CollegeData.fyi is increasingly becoming a page people want to send to someone else:
+
+- a parent sending a school page to a student
+- a student sending a CDS year page to a counselor
+- a counselor sending a Match list to a family
+- a journalist or researcher citing a source-backed admissions or aid fact
+- an IR professional sharing a coverage/missing-CDS page internally
+
+The site has canonical URLs and good page metadata, and `/match` already has a stateless share-code pattern. That code is useful but not anonymous: the current implementation reversibly packs GPA, SAT, ACT, and GPA scale into the code. Sharing is inconsistent: most pages require users to manually copy the browser URL, and there is no reusable pattern for sharing the exact page or source-backed fact that prompted the user to share.
+
+The share button should be a small utility surface, not a social growth gimmick. Its job is to help a user send the right CollegeData.fyi artifact with enough context that the recipient understands what they are opening. For Match, that means going beyond a naked URL while being honest that the current code is a sensitive, reversible profile payload.
+
+## Problem
+
+Users can technically share any page today, but the experience is brittle:
+
+1. Manual URL copying is awkward on mobile and easy to get wrong.
+2. School pages contain several distinct artifacts, but the URL usually lands at the top instead of the relevant section.
+3. Match sharing uses a special "Copy code" control that is not visually or behaviorally aligned with the rest of the site.
+4. A copied URL alone does not explain whether the user is sharing a school profile, a CDS source document, an admissions visualization, a merit-aid card, or a filtered coverage view.
+5. We have no clean product signal for which pages and artifacts users find worth sharing.
+
+## Goals
+
+1. Add a consistent, accessible Share button to high-value public pages.
+2. Let users share the current page-level artifact first: school overview, year detail, Match list, and coverage filter state. Section-level sharing comes after stable anchors exist.
+3. Prefer native sharing on devices that support it, with reliable copy-link fallback everywhere.
+4. Preserve the project's privacy posture by treating Match share codes as sensitive profile payloads: do not log them, do not send them to analytics, and do not imply they anonymize student stats.
+5. Add a Wordle-like Match share card that summarizes only URL-reproducible result distribution and includes the share URL.
+6. Make Match links eligible for polished unfurls only after the privacy posture is explicit and preview data is URL-reproducible.
+7. Add low-cardinality analytics events that show share intent without collecting sensitive payloads.
+
+## Non-goals
+
+- No login, contacts import, email sending, or server-side saved shares.
+- No third-party social SDKs or embedded share widgets.
+- No automatic posting to Facebook, X, LinkedIn, Reddit, TikTok, or similar networks.
+- No public short-link service in MVP.
+- No code-specific image-generation pipeline for dynamic Match social cards until the Match preview privacy gate is cleared.
+- No claim that Match share codes anonymize student stats. The existing stateless code is reversible and must be treated as sensitive.
+- No public leaderboard, virality loop, or gamified ranking pressure around student profiles.
+
+## Users and Jobs
+
+### Parent or student
+
+"I found the page for a school we are considering and want to text it to someone with a short explanation."
+
+### Counselor
+
+"I built or found a useful view and want to send the exact list or source-backed section to a family without exposing more student data than necessary."
+
+### Researcher or journalist
+
+"I need a stable link or citation snippet for the exact data point I am referencing."
+
+### IR professional
+
+"I want to share a school's coverage status or archived document page with a colleague who may not know CollegeData.fyi."
+
+## UX
+
+### Placement
+
+MVP placements:
+
+1. `/schools/[school_id]` header: share the school overview.
+2. `/schools/[school_id]/[year]` header: share the exact CDS year page.
+3. `/match`: replace or wrap the existing "Copy code" control with the shared component, preserving the stateless profile code and clearly labeling it as shareable with anyone who has the link.
+4. `/coverage`: share the current filtered view, since PRD 015 made filters URL-persisted.
+
+Nice-to-have after MVP:
+
+- school-page section actions after stable anchors ship: admissions strategy, positioning, merit profile, what changed, federal baseline, and documents ledger
+- recipe pages under `/recipes`
+- API examples and public-data pages
+- reconstructed CDS tables from PRD 020
+
+### Interaction
+
+Desktop:
+
+- A compact icon+text button labeled "Share" in page headers.
+- Section-level share controls, once they ship, can be icon-only with an accessible label and tooltip.
+- Clicking opens a small popover:
+  - Copy link
+  - Share with device, shown only when `navigator.share` is available
+  - Copy citation, shown for source-backed school/year artifacts
+
+Mobile:
+
+- Tapping Share calls `navigator.share()` directly when supported.
+- If native share fails or is unsupported, open the same popover with copy controls.
+
+Feedback:
+
+- After copy, the button reads "Copied" for about 1.6 seconds.
+- Do not use modal confirmations.
+- Do not block sharing if analytics fails.
+
+### Match share card
+
+For `/match`, add a second share action: "Copy summary". This copies a compact text block modeled on Wordle's share output. The summary must be computed from the exact URL-reproducible state represented by the shared URL.
+
+```text
+CollegeData.fyi Match K9F-3XQ
+42 source-backed schools ranked
+
+Strong fit  ████████ 8
+Above range █████ 5
+In range    ███████████████ 15
+Below range █████████ 9
+Unknown     █████ 5
+
+https://www.collegedata.fyi/match?code=K9F-3XQ
+```
+
+The exact visual treatment can use block characters or simple colored squares if they render cleanly across iMessage, Slack, Gmail, and plain SMS. Default to ASCII/block characters over emoji if emoji alignment looks noisy.
+
+The share card may include:
+
+- profile code
+- total ranked schools
+- counts by academic-fit bucket
+- active non-sensitive filters, only if they are part of the URL
+- the share URL
+
+The share card must not include:
+
+- SAT, ACT, GPA, home state, intended major, or any free-form student profile text
+- top-school names by default
+- school IDs or document IDs
+- hidden JSON payloads or base64 blobs beyond the existing profile code
+- counts computed from filters or state that the URL cannot reproduce
+
+Top-school names can be a later opt-in variant ("Include top 5 schools") after privacy review. The MVP should keep the card spoiler-light: enough to make the share legible, not enough to disclose a student's exact list in a notification preview.
+
+MVP default: compute the copied summary from `rankMatchSchools(profile, schools, DEFAULT_MATCH_FILTERS)` unless allowed filter params have been added to the URL. Do not summarize transient client-only filter state.
+
+### Rich link preview
+
+When the Match URL is pasted into Slack, iMessage, Discord, LinkedIn, or similar clients, the URL should unfurl into a visual card using Open Graph metadata. This is separate from the copied Wordle-like text: the copied text gives a readable plain-text summary, while the URL preview gives the polished card.
+
+MVP preview behavior:
+
+- `/match?code=K9F-3XQ` uses generic Match metadata by default.
+- `openGraph.title`: `CollegeData.fyi Match List Builder`
+- `openGraph.description`: `Build a college match list from source-backed admissions data.`
+- `openGraph.images`: a generic Match card, not code-specific.
+- `twitter.card`: `summary_large_image` if the route metadata supports it cleanly.
+
+Code-specific preview behavior is gated. It can ship only after an explicit product decision that Match links are sensitive share links and that preview platforms may fetch, cache, and display derived Match results. If that gate clears, the code-specific card may show:
+
+- prominent `CollegeData.fyi Match`
+- share code
+- total ranked schools
+- a horizontal distribution chart by academic-fit bucket
+- small source line: `Built from Common Data Set score bands`
+- no SAT, ACT, GPA, home state, intended major, top-school names, or full school list
+
+Implementation default:
+
+- Add generic Match Open Graph metadata to `web/src/app/match/page.tsx`.
+- Optionally add `web/src/app/match/og/route.tsx` for the generic 1200x630 Match card.
+- Do not point `openGraph.images` at a code-specific `/match/og?code=...` route in M1.
+- Do not decode profile codes in an Open Graph image route in M1.
+- If the code is missing or invalid, render a generic Match card instead of erroring.
+- Keep `revalidate = 3600` unless preview bots need fresher results.
+
+Post-MVP code-specific preview implementation, if approved:
+
+- Add `generateMetadata()` to `web/src/app/match/page.tsx` so `/match?code=...` can produce code-specific `openGraph` and Twitter metadata.
+- Add `web/src/app/match/og/route.tsx` as a dynamic image route that returns an `ImageResponse` and reads `code` from `request.url`.
+- Point `openGraph.images` at `/match/og?code=K9F-3XQ`.
+- Decode `code`, compute ranked groups from `fetchMatchBuilderSchools()`, and render the visual distribution.
+- Show copy near the share action: `Anyone with this link, and some preview services, can open or process this Match code.`
+
+Preview card quality bar:
+
+- 1200x630 image.
+- Text readable at Slack sidebar width and phone notification/card width.
+- High contrast, no tiny table text.
+- Looks like a result artifact, not a marketing banner.
+- Works when the client crops or letterboxes the image.
+- Uses the same bucket labels as the Match UI if the card is code-specific.
+
+Important platform caveat: the sender cannot force Slack, iMessage, or every texting app to show a preview. Many clients cache unfurls, suppress previews in some contexts, or let users disable previews. CollegeData.fyi can only provide strong Open Graph metadata and a valid preview image.
+
+### Shared Text
+
+Payload examples:
+
+- School page title: `Yale University Common Data Set archive`
+- School page text: `Source-linked admissions, enrollment, aid, and CDS documents from CollegeData.fyi.`
+- Section title: `Yale University admission strategy`
+- Year page title: `Yale University Common Data Set 2024-25`
+- Match title: `CollegeData.fyi match list`
+- Coverage title: `CollegeData.fyi CDS coverage view`
+
+The copied URL should be canonical and absolute. Section shares append a stable hash such as:
+
+- `/schools/yale#admission-strategy`
+- `/schools/yale#merit-profile`
+- `/schools/yale#documents`
+
+## Functional Requirements
+
+### Reusable component
+
+Create a single client component, likely `web/src/components/ShareButton.tsx`, with this shape:
+
+```ts
+type ShareButtonProps = {
+  title: string;
+  text?: string;
+  path: string;
+  sectionId?: string;
+  citation?: string;
+  surface: "school" | "school_year" | "school_section" | "match" | "coverage" | "recipe" | "api";
+  variant?: "header" | "icon";
+};
+```
+
+The component builds an absolute URL from `window.location.origin` plus `path` and optional `sectionId`.
+
+### Copy behavior
+
+1. Try `navigator.clipboard.writeText(url)`.
+2. Fall back to a hidden `textarea` and `document.execCommand("copy")`, matching the current `/match` behavior.
+3. If both fail, render the URL in a selectable field inside the popover.
+
+### Native share behavior
+
+Use `navigator.share({ title, text, url })` only when available. Treat cancellation as a non-error.
+
+### Match integration
+
+The existing Match URL remains:
+
+`/match?code={statelessCode}`
+
+The Share button may show the code in the UI, but the code must be treated as a sensitive profile payload because it is reversible. The share UI should say: `Anyone with this link can open this Match profile.`
+
+Add a small formatter, likely in `web/src/lib/match-share.ts`, that takes URL-reproducible ranked result groups and returns the share-card text. This should be a pure function so it can be snapshot-tested against stable fixtures.
+
+MVP summary state rule:
+
+- If the URL is `/match?code=...`, compute the summary from default filters only.
+- If the product wants summaries for active filters, first encode allowed filters into the shared URL and load them on page open.
+- Encode only low-sensitivity UI state such as school type, region, admit-rate bucket, Carnegie bucket, current-cycle-only, and sort.
+- Do not encode home state or intended major unless a separate privacy review decides they are safe and product-critical.
+
+### Section anchors
+
+School-page modules must expose stable `id` attributes before section-level share ships:
+
+- `academic-positioning`
+- `admission-strategy`
+- `merit-profile`
+- `what-changed`
+- `federal-baseline`
+- `documents`
+
+Changing these IDs later is a breaking URL change.
+
+### Metadata
+
+Existing Next.js page metadata is mostly sufficient. MVP should audit:
+
+- `metadataBase` remains `https://www.collegedata.fyi`
+- school pages include `openGraph.title`, `openGraph.description`, and `openGraph.url`
+- year pages include title, description, canonical, and Open Graph URL
+- `/match` and `/coverage` have meaningful descriptions
+- `/match?code=...` uses generic metadata in M1; code-specific title, description, and image metadata are gated until preview privacy is approved
+
+Do not block the generic Share button MVP on dynamic OG images for every route. A generic Match preview card can ship in M1. Code-specific Match cards are post-MVP unless the privacy gate is explicitly cleared.
+
+## Analytics
+
+Use Vercel Analytics through the existing analytics posture from PRD 013.
+
+Events:
+
+- `share_opened`
+- `share_copy_link`
+- `share_native`
+- `share_copy_match_summary`
+- `share_copy_citation`
+- `share_failed`
+
+Properties:
+
+- `surface`
+- `variant`
+- `has_section`
+- `method`
+
+Do not send:
+
+- full URL
+- school name
+- school id
+- Match code
+- Match summary text
+- student profile values
+- citation text
+
+## Accessibility
+
+- Button is reachable by keyboard.
+- Popover has a focus path and closes on Escape.
+- Icon-only variants have `aria-label="Share this section"`.
+- Copy status is announced with an `aria-live="polite"` region.
+- The fallback URL field is selectable and labeled.
+- No keyboard trap.
+
+## Privacy and Security
+
+- Do not put literal raw student scores, GPA, home state, intended major, or free-form profile data into share URLs.
+- Treat current Match codes as reversible student-profile payloads, not anonymized IDs.
+- Do not place Match codes in Open Graph titles, descriptions, or images in M1.
+- Do not decode Match codes in preview-bot routes in M1.
+- Do not persist share records server-side in MVP.
+- Do not use third-party share SDKs.
+- Treat citations as plain text only.
+- Avoid `dangerouslySetInnerHTML`; the share component renders only strings.
+
+## Rollout
+
+### M1: Page-level share
+
+- Ship `ShareButton`.
+- Add header-level share to school pages, school-year pages, `/match`, and `/coverage`.
+- Replace `/match` copy-code logic with the shared component or a thin adapter around it.
+- Add `/match` "Copy summary" using the Wordle-like text formatter, computed from URL-reproducible default filter state.
+- Add generic Match Open Graph metadata; optionally add a generic `web/src/app/match/og/route.tsx`.
+
+### M2: Section-level share
+
+- Add stable anchors to school-page modules.
+- Add section-level share controls to admissions, positioning, merit, changes, federal facts, and documents.
+- Add copy-citation for source-backed sections.
+
+### M3: Code-specific Match preview, gated
+
+- Decide whether Match codes remain reversible stateless payloads, move to an opaque/stateful share architecture, or keep previews generic.
+- If retaining reversible codes, add explicit user-facing copy before code-specific preview sharing.
+- If using an opaque/stateful share architecture, design retention, deletion, abuse controls, and privacy copy before implementation.
+- Add code-specific Match Open Graph metadata and `web/src/app/match/og/route.tsx` only after this gate.
+
+### M4: Polish and expansion
+
+- Add recipe/API page share where it feels natural.
+- Review Open Graph previews.
+- Consider static per-route OG images if shared-page traffic becomes meaningful.
+
+## Success Metrics
+
+Within 30 days of ship:
+
+- At least 2% of school-page visitors click Share.
+- At least 60% of opened share menus result in copy or native share.
+- Match share uses increase without a rise in invalid-code loads.
+- No support reports that Match code sensitivity was unclear.
+- Shared-section links land on the intended module on desktop and mobile once M2 ships.
+
+## Implementation Notes
+
+Likely files:
+
+- `web/src/components/ShareButton.tsx`
+- `web/src/components/CopyButton.tsx` may be simplified or made an internal primitive
+- `web/src/app/schools/[school_id]/page.tsx`
+- `web/src/app/schools/[school_id]/[year]/page.tsx`
+- `web/src/app/match/page.tsx`
+- `web/src/app/match/og/route.tsx`
+- `web/src/components/MatchListBuilder.tsx`
+- `web/src/lib/match-share.ts`
+- `web/src/app/coverage/page.tsx`
+- `web/src/lib/analytics.ts` if the current analytics helper lands before this work
+
+Tests:
+
+- unit test URL building and hash behavior
+- snapshot test Match summary formatting for empty, small, and large result sets
+- snapshot test that Match summaries ignore transient filters unless filters are encoded into the URL
+- screenshot test generic Match OG image at 1200x630
+- component test copy fallback where possible
+- browser QA on Chrome desktop, Safari desktop, iOS Safari, and Android Chrome
+- verify Match share UI labels the code/link as shareable to anyone with the link
+- verify no Match raw profile values appear in copied summary text
+- verify no Match code or raw profile values appear in M1 Open Graph title, description, or image
+- verify section anchors scroll cleanly below the fixed nav, if the nav remains fixed
+
+## Open Questions
+
+1. Should "Copy citation" ship in M1 for year pages, or wait for PRD 020 reconstructed tables?
+2. Should section-level share controls be always visible or appear on hover/focus?
+3. Do we want a small "Copied from CollegeData.fyi" text snippet, or only the URL?
+4. Should `/coverage` share include all filter params or only non-default filters?
+5. Should Match URL sharing preserve filters in addition to the profile code?
+6. Should "Include top 5 schools" exist as an explicit opt-in, or is that too easy to overshare?
+7. What explicit privacy/product gate would justify code-specific Match OG cards later: reversible-code warning, opaque share architecture, or no code-specific previews at all?
+
+## Default Decision
+
+Ship M1 first. The smallest useful version is a reusable Share button on school, year, Match, and coverage pages that uses native share when possible and copy-link everywhere else. Match gets a URL-reproducible Wordle-like text summary plus generic Open Graph preview only. Section-level links, citations, active-filter Match summaries, and code-specific Match preview cards are later gates.

--- a/tools/extraction_worker/test_worker_reconcile.py
+++ b/tools/extraction_worker/test_worker_reconcile.py
@@ -1,0 +1,176 @@
+"""Tests for the cheap, extraction-free pending-status reconcile pass.
+
+These cover the gate that decides whether a document is *actually* extracted
+(``has_canonical_for_current_bytes``) and the pass that flips such documents
+out of ``extraction_pending`` without re-running Docling
+(``reconcile_pending_documents``). This is the durable fix for documents that
+serve real data yet show "pending/processing" in cds_manifest.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from worker import (
+    has_canonical_for_current_bytes,
+    reconcile_pending_documents,
+)
+
+CUR = "sha-current"
+OLD = "sha-old"
+
+
+def _src(sha, created_at):
+    return {"kind": "source", "sha256": sha, "created_at": created_at}
+
+
+def _canon(created_at):
+    return {"kind": "canonical", "sha256": "art-sha", "created_at": created_at}
+
+
+class _ArtifactQuery:
+    """Stands in for client.table('cds_artifacts').select(...).eq(...).execute()."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, _col, _val):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=list(self._rows))
+
+
+class _DocUpdateQuery:
+    """Records cds_documents update(...).eq(...)[.in_(...)].execute() calls."""
+
+    def __init__(self, sink, payload):
+        self._sink = sink
+        self._payload = payload
+
+    def eq(self, _col, value):
+        self._sink.append((value, self._payload))
+        return self
+
+    def in_(self, _col, _values):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=[])
+
+
+class _FakeClient:
+    def __init__(self, artifacts_by_doc):
+        self._artifacts_by_doc = artifacts_by_doc
+        self.updates: list[tuple[str, dict]] = []
+        self._last_doc_id = None
+
+    def table(self, name):
+        self._table = name
+        return self
+
+    # cds_artifacts path
+    def select(self, _cols):
+        return self
+
+    # shared eq: artifacts query filters by document_id; remember which doc
+    def eq(self, col, value):
+        if self._table == "cds_artifacts" and col == "document_id":
+            rows = self._artifacts_by_doc.get(value, [])
+            return _ArtifactQuery(rows)
+        return self
+
+    def update(self, payload):
+        return _DocUpdateQuery(self.updates, payload)
+
+
+class HasCanonicalForCurrentBytesTests(unittest.TestCase):
+    def _client(self, rows):
+        return _FakeClient({"doc": rows})
+
+    def test_canonical_after_current_source_is_extracted(self):
+        rows = [_src(CUR, "2026-04-14T00:00:00+00:00"), _canon("2026-05-11T00:00:00+00:00")]
+        self.assertTrue(has_canonical_for_current_bytes(self._client(rows), "doc", CUR))
+
+    def test_canonical_predating_current_source_is_stale(self):
+        # Source republished after the only extraction -> not extracted yet.
+        rows = [
+            _canon("2026-04-20T00:00:00+00:00"),
+            _src(OLD, "2026-04-14T00:00:00+00:00"),
+            _src(CUR, "2026-05-01T00:00:00+00:00"),
+        ]
+        self.assertFalse(has_canonical_for_current_bytes(self._client(rows), "doc", CUR))
+
+    def test_no_canonical_is_not_extracted(self):
+        rows = [_src(CUR, "2026-04-14T00:00:00+00:00")]
+        self.assertFalse(has_canonical_for_current_bytes(self._client(rows), "doc", CUR))
+
+    def test_no_source_row_matching_current_sha_is_conservative(self):
+        rows = [_src(OLD, "2026-04-14T00:00:00+00:00"), _canon("2026-05-11T00:00:00+00:00")]
+        self.assertFalse(has_canonical_for_current_bytes(self._client(rows), "doc", CUR))
+
+    def test_missing_source_sha_returns_false(self):
+        rows = [_canon("2026-05-11T00:00:00+00:00")]
+        self.assertFalse(has_canonical_for_current_bytes(self._client(rows), "doc", None))
+
+
+class ReconcilePendingDocumentsTests(unittest.TestCase):
+    def test_flips_only_current_bytes_docs_and_excludes_them(self):
+        artifacts = {
+            "extracted-doc": [
+                _src(CUR, "2026-04-14T00:00:00+00:00"),
+                _canon("2026-05-11T00:00:00+00:00"),
+            ],
+            "stale-doc": [
+                _canon("2026-04-20T00:00:00+00:00"),
+                _src(CUR, "2026-05-01T00:00:00+00:00"),
+            ],
+            "fresh-doc": [_src(CUR, "2026-04-14T00:00:00+00:00")],
+        }
+        client = _FakeClient(artifacts)
+        docs = [
+            {"id": "extracted-doc", "source_sha256": CUR},
+            {"id": "stale-doc", "source_sha256": CUR},
+            {"id": "fresh-doc", "source_sha256": CUR},
+        ]
+
+        reconciled, counts = reconcile_pending_documents(
+            client, docs, projection_definitions=None,
+            projection_enabled=False, dry_run=False,
+        )
+
+        self.assertEqual(reconciled, {"extracted-doc"})
+        self.assertEqual(counts["reconciled"], 1)
+        # exactly one document flipped to extracted
+        extracted_updates = [
+            doc_id for doc_id, payload in client.updates
+            if payload.get("extraction_status") == "extracted"
+        ]
+        self.assertEqual(extracted_updates, ["extracted-doc"])
+
+    def test_dry_run_classifies_without_writing(self):
+        artifacts = {
+            "extracted-doc": [
+                _src(CUR, "2026-04-14T00:00:00+00:00"),
+                _canon("2026-05-11T00:00:00+00:00"),
+            ],
+        }
+        client = _FakeClient(artifacts)
+        docs = [{"id": "extracted-doc", "source_sha256": CUR}]
+
+        reconciled, counts = reconcile_pending_documents(
+            client, docs, projection_definitions=None,
+            projection_enabled=False, dry_run=True,
+        )
+
+        self.assertEqual(reconciled, {"extracted-doc"})
+        self.assertEqual(counts["reconciled"], 1)
+        self.assertEqual(client.updates, [])  # no writes in dry run
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -86,7 +86,7 @@ import tempfile
 import zipfile
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional
@@ -131,8 +131,12 @@ class SchemaResolution:
     fallback_used: bool
     fallback_reason: Optional[str]
     schema_path: Path
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return utc_now().isoformat()
 
 
 def parsed_field_count(action: str) -> int | None:
@@ -1021,6 +1025,106 @@ def clear_recoverable_quality_flag(client: Client, document_id: str) -> None:
     ).execute()
 
 
+def has_canonical_for_current_bytes(
+    client: Client,
+    document_id: str,
+    source_sha256: Optional[str],
+) -> bool:
+    """True if a canonical artifact produced from the document's CURRENT
+    source bytes already exists.
+
+    Notes-free heuristic, deliberately conservative: a canonical artifact
+    whose ``created_at`` is at or after the moment the current source bytes
+    were first archived was necessarily produced from those bytes, because
+    extraction always downloads the document's current source. When the
+    current source artifact can't be identified (no source row matching the
+    document's ``source_sha256``), this returns False so the document stays
+    pending rather than being marked extracted against stale bytes.
+
+    This is the gate for the reconcile pass — it answers "is this document
+    actually extracted?" without paying the cost of re-running Docling.
+    """
+    if not source_sha256:
+        return False
+    rows = (
+        client.table("cds_artifacts")
+        .select("kind,sha256,created_at")
+        .eq("document_id", document_id)
+        .execute()
+        .data
+        or []
+    )
+    canonical_times = [r["created_at"] for r in rows if r.get("kind") == "canonical"]
+    if not canonical_times:
+        return False
+    current_source_times = [
+        r["created_at"]
+        for r in rows
+        if r.get("kind") == "source" and r.get("sha256") == source_sha256
+    ]
+    if not current_source_times:
+        return False
+    current_bytes_archived_at = min(current_source_times)
+    # ISO-8601 timestamps from PostgREST compare correctly as strings here
+    # because they share the same +00:00 offset.
+    return any(t >= current_bytes_archived_at for t in canonical_times)
+
+
+def reconcile_pending_documents(
+    client: Client,
+    docs: list[dict[str, Any]],
+    projection_definitions: Optional[dict],
+    projection_enabled: bool,
+    dry_run: bool,
+) -> tuple[set[str], Counter]:
+    """Cheap, extraction-free status repair.
+
+    A document can sit in ``extraction_pending`` even though a valid canonical
+    artifact of its current bytes already exists — e.g. after a producer-version
+    requeue that the heavy drain never caught up on, or a worker run killed
+    mid-batch. Those documents serve real data but the public ``cds_manifest``
+    still reports "pending/processing" to users. This pass flips every such
+    document to ``extracted`` with a single DB query per row and no Docling, so
+    the symptom self-heals instead of persisting for weeks.
+
+    Producer-version upgrades are intentionally NOT handled here: this only
+    decides whether the current bytes have been extracted at all. Re-running a
+    newer extractor over already-extracted bytes is a separate quality concern,
+    driven explicitly via ``--force-reextract``, and must not hold a document in
+    a user-visible "pending" state.
+
+    Returns the set of reconciled document ids (to exclude from the heavy
+    drain) and a Counter of outcomes.
+    """
+    reconciled: set[str] = set()
+    counts: Counter = Counter()
+    for doc in docs:
+        document_id = str(doc["id"])
+        if not has_canonical_for_current_bytes(
+            client, document_id, doc.get("source_sha256")
+        ):
+            continue
+        reconciled.add(document_id)
+        counts["reconciled"] += 1
+        if dry_run:
+            continue
+        mark_extraction_status(client, document_id, "extracted")
+        clear_recoverable_quality_flag(client, document_id)
+        if projection_enabled and projection_definitions is not None:
+            try:
+                refresh_browser_projection(client, document_id, projection_definitions)
+            except Exception as e:
+                counts["projection_errors"] += 1
+                message = str(e).splitlines()[0][:200]
+                print(
+                    f"    reconcile_projection_error: document={document_id} "
+                    f"{type(e).__name__}: {message}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    return reconciled, counts
+
+
 def write_source_metadata(
     client: Client,
     document_id: str,
@@ -1549,6 +1653,29 @@ def main() -> int:
         ),
     )
     parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--deadline-minutes",
+        type=float,
+        default=None,
+        help=(
+            "Wall-clock budget. The worker stops the heavy drain gracefully "
+            "before this many minutes elapse, writes its summary, and exits 0 "
+            "instead of being hard-killed by a CI job timeout (which loses "
+            "forward progress and reports the run as cancelled). Set it below "
+            "the workflow's timeout-minutes."
+        ),
+    )
+    parser.add_argument(
+        "--reconcile-pending",
+        action="store_true",
+        help=(
+            "Before the heavy drain, cheaply flip any extraction_pending "
+            "document that already has a canonical artifact of its current "
+            "source bytes to 'extracted' (no re-extraction). Repairs documents "
+            "left stuck as 'pending/processing' in cds_manifest. Reconciled "
+            "documents are excluded from the drain."
+        ),
+    )
     parser.add_argument("--school", default=None, help="Only process this school_id")
     parser.add_argument(
         "--document-ids",
@@ -1734,7 +1861,8 @@ def main() -> int:
         )
 
     query = client.table("cds_documents").select(
-        "id, school_id, cds_year, detected_year, source_format, extraction_status, discovered_at",
+        "id, school_id, cds_year, detected_year, source_format, "
+        "extraction_status, discovered_at, source_sha256",
     )
     if args.include_failed:
         query = query.in_("extraction_status", ["extraction_pending", "failed"])
@@ -1756,35 +1884,6 @@ def main() -> int:
             if (row_start_year(doc) or 0) >= args.min_year_start
         ]
     docs = sorted(docs, key=pending_doc_priority_key)
-    if args.limit:
-        docs = docs[:args.limit]
-    if not docs:
-        print(
-            "No rows to process. Try --include-failed to re-process earlier failures.",
-        )
-        if args.summary_json:
-            write_run_summary(args.summary_json, {
-                "started_at": started_at,
-                "finished_at": utc_now_iso(),
-                "dry_run": args.dry_run,
-                "limit": args.limit,
-                "school": args.school,
-                "include_failed": args.include_failed,
-                "low_field_threshold": args.low_field_threshold,
-                "processed_count": 0,
-                "failure_count": 0,
-                "mean_fields": None,
-                "low_field_docs": [],
-                "extraction_counts": {},
-                "projection_counts": {},
-                "documents": [],
-            })
-        return 0
-
-    print(
-        f"Processing {len(docs)} document(s){' (dry run)' if args.dry_run else ''}...",
-        flush=True,
-    )
 
     projection_definitions: dict | None = None
     projection_enabled = not args.dry_run and not args.skip_projection_refresh
@@ -1805,20 +1904,108 @@ def main() -> int:
                 flush=True,
             )
 
+    # Cheap status repair runs over the FULL pending set (before --limit), so a
+    # single scheduled run heals the whole "stuck pending" backlog instead of
+    # nibbling at it 25 rows a day. --force-reextract opts out: the operator
+    # explicitly wants the bytes re-extracted, not short-circuited.
+    reconcile_counts: Counter = Counter()
+    if args.reconcile_pending and not args.force_reextract:
+        reconciled_ids, reconcile_counts = reconcile_pending_documents(
+            client, docs, projection_definitions, projection_enabled, args.dry_run,
+        )
+        if reconciled_ids:
+            verb = "Would reconcile" if args.dry_run else "Reconciled"
+            print(
+                f"{verb} {len(reconciled_ids)} already-extracted document(s) "
+                "to 'extracted' (no re-extraction).",
+                flush=True,
+            )
+            docs = [d for d in docs if str(d["id"]) not in reconciled_ids]
+
+    if args.limit:
+        docs = docs[:args.limit]
+    if not docs:
+        print(
+            "No rows left to drain"
+            + (" after reconcile." if reconcile_counts.get("reconciled") else "."),
+        )
+        if args.summary_json:
+            write_run_summary(args.summary_json, {
+                "started_at": started_at,
+                "finished_at": utc_now_iso(),
+                "dry_run": args.dry_run,
+                "limit": args.limit,
+                "school": args.school,
+                "include_failed": args.include_failed,
+                "low_field_threshold": args.low_field_threshold,
+                "processed_count": 0,
+                "failure_count": 0,
+                "mean_fields": None,
+                "low_field_docs": [],
+                "extraction_counts": {},
+                "projection_counts": dict(projection_counts),
+                "reconcile_counts": dict(reconcile_counts),
+                "stopped_early": False,
+                "documents": [],
+            })
+        return 0
+
+    print(
+        f"Processing {len(docs)} document(s){' (dry run)' if args.dry_run else ''}...",
+        flush=True,
+    )
+
+    deadline: datetime | None = None
+    if args.deadline_minutes:
+        deadline = utc_now() + timedelta(minutes=args.deadline_minutes)
+
     counts: Counter = Counter()
     summary_docs: list[dict[str, Any]] = []
     field_counts: list[int] = []
     low_field_docs: list[dict[str, Any]] = []
     failure_count = 0
+    stopped_early = False
     for i, doc in enumerate(docs, 1):
-        outcome = extract_one(
-            client,
-            doc,
-            schema_registry,
-            args.dry_run,
-            cell_maps,
-            force_reextract=args.force_reextract,
-        )
+        if deadline is not None and utc_now() >= deadline:
+            remaining = len(docs) - (i - 1)
+            print(
+                f"Deadline reached ({args.deadline_minutes:g} min); stopping "
+                f"gracefully with {remaining} document(s) unprocessed. Their "
+                "extraction_status is unchanged and the next run will resume.",
+                flush=True,
+            )
+            stopped_early = True
+            break
+        # extract_one is contracted not to raise, but schema/format setup
+        # paths can still throw on a malformed or out-of-range document (e.g.
+        # an old CDS year that resolves to a schema without a 'fields' key).
+        # One bad row must not abort the whole drain and strand every
+        # remaining document — mark it failed and keep going.
+        try:
+            outcome = extract_one(
+                client,
+                doc,
+                schema_registry,
+                args.dry_run,
+                cell_maps,
+                force_reextract=args.force_reextract,
+            )
+        except Exception as e:
+            if not args.dry_run:
+                try:
+                    mark_extraction_status(
+                        client, str(doc["id"]), "failed", doc.get("source_format"),
+                    )
+                except Exception:
+                    pass
+            message = str(e).splitlines()[0][:200]
+            print(
+                f"    worker_error: school={doc.get('school_id')} "
+                f"document={doc['id']} {type(e).__name__}: {message}",
+                file=sys.stderr,
+                flush=True,
+            )
+            outcome = extraction_no_project(f"worker_error: {type(e).__name__}: {message}")
         bucket = outcome.action.split(":")[0].split(" ")[0]
         counts[bucket] += 1
         fields = parsed_field_count(outcome.action)
@@ -1876,11 +2063,17 @@ def main() -> int:
         })
         print(f"[{i:4d}/{len(docs)}] {doc['school_id']}: {outcome.action}{projection_note}", flush=True)
 
+    processed_count = sum(counts.values())
+
     print()
+    if reconcile_counts.get("reconciled"):
+        print(f"=== reconciled (no re-extraction): {reconcile_counts['reconciled']} ===")
     print("=== extraction results ===")
     for bucket, n in counts.most_common():
         print(f"  {bucket:30s} {n:5d}")
-    print(f"  {'total':30s} {sum(counts.values()):5d}")
+    print(f"  {'total':30s} {processed_count:5d}")
+    if stopped_early:
+        print(f"  {'(stopped at deadline)':30s}")
     if projection_enabled or projection_counts:
         print()
         print("=== browser projection refresh ===")
@@ -1897,12 +2090,14 @@ def main() -> int:
                     "school": args.school,
                     "include_failed": args.include_failed,
                     "low_field_threshold": args.low_field_threshold,
-                    "processed_count": len(docs),
+                    "processed_count": processed_count,
                     "failure_count": failure_count,
                     "mean_fields": mean_or_none(field_counts),
                     "low_field_docs": low_field_docs,
                     "extraction_counts": dict(counts),
                     "projection_counts": dict(projection_counts),
+                    "reconcile_counts": dict(reconcile_counts),
+                    "stopped_early": stopped_early,
                     "documents": summary_docs,
                 })
             return 2
@@ -1915,12 +2110,14 @@ def main() -> int:
             "school": args.school,
             "include_failed": args.include_failed,
             "low_field_threshold": args.low_field_threshold,
-            "processed_count": len(docs),
+            "processed_count": processed_count,
             "failure_count": failure_count,
             "mean_fields": mean_or_none(field_counts),
             "low_field_docs": low_field_docs,
             "extraction_counts": dict(counts),
             "projection_counts": dict(projection_counts),
+            "reconcile_counts": dict(reconcile_counts),
+            "stopped_early": stopped_early,
             "documents": summary_docs,
         })
     return 0


### PR DESCRIPTION
## What & why

The latest Harvard CDS (2024-25) was showing **"pending/processing"** on its school page even though it had been fully extracted (455 fields, canonical artifact from 2026-05-11). Investigation found this was **systemic, not Harvard-specific**: ~150 documents that already had a valid canonical artifact were stranded in `extraction_pending`.

**Root cause chain:**
1. The scheduled `Ops extraction worker` does Docling re-extraction and hit its **60-min job timeout**, so GitHub hard-killed it — **20 consecutive "cancelled" runs (2026-05-12 → 05-31)**. The daily drain made no forward progress for three weeks.
2. The worker's priority sorts newest-discovered first, so even partial runs cleared fresh discoveries and never reached the April-discovered backlog (Harvard was discovered 2026-04-14).
3. There was no cheap way to reconcile a document that's *already extracted* but still flagged pending — it required a full (re-)extraction pass to flip the status.

The data was never lost; the status flag was stale and the public `cds_manifest` faithfully reported it as "pending."

## Changes

- **`--reconcile-pending`** — a cheap, extraction-free pre-pass that flips any `extraction_pending` document which already has a canonical artifact of its **current source bytes** to `extracted`. Runs over the full pending set before `--limit`, so one run heals the whole backlog. Reframes `extraction_pending` to mean "no valid extraction of current bytes"; producer-version upgrades are a separate quality concern (`--force-reextract`) and must not show users a "pending" state. `has_canonical_for_current_bytes` is conservative — only a canonical produced at/after the current bytes were archived counts.
- **`--deadline-minutes`** — a wall-clock budget. The worker stops the drain gracefully, writes its summary and exits 0 before the CI job timeout can hard-kill it. Workflow sets `100` under a raised `timeout-minutes: 120`.
- **Per-document guard in the drain loop** — `extract_one` is contracted not to raise, but schema/format setup can still throw on a malformed/out-of-range document (e.g. an old CDS year resolving to a schema without a `fields` key). One bad row no longer aborts the run and strands every remaining document; it is marked `failed` and the drain continues. (Validated in prod: previously-crashing docs now fail cleanly while the rest proceed.)
- Workflow wires `--reconcile-pending` into every run and `--deadline-minutes` (new dispatch input, default 100).

## Operational note

The production backlog has already been drained out-of-band as part of this investigation: 109 falsely-pending docs reconciled (incl. Harvard, now `extracted`), and the genuinely-stale docs re-extracted. Remaining are a few old back-years hitting the `KeyError: 'fields'` schema-resolution bug — now contained by the guard (marked `failed`), tracked as a follow-up.

## Tests

`tools/extraction_worker/test_worker_reconcile.py` — 7 tests covering the reconcile gate (current-bytes vs stale canonical, no-canonical, conservative no-source-match, missing sha) and the reconcile pass (flips only current-bytes docs, excludes them, dry-run writes nothing). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)