### PR TITLE
Add test-optional outcome tracker

### DIFF
--- a/docs/prd/025-test-optional-outcome-tracker.md
+++ b/docs/prd/025-test-optional-outcome-tracker.md
@@ -1,0 +1,737 @@
+# PRD 025: Test-optional observability and outcome tracker
+
+**Status:** Draft
+**Created:** 2026-06-03
+**Author:** Anthony + Codex
+**Related:** [PRD 010](010-queryable-data-browser.md), [PRD 016](016-academic-positioning-card.md), [PRD 019](019-cds-change-intelligence.md), [PRD 021](021-ipeds-coverage-layer.md), [Admission visualization upgrades](023-admission-visualization-upgrades.md)
+
+---
+
+## Executive summary
+
+National education coverage has moved from "some elite schools are reinstating
+the SAT" to a broader claim: test-optional and test-blind admissions may have
+reduced student preparedness, especially in quantitative fields.
+
+CollegeData.fyi should respond by doing what the product is built to do:
+publish source-linked data that lets readers pressure-test the claim without
+turning the site into an SAT advocacy project.
+
+PRD 025 creates a public **Test-Optional Observability and Outcome Tracker**: a
+reusable recipe and dataset that shows what testing-policy changes made visible
+or invisible in public CDS data, then keeps a careful watchlist of coarse
+downstream outcome signals.
+
+The defensible launch headline is not "flat retention proves the preparedness
+concern is wrong." It is:
+
+> Test-optional and test-blind policies changed what the public can observe.
+> Institution-level outcomes are worth watching, but the available public
+> measures are coarse, lagged, and confounded.
+
+The first launch is intentionally narrow:
+
+1. Start with the University of California system and a small elite-reinstater
+   panel because they are the current public-news focus.
+2. Show observable score-reporting signals from CDS where available:
+   SAT submit rate, ACT submit rate, and reported SAT/ACT bands.
+3. Show coarse outcome-watchlist signals from federal data:
+   first-year retention, six-year graduation, transfer-out, and selected
+   Scorecard context.
+4. Make the conclusion format explicit: "observability changed," "no obvious
+   institution-level retention shock," "too lagged to judge," or "signal worth
+   investigating," not "SAT good" or "SAT bad."
+
+The launch artifact should be linkable every time another SAT reinstatement
+article appears. It should read like a data essay with a reproducible table, not
+like a generic dashboard.
+
+## News context
+
+The June 2026 WSJ coverage makes four claims that are product-relevant:
+
+- Most schools remain test-optional, but many students still submit scores.
+- SAT benchmark attainment and mean scores have fallen in recent years.
+- High-school GPA inflation makes GPA less useful as a college-readiness signal.
+- Elite schools and UC faculty are revisiting test requirements because they
+  believe preparedness has weakened.
+
+CollegeData.fyi cannot verify every upstream claim from College Board, ACT,
+FairTest, or campus faculty anecdotes. The page should name provenance:
+FairTest is an anti-test advocacy organization; College Board and ACT are test
+vendors. Those sources can define the news context, but they are not neutral
+CollegeData.fyi source layers.
+
+CollegeData.fyi can add two public-data checks:
+
+1. **Observability check:** after policy changes, what admissions/testing
+   signals are still visible in school-published CDS data?
+2. **Outcome watchlist:** are coarse institution-level public outcomes showing
+   obvious stress yet?
+
+The product stance should be sober:
+
+- A retention collapse would be noteworthy.
+- Flat retention is not proof that the concern is wrong.
+- Retention at selective schools often sits near a ceiling, so it is a weak
+  instrument for detecting subtle preparedness changes.
+- Graduation, transfer-out, and earnings are lagged and may not fully reflect
+  post-2020 cohorts yet.
+- The pandemic and test-blind/test-optional changes overlap in time, so this
+  data cannot isolate policy effects from pandemic disruption.
+- Major-specific STEM preparedness may not be visible in institution-level
+  public data.
+
+## Problem
+
+The public SAT debate is dominated by inputs:
+
+- test-required, test-optional, test-flexible, test-blind;
+- submitted scores;
+- average SAT scores;
+- GPA inflation;
+- faculty anecdotes about classroom readiness.
+
+Those inputs matter, but CollegeData.fyi should not pretend that UC retention
+alone tests a national applicant-pool claim. UC enrolls a highly selected slice
+of students, and national SAT benchmark trends need not appear in UC outcomes.
+
+The practical questions for students, parents, counselors, and journalists are
+more precise:
+
+> What did schools stop showing, keep showing, or newly show after testing
+> policy changed?
+
+> Are the coarse outcome signals available in public data showing obvious
+> institution-level stress yet?
+
+CollegeData.fyi already has the ingredients to test part of that question, but
+they are spread across multiple surfaces:
+
+- CDS extraction exposes current admissions, test-score, and test-submit
+  metrics through `school_browser_rows`.
+- Historical IPEDS facts expose retention and completion-adjacent time series
+  through `ipeds_facts`.
+- Scorecard exposes current outcomes, including six-year graduation,
+  transfer-out, and retention through `scorecard_summary`.
+
+Without a purpose-built public artifact, each new article forces another manual
+analysis. PRD 025 turns the analysis into a durable product surface while
+keeping the limits of the instrument visible.
+
+## Goals
+
+1. Publish a public data essay / recipe page that responds to the
+   SAT-reinstatement news cycle with source-linked CollegeData.fyi data.
+2. Lead with observable CDS testing signals: SAT submit rate, ACT submit rate,
+   score-band presence, and score-band values where available.
+3. Provide a reproducible UC outcome-watchlist table showing first-year
+   retention by year since 2019, explicitly labeled as a coarse and
+   ceiling-limited signal.
+4. Show graduation and transfer-out only as lagged baseline / watchlist data,
+   not as evidence about post-2020 test-blind cohorts.
+5. Expose the same data through a lightweight JSON endpoint or static dataset
+   so journalists, counselors, and other agents can reuse it.
+6. Make uncertainty explicit. The page should distinguish "observability
+   changed," "flat observed retention," and "the preparedness claim is false."
+7. Use the tracker as a repeatable response surface for future SAT/test-optional
+   coverage.
+
+## Non-goals
+
+- No causal claim that test-optional policies caused any observed outcome.
+- No endorsement or rejection of SAT/ACT requirements.
+- No student-level inference.
+- No race, income, disability, or demographic subgroup analysis in V1 unless the
+  source and methodology are reviewed separately.
+- No major-level STEM preparedness claim in V1; institution-level public data is
+  too coarse.
+- No ranking of schools by "test policy quality."
+- No attempt to infer a school's formal test policy solely from submit rates.
+- No private or scraped admissions-office policy database in V1.
+- No annual report PDF before the web recipe proves the signal and framing.
+- No "statistically unchanged" language in V1 unless a formal model is shipped.
+- No claim that UC outcomes represent the national applicant pool.
+
+## Users and jobs
+
+### Journalist or columnist
+
+"I need a public, source-linked dataset that shows what testing-policy changes
+made visible or invisible, and what coarse public outcomes show so far."
+
+### Counselor
+
+"I want to explain to families what test-optional means in practice: scores may
+be optional, but many students still submit them, and outcomes data is lagged."
+
+### Parent or student
+
+"I want to know what the public data can and cannot tell me about schools that
+changed testing policies."
+
+### CollegeData.fyi maintainer
+
+"I want a repeatable link to share when national coverage makes a strong claim
+about admissions policy."
+
+## V1 launch surface
+
+### Route
+
+Create a recipe page:
+
+```text
+/recipes/test-optional-outcome-tracker
+```
+
+This is preferable to a school-page module for V1 because the first job is
+editorial response and cross-school comparison, not per-school discovery.
+
+### Page structure
+
+1. **Headline**
+   - "Test-Optional Observability and Outcome Tracker"
+   - Subhead: "A source-linked check on what testing-policy changes made
+     visible, and what coarse outcome data shows so far."
+
+2. **Context panel**
+   - Briefly summarize the public question without quoting paywalled article
+     text.
+   - Link to the public sources when available:
+     - College Board SAT reports for score/benchmark trends.
+     - ACT research for GPA inflation if cited.
+     - CollegeData.fyi API/methodology pages for our data.
+
+3. **Testing observability table**
+   - Rows: UC campuses and news-comparison schools where CDS coverage exists.
+   - Columns:
+     - formal policy label, if manually sourced and linked;
+     - latest CDS year;
+     - SAT submit rate;
+     - ACT submit rate;
+     - SAT p25/p50/p75;
+     - ACT p25/p50/p75;
+     - score-band reporting status.
+   - Source: `school_browser_rows` plus manual policy notes where included.
+   - Label submit rates as "reported by CDS," not formal policy.
+   - For UC campuses, expect many SAT/ACT fields to be null under test-blind
+     reporting; that missingness is itself an observability signal.
+
+4. **UC first-year retention watchlist**
+   - Rows: UC campuses.
+   - Columns: data years 2019 through latest loaded IPEDS data year.
+   - Values: `retention_rate_full_time` from `ipeds_facts`.
+   - Include simple per-campus delta from 2019 to latest.
+   - Include system-level median and range.
+   - Caption: "Retention is a coarse, ceiling-limited institutional signal, not
+     a direct measure of classroom preparedness."
+
+5. **Completion and transfer-out baseline table**
+   - Rows: same UC campuses.
+   - Columns:
+     - six-year graduation rate by available data year;
+     - transfer-out rate by available data year;
+     - notes about cohort lag.
+   - Prefer IPEDS historical fields where loaded:
+     - `bachelor_6yr_grad_rate`
+     - `transfer_out_rate_total`
+   - Use Scorecard only for current context if historical IPEDS coverage is
+     insufficient.
+   - Caption: "Completion outcomes are too lagged to evaluate post-2020
+     entering cohorts in June 2026. Treat this table as baseline context."
+
+6. **Interpretation box**
+   - Use plain-language findings:
+     - "Testing-policy changes changed what the public can observe."
+     - "UC retention is not showing an obvious institution-level collapse."
+     - "Retention is a weak instrument for subtle preparedness shifts at
+       high-retention schools."
+     - "Completion data is too lagged to fully judge post-2020 cohorts."
+   - Avoid causal language.
+
+7. **Reproducibility**
+   - Include API links or a downloadable JSON/CSV.
+   - Include the exact field keys and source tables.
+
+## Initial school panels
+
+### UC outcome-watchlist panel
+
+The first panel should include the nine undergraduate UC campuses:
+
+- UC Berkeley
+- UC Davis
+- UC Irvine
+- UCLA
+- UC Merced
+- UC Riverside
+- UC San Diego
+- UC Santa Barbara
+- UC Santa Cruz
+
+Rationale: UC is test-blind, current WSJ coverage references UC faculty
+pressure, and the system is large enough to inspect manually. The UC panel is
+not a national applicant-pool test; it is a high-profile system watchlist.
+
+### News-comparison observability panel
+
+Use a small editorial comparison set, not a ranked peer model. Every row must
+carry a formal policy label with source URL and verification date if the row is
+used to discuss policy rather than just CDS reporting.
+
+- MIT
+- Dartmouth
+- Yale
+- Harvard
+- Brown
+- Caltech
+- University of Chicago, only if explicitly labeled as a long-running
+  test-optional contrast rather than a reinstater
+
+Rationale: several elite institutions have changed or revisited testing rules,
+and their CDS submit rates / score bands are likely to be closely watched.
+
+The comparison panel should be labeled "news-comparison schools," not peers.
+If V1 cannot source policy labels, omit formal policy language and publish only
+the observable CDS submit-rate / score-band table.
+
+## Data contracts
+
+### Historical IPEDS facts
+
+Source table:
+
+```text
+ipeds_facts
+```
+
+Query shape:
+
+```text
+ipeds_id = eq.<six digit UNITID>
+field_key = in.(retention_rate_full_time,bachelor_6yr_grad_rate,transfer_out_rate_total)
+data_year = gte.2019
+data_year = lte.<latest loaded data year>
+```
+
+Use `ipeds_id`, `field_key`, and bounded `data_year` to stay on the intended
+serving indexes. Do not filter by raw `unitid` in public examples.
+
+Required fields:
+
+| Field | Meaning | Source notes |
+|---|---|---|
+| `retention_rate_full_time` | First-year full-time retention rate | IPEDS Fall Enrollment |
+| `bachelor_6yr_grad_rate` | Six-year graduation/completion rate | IPEDS Graduation Rates / derived tables |
+| `transfer_out_rate_total` | Transfer-out rate | IPEDS Graduation Rates / derived tables |
+
+All values should keep:
+
+- `collection_year`
+- `data_year`
+- `release_type`
+- `source_table`
+- `source_variable`
+- `quality_flag`
+- `definition_alignment`
+
+### Scorecard summary
+
+Source table:
+
+```text
+scorecard_summary
+```
+
+Use Scorecard for current context, not as the primary historical tracker in V1:
+
+- `graduation_rate_6yr`
+- `transfer_out_rate`
+- `retention_rate_ft`
+- `scorecard_data_year`
+
+Scorecard outcomes are already surfaced on school pages. The tracker should
+make the vintage explicit because Scorecard data lags and is not a direct
+measure of 2024+ entering cohorts.
+
+### Verified production availability
+
+As of 2026-06-03, production has 21 loaded IPEDS releases and Berkeley
+`retention_rate_full_time` rows from 2004 through 2024. Phase 0 still must
+re-check the full UC campus panel before launch, because the public artifact
+should report missingness explicitly rather than assume every field is complete.
+
+### CDS testing signals
+
+Source table:
+
+```text
+school_browser_rows
+```
+
+Fields:
+
+- `canonical_year`
+- `year_start`
+- `sat_submit_rate`
+- `act_submit_rate`
+- `sat_composite_p25`
+- `sat_composite_p50`
+- `sat_composite_p75`
+- `act_composite_p25`
+- `act_composite_p50`
+- `act_composite_p75`
+- `archive_url`
+- `data_quality_flag`
+
+Important limitation:
+
+Submit rates and score bands are not a formal test-policy database. They are
+observable CDS reporting signals. A school can be test-optional while still
+receiving many submitted scores.
+
+## Derived metrics
+
+### Retention delta
+
+```text
+latest_retention_delta = latest_retention_rate_full_time - 2019_retention_rate_full_time
+```
+
+Display as percentage points.
+
+### System median retention
+
+For each data year:
+
+```text
+median(retention_rate_full_time across included UC campuses)
+```
+
+Display with campus count, e.g. `median across 9 campuses`.
+
+### Flatness language
+
+Do not use "statistically unchanged" unless a statistical test is implemented.
+For V1, use descriptive language:
+
+- "basically flat"
+- "no obvious decline"
+- "within a narrow range"
+- "not a smoking gun"
+
+If a formal method is added later, use:
+
+- campus fixed-effects linear trend for system-wide direction;
+- Mann-Kendall trend as a non-parametric sensitivity check;
+- bootstrap confidence interval for median year-over-year change.
+
+The page should explain that with nine campuses and a short time window, the
+analysis is descriptive, not a definitive causal model. It should also say why
+retention is a weak instrument here:
+
+- UC campuses are high-retention institutions, so there is limited room for a
+  visible decline.
+- Institution-level retention cannot see course DFW rates, first-term GPA,
+  STEM-major persistence, or instructor remediation burden.
+- A flat retention line is weak evidence either way.
+
+## Methodology copy
+
+The page should include a compact methodology section:
+
+1. We selected UC because it is test-blind and currently central to the public
+   debate.
+2. We used public federal IPEDS retention/completion data and source-linked CDS
+   test-reporting data.
+3. We use 2019 as a descriptive pre-policy reference year, not as a clean causal
+   baseline. The pandemic and test-blind/test-optional policy changes overlap
+   in time, so post-2020 movements cannot be attributed to testing policy.
+4. We did not attempt to measure classroom preparedness directly.
+5. We did not infer STEM-specific readiness.
+6. We did not infer causality from institutional aggregates.
+7. We did not treat UC as representative of the national applicant pool.
+8. We flagged lagged outcomes where the relevant entering cohorts have not yet
+   reached the measurement window.
+
+## UX requirements
+
+The surface should feel like a compact research artifact, not a marketing page.
+
+- Use dense tables with sticky first column on mobile if needed.
+- Prefer line charts only where at least four comparable years exist.
+- Put source labels close to each table.
+- Use small badges for data source:
+  - `IPEDS`
+  - `Scorecard`
+  - `CDS`
+- Include a "Copy API query" control for each table.
+- Include a "Download CSV" control for the assembled tracker dataset.
+- Include a "Last updated" timestamp.
+- Avoid a hero layout; this is a recipe/data page.
+
+## API and export
+
+V1 can be implemented without a new database table by assembling data in the
+Next.js route from existing public tables. However, the page should expose a
+stable export:
+
+```text
+/api/recipes/test-optional-outcome-tracker
+```
+
+Response shape:
+
+```json
+{
+  "generated_at": "2026-06-03T00:00:00.000Z",
+  "methodology": {
+    "baseline_data_year": 2019,
+    "latest_ipeds_data_year": 2024,
+    "panel": "uc-system"
+  },
+  "schools": [
+    {
+      "school_id": "uc-berkeley",
+      "school_name": "University of California-Berkeley",
+      "ipeds_id": "110635",
+      "outcomes": [
+        {
+          "data_year": 2019,
+          "field_key": "retention_rate_full_time",
+          "value": 97,
+          "unit": "percent",
+          "source_table": "EF2019D",
+          "source_variable": "RET_PCF"
+        }
+      ],
+      "testing_signal": {
+        "canonical_year": "2025-26",
+        "sat_submit_rate": null,
+        "act_submit_rate": null,
+        "archive_url": "https://www.collegedata.fyi/schools/uc-berkeley/2025-26"
+      }
+    }
+  ]
+}
+```
+
+The API should be read-only, unauthenticated, and derived entirely from already
+public data.
+
+## Editorial launch plan
+
+### First post
+
+Use the tracker to publish a short CollegeData.fyi post:
+
+> WSJ is covering a real SAT policy debate. The harder question is what became
+> more or less observable when schools changed testing policy. We checked the
+> public data CollegeData.fyi already tracks: CDS testing signals, UC first-year
+> retention since 2019, and completion/transfer-out baselines. The early read:
+> testing-policy changes clearly changed score visibility; UC retention does not
+> show an obvious institution-level collapse, but retention is a coarse,
+> ceiling-limited measure and graduation outcomes remain too lagged for
+> post-2020 cohorts.
+
+### LinkedIn frame
+
+The LinkedIn post should use:
+
+- one screenshot of the testing observability table;
+- one screenshot or crop of the UC retention watchlist;
+- one sentence on why observability changed when testing policy changed;
+- one sentence on why retention is only a coarse first watchlist signal;
+- a link to the recipe.
+
+Do not lead with "WSJ is wrong." Lead with "the public data can clarify what is
+visible now and what remains too early to call."
+
+### Future article response
+
+Every future SAT/test-optional article can be answered with one of four updates:
+
+1. Add a school/system panel.
+2. Refresh the outcome data when new IPEDS/Scorecard vintages land.
+3. Add or update a policy-status source note where formal policy matters.
+4. Add a short interpretation note if the data changes.
+
+## Implementation plan
+
+### Phase 0: Data validation
+
+- Confirm the UC panel maps to correct `school_id` and `ipeds_id` values.
+- Query `ipeds_facts` for `retention_rate_full_time`,
+  `bachelor_6yr_grad_rate`, and `transfer_out_rate_total` from 2019 through the
+  latest loaded data year.
+- Query `school_browser_rows` for latest CDS test-submit and score-band fields.
+- Query `scorecard_summary` for current outcomes/vintage.
+- Export a scratch CSV for manual inspection.
+
+Exit criteria:
+
+- Every UC campus has at least one retention row for 2019 and latest loaded year,
+  or the missingness is explicitly documented.
+- No row uses a parent-campus federal value for a sub-institutional CDS variant.
+- Production availability is re-checked before launch even if local validation
+  passes.
+
+### Phase 1: Public recipe page
+
+- Add `/recipes/test-optional-outcome-tracker`.
+- Render testing observability table.
+- Render UC retention watchlist table.
+- Render completion/transfer baseline table with lag caveats.
+- Add methodology and source labels.
+- Add CSV download from the assembled in-memory dataset.
+
+Exit criteria:
+
+- Page is linkable and comprehensible without reading the WSJ article.
+- Data source labels are visible above every table.
+- Mobile table layout is usable.
+
+### Phase 2: Public API export
+
+- Add `/api/recipes/test-optional-outcome-tracker`.
+- Return the same dataset used by the page.
+- Include generated timestamp, field keys, source tables/variables, and notes.
+
+Exit criteria:
+
+- API response can reproduce every visible table.
+- API route has smoke coverage.
+
+### Phase 3: Comparison panels
+
+- Add the news-comparison observability panel.
+- Add a small "policy status" note only where manually sourced, linked, and
+  verification-dated.
+- Keep CDS submit rates separate from formal policy.
+- If formal policy labels are not ready, publish CDS observability values only.
+
+Exit criteria:
+
+- The comparison panel does not imply causal peer analysis.
+- Every manually sourced policy note has a URL and date.
+
+### Phase 4: Tracker refresh workflow
+
+- Add a lightweight script or documented command that regenerates the tracker
+  export after IPEDS/Scorecard/CDS refreshes.
+- Add a freshness note to the page.
+
+Exit criteria:
+
+- Maintainer can refresh and verify the artifact in under 15 minutes.
+
+## Data quality and caveats
+
+### Main caveats
+
+- Retention is institution-level, not course-level or major-level preparedness.
+- UC campuses have high baseline retention rates, so retention has limited room
+  to reveal subtle preparedness changes.
+- UC is a highly selected public system and should not be treated as a proxy for
+  the national applicant pool.
+- COVID disruption and test-policy changes overlap, so post-2020 movements
+  cannot be attributed to testing policy alone.
+- Six-year graduation lags entering-cohort changes by years.
+- As of June 2026, six-year graduation mostly reflects cohorts admitted before
+  or during the initial policy transition, not mature post-2020 cohorts.
+- Transfer-out can be positive or negative depending on context.
+- CDS submit rates reflect submitted-score reporting, not formal policy alone.
+- UC test-blind campuses may not report SAT/ACT score bands in the same way as
+  test-optional institutions.
+- Formal policy labels require separate sourced URLs and verification dates.
+- Public federal data may revise between provisional and final releases.
+
+### Required caveat copy
+
+Use this near the conclusion:
+
+> This is not a causal test of the SAT. The primary signal is observability:
+> when schools stop requiring or collecting scores, public score reporting gets
+> thinner. UC first-year retention does not show an obvious institution-level
+> collapse, but retention is coarse, ceiling-limited, and confounded by the
+> pandemic era. Completion and transfer-out remain useful watchlist measures,
+> but they are too lagged to fully evaluate post-2020 cohorts.
+
+## Acceptance criteria
+
+- A public recipe page exists at `/recipes/test-optional-outcome-tracker`.
+- The page leads with a testing observability table using CDS submit-rate and
+  score-band availability where available.
+- The UC retention watchlist covers every available data year from 2019 through
+  the latest loaded IPEDS year.
+- The page includes at least one completion or transfer-out baseline signal
+  beyond retention.
+- Formal policy labels appear only when a source URL and verification date are
+  attached.
+- Every visible value has a source family and, where possible, source
+  table/variable metadata.
+- The page includes methodology and caveat copy covering retention ceiling
+  effects, pandemic overlap, outcome lag, and UC generalizability limits.
+- The page does not use "statistically unchanged" or equivalent language unless
+  a formal model is implemented.
+- The page can export CSV or JSON.
+- The page passes mobile and desktop smoke tests.
+- The route can be linked in a LinkedIn post without additional explanation.
+
+## Open questions
+
+1. Should the first launch include only UC, or UC plus the news-comparison
+   observability panel?
+2. Should manually sourced formal test-policy labels be included in V1, or
+   should V1 only use observable CDS submit-rate signals?
+3. Should the tracker live under `/recipes/` permanently, or graduate into a
+   broader `/research/` or `/trackers/` section after the first launch?
+4. Should we add a static saved dataset per refresh, or recompute live from
+   public tables at request time?
+5. What evidence would justify moving from "observability changed" to "public
+   outcomes show stress"?
+
+## Risks
+
+### Risk: The page is read as anti-SAT or pro-SAT advocacy
+
+Mitigation: keep the conclusion as a pressure test, not a policy claim. Use
+neutral labels and caveats.
+
+### Risk: Outcome data is too lagged
+
+Mitigation: make lag the point. The page should say exactly which outcomes are
+early watchlist indicators and which are still too lagged for post-2020 cohorts.
+
+### Risk: The page overstates a weak null signal
+
+Mitigation: lead with observability, label retention as a coarse watchlist, and
+avoid claiming that flat retention disproves classroom-level preparedness
+problems.
+
+### Risk: Users confuse submit rates with policy
+
+Mitigation: label CDS fields as "reported submit rate" and keep formal policy
+notes separate.
+
+### Risk: Time-series queries become slow
+
+Mitigation: use the documented `ipeds_id` + `field_key` + bounded `data_year`
+query shape and avoid unbounded PostgREST reads.
+
+### Risk: UC-specific conclusions are overgeneralized
+
+Mitigation: call the first panel "UC outcome watchlist" and avoid generalizing
+to all test-optional schools or the national applicant pool until broader panels
+ship.
+
+## Product thesis
+
+The best response to repeated SAT coverage is not another opinion. It is a
+repeatable artifact:
+
+> The debate is real. The claims are testable. Here is what the public outcomes
+> and observability data can show so far, with sources attached.
+
+That is the CollegeData.fyi wedge.

