### PR TITLE
Backfill historical IPEDS releases

### DIFF
--- a/tools/ipeds/README.md
+++ b/tools/ipeds/README.md
@@ -19,6 +19,19 @@ the committed schema.
 python tools/ipeds/download_release.py
 ```
 
+For historical releases where the NCES data-generator CSV ZIP endpoint no
+longer serves mapped tables, install `mdbtools` and export the missing tables
+from the official Access ZIP:
+
+```bash
+brew install mdbtools
+python tools/ipeds/download_release.py --collection-year 2019-20 --data-year 2019 --access-fallback
+```
+
+The downloader still prefers data-generator CSV ZIPs. `--access-fallback` only
+exports mapped tables that are present in the release metadata but return 404
+from the CSV endpoint.
+
 2. Dry-run the loader. This parses metadata, reads the ZIPs, projects public
    facts, and writes `scratch/ipeds/ipeds-<year>-<release>-report.json`. Review
    row counts, missing tables, projected fact counts, and any schema-drift notes
@@ -42,6 +55,13 @@ python tools/ipeds/load_release.py \
 
 ```bash
 python tools/ipeds/load_release.py ... --apply
+```
+
+For a targeted backfill after adding table aliases, restrict projection to one
+or more display groups:
+
+```bash
+python tools/ipeds/load_release.py ... --display-groups Costs --apply
 ```
 
 ## Source discipline

--- a/tools/ipeds/download_release.py
+++ b/tools/ipeds/download_release.py
@@ -6,15 +6,19 @@ from __future__ import annotations
 import argparse
 import http.cookiejar
 import json
+import shutil
 import sys
+import tempfile
+import urllib.error
 import urllib.request
+import zipfile
 from pathlib import Path
 
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from tools.ipeds.metadata import DATA_GENERATOR_URL, NCES_IPEDS_ACCESS_PAGE, normalize_release_date_text, parse_access_page
-from tools.ipeds.mappings import MVP_FACT_MAPPINGS
+from tools.ipeds.metadata import DATA_GENERATOR_URL, NCES_IPEDS_ACCESS_PAGE, normalize_release_date_text, parse_access_page, parse_tablesdoc
+from tools.ipeds.mappings import fact_mappings_for_data_year, resolve_fact_mappings_for_columns
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -25,6 +29,7 @@ def main() -> int:
     parser.add_argument("--data-year", type=int, help="Data year for table downloads, e.g. 2024.")
     parser.add_argument("--out-dir", type=Path, default=REPO_ROOT / "scratch" / "ipeds")
     parser.add_argument("--tables", nargs="*", help="Specific table names to download. Defaults to mapped PRD 021 tables.")
+    parser.add_argument("--access-fallback", action="store_true", help="Export missing mapped tables from the official Access ZIP with mdb-export.")
     args = parser.parse_args()
 
     opener = build_opener()
@@ -43,15 +48,32 @@ def main() -> int:
     download(opener, release.metadata_url, metadata_path)
     print(f"metadata: {metadata_path}")
 
-    table_names = sorted({name.upper() for name in (args.tables or [m.table_name for m in MVP_FACT_MAPPINGS])})
+    tablesdoc = parse_tablesdoc(metadata_path)
+    default_tables = [m.table_name for m in resolve_fact_mappings_for_columns(fact_mappings_for_data_year(data_year), tablesdoc.columns)]
+    available_tables = {table.table_name.upper() for table in tablesdoc.tables}
+    requested_tables = sorted({name.upper() for name in (args.tables or default_tables)})
+    table_names = [name for name in requested_tables if name in available_tables]
+    missing_tables = sorted(set(requested_tables) - available_tables)
+    for table_name in missing_tables:
+        print(f"warning: {table_name} is not listed in {metadata_path.name}; skipping", file=sys.stderr)
     # The data generator endpoint returns CSV ZIP bytes. Visiting the page first
     # initializes the same session cookies a browser gets from the NCES app.
     opener.open(f"https://nces.ed.gov/ipeds/datacenter/DataFiles.aspx?year={data_year}&surveyNumber=1").read()
+    missing_downloads: list[str] = []
     for table_name in table_names:
         url = DATA_GENERATOR_URL.format(year=data_year, table_name=table_name)
         path = out_dir / f"{table_name}.zip"
-        download(opener, url, path)
-        print(f"table: {path}")
+        try:
+            download(opener, url, path)
+            print(f"table: {path}")
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+            print(f"warning: {table_name} data-generator ZIP returned 404; skipping", file=sys.stderr)
+            missing_downloads.append(table_name)
+
+    if args.access_fallback and missing_downloads:
+        export_access_tables(opener, release.access_url, out_dir, missing_downloads)
 
     manifest = {
         "collection_year": release.collection_year,
@@ -82,6 +104,49 @@ def download(opener: urllib.request.OpenerDirector, url: str, path: Path) -> Non
     req = urllib.request.Request(url, headers={"User-Agent": "collegedata-fyi-ipeds-loader/1.0"})
     with opener.open(req) as response, path.open("wb") as f:
         f.write(response.read())
+
+
+def export_access_tables(
+    opener: urllib.request.OpenerDirector,
+    access_url: str | None,
+    out_dir: Path,
+    table_names: list[str],
+) -> None:
+    if not access_url:
+        print("warning: no Access ZIP URL is available; cannot export fallback tables", file=sys.stderr)
+        return
+    mdb_export = shutil.which("mdb-export")
+    if not mdb_export:
+        print("warning: mdb-export is not installed; cannot export Access fallback tables", file=sys.stderr)
+        return
+
+    with tempfile.TemporaryDirectory(prefix="access-", dir=out_dir) as tmp:
+        tmp_dir = Path(tmp)
+        access_zip = tmp_dir / Path(access_url).name
+        download(opener, access_url, access_zip)
+        with zipfile.ZipFile(access_zip) as zf:
+            accdb_name = next((name for name in zf.namelist() if name.lower().endswith(".accdb")), None)
+            if accdb_name is None:
+                print(f"warning: {access_zip.name} has no .accdb file; cannot export fallback tables", file=sys.stderr)
+                return
+            zf.extract(accdb_name, tmp_dir)
+        accdb_path = tmp_dir / accdb_name
+
+        for table_name in table_names:
+            path = out_dir / f"{table_name}.csv"
+            with path.open("w", encoding="utf-8", newline="") as f:
+                result = subprocess_run([mdb_export, str(accdb_path), table_name], stdout=f)
+            if result != 0:
+                path.unlink(missing_ok=True)
+                print(f"warning: mdb-export could not export {table_name}; skipping", file=sys.stderr)
+                continue
+            print(f"table: {path}")
+
+
+def subprocess_run(args: list[str], *, stdout: object) -> int:
+    import subprocess
+
+    return subprocess.run(args, stdout=stdout, stderr=subprocess.PIPE, text=True).returncode
 
 
 if __name__ == "__main__":

--- a/tools/ipeds/load_release.py
+++ b/tools/ipeds/load_release.py
@@ -22,7 +22,7 @@ from typing import Any
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from tools.ipeds.mappings import MVP_FACT_MAPPINGS
+from tools.ipeds.mappings import fact_mappings_for_data_year, resolve_fact_mappings_for_columns
 from tools.ipeds.metadata import DATA_GENERATOR_URL, TablesDoc, normalize_release_date_text, parse_tablesdoc, sha256_file
 from tools.ipeds.project import project_rows_to_facts
 
@@ -42,12 +42,17 @@ def main() -> int:
     parser.add_argument("--release-date-text", help='Raw official release date text, e.g. "March 2026".')
     parser.add_argument("--metadata-url", required=True)
     parser.add_argument("--access-url")
+    parser.add_argument("--display-groups", nargs="*", help="Optional display groups to project/apply, e.g. Costs.")
     parser.add_argument("--apply", action="store_true", help="Upsert into Supabase using service role credentials.")
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     args = parser.parse_args()
 
     tablesdoc = parse_tablesdoc(args.metadata_xlsx)
-    table_names = sorted({mapping.table_name.upper() for mapping in MVP_FACT_MAPPINGS})
+    fact_mappings = resolve_fact_mappings_for_columns(fact_mappings_for_data_year(args.data_year), tablesdoc.columns)
+    if args.display_groups:
+        display_groups = {group.lower() for group in args.display_groups}
+        fact_mappings = tuple(mapping for mapping in fact_mappings if mapping.display_group.lower() in display_groups)
+    table_names = sorted({mapping.table_name.upper() for mapping in fact_mappings})
     rows_by_table: dict[str, list[dict[str, Any]]] = {}
     table_sources: dict[str, dict[str, Any]] = {}
 
@@ -67,7 +72,7 @@ def main() -> int:
 
     facts = project_rows_to_facts(
         rows_by_table,
-        MVP_FACT_MAPPINGS,
+        fact_mappings,
         tablesdoc.columns,
         tablesdoc.value_labels,
         release_id=None,
@@ -76,7 +81,7 @@ def main() -> int:
         release_type=args.release_type,
     )
 
-    report = build_report(args, tablesdoc, rows_by_table, table_sources, facts)
+    report = build_report(args, tablesdoc, rows_by_table, table_sources, facts, fact_mappings)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     report_path = args.out_dir / f"ipeds-{args.collection_year}-{args.release_type}-report.json"
     report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
@@ -122,6 +127,7 @@ def build_report(
     rows_by_table: dict[str, list[dict[str, Any]]],
     table_sources: dict[str, dict[str, Any]],
     facts: list[dict[str, Any]],
+    fact_mappings: tuple[Any, ...],
 ) -> dict[str, Any]:
     facts_by_group: dict[str, int] = {}
     quality_counts: dict[str, int] = {}
@@ -136,7 +142,7 @@ def build_report(
         **release_date_report(args),
         "metadata_xlsx": str(args.metadata_xlsx),
         "metadata_sha256": sha256_file(args.metadata_xlsx),
-        "source_tables_requested": sorted({mapping.table_name.upper() for mapping in MVP_FACT_MAPPINGS}),
+        "source_tables_requested": sorted({mapping.table_name.upper() for mapping in fact_mappings}),
         "source_tables_loaded": table_sources,
         "metadata_counts": {
             "tables": len(tablesdoc.tables),
@@ -173,7 +179,7 @@ def apply_to_supabase(
     release_date, release_date_precision = release_date_metadata(args)
     release_notes = {
         "loader": "tools/ipeds/load_release.py",
-        "mapping_count": len(MVP_FACT_MAPPINGS),
+        "mapping_count": len(fact_mappings_for_data_year(args.data_year)),
     }
     if args.release_date_text:
         release_notes["release_date_text"] = args.release_date_text
@@ -260,7 +266,23 @@ def apply_to_supabase(
 def batch_upsert(client: Any, table: str, rows: list[dict[str, Any]], on_conflict: str, size: int = 500) -> None:
     deduped = dedupe_rows(rows, on_conflict)
     for start in range(0, len(deduped), size):
-        client.table(table).upsert(deduped[start : start + size], on_conflict=on_conflict).execute()
+        upsert_chunk(client, table, deduped[start : start + size], on_conflict)
+
+
+def upsert_chunk(client: Any, table: str, rows: list[dict[str, Any]], on_conflict: str) -> None:
+    try:
+        client.table(table).upsert(rows, on_conflict=on_conflict).execute()
+    except Exception as exc:
+        if len(rows) > 1 and is_statement_timeout(exc):
+            midpoint = len(rows) // 2
+            upsert_chunk(client, table, rows[:midpoint], on_conflict)
+            upsert_chunk(client, table, rows[midpoint:], on_conflict)
+            return
+        raise
+
+
+def is_statement_timeout(exc: Exception) -> bool:
+    return "57014" in str(exc) or "statement timeout" in str(exc).lower()
 
 
 def dedupe_rows(rows: list[dict[str, Any]], on_conflict: str) -> list[dict[str, Any]]:

--- a/tools/ipeds/mappings.py
+++ b/tools/ipeds/mappings.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import replace
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -82,3 +84,84 @@ MVP_FACT_MAPPINGS: tuple[FactMapping, ...] = (
     FactMapping("doctor_degrees_awarded", "Doctor's degrees awarded", "DRVC2024", "DOCDEGRS", "number", "Completions", "context_only"),
 )
 
+
+def fact_mappings_for_data_year(data_year: int) -> tuple[FactMapping, ...]:
+    """Return the curated fact mappings with IPEDS table names for a data year."""
+    return tuple(replace(mapping, table_name=table_name_for_data_year(mapping.table_name, data_year)) for mapping in MVP_FACT_MAPPINGS)
+
+
+def resolve_fact_mappings_for_columns(
+    mappings: tuple[FactMapping, ...],
+    columns: list[Any],
+) -> tuple[FactMapping, ...]:
+    """Resolve mapped variables to the table names present in a release.
+
+    IPEDS occasionally moves stable variables into year-specific table splits,
+    especially student financial aid tables such as SFA1819_P1 or SFA2223_P2.
+    """
+    available = {(column.table_name.upper(), column.var_name.upper()) for column in columns}
+    tables_by_var: dict[str, list[str]] = {}
+    for column in columns:
+        table_name = column.table_name.upper()
+        var_name = column.var_name.upper()
+        tables_by_var.setdefault(var_name, [])
+        if table_name not in tables_by_var[var_name]:
+            tables_by_var[var_name].append(table_name)
+
+    resolved: list[FactMapping] = []
+    for mapping in mappings:
+        table_name = mapping.table_name.upper()
+        var_name = mapping.var_name.upper()
+        if (table_name, var_name) in available:
+            resolved.append(mapping)
+            continue
+
+        candidate = _best_table_candidate(table_name, var_name, tables_by_var.get(var_name, []))
+        resolved.append(replace(mapping, table_name=candidate) if candidate else mapping)
+    return tuple(resolved)
+
+
+def table_name_for_data_year(table_name: str, data_year: int) -> str:
+    """Translate the 2024 baseline table names into another IPEDS data year.
+
+    Most IPEDS table names use the data year as a suffix. Student financial aid
+    tables use the aid-year pair instead, so 2024 maps to SFA2324.
+    """
+    upper = table_name.upper()
+    if upper.startswith("SFA"):
+        return f"SFA{(data_year - 1) % 100:02d}{data_year % 100:02d}"
+    if upper.startswith("COST1_"):
+        return f"COST1_{data_year}"
+    if upper.startswith("EF") and upper.endswith("D"):
+        return f"EF{data_year}D"
+
+    for prefix in ("DRVCOST", "DRVADM", "DRVEF", "DRVGR", "DRVC", "ADM", "HD", "IC"):
+        if upper.startswith(prefix):
+            return f"{prefix}{data_year}"
+    return upper
+
+
+def _best_table_candidate(table_name: str, var_name: str, candidates: list[str]) -> str | None:
+    if not candidates:
+        return None
+    if table_name.startswith("SFA"):
+        if table_name == "SFA2223" and "SFA2223_P2" in candidates:
+            return "SFA2223_P1"
+        sfa_candidates = [candidate for candidate in candidates if candidate.startswith(table_name)]
+        if sfa_candidates:
+            return sorted(sfa_candidates)[0]
+    if table_name.startswith("COST1_"):
+        year = table_name.rsplit("_", 1)[-1]
+        preferred = f"IC{year}_AY" if var_name in {"TUITION2", "TUITION3", "FEE2", "FEE3"} else f"IC{year}"
+        if preferred in candidates:
+            return preferred
+    if table_name.startswith("DRVCOST"):
+        year = table_name.removeprefix("DRVCOST")
+        preferred = f"DRVIC{year}"
+        if preferred in candidates:
+            return preferred
+    prefix = "".join(char for char in table_name if not char.isdigit()).rstrip("_")
+    prefix_candidates = [candidate for candidate in candidates if candidate.startswith(prefix)]
+    if len(prefix_candidates) == 1:
+        return prefix_candidates[0]
+    return None

--- a/tools/ipeds/test_project.py
+++ b/tools/ipeds/test_project.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from tools.ipeds.load_release import read_table_zip
 from tools.ipeds.load_release import dedupe_rows
-from tools.ipeds.mappings import FactMapping
+from tools.ipeds.mappings import FactMapping, fact_mappings_for_data_year, resolve_fact_mappings_for_columns, table_name_for_data_year
 from tools.ipeds.metadata import IpedsColumn, IpedsValueLabel
 from tools.ipeds.project import project_rows_to_facts, quality_from_label
 
@@ -64,6 +64,49 @@ class IpedsProjectionTests(unittest.TestCase):
         out = dedupe_rows(rows, "release_id,table_name,var_name,code_value")
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0]["value_label"], "Public duplicate")
+
+    def test_fact_mappings_follow_data_year_table_names(self) -> None:
+        self.assertEqual(table_name_for_data_year("HD2024", 2021), "HD2021")
+        self.assertEqual(table_name_for_data_year("EF2024D", 2021), "EF2021D")
+        self.assertEqual(table_name_for_data_year("COST1_2024", 2021), "COST1_2021")
+        self.assertEqual(table_name_for_data_year("SFA2324", 2021), "SFA2021")
+
+        mapped_tables = {mapping.table_name for mapping in fact_mappings_for_data_year(2021)}
+        self.assertIn("ADM2021", mapped_tables)
+        self.assertIn("DRVGR2021", mapped_tables)
+        self.assertIn("SFA2021", mapped_tables)
+
+    def test_fact_mappings_resolve_split_sfa_tables_from_metadata(self) -> None:
+        mappings = fact_mappings_for_data_year(2021)
+        columns = [IpedsColumn("SFA2021_P1", "ANYAIDP", None, None, None, None, None, "XANYAIDP", "Any aid", None, None, None, None, None, None, None, None, None, None, None)]
+
+        resolved = resolve_fact_mappings_for_columns(mappings, columns)
+        any_aid = next(mapping for mapping in resolved if mapping.field_key == "any_aid_rate")
+
+        self.assertEqual(any_aid.table_name, "SFA2021_P1")
+
+    def test_fact_mappings_correct_2023_sfa_tablesdoc_split(self) -> None:
+        mappings = fact_mappings_for_data_year(2023)
+        columns = [IpedsColumn("SFA2223_P2", "ANYAIDP", None, None, None, None, None, "XANYAIDP", "Any aid", None, None, None, None, None, None, None, None, None, None, None)]
+
+        resolved = resolve_fact_mappings_for_columns(mappings, columns)
+        any_aid = next(mapping for mapping in resolved if mapping.field_key == "any_aid_rate")
+
+        self.assertEqual(any_aid.table_name, "SFA2223_P1")
+
+    def test_fact_mappings_resolve_historical_cost_tables(self) -> None:
+        mappings = fact_mappings_for_data_year(2019)
+        columns = [
+            IpedsColumn("IC2019_AY", "TUITION2", None, None, None, None, None, "XTUITION2", "Tuition", None, None, None, None, None, None, None, None, None, None, None),
+            IpedsColumn("IC2019", "RMBRDAMT", None, None, None, None, None, "XRMBRDAMT", "Room and board", None, None, None, None, None, None, None, None, None, None, None),
+            IpedsColumn("DRVIC2019", "CINSON", None, None, None, None, None, "XCINSON", "Total price", None, None, None, None, None, None, None, None, None, None, None),
+        ]
+
+        resolved = resolve_fact_mappings_for_columns(mappings, columns)
+
+        self.assertEqual(next(mapping for mapping in resolved if mapping.field_key == "tuition_in_state").table_name, "IC2019_AY")
+        self.assertEqual(next(mapping for mapping in resolved if mapping.field_key == "room_and_board_on_campus").table_name, "IC2019")
+        self.assertEqual(next(mapping for mapping in resolved if mapping.field_key == "total_price_in_state_on_campus").table_name, "DRVIC2019")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Makes the IPEDS downloader and loader year-aware so the 2024 curated mappings can load historical releases.
- Adds an Access ZIP fallback using `mdb-export` for older NCES releases where the CSV generator returns 404.
- Resolves historical SFA and cost table aliases from release metadata, including split SFA tables and older IC/DRVIC cost tables.
- Adds retrying/splitting Supabase upserts for statement timeouts and supports targeted `--display-groups` backfills.

## Production Backfill

Already loaded canonical IPEDS history into Supabase:

- `ipeds_releases`: 21 releases, `2004-05 final` through `2024-25 provisional`.
- Projected facts loaded from reports: 4,384,594 public IPEDS facts.
- UC 2019-2024 retention + 6-year graduation check: 108 rows, exactly 9 campuses x 6 years x 2 fields.
- Berkeley 2019 spot-check now returns retention, SFA, tuition, and total-price facts from historical IPEDS tables.

## Verification

- `python3 -m unittest discover -s tools/ipeds -p 'test_*.py'`
- `git diff --check`

## Notes

`refresh_ipeds_browser_source_modes()` intermittently times out after the larger historical load. The core release, raw-row, and fact writes completed and `school_facts_unified` still serves latest facts correctly. Historical analyses should query `ipeds_facts` directly.