--- a/docs/recipes/test-optional-outcome-tracker.md
+++ b/docs/recipes/test-optional-outcome-tracker.md
@@ -1,0 +1,49 @@
+# Test-optional outcome tracker
+
+This recipe responds to SAT-reinstatement coverage by separating three
+questions that often get collapsed together:
+
+1. What testing data is still visible in school-published Common Data Set rows?
+2. Do UC first-year retention outcomes show an obvious institution-level shock?
+3. What completion or transfer-out outcomes should stay on the watchlist?
+
+The public page is:
+
+```text
+https://www.collegedata.fyi/recipes/test-optional-outcome-tracker
+```
+
+The reusable export is:
+
+```text
+https://www.collegedata.fyi/api/recipes/test-optional-outcome-tracker
+https://www.collegedata.fyi/api/recipes/test-optional-outcome-tracker?format=csv
+```
+
+## Data sources
+
+- `school_browser_rows` for latest CDS testing observability:
+  SAT submit rate, ACT submit rate, and SAT/ACT composite score bands.
+- `ipeds_facts` for UC historical outcomes:
+  `retention_rate_full_time`, `bachelor_6yr_grad_rate`, and
+  `transfer_out_rate_total`.
+- `scorecard_summary` for current Scorecard context:
+  `retention_rate_ft`, `graduation_rate_6yr`, and `transfer_out_rate`.
+
+## Interpretation
+
+This is not a causal test of the SAT. The primary signal is observability: when
+schools stop requiring or collecting scores, public score reporting gets
+thinner. UC first-year retention does not show an obvious institution-level
+collapse, but retention is coarse, ceiling-limited, and confounded by the
+pandemic era. Completion and transfer-out remain useful watchlist measures, but
+they are too lagged to fully evaluate post-2020 cohorts.
+
+## Caveats
+
+- Formal test-policy labels are not inferred from CDS submit rates.
+- UC is a highly selected public system, not the national applicant pool.
+- IPEDS retention is not course-level math readiness, DFW rates, GPA, or STEM
+  persistence.
+- COVID disruption and test-policy changes overlap, so the analysis is
+  descriptive, not causal.

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -85,6 +85,10 @@ curl 'https://www.collegedata.fyi/api/schools/mit/sources'
 
 curl 'https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chicago&categories=admissions,cost,outcomes'
 
+curl 'https://www.collegedata.fyi/api/recipes/test-optional-outcome-tracker'
+
+curl 'https://www.collegedata.fyi/api/recipes/test-optional-outcome-tracker?format=csv'
+
 curl 'https://www.collegedata.fyi/api/fields'
 
 curl 'https://www.collegedata.fyi/openapi.json'`}</CodeBlock>
@@ -875,7 +879,7 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         a bounded <code>data_year</code> range. Avoid filtering raw{" "}
         <code>unitid</code> unless you also know the matching index exists.
       </p>
-      <CodeBlock>{`curl '${BASE}/rest/v1/ipeds_facts?ipeds_id=eq.110635&field_key=in.(retention_rate_full_time,graduation_rate_6yr)&data_year=gte.2019&data_year=lte.2024&select=ipeds_id,data_year,field_key,value_numeric,source_table,source_variable&order=data_year.asc' \\
+      <CodeBlock>{`curl '${BASE}/rest/v1/ipeds_facts?ipeds_id=eq.110635&field_key=in.(retention_rate_full_time,bachelor_6yr_grad_rate,transfer_out_rate_total)&data_year=gte.2019&data_year=lte.2024&select=ipeds_id,data_year,field_key,value_numeric,source_table,source_variable&order=data_year.asc' \\
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 

--- a/web/src/app/api/recipes/test-optional-outcome-tracker/route.ts
+++ b/web/src/app/api/recipes/test-optional-outcome-tracker/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import {
+  fetchTestOptionalOutcomeTracker,
+  testOptionalOutcomeTrackerCsv,
+} from "@/lib/test-optional-outcome-tracker";
+
+export const revalidate = 3600;
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const data = await fetchTestOptionalOutcomeTracker();
+
+  if (url.searchParams.get("format") === "csv") {
+    return new Response(testOptionalOutcomeTrackerCsv(data), {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="test-optional-outcome-tracker.csv"',
+      },
+    });
+  }
+
+  return NextResponse.json(data, {
+    headers: {
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/web/src/app/openapi.json/route.ts
+++ b/web/src/app/openapi.json/route.ts
@@ -60,6 +60,25 @@ export async function GET() {
             responses: { "200": { description: "Sparse comparison matrix" } },
           },
         },
+        "/api/recipes/test-optional-outcome-tracker": {
+          get: {
+            summary: "Get the test-optional observability and UC outcome tracker",
+            parameters: [
+              {
+                name: "format",
+                in: "query",
+                required: false,
+                schema: { type: "string", enum: ["csv"] },
+              },
+            ],
+            responses: {
+              "200": {
+                description:
+                  "Tracker JSON by default, or CSV when ?format=csv is passed.",
+              },
+            },
+          },
+        },
         "/api/fields": {
           get: {
             summary: "List V1 friendly field definitions",
@@ -107,4 +126,3 @@ export async function GET() {
     },
   );
 }
-

--- a/web/src/app/recipes/page.tsx
+++ b/web/src/app/recipes/page.tsx
@@ -53,6 +53,18 @@ const RECIPES: Recipe[] = [
     sections: "C8, C9",
   },
   {
+    slug: "test-optional-outcome-tracker",
+    title: "Test-optional outcome tracker",
+    tagline:
+      "A source-linked response to the SAT-reinstatement news cycle: what CDS testing rows still reveal, and what UC retention, graduation, and transfer-out data show so far.",
+    audience:
+      "Reporters, counselors, and parents trying to pressure-test preparedness claims without turning institution-level public data into a culture-war proxy.",
+    demoPath: "/recipes/test-optional-outcome-tracker",
+    writeupUrl:
+      "https://github.com/bolewood/collegedata-fyi/blob/main/docs/recipes/test-optional-outcome-tracker.md",
+    sections: "CDS + IPEDS",
+  },
+  {
     slug: "waitlist-odds",
     title: "Wait-list odds",
     tagline:

--- a/web/src/app/recipes/test-optional-outcome-tracker/page.tsx
+++ b/web/src/app/recipes/test-optional-outcome-tracker/page.tsx
@@ -1,0 +1,603 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { TrackedLink } from "@/components/TrackedLink";
+import {
+  fetchTestOptionalOutcomeTracker,
+  type OutcomeValue,
+  type TestingObservabilityRow,
+  type UcOutcomeRow,
+} from "@/lib/test-optional-outcome-tracker";
+
+export const metadata: Metadata = {
+  title: "Test-optional observability and outcome tracker",
+  description:
+    "A source-linked CollegeData.fyi check on what testing-policy changes made visible, and what coarse UC outcome data shows so far.",
+  alternates: { canonical: "/recipes/test-optional-outcome-tracker" },
+  openGraph: { url: "/recipes/test-optional-outcome-tracker" },
+};
+
+export const revalidate = 3600;
+
+const API_PATH = "/api/recipes/test-optional-outcome-tracker";
+
+function fmtCdsRate(value: number | null): string {
+  if (value == null) return "n/a";
+  return `${(value * 100).toFixed(value * 100 < 10 ? 1 : 0)}%`;
+}
+
+function fmtIpedsPercent(value: number | null): string {
+  if (value == null) return "n/a";
+  return `${value.toFixed(Number.isInteger(value) ? 0 : 1)}%`;
+}
+
+function fmtDelta(value: number | null): string {
+  if (value == null) return "n/a";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(Number.isInteger(value) ? 0 : 1)} pts`;
+}
+
+function fmtScore(value: number | null): string {
+  return value == null ? "n/a" : value.toLocaleString("en-US");
+}
+
+function fmtDate(value: string | null | undefined): string {
+  if (!value) return "n/a";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "n/a";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function statusLabel(status: TestingObservabilityRow["scoreBandStatus"]): string {
+  switch (status) {
+    case "reported":
+      return "Bands reported";
+    case "submit-rates-only":
+      return "Submit rates only";
+    case "no-cds-row":
+      return "No CDS row";
+    case "not-reported":
+      return "Not reported";
+  }
+}
+
+function statusChipClass(status: TestingObservabilityRow["scoreBandStatus"]): string {
+  if (status === "reported") return "cd-chip cd-chip--forest";
+  if (status === "submit-rates-only") return "cd-chip cd-chip--ochre";
+  return "cd-chip";
+}
+
+function Cell({
+  children,
+  align = "left",
+}: {
+  children: ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <td
+      style={{
+        borderTop: "1px solid var(--rule)",
+        color: "var(--ink-2)",
+        padding: "10px 12px",
+        textAlign: align,
+        verticalAlign: "top",
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function HeaderCell({
+  children,
+  align = "left",
+}: {
+  children: ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <th
+      scope="col"
+      style={{
+        borderBottom: "1px solid var(--rule-strong)",
+        color: "var(--ink)",
+        fontFamily: "var(--mono)",
+        fontSize: 10.5,
+        fontWeight: 500,
+        letterSpacing: "0.06em",
+        padding: "10px 12px",
+        textAlign: align,
+        textTransform: "uppercase",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function TableFrame({
+  children,
+  label,
+  minWidth = 900,
+}: {
+  children: ReactNode;
+  label: string;
+  minWidth?: number;
+}) {
+  return (
+    <div
+      className="cd-card cd-reconstructed__table-wrap"
+      aria-label={label}
+      style={{ marginTop: 14, overflowX: "auto" }}
+    >
+      <table
+        className="nums"
+        style={{
+          borderCollapse: "collapse",
+          fontSize: 13,
+          minWidth,
+          width: "100%",
+        }}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}
+
+function OutcomeCell({ value }: { value: OutcomeValue | undefined }) {
+  const source =
+    value?.sourceTable && value.sourceVariable
+      ? `${value.sourceTable}.${value.sourceVariable}`
+      : null;
+  return (
+    <span title={source ?? undefined}>
+      {fmtIpedsPercent(value?.value ?? null)}
+    </span>
+  );
+}
+
+function TestingTable({ rows }: { rows: TestingObservabilityRow[] }) {
+  return (
+    <TableFrame label="Testing observability table" minWidth={1120}>
+      <thead>
+        <tr>
+          <HeaderCell>School</HeaderCell>
+          <HeaderCell>Panel</HeaderCell>
+          <HeaderCell>CDS year</HeaderCell>
+          <HeaderCell align="right">SAT submit</HeaderCell>
+          <HeaderCell align="right">ACT submit</HeaderCell>
+          <HeaderCell align="right">SAT 25/50/75</HeaderCell>
+          <HeaderCell align="right">ACT 25/50/75</HeaderCell>
+          <HeaderCell>Status</HeaderCell>
+          <HeaderCell>Note</HeaderCell>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.schoolId}>
+            <Cell>
+              <Link href={`/schools/${row.schoolId}`} style={{ color: "var(--ink)" }}>
+                {row.schoolName}
+              </Link>
+            </Cell>
+            <Cell>{row.panel === "uc" ? "UC" : "News comparison"}</Cell>
+            <Cell>
+              {row.archiveUrl ? (
+                <TrackedLink
+                  external
+                  href={row.archiveUrl}
+                  analyticsEvent="recipe_source_opened"
+                  analyticsProperties={{
+                    recipe: "test-optional-outcome-tracker",
+                    source: "cds_archive",
+                    school_id: row.schoolId,
+                  }}
+                >
+                  {row.latestCdsYear ?? "n/a"}
+                </TrackedLink>
+              ) : (
+                row.latestCdsYear ?? "n/a"
+              )}
+            </Cell>
+            <Cell align="right">{fmtCdsRate(row.satSubmitRate)}</Cell>
+            <Cell align="right">{fmtCdsRate(row.actSubmitRate)}</Cell>
+            <Cell align="right">
+              {fmtScore(row.satCompositeP25)} / {fmtScore(row.satCompositeP50)} /{" "}
+              {fmtScore(row.satCompositeP75)}
+            </Cell>
+            <Cell align="right">
+              {fmtScore(row.actCompositeP25)} / {fmtScore(row.actCompositeP50)} /{" "}
+              {fmtScore(row.actCompositeP75)}
+            </Cell>
+            <Cell>
+              <span className={statusChipClass(row.scoreBandStatus)}>
+                {statusLabel(row.scoreBandStatus)}
+              </span>
+            </Cell>
+            <Cell>{row.note}</Cell>
+          </tr>
+        ))}
+      </tbody>
+    </TableFrame>
+  );
+}
+
+function RetentionTable({
+  rows,
+  years,
+}: {
+  rows: UcOutcomeRow[];
+  years: number[];
+}) {
+  return (
+    <TableFrame label="UC first-year retention watchlist" minWidth={980}>
+      <thead>
+        <tr>
+          <HeaderCell>UC campus</HeaderCell>
+          {years.map((year) => (
+            <HeaderCell key={year} align="right">
+              {year}
+            </HeaderCell>
+          ))}
+          <HeaderCell align="right">Delta</HeaderCell>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.schoolId}>
+            <Cell>
+              <Link href={`/schools/${row.schoolId}`} style={{ color: "var(--ink)" }}>
+                {row.schoolName}
+              </Link>
+            </Cell>
+            {years.map((year) => (
+              <Cell key={year} align="right">
+                <OutcomeCell value={row.retentionByYear[year]} />
+              </Cell>
+            ))}
+            <Cell align="right">{fmtDelta(row.retentionDelta)}</Cell>
+          </tr>
+        ))}
+      </tbody>
+    </TableFrame>
+  );
+}
+
+function CompletionTable({
+  rows,
+  latestYear,
+}: {
+  rows: UcOutcomeRow[];
+  latestYear: number | null;
+}) {
+  return (
+    <TableFrame label="UC completion and transfer-out baseline table" minWidth={900}>
+      <thead>
+        <tr>
+          <HeaderCell>UC campus</HeaderCell>
+          <HeaderCell align="right">{latestYear ?? "Latest"} retention</HeaderCell>
+          <HeaderCell align="right">{latestYear ?? "Latest"} six-year grad</HeaderCell>
+          <HeaderCell align="right">{latestYear ?? "Latest"} transfer-out</HeaderCell>
+          <HeaderCell>Scorecard context</HeaderCell>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.schoolId}>
+            <Cell>
+              <Link href={`/schools/${row.schoolId}`} style={{ color: "var(--ink)" }}>
+                {row.schoolName}
+              </Link>
+            </Cell>
+            <Cell align="right">
+              <OutcomeCell
+                value={latestYear == null ? undefined : row.retentionByYear[latestYear]}
+              />
+            </Cell>
+            <Cell align="right">
+              <OutcomeCell
+                value={latestYear == null ? undefined : row.graduationByYear[latestYear]}
+              />
+            </Cell>
+            <Cell align="right">
+              <OutcomeCell
+                value={latestYear == null ? undefined : row.transferOutByYear[latestYear]}
+              />
+            </Cell>
+            <Cell>
+              {row.scorecard ? (
+                <span>
+                  Scorecard {row.scorecard.dataYear}: retention{" "}
+                  {fmtCdsRate(row.scorecard.retentionRateFt)}, grad{" "}
+                  {fmtCdsRate(row.scorecard.graduationRate6yr)}, transfer-out{" "}
+                  {fmtCdsRate(row.scorecard.transferOutRate)}
+                </span>
+              ) : (
+                "n/a"
+              )}
+            </Cell>
+          </tr>
+        ))}
+      </tbody>
+    </TableFrame>
+  );
+}
+
+export default async function TestOptionalOutcomeTrackerPage() {
+  const data = await fetchTestOptionalOutcomeTracker();
+  const latestYear = data.methodology.latestIpedsDataYear;
+  const latestRelease = data.methodology.latestIpedsRelease;
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 py-8">
+      <header
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) auto",
+          alignItems: "end",
+          gap: 24,
+          paddingTop: 16,
+          paddingBottom: 8,
+        }}
+        className="test-optional-outcome-header"
+      >
+        <div>
+          <div
+            className="mono"
+            style={{
+              color: "var(--ink-3)",
+              fontSize: 11,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            <Link href="/recipes" style={{ color: "var(--ink-3)", textDecoration: "none" }}>
+              RECIPES
+            </Link>{" "}
+            /{" "}
+            <span style={{ color: "var(--ink)" }}>
+              TEST-OPTIONAL OUTCOME TRACKER
+            </span>
+          </div>
+          <h1
+            className="serif"
+            style={{
+              fontSize: "clamp(34px, 5.4vw, 56px)",
+              fontWeight: 400,
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+              margin: "12px 0 0",
+              maxWidth: 820,
+            }}
+          >
+            What did test-optional policy make harder to see?
+          </h1>
+          <p
+            style={{
+              color: "var(--ink-2)",
+              fontSize: 16,
+              lineHeight: 1.6,
+              marginTop: 14,
+              maxWidth: 780,
+            }}
+          >
+            WSJ is covering a real SAT policy debate. This tracker uses
+            CollegeData.fyi source layers to separate what changed in public
+            testing visibility from what coarse UC outcome measures show so far.
+          </p>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <span className="cd-chip">CDS C8/C9</span>
+          <span className="cd-chip">IPEDS</span>
+          <span className="cd-chip">Scorecard</span>
+        </div>
+      </header>
+
+      <section
+        className="rule-2 test-optional-outcome-stats"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+          gap: 14,
+          marginTop: 28,
+          paddingTop: 18,
+        }}
+      >
+        <div className="cd-card" style={{ padding: 16 }}>
+          <div className="meta">UC campuses</div>
+          <div className="serif nums" style={{ fontSize: 34, lineHeight: 1, marginTop: 8 }}>
+            {data.methodology.ucPanelSize}
+          </div>
+          <p style={{ color: "var(--ink-2)", fontSize: 13, lineHeight: 1.45, margin: "8px 0 0" }}>
+            Undergraduate UC campuses in the outcome watchlist.
+          </p>
+        </div>
+        <div className="cd-card" style={{ padding: 16 }}>
+          <div className="meta">Latest IPEDS year</div>
+          <div className="serif nums" style={{ fontSize: 34, lineHeight: 1, marginTop: 8 }}>
+            {latestYear ?? "n/a"}
+          </div>
+          <p style={{ color: "var(--ink-2)", fontSize: 13, lineHeight: 1.45, margin: "8px 0 0" }}>
+            Retention, completion, and transfer-out come from{" "}
+            <code>ipeds_facts</code>.
+          </p>
+        </div>
+        <div className="cd-card" style={{ padding: 16 }}>
+          <div className="meta">Median latest retention</div>
+          <div className="serif nums" style={{ fontSize: 34, lineHeight: 1, marginTop: 8 }}>
+            {fmtIpedsPercent(data.summary.latestRetentionMedian)}
+          </div>
+          <p style={{ color: "var(--ink-2)", fontSize: 13, lineHeight: 1.45, margin: "8px 0 0" }}>
+            High baseline retention leaves limited room for visible shock.
+          </p>
+        </div>
+        <div className="cd-card" style={{ padding: 16 }}>
+          <div className="meta">UC score bands hidden</div>
+          <div className="serif nums" style={{ fontSize: 34, lineHeight: 1, marginTop: 8 }}>
+            {data.summary.ucTestingRowsWithoutScoreBands}/{data.methodology.ucPanelSize}
+          </div>
+          <p style={{ color: "var(--ink-2)", fontSize: 13, lineHeight: 1.45, margin: "8px 0 0" }}>
+            Current UC CDS serving rows with no reported SAT/ACT score bands.
+          </p>
+        </div>
+      </section>
+
+      <section
+        className="cd-card cd-card--cut"
+        style={{ marginTop: 28, padding: 20 }}
+      >
+        <div className="meta">Early read</div>
+        <p style={{ color: "var(--ink-2)", fontSize: 16, lineHeight: 1.65, margin: "10px 0 0" }}>
+          The primary signal is observability: when schools stop requiring or
+          collecting scores, public score reporting gets thinner. UC first-year
+          retention does not show an obvious institution-level collapse, but
+          retention is coarse, ceiling-limited, and confounded by the pandemic
+          era. Completion and transfer-out remain useful watchlist measures, but
+          they are too lagged to fully evaluate post-2020 cohorts.
+        </p>
+      </section>
+
+      <section style={{ marginTop: 44 }}>
+        <div className="meta">§ Testing observability</div>
+        <h2
+          className="serif"
+          style={{ fontSize: 30, lineHeight: 1.08, margin: "8px 0 0" }}
+        >
+          What is still visible in CDS testing rows?
+        </h2>
+        <p style={{ color: "var(--ink-2)", fontSize: 15, lineHeight: 1.6, marginTop: 10, maxWidth: 820 }}>
+          This table uses current <code>school_browser_rows</code> values only.
+          It does not infer formal policy from submit rates, and it treats UC
+          missingness as an observability result rather than as a score result.
+        </p>
+        <TestingTable rows={data.testing} />
+      </section>
+
+      <section style={{ marginTop: 44 }}>
+        <div className="meta">§ UC first-year retention watchlist</div>
+        <h2
+          className="serif"
+          style={{ fontSize: 30, lineHeight: 1.08, margin: "8px 0 0" }}
+        >
+          Retention is basically flat, but it is a weak instrument.
+        </h2>
+        <p style={{ color: "var(--ink-2)", fontSize: 15, lineHeight: 1.6, marginTop: 10, maxWidth: 840 }}>
+          First-year retention is the fastest public outcome check available in
+          IPEDS. It is also institution-level, high-ceiling data. Flat retention
+          is useful evidence against a broad retention shock, not proof that
+          classroom preparedness concerns are false.
+        </p>
+        <RetentionTable rows={data.outcomes} years={data.years} />
+      </section>
+
+      <section style={{ marginTop: 44 }}>
+        <div className="meta">§ Completion and transfer-out baseline</div>
+        <h2
+          className="serif"
+          style={{ fontSize: 30, lineHeight: 1.08, margin: "8px 0 0" }}
+        >
+          Completion data is still mostly a baseline.
+        </h2>
+        <p style={{ color: "var(--ink-2)", fontSize: 15, lineHeight: 1.6, marginTop: 10, maxWidth: 840 }}>
+          Six-year graduation and transfer-out are worth tracking, but in June
+          2026 they are still too lagged to cleanly evaluate mature post-2020
+          test-blind cohorts. Treat these as baseline context and refresh them
+          when new IPEDS vintages land.
+        </p>
+        <CompletionTable rows={data.outcomes} latestYear={latestYear} />
+      </section>
+
+      <section
+        className="rule-2 test-optional-outcome-methodology"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) minmax(260px, 360px)",
+          gap: 28,
+          marginTop: 48,
+          paddingTop: 22,
+        }}
+      >
+        <div>
+          <div className="meta">§ Methodology limits</div>
+          <ul style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.65, margin: "10px 0 0", paddingLeft: 20 }}>
+            <li>Formal test-policy labels require separately sourced URLs and verification dates.</li>
+            <li>UC is a highly selected public system, not the national applicant pool.</li>
+            <li>IPEDS retention is not course-level math readiness, DFW rates, GPA, or STEM persistence.</li>
+            <li>COVID disruption and test-policy changes overlap, so this is descriptive, not causal.</li>
+          </ul>
+        </div>
+        <div className="cd-card" style={{ padding: 18 }}>
+          <div className="meta">Export</div>
+          <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "8px 0 0" }}>
+            The page and API use the same assembled dataset. Generated{" "}
+            {fmtDate(data.generatedAt)} from public CollegeData.fyi tables.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14 }}>
+            <TrackedLink
+              href={API_PATH}
+              className="cd-btn cd-btn--ghost"
+              analyticsEvent="recipe_api_opened"
+              analyticsProperties={{ recipe: "test-optional-outcome-tracker", format: "json" }}
+            >
+              JSON
+            </TrackedLink>
+            <TrackedLink
+              href={`${API_PATH}?format=csv`}
+              className="cd-btn"
+              analyticsEvent="download_clicked"
+              analyticsProperties={{
+                surface: "test_optional_outcome_tracker",
+                file_type: "csv",
+                item: "tracker_export",
+              }}
+            >
+              Download CSV
+            </TrackedLink>
+          </div>
+          <p className="mono" style={{ color: "var(--ink-3)", fontSize: 11, lineHeight: 1.45, marginTop: 12 }}>
+            Latest IPEDS release: {latestRelease?.collection_year ?? "n/a"}{" "}
+            {latestRelease?.release_type ?? ""} ({latestRelease?.release_date ?? "no date"}).
+          </p>
+        </div>
+      </section>
+
+      <style>{`
+        @media (max-width: 900px) {
+          .test-optional-outcome-header {
+            grid-template-columns: 1fr !important;
+          }
+          .test-optional-outcome-header > div:last-child {
+            justify-content: flex-start !important;
+          }
+        }
+        @media (max-width: 820px) {
+          .test-optional-outcome-stats {
+            grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+          }
+          .test-optional-outcome-methodology {
+            grid-template-columns: 1fr !important;
+          }
+        }
+        @media (max-width: 560px) {
+          .test-optional-outcome-stats {
+            grid-template-columns: 1fr !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -81,6 +81,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.5,
     },
+    {
+      url: `${SITE_URL}/recipes/test-optional-outcome-tracker`,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
   ];
 
   const schoolPages: MetadataRoute.Sitemap = schools.map((s) => ({

--- a/web/src/lib/test-optional-outcome-tracker.ts
+++ b/web/src/lib/test-optional-outcome-tracker.ts
@@ -1,0 +1,565 @@
+import { cache } from "react";
+import { supabase } from "./supabase";
+
+type UntypedSupabase = {
+  from: (table: string) => any;
+};
+
+type Panel = "uc" | "comparison";
+type OutcomeFieldKey =
+  | "retention_rate_full_time"
+  | "bachelor_6yr_grad_rate"
+  | "transfer_out_rate_total";
+
+type PanelSchool = {
+  panel: Panel;
+  schoolId: string;
+  schoolName: string;
+  ipedsId: string;
+};
+
+type DirectoryRow = {
+  school_id: string | null;
+  school_name: string | null;
+  ipeds_id: string | null;
+};
+
+type BrowserRow = {
+  school_id: string | null;
+  school_name: string | null;
+  canonical_year: string | null;
+  year_start: number | null;
+  sat_submit_rate: unknown;
+  act_submit_rate: unknown;
+  sat_composite_p25: unknown;
+  sat_composite_p50: unknown;
+  sat_composite_p75: unknown;
+  act_composite_p25: unknown;
+  act_composite_p50: unknown;
+  act_composite_p75: unknown;
+  archive_url: string | null;
+  data_quality_flag: string | null;
+};
+
+type IpedsFactRow = {
+  ipeds_id: string | null;
+  data_year: number | null;
+  field_key: string | null;
+  value_numeric: unknown;
+  source_table: string | null;
+  source_variable: string | null;
+  release_type: string | null;
+};
+
+type ScorecardRow = {
+  ipeds_id: string | null;
+  scorecard_data_year: string | null;
+  retention_rate_ft: unknown;
+  graduation_rate_6yr: unknown;
+  transfer_out_rate: unknown;
+};
+
+type IpedsReleaseRow = {
+  data_year: number | null;
+  collection_year: string | null;
+  release_type: string | null;
+  release_date: string | null;
+};
+
+export type TestingObservabilityRow = {
+  panel: Panel;
+  schoolId: string;
+  schoolName: string;
+  ipedsId: string;
+  latestCdsYear: string | null;
+  archiveUrl: string | null;
+  satSubmitRate: number | null;
+  actSubmitRate: number | null;
+  satCompositeP25: number | null;
+  satCompositeP50: number | null;
+  satCompositeP75: number | null;
+  actCompositeP25: number | null;
+  actCompositeP50: number | null;
+  actCompositeP75: number | null;
+  scoreBandStatus: "reported" | "submit-rates-only" | "not-reported" | "no-cds-row";
+  note: string;
+  dataQualityFlag: string | null;
+};
+
+export type OutcomeValue = {
+  value: number | null;
+  sourceTable: string | null;
+  sourceVariable: string | null;
+  releaseType: string | null;
+};
+
+export type UcOutcomeRow = {
+  schoolId: string;
+  schoolName: string;
+  ipedsId: string;
+  retentionByYear: Record<number, OutcomeValue>;
+  graduationByYear: Record<number, OutcomeValue>;
+  transferOutByYear: Record<number, OutcomeValue>;
+  retentionDelta: number | null;
+  latestRetention: number | null;
+  latestGraduation: number | null;
+  latestTransferOut: number | null;
+  latestDataYear: number | null;
+  scorecard: {
+    dataYear: string | null;
+    retentionRateFt: number | null;
+    graduationRate6yr: number | null;
+    transferOutRate: number | null;
+  } | null;
+};
+
+export type TestOptionalOutcomeTrackerData = {
+  generatedAt: string;
+  methodology: {
+    baselineDataYear: number;
+    latestIpedsDataYear: number | null;
+    latestIpedsRelease: IpedsReleaseRow | null;
+    ucPanelSize: number;
+    comparisonPanelSize: number;
+    notes: string[];
+  };
+  years: number[];
+  testing: TestingObservabilityRow[];
+  outcomes: UcOutcomeRow[];
+  summary: {
+    ucCampusesWithRetentionBaseline: number;
+    ucCampusesWithLatestRetention: number;
+    latestRetentionMedian: number | null;
+    retentionDeltaMedian: number | null;
+    ucTestingRowsWithoutScoreBands: number;
+  };
+};
+
+const BASELINE_DATA_YEAR = 2019;
+
+const UC_PANEL: PanelSchool[] = [
+  {
+    panel: "uc",
+    schoolId: "uc-berkeley",
+    schoolName: "University of California-Berkeley",
+    ipedsId: "110635",
+  },
+  {
+    panel: "uc",
+    schoolId: "uc-davis",
+    schoolName: "University of California-Davis",
+    ipedsId: "110644",
+  },
+  {
+    panel: "uc",
+    schoolId: "uc-irvine",
+    schoolName: "University of California-Irvine",
+    ipedsId: "110653",
+  },
+  {
+    panel: "uc",
+    schoolId: "ucla",
+    schoolName: "University of California-Los Angeles",
+    ipedsId: "110662",
+  },
+  {
+    panel: "uc",
+    schoolId: "university-of-california-merced",
+    schoolName: "University of California-Merced",
+    ipedsId: "445188",
+  },
+  {
+    panel: "uc",
+    schoolId: "university-of-california-riverside",
+    schoolName: "University of California-Riverside",
+    ipedsId: "110671",
+  },
+  {
+    panel: "uc",
+    schoolId: "uc-san-diego",
+    schoolName: "University of California-San Diego",
+    ipedsId: "110680",
+  },
+  {
+    panel: "uc",
+    schoolId: "uc-santa-barbara",
+    schoolName: "University of California-Santa Barbara",
+    ipedsId: "110705",
+  },
+  {
+    panel: "uc",
+    schoolId: "university-of-california-santa-cruz",
+    schoolName: "University of California-Santa Cruz",
+    ipedsId: "110714",
+  },
+];
+
+const COMPARISON_PANEL: PanelSchool[] = [
+  {
+    panel: "comparison",
+    schoolId: "mit",
+    schoolName: "Massachusetts Institute of Technology",
+    ipedsId: "166683",
+  },
+  {
+    panel: "comparison",
+    schoolId: "dartmouth",
+    schoolName: "Dartmouth College",
+    ipedsId: "182670",
+  },
+  {
+    panel: "comparison",
+    schoolId: "yale",
+    schoolName: "Yale University",
+    ipedsId: "130794",
+  },
+];
+
+const ALL_PANEL_SCHOOLS = [...UC_PANEL, ...COMPARISON_PANEL];
+const OUTCOME_FIELD_KEYS: OutcomeFieldKey[] = [
+  "retention_rate_full_time",
+  "bachelor_6yr_grad_rate",
+  "transfer_out_rate_total",
+];
+
+function numberOrNull(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function median(values: Array<number | null | undefined>): number | null {
+  const clean = values
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    .sort((a, b) => a - b);
+  if (clean.length === 0) return null;
+  const middle = Math.floor(clean.length / 2);
+  if (clean.length % 2) return clean[middle];
+  return (clean[middle - 1] + clean[middle]) / 2;
+}
+
+function latestBrowserRows(rows: BrowserRow[]): Map<string, BrowserRow> {
+  const latest = new Map<string, BrowserRow>();
+  for (const row of rows) {
+    if (!row.school_id) continue;
+    const current = latest.get(row.school_id);
+    const rowYear = numberOrNull(row.year_start) ?? 0;
+    const currentYear = numberOrNull(current?.year_start) ?? 0;
+    if (!current || rowYear > currentYear) latest.set(row.school_id, row);
+  }
+  return latest;
+}
+
+function scoreBandStatus(row: BrowserRow | undefined): TestingObservabilityRow["scoreBandStatus"] {
+  if (!row) return "no-cds-row";
+  const hasBands =
+    numberOrNull(row.sat_composite_p25) != null ||
+    numberOrNull(row.sat_composite_p50) != null ||
+    numberOrNull(row.sat_composite_p75) != null ||
+    numberOrNull(row.act_composite_p25) != null ||
+    numberOrNull(row.act_composite_p50) != null ||
+    numberOrNull(row.act_composite_p75) != null;
+  if (hasBands) return "reported";
+  const hasSubmitRates =
+    numberOrNull(row.sat_submit_rate) != null || numberOrNull(row.act_submit_rate) != null;
+  return hasSubmitRates ? "submit-rates-only" : "not-reported";
+}
+
+function observabilityNote(
+  panel: Panel,
+  status: TestingObservabilityRow["scoreBandStatus"],
+): string {
+  if (status === "no-cds-row") return "No current primary CDS browser row in the public serving table.";
+  if (status === "reported") return "CDS reports score bands in the current serving row.";
+  if (status === "submit-rates-only") return "CDS reports submit rates but not score bands in the current serving row.";
+  if (panel === "uc") {
+    return "CDS row exists, but SAT/ACT submit rates and bands are not reported in the serving row.";
+  }
+  return "CDS row exists, but SAT/ACT score fields are not reported in the serving row.";
+}
+
+function valueForYear(
+  facts: IpedsFactRow[],
+  ipedsId: string,
+  fieldKey: OutcomeFieldKey,
+  dataYear: number,
+): OutcomeValue {
+  const row = facts.find(
+    (fact) =>
+      fact.ipeds_id === ipedsId &&
+      fact.field_key === fieldKey &&
+      fact.data_year === dataYear,
+  );
+  return {
+    value: numberOrNull(row?.value_numeric),
+    sourceTable: row?.source_table ?? null,
+    sourceVariable: row?.source_variable ?? null,
+    releaseType: row?.release_type ?? null,
+  };
+}
+
+function normalizeName(
+  school: PanelSchool,
+  directory: Map<string, DirectoryRow>,
+  browser: BrowserRow | undefined,
+): string {
+  return browser?.school_name ?? directory.get(school.schoolId)?.school_name ?? school.schoolName;
+}
+
+async function fetchTrackerDataUncached(): Promise<TestOptionalOutcomeTrackerData> {
+  const client = supabase as unknown as UntypedSupabase;
+  const schoolIds = ALL_PANEL_SCHOOLS.map((school) => school.schoolId);
+  const ucIpedsIds = UC_PANEL.map((school) => school.ipedsId);
+
+  const [
+    directoryResult,
+    browserResult,
+    factsResult,
+    scorecardResult,
+    releaseResult,
+  ] = await Promise.all([
+    client
+      .from("institution_directory")
+      .select("school_id,school_name,ipeds_id")
+      .in("school_id", schoolIds),
+    client
+      .from("school_browser_rows")
+      .select(
+        "school_id,school_name,canonical_year,year_start,sat_submit_rate,act_submit_rate,sat_composite_p25,sat_composite_p50,sat_composite_p75,act_composite_p25,act_composite_p50,act_composite_p75,archive_url,data_quality_flag",
+      )
+      .in("school_id", schoolIds)
+      .is("sub_institutional", null)
+      .gte("year_start", 2024)
+      .order("school_id", { ascending: true })
+      .order("year_start", { ascending: false }),
+    client
+      .from("ipeds_facts")
+      .select(
+        "ipeds_id,data_year,field_key,value_numeric,source_table,source_variable,release_type",
+      )
+      .in("ipeds_id", ucIpedsIds)
+      .in("field_key", OUTCOME_FIELD_KEYS)
+      .gte("data_year", BASELINE_DATA_YEAR)
+      .order("ipeds_id", { ascending: true })
+      .order("field_key", { ascending: true })
+      .order("data_year", { ascending: true }),
+    client
+      .from("scorecard_summary")
+      .select("ipeds_id,scorecard_data_year,retention_rate_ft,graduation_rate_6yr,transfer_out_rate")
+      .in("ipeds_id", ucIpedsIds),
+    client
+      .from("ipeds_releases")
+      .select("data_year,collection_year,release_type,release_date")
+      .order("data_year", { ascending: false })
+      .order("release_date", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (directoryResult.error) {
+    throw new Error(`test optional tracker directory query failed: ${directoryResult.error.message}`);
+  }
+  if (browserResult.error) {
+    throw new Error(`test optional tracker browser query failed: ${browserResult.error.message}`);
+  }
+  if (factsResult.error) {
+    throw new Error(`test optional tracker IPEDS query failed: ${factsResult.error.message}`);
+  }
+  if (scorecardResult.error) {
+    throw new Error(`test optional tracker Scorecard query failed: ${scorecardResult.error.message}`);
+  }
+  if (releaseResult.error) {
+    throw new Error(`test optional tracker release query failed: ${releaseResult.error.message}`);
+  }
+
+  const directoryBySchool = new Map(
+    ((directoryResult.data ?? []) as DirectoryRow[])
+      .filter((row): row is DirectoryRow & { school_id: string } => Boolean(row.school_id))
+      .map((row) => [row.school_id, row]),
+  );
+  const latestBrowserBySchool = latestBrowserRows((browserResult.data ?? []) as BrowserRow[]);
+  const facts = (factsResult.data ?? []) as IpedsFactRow[];
+  const scorecardByIpeds = new Map(
+    ((scorecardResult.data ?? []) as ScorecardRow[])
+      .filter((row): row is ScorecardRow & { ipeds_id: string } => Boolean(row.ipeds_id))
+      .map((row) => [row.ipeds_id, row]),
+  );
+
+  const years = Array.from(
+    new Set(
+      facts
+        .map((row) => row.data_year)
+        .filter((year): year is number => typeof year === "number" && year >= BASELINE_DATA_YEAR),
+    ),
+  ).sort((a, b) => a - b);
+  const latestIpedsDataYear = years.at(-1) ?? null;
+
+  const testing = ALL_PANEL_SCHOOLS.map((school): TestingObservabilityRow => {
+    const browser = latestBrowserBySchool.get(school.schoolId);
+    const status = scoreBandStatus(browser);
+    return {
+      panel: school.panel,
+      schoolId: school.schoolId,
+      schoolName: normalizeName(school, directoryBySchool, browser),
+      ipedsId: directoryBySchool.get(school.schoolId)?.ipeds_id ?? school.ipedsId,
+      latestCdsYear: browser?.canonical_year ?? null,
+      archiveUrl: browser?.archive_url ?? null,
+      satSubmitRate: numberOrNull(browser?.sat_submit_rate),
+      actSubmitRate: numberOrNull(browser?.act_submit_rate),
+      satCompositeP25: numberOrNull(browser?.sat_composite_p25),
+      satCompositeP50: numberOrNull(browser?.sat_composite_p50),
+      satCompositeP75: numberOrNull(browser?.sat_composite_p75),
+      actCompositeP25: numberOrNull(browser?.act_composite_p25),
+      actCompositeP50: numberOrNull(browser?.act_composite_p50),
+      actCompositeP75: numberOrNull(browser?.act_composite_p75),
+      scoreBandStatus: status,
+      note: observabilityNote(school.panel, status),
+      dataQualityFlag: browser?.data_quality_flag ?? null,
+    };
+  });
+
+  const outcomes = UC_PANEL.map((school): UcOutcomeRow => {
+    const browser = latestBrowserBySchool.get(school.schoolId);
+    const schoolName = normalizeName(school, directoryBySchool, browser);
+    const retentionByYear: Record<number, OutcomeValue> = {};
+    const graduationByYear: Record<number, OutcomeValue> = {};
+    const transferOutByYear: Record<number, OutcomeValue> = {};
+    for (const year of years) {
+      retentionByYear[year] = valueForYear(facts, school.ipedsId, "retention_rate_full_time", year);
+      graduationByYear[year] = valueForYear(facts, school.ipedsId, "bachelor_6yr_grad_rate", year);
+      transferOutByYear[year] = valueForYear(facts, school.ipedsId, "transfer_out_rate_total", year);
+    }
+    const latestRetention =
+      latestIpedsDataYear == null ? null : retentionByYear[latestIpedsDataYear]?.value ?? null;
+    const baselineRetention = retentionByYear[BASELINE_DATA_YEAR]?.value ?? null;
+    const latestGraduation =
+      latestIpedsDataYear == null ? null : graduationByYear[latestIpedsDataYear]?.value ?? null;
+    const latestTransferOut =
+      latestIpedsDataYear == null ? null : transferOutByYear[latestIpedsDataYear]?.value ?? null;
+    const scorecard = scorecardByIpeds.get(school.ipedsId);
+
+    return {
+      schoolId: school.schoolId,
+      schoolName,
+      ipedsId: school.ipedsId,
+      retentionByYear,
+      graduationByYear,
+      transferOutByYear,
+      retentionDelta:
+        latestRetention == null || baselineRetention == null
+          ? null
+          : latestRetention - baselineRetention,
+      latestRetention,
+      latestGraduation,
+      latestTransferOut,
+      latestDataYear: latestIpedsDataYear,
+      scorecard: scorecard
+        ? {
+            dataYear: scorecard.scorecard_data_year,
+            retentionRateFt: numberOrNull(scorecard.retention_rate_ft),
+            graduationRate6yr: numberOrNull(scorecard.graduation_rate_6yr),
+            transferOutRate: numberOrNull(scorecard.transfer_out_rate),
+          }
+        : null,
+    };
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    methodology: {
+      baselineDataYear: BASELINE_DATA_YEAR,
+      latestIpedsDataYear,
+      latestIpedsRelease: (releaseResult.data ?? null) as IpedsReleaseRow | null,
+      ucPanelSize: UC_PANEL.length,
+      comparisonPanelSize: COMPARISON_PANEL.length,
+      notes: [
+        "Formal test-policy labels are not inferred from CDS submit rates.",
+        "UC outcome rows use undergraduate UC campuses only; UC San Francisco and UC Law SF are excluded from the panel.",
+        "IPEDS percentages are institution-level values. They are not course-level or major-level readiness measures.",
+        "Completion and transfer-out rates are lagged entering-cohort outcomes.",
+      ],
+    },
+    years,
+    testing,
+    outcomes,
+    summary: {
+      ucCampusesWithRetentionBaseline: outcomes.filter(
+        (row) => row.retentionByYear[BASELINE_DATA_YEAR]?.value != null,
+      ).length,
+      ucCampusesWithLatestRetention: outcomes.filter((row) => row.latestRetention != null).length,
+      latestRetentionMedian: median(outcomes.map((row) => row.latestRetention)),
+      retentionDeltaMedian: median(outcomes.map((row) => row.retentionDelta)),
+      ucTestingRowsWithoutScoreBands: testing.filter(
+        (row) => row.panel === "uc" && row.scoreBandStatus !== "reported",
+      ).length,
+    },
+  };
+}
+
+export const fetchTestOptionalOutcomeTracker = cache(fetchTrackerDataUncached);
+
+function csvEscape(value: string | number | null | undefined): string {
+  if (value == null) return "";
+  const text = String(value);
+  if (!/[",\n\r]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function testOptionalOutcomeTrackerCsv(data: TestOptionalOutcomeTrackerData): string {
+  const headers = [
+    "panel",
+    "school_id",
+    "school_name",
+    "ipeds_id",
+    "latest_cds_year",
+    "score_band_status",
+    "sat_submit_rate",
+    "act_submit_rate",
+    "sat_composite_p25",
+    "sat_composite_p50",
+    "sat_composite_p75",
+    "act_composite_p25",
+    "act_composite_p50",
+    "act_composite_p75",
+    "retention_2019",
+    `retention_${data.methodology.latestIpedsDataYear ?? "latest"}`,
+    "retention_delta_points",
+    `bachelor_6yr_grad_rate_${data.methodology.latestIpedsDataYear ?? "latest"}`,
+    `transfer_out_rate_total_${data.methodology.latestIpedsDataYear ?? "latest"}`,
+    "archive_url",
+    "note",
+  ];
+
+  const outcomeBySchool = new Map(data.outcomes.map((row) => [row.schoolId, row]));
+  const rows = data.testing.map((testing) => {
+    const outcome = outcomeBySchool.get(testing.schoolId);
+    const latestYear = data.methodology.latestIpedsDataYear;
+    return [
+      testing.panel,
+      testing.schoolId,
+      testing.schoolName,
+      testing.ipedsId,
+      testing.latestCdsYear,
+      testing.scoreBandStatus,
+      testing.satSubmitRate,
+      testing.actSubmitRate,
+      testing.satCompositeP25,
+      testing.satCompositeP50,
+      testing.satCompositeP75,
+      testing.actCompositeP25,
+      testing.actCompositeP50,
+      testing.actCompositeP75,
+      outcome?.retentionByYear[BASELINE_DATA_YEAR]?.value,
+      latestYear == null ? null : outcome?.retentionByYear[latestYear]?.value,
+      outcome?.retentionDelta,
+      latestYear == null ? null : outcome?.graduationByYear[latestYear]?.value,
+      latestYear == null ? null : outcome?.transferOutByYear[latestYear]?.value,
+      testing.archiveUrl,
+      testing.note,
+    ];
+  });
+
+  return [headers, ...rows]
+    .map((row) => row.map((value) => csvEscape(value)).join(","))
+    .join("\n");
+}


### PR DESCRIPTION
## Summary
- Add a public `/recipes/test-optional-outcome-tracker` page for the WSJ SAT/test-optional response surface
- Add shared tracker data assembly over `school_browser_rows`, `ipeds_facts`, `scorecard_summary`, and `ipeds_releases`
- Add JSON/CSV export at `/api/recipes/test-optional-outcome-tracker`
- Wire the tracker into recipes, sitemap, OpenAPI, API docs, and recipe documentation

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Local smoke: page 200, JSON summary returned 12 testing rows / 9 UC outcome rows, CSV export returned rows
- Playwright smoke: 3 tables rendered, CSV link present, no console/page errors

## Notes
- The tracker does not infer formal test policy labels from CDS submit rates
- UC retention is labeled as a coarse, ceiling-limited watchlist signal, not a causal readiness test