### PR TITLE
Fix sparse CDS extraction and sectionized sources

### DIFF
--- a/docs/archive-pipeline.md
+++ b/docs/archive-pipeline.md
@@ -93,6 +93,9 @@ clock.
 │           (CMU pattern), fan out via pickCandidates (ADR     │
 │           0007 Stage B — multi-candidate, prefer full-CDS    │
 │           over section, deprioritize test artifacts).        │
+│           When one CDS year is published as multiple section │
+│           PDFs, group recognized A-J files into a section    │
+│           package instead of picking only Section C.         │
 │           Year is a URL-side guess only; content year is     │
 │           written later by the extraction worker.            │
 │                                                              │
@@ -127,6 +130,35 @@ clock.
 │                  flip extraction_status='extraction_pending' │
 └──────────────────────────────────────────────────────────────┘
 ```
+
+### Sectionized CDS packages
+
+Some schools publish one CDS year as separate section PDFs rather than a
+single filled template. CMU's 2025-26 page is the motivating case: links such
+as `cds-2025-a-general-information.pdf`,
+`cds-2025-b-enrollment-and-persistence.pdf`, and
+`cds-2025-c-first-time-first-year-admission.pdf` are all parts of one logical
+CDS response.
+
+The archive layer handles this before extraction:
+
+1. The resolver detects same-year section files from filenames and returns a
+   `section_package` candidate when two or more section letters are available
+   and no full-CDS file exists for that year.
+2. The archiver downloads and uploads every original section PDF as
+   `cds_artifacts.kind='source_part'`. Each row records section letter, source
+   URL, final URL, SHA, storage path, and sort order in `notes`.
+3. The archiver merges the section PDFs in A-J order into a derived PDF bundle.
+   That bundle is stored as the document's latest `kind='source'` artifact so
+   the extraction worker still consumes one complete logical source file.
+4. The `kind='source'` artifact's `notes.source_package` manifest records all
+   parts used to build the bundle. The original section PDFs remain the
+   provenance; the merged PDF is an extraction convenience.
+
+Full CDS files still win over packages. Single section-only years keep the
+legacy fallback behavior and can archive Section C by itself, but multiple
+recognized sections now become one logical source instead of colliding across
+successive refreshes.
 
 Downstream of the archive queue, the operator-run Python workers complete the
 data path:

--- a/supabase/functions/_shared/archive.ts
+++ b/supabase/functions/_shared/archive.ts
@@ -5,15 +5,20 @@
 // context and finally-block accounting.
 
 import { SupabaseClient } from "jsr:@supabase/supabase-js@2";
+import { PDFDocument } from "npm:pdf-lib@1.17.1";
 import {
   isSafeUrl,
   resolveCdsForSchool,
+  ResolvedCandidate,
   ResolveProbeData,
   ResolveResult,
+  ResolvedSectionPackage,
   USER_AGENT,
 } from "./resolve.ts";
 import { inferHosting, inferWaf, type HostingInference } from "./hosting.ts";
 import {
+  ARCHIVER_PRODUCER,
+  ARCHIVER_VERSION,
   bumpVerified,
   fetchDocumentForSchoolYear,
   fetchLatestSourceArtifact,
@@ -453,8 +458,13 @@ export async function archiveManualUrls(
       normalizeYear(filename);
     try {
       candidates.push(await archiveOneCandidate(supabase, school, {
+        candidate_kind: "single_document",
         url,
         cds_year: year ?? UNKNOWN_YEAR_SENTINEL,
+        filename,
+        is_section_file: false,
+        is_test_artifact: false,
+        discovered_via: "direct",
       }, { source_provenance: options.source_provenance }));
     } catch (e) {
       if (e instanceof PermanentError) {
@@ -504,6 +514,248 @@ export async function archiveManualUrls(
   };
 }
 
+interface DownloadedSectionPart {
+  section: string;
+  filename: string;
+  source_url: string;
+  final_url: string;
+  sha256: string;
+  storage_path: string;
+  size_bytes: number;
+  http_last_modified: string | null;
+  bytes: Uint8Array;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const hashBuf = await crypto.subtle.digest("SHA-256", copy.buffer as ArrayBuffer);
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function buildPdfBundle(parts: DownloadedSectionPart[]): Promise<Uint8Array> {
+  const merged = await PDFDocument.create();
+  for (const part of parts) {
+    let pdf: PDFDocument;
+    try {
+      pdf = await PDFDocument.load(part.bytes);
+    } catch (e) {
+      throw new PermanentError(
+        `section ${part.section} is not a mergeable PDF (${part.final_url}): ${(e as Error).message}`,
+        "wrong_content_type",
+      );
+    }
+    const copied = await merged.copyPages(pdf, pdf.getPageIndices());
+    for (const page of copied) merged.addPage(page);
+  }
+  return await merged.save();
+}
+
+function packageSourceNotes(
+  pkg: ResolvedSectionPackage,
+  parts: DownloadedSectionPart[],
+  bundleSha256: string,
+): Record<string, unknown> {
+  return {
+    source_package: {
+      kind: "section_package",
+      assembled_at: new Date().toISOString(),
+      bundle_sha256: bundleSha256,
+      section_count: parts.length,
+      sections: parts.map((p) => p.section),
+      package_filename: pkg.filename,
+      parts: parts.map((p, index) => ({
+        sort_order: index + 1,
+        section: p.section,
+        filename: p.filename,
+        source_url: p.source_url,
+        final_url: p.final_url,
+        sha256: p.sha256,
+        storage_path: p.storage_path,
+        size_bytes: p.size_bytes,
+        source_http_last_modified: p.http_last_modified,
+      })),
+    },
+  };
+}
+
+async function insertSourcePartArtifacts(
+  supabase: SupabaseClient,
+  documentId: string,
+  parts: DownloadedSectionPart[],
+): Promise<void> {
+  if (parts.length === 0) return;
+  const { error } = await supabase.from("cds_artifacts").insert(
+    parts.map((p, index) => ({
+      document_id: documentId,
+      kind: "source_part",
+      producer: ARCHIVER_PRODUCER,
+      producer_version: ARCHIVER_VERSION,
+      storage_path: p.storage_path,
+      sha256: p.sha256,
+      notes: {
+        sort_order: index + 1,
+        section: p.section,
+        filename: p.filename,
+        source_url: p.source_url,
+        final_url: p.final_url,
+        size_bytes: p.size_bytes,
+        source_http_last_modified: p.http_last_modified,
+      },
+    })),
+  );
+  if (error) throw new Error(`insertSourcePartArtifacts: ${error.message}`);
+}
+
+async function effectiveIpedsIdForSchool(
+  supabase: SupabaseClient,
+  school: SchoolInput,
+): Promise<string | null> {
+  let effectiveIpedsId: string | null = school.ipeds_id ?? null;
+  if (effectiveIpedsId) return effectiveIpedsId;
+  const { data: sibling } = await supabase
+    .from("cds_documents")
+    .select("ipeds_id")
+    .eq("school_id", school.school_id)
+    .not("ipeds_id", "is", null)
+    .limit(1)
+    .maybeSingle();
+  if (sibling?.ipeds_id) effectiveIpedsId = sibling.ipeds_id as string;
+  return effectiveIpedsId;
+}
+
+async function archiveSectionPackage(
+  supabase: SupabaseClient,
+  school: SchoolInput,
+  pkg: ResolvedSectionPackage,
+  options: { source_provenance?: string } = {},
+): Promise<CandidateOutcome> {
+  const parts: DownloadedSectionPart[] = [];
+  for (const part of pkg.parts) {
+    const downloaded = await downloadWithCaps(part.url);
+    const ext = extForResponse(downloaded.contentType, downloaded.finalUrl, downloaded.bytes);
+    if (ext !== "pdf") {
+      throw new PermanentError(
+        `section ${part.section} is ${ext ?? "unknown"}, expected pdf at ${downloaded.finalUrl}`,
+        "wrong_content_type",
+      );
+    }
+    const storagePath = buildSourcePath(
+      school.school_id,
+      pkg.cds_year,
+      downloaded.sha256,
+      "pdf",
+    );
+    await ensureObjectUploaded(supabase, storagePath, downloaded.bytes, "pdf");
+    parts.push({
+      section: part.section,
+      filename: part.filename,
+      source_url: part.url,
+      final_url: downloaded.finalUrl,
+      sha256: downloaded.sha256,
+      storage_path: storagePath,
+      size_bytes: downloaded.bytes.byteLength,
+      http_last_modified: downloaded.httpLastModified,
+      bytes: downloaded.bytes,
+    });
+  }
+
+  const bundleBytes = await buildPdfBundle(parts);
+  const bundleSha256 = await sha256Hex(bundleBytes);
+  const bundleStoragePath = buildSourcePath(
+    school.school_id,
+    pkg.cds_year,
+    bundleSha256,
+    "pdf",
+  );
+  await ensureObjectUploaded(supabase, bundleStoragePath, bundleBytes, "pdf");
+
+  const sourceUrl = parts[0]?.final_url ?? pkg.url;
+  const sourceNotes = packageSourceNotes(pkg, parts, bundleSha256);
+  const existing = await fetchDocumentForSchoolYear(
+    supabase,
+    school.school_id,
+    pkg.cds_year,
+  );
+
+  if (!existing) {
+    const docId = await insertFreshDocument(supabase, {
+      school_id: school.school_id,
+      school_name: school.school_name,
+      ipeds_id: await effectiveIpedsIdForSchool(supabase, school),
+      cds_year: pkg.cds_year,
+      source_url: sourceUrl,
+      source_sha256: bundleSha256,
+      storage_path: bundleStoragePath,
+      source_provenance: options.source_provenance,
+      source_http_last_modified: null,
+      source_artifact_notes: sourceNotes,
+    });
+    await insertSourcePartArtifacts(supabase, docId, parts);
+    return {
+      action: "inserted",
+      document_id: docId,
+      cds_year: pkg.cds_year,
+      source_sha256: bundleSha256,
+      resolved_url: sourceUrl,
+      storage_path: bundleStoragePath,
+    };
+  }
+
+  const latestArtifact = await fetchLatestSourceArtifact(supabase, existing.id);
+  if (latestArtifact && latestArtifact.sha256 === bundleSha256) {
+    const present = await objectExists(supabase, latestArtifact.storage_path);
+    if (present) {
+      await bumpVerified(supabase, existing.id, sourceUrl);
+      return {
+        action: "unchanged_verified",
+        document_id: existing.id,
+        cds_year: pkg.cds_year,
+        source_sha256: bundleSha256,
+        resolved_url: sourceUrl,
+        storage_path: latestArtifact.storage_path,
+      };
+    }
+    await ensureObjectUploaded(supabase, latestArtifact.storage_path, bundleBytes, "pdf");
+    await recordRepair(
+      supabase,
+      existing.id,
+      bundleSha256,
+      latestArtifact.storage_path,
+      sourceUrl,
+    );
+    return {
+      action: "unchanged_repaired",
+      document_id: existing.id,
+      cds_year: pkg.cds_year,
+      source_sha256: bundleSha256,
+      resolved_url: sourceUrl,
+      storage_path: latestArtifact.storage_path,
+    };
+  }
+
+  await refreshDocumentWithNewSha(supabase, {
+    document_id: existing.id,
+    source_url: sourceUrl,
+    source_sha256: bundleSha256,
+    storage_path: bundleStoragePath,
+    source_provenance: options.source_provenance,
+    source_http_last_modified: null,
+    source_artifact_notes: sourceNotes,
+  });
+  await insertSourcePartArtifacts(supabase, existing.id, parts);
+  return {
+    action: "refreshed",
+    document_id: existing.id,
+    cds_year: pkg.cds_year,
+    source_sha256: bundleSha256,
+    resolved_url: sourceUrl,
+    storage_path: bundleStoragePath,
+  };
+}
+
 // Archive a single resolved candidate. Shared by archiveOneSchool for
 // both the single-candidate direct-doc path and the multi-candidate
 // landing-page fan-out. This is the body of the pre-Stage-B
@@ -511,7 +763,7 @@ export async function archiveManualUrls(
 async function archiveOneCandidate(
   supabase: SupabaseClient,
   school: SchoolInput,
-  resolved: { url: string; cds_year: string },
+  resolved: ResolvedCandidate,
   // options.source_provenance propagates into insertFreshDocument and
   // refreshDocumentWithNewSha. Defaults to undefined (→ 'school_direct'
   // via db.ts default), which is correct for the resolver-driven path
@@ -520,6 +772,10 @@ async function archiveOneCandidate(
   // archiveManualUrls.
   options: { source_provenance?: string } = {},
 ): Promise<CandidateOutcome> {
+  if (resolved.candidate_kind === "section_package") {
+    return archiveSectionPackage(supabase, school, resolved, options);
+  }
+
   // Download with a hard memory + wall clock cap.
   const { bytes, sha256, contentType, finalUrl, httpLastModified } =
     await downloadWithCaps(resolved.url);

--- a/supabase/functions/_shared/db.ts
+++ b/supabase/functions/_shared/db.ts
@@ -111,6 +111,7 @@ export interface InsertFreshArgs {
   // cds_documents.source_http_last_modified by migration
   // 20260505160000_archive_observability.sql for freshness audits.
   source_http_last_modified?: string | null;
+  source_artifact_notes?: Record<string, unknown>;
 }
 
 // Used for the "no existing row" branch. Inserts cds_documents + the first
@@ -150,6 +151,7 @@ export async function insertFreshDocument(
     producer_version: ARCHIVER_VERSION,
     storage_path: args.storage_path,
     sha256: args.source_sha256,
+    notes: args.source_artifact_notes ?? {},
   });
   if (artErr) throw new Error(`insertFreshDocument (artifact): ${artErr.message}`);
 
@@ -173,6 +175,7 @@ export interface RefreshArgs {
   // re-archive; clears Stale value if the school stopped emitting
   // the header. Null is the correct "not reported by host" value.
   source_http_last_modified?: string | null;
+  source_artifact_notes?: Record<string, unknown>;
 }
 
 // Used when a new SHA is seen for an existing (school, year) row.
@@ -216,6 +219,7 @@ export async function refreshDocumentWithNewSha(
     producer_version: ARCHIVER_VERSION,
     storage_path: args.storage_path,
     sha256: args.source_sha256,
+    notes: args.source_artifact_notes ?? {},
   });
   if (artErr) {
     throw new Error(`refreshDocumentWithNewSha (artifact): ${artErr.message}`);

--- a/supabase/functions/_shared/resolve.test.ts
+++ b/supabase/functions/_shared/resolve.test.ts
@@ -72,10 +72,11 @@ Deno.test("extractCdsAnchors: section marker detected", () => {
   const html = `
     <a href="/files/cds-section-d-2024-25.pdf">Common Data Set Section D 2024-25</a>
     <a href="/files/CDS_C_2526_0.pdf">Admissions</a>
+    <a href="/ira/CDS/pdf/cds_2025_26/cds-2025-a-general-information.pdf">General Information</a>
     <a href="/CDS/2025-2026/J.pdf">Degrees Conferred</a>
   `;
   const anchors = extractCdsAnchors(html, BASE);
-  assertEquals(anchors.length, 3);
+  assertEquals(anchors.length, 4);
   assertEquals(anchors.every((a) => a.is_section_file), true);
 });
 
@@ -512,7 +513,7 @@ Deno.test("pickCandidates: clean beats demoted when a clean sibling exists", () 
   assertEquals(result[0].is_test_artifact, false);
 });
 
-Deno.test("pickCandidates: section-only years select Section C instead of Section J", () => {
+Deno.test("pickCandidates: section-only years become a section package", () => {
   const anchors = [
     {
       url: "https://aire.ku.edu/sites/aire/files/files/CDS/2025-2026/C.pdf",
@@ -538,7 +539,11 @@ Deno.test("pickCandidates: section-only years select Section C instead of Sectio
   const result = pickCandidates(anchors, "landing");
   assertExists(result);
   assertEquals(result.length, 1);
-  assertEquals(result[0].filename, "C.pdf");
+  assertEquals(result[0].candidate_kind, "section_package");
+  assertEquals(result[0].filename, "cds-2025-26-sections-CJ.pdf");
+  if (result[0].candidate_kind === "section_package") {
+    assertEquals(result[0].parts.map((p) => p.section), ["C", "J"]);
+  }
 });
 
 Deno.test("pickCandidates: older full CDS and current sectionized CDS can coexist", () => {
@@ -578,8 +583,28 @@ Deno.test("pickCandidates: older full CDS and current sectionized CDS can coexis
   assertExists(result);
   assertEquals(result.map((r) => r.filename).sort(), [
     "CDS 2023-24.pdf",
-    "CDS_C_2526_0.pdf",
+    "cds-2025-26-sections-CJ.pdf",
   ]);
+});
+
+Deno.test("pickCandidates: single section-only year preserves Section C fallback", () => {
+  const anchors = [
+    {
+      url: "https://www.cmu.edu/ira/CDS/pdf/cds_2025_26/cds-2025-c-first-time-first-year-admission.pdf",
+      filename: "cds-2025-c-first-time-first-year-admission.pdf",
+      link_text: "First-Time, First-Year Admission",
+      year: "2025-26",
+      year_source: "url_path" as const,
+      kind: "document" as const,
+      is_section_file: true,
+      is_test_artifact: false,
+    },
+  ];
+  const result = pickCandidates(anchors, "landing");
+  assertExists(result);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].candidate_kind, "single_document");
+  assertEquals(result[0].filename, "cds-2025-c-first-time-first-year-admission.pdf");
 });
 
 Deno.test("pickCandidates: reference-only documents are skipped", () => {

--- a/supabase/functions/_shared/resolve.ts
+++ b/supabase/functions/_shared/resolve.ts
@@ -44,6 +44,7 @@ const DOCUMENT_EXT_RE = /\.(pdf|xlsx|docx)(\?|#|$)/i;
 // layouts such as KU's `/CDS/2025-2026/C.pdf` and Oxy's
 // `CDS_C_2526_0.pdf`.
 const EXPLICIT_SECTION_MARKER_RE = /(?:^|[-_ .])section[-_ ]?([a-j])(?:[-_ .]|$)/i;
+const CDS_YEAR_SECTION_FILENAME_RE = /\bcds[-_ ]?\d{4}(?:[-_ ]?\d{2})?[-_ ]?([a-j])(?:[-_ .]|$)/i;
 const CDS_SECTION_FILENAME_RE = /\bcds[-_ ]?([a-j])(?:[-_ .]|\d|$)/i;
 const SINGLE_SECTION_FILENAME_RE = /^([a-j])\d*\.pdf$/i;
 
@@ -55,6 +56,9 @@ const REFERENCE_ARTIFACT_RE =
 function sectionLetterFromFilename(filename: string): string | null {
   const explicit = filename.match(EXPLICIT_SECTION_MARKER_RE);
   if (explicit) return explicit[1].toUpperCase();
+
+  const yearSection = filename.match(CDS_YEAR_SECTION_FILENAME_RE);
+  if (yearSection) return yearSection[1].toUpperCase();
 
   const cdsSection = filename.match(CDS_SECTION_FILENAME_RE);
   if (cdsSection) return cdsSection[1].toUpperCase();
@@ -274,6 +278,7 @@ export interface CdsAnchor {
 }
 
 export interface ResolvedDocument {
+  candidate_kind?: "single_document";
   url: string;
   cds_year: string;
   filename: string;
@@ -282,6 +287,29 @@ export interface ResolvedDocument {
   discovered_via: "direct" | "landing" | "subpage";
   parent_subpage_url?: string;
 }
+
+export interface ResolvedSectionPart {
+  url: string;
+  cds_year: string;
+  filename: string;
+  section: string;
+  is_test_artifact: boolean;
+  discovered_via: "direct" | "landing" | "subpage";
+  parent_subpage_url?: string;
+}
+
+export interface ResolvedSectionPackage {
+  candidate_kind: "section_package";
+  url: string;
+  cds_year: string;
+  filename: string;
+  is_section_file: true;
+  is_test_artifact: boolean;
+  discovered_via: "landing" | "subpage";
+  parts: ResolvedSectionPart[];
+}
+
+export type ResolvedCandidate = ResolvedDocument | ResolvedSectionPackage;
 
 // Sentinel cds_year for direct-doc hints whose filename carries no
 // parseable year (e.g. `cds_all.pdf`, `common-data-set.pdf`, UCLA's
@@ -299,11 +327,13 @@ export const UNKNOWN_YEAR_SENTINEL = "unknown";
 // cds_documents.removed_at to fire on DNS blips. Codex flagged it as the
 // #1 critical finding in review.
 //
-// The `resolved` variant carries `docs: ResolvedDocument[]` — a
+// The `resolved` variant carries `docs: ResolvedCandidate[]` — a
 // non-empty list of candidates — rather than a single doc, so the
 // archiver can fan out into multiple cds_documents rows per school
 // (ADR 0007 Stage B: one row per historical year for schools like
-// Lafayette that expose 20 years on a single landing page).
+// Lafayette that expose 20 years on a single landing page). A candidate
+// can also be a section package when a school publishes one CDS year as
+// separate A/J section PDFs (CMU pattern).
 //
 // The optional `probe` field carries hosting-inference signal from
 // the resolver's first fetchText call when one happened (Cases B/C/D
@@ -320,7 +350,7 @@ export interface ResolveProbeData {
 }
 
 export type ResolveResult =
-  | { kind: "resolved"; docs: ResolvedDocument[]; probe?: ResolveProbeData }
+  | { kind: "resolved"; docs: ResolvedCandidate[]; probe?: ResolveProbeData }
   | { kind: "upstream_gone"; status: number; reason: string; probe?: ResolveProbeData }
   | { kind: "transient"; reason: string; probe?: ResolveProbeData }
   | { kind: "no_cds_found"; reason: string; probe?: ResolveProbeData }
@@ -677,7 +707,7 @@ export function findBestSourceAnchor(
 export function pickCandidates(
   docs: CdsAnchor[],
   discoveredVia: "landing" | "subpage",
-): ResolvedDocument[] | null {
+): ResolvedCandidate[] | null {
   if (docs.length === 0) return [];
 
   // Dedupe by URL (minus fragment). extractCdsAnchors does this on
@@ -694,7 +724,7 @@ export function pickCandidates(
   const withYear = unique.filter((a) => a.year !== null);
   const withoutYear = unique.filter((a) => a.year === null);
 
-  let chosen: CdsAnchor[] = [];
+  const chosen: ResolvedCandidate[] = [];
   if (withYear.length > 0) {
     const byYear = new Map<string, CdsAnchor[]>();
     for (const d of withYear) {
@@ -705,17 +735,25 @@ export function pickCandidates(
     for (const [, group] of byYear) {
       const fullClean = group.filter((d) => !d.is_section_file && !d.is_test_artifact);
       const fullTest = group.filter((d) => !d.is_section_file && d.is_test_artifact);
-      const sectionC = group.filter((d) => sectionLetterFromFilename(d.filename) === "C");
-      const pool = fullClean.length > 0
-        ? fullClean
-        : fullTest.length > 0
-        ? fullTest
-        : sectionC;
-      if (pool.length > 0) chosen.push(pool[0]);
+      const sectionParts = group
+        .map((d) => ({ anchor: d, section: sectionLetterFromFilename(d.filename) }))
+        .filter((d): d is { anchor: CdsAnchor; section: string } => d.section !== null)
+        .sort((a, b) => a.section.localeCompare(b.section));
+
+      if (fullClean.length > 0) {
+        chosen.push(anchorToResolvedDocument(fullClean[0], discoveredVia));
+      } else if (fullTest.length > 0) {
+        chosen.push(anchorToResolvedDocument(fullTest[0], discoveredVia));
+      } else if (sectionParts.length >= 2) {
+        chosen.push(sectionPackageFromAnchors(sectionParts, discoveredVia));
+      } else {
+        const sectionC = group.find((d) => sectionLetterFromFilename(d.filename) === "C");
+        if (sectionC) chosen.push(anchorToResolvedDocument(sectionC, discoveredVia));
+      }
     }
   } else if (unique.length === 1) {
     // Single year-less candidate — sentinel is safe, no collision.
-    chosen = unique;
+    chosen.push(anchorToResolvedDocument(unique[0], discoveredVia));
   } else if (withoutYear.length > 1) {
     // Multiple year-less candidates. Out of Stage B scope.
     return null;
@@ -723,14 +761,48 @@ export function pickCandidates(
 
   if (chosen.length === 0) return [];
 
-  return chosen.map((d) => ({
+  return chosen;
+}
+
+function anchorToResolvedDocument(
+  d: CdsAnchor,
+  discoveredVia: "landing" | "subpage",
+): ResolvedDocument {
+  return {
+    candidate_kind: "single_document",
     url: d.url,
     cds_year: d.year ?? UNKNOWN_YEAR_SENTINEL,
     filename: d.filename,
     is_section_file: d.is_section_file,
     is_test_artifact: d.is_test_artifact,
     discovered_via: discoveredVia,
+  };
+}
+
+function sectionPackageFromAnchors(
+  sectionParts: { anchor: CdsAnchor; section: string }[],
+  discoveredVia: "landing" | "subpage",
+): ResolvedSectionPackage {
+  const parts = sectionParts.map(({ anchor, section }) => ({
+    url: anchor.url,
+    cds_year: anchor.year ?? UNKNOWN_YEAR_SENTINEL,
+    filename: anchor.filename,
+    section,
+    is_test_artifact: anchor.is_test_artifact,
+    discovered_via: discoveredVia,
   }));
+  const year = parts[0]?.cds_year ?? UNKNOWN_YEAR_SENTINEL;
+  const sections = parts.map((p) => p.section).join("");
+  return {
+    candidate_kind: "section_package",
+    url: parts[0]?.url ?? "",
+    cds_year: year,
+    filename: `cds-${year}-sections-${sections}.pdf`,
+    is_section_file: true,
+    is_test_artifact: parts.every((p) => p.is_test_artifact),
+    discovered_via: discoveredVia,
+    parts,
+  };
 }
 
 // Translates a content-type header into an extension symbol. Shared with
@@ -810,7 +882,7 @@ export function parentLandingCandidates(hint: string): string[] {
 // page hints already get the full Case C treatment and don't need this.
 async function findSiblingDocsFromParents(
   hint: string,
-): Promise<ResolvedDocument[]> {
+): Promise<ResolvedCandidate[]> {
   const candidates = parentLandingCandidates(hint);
   for (const ancestorUrl of candidates) {
     const resp = await fetchText(ancestorUrl, SUBPAGE_TIMEOUT_MS);
@@ -884,7 +956,7 @@ export function wellKnownPathUrls(hint: string): string[] {
 
 async function findDocsViaWellKnownPaths(
   hint: string,
-): Promise<ResolvedDocument[]> {
+): Promise<ResolvedCandidate[]> {
   for (const url of wellKnownPathUrls(hint)) {
     const resp = await fetchText(url, SUBPAGE_TIMEOUT_MS);
     if (!resp.ok) continue;
@@ -939,6 +1011,7 @@ export async function resolveCdsForSchool(
     );
     const year = normalizeYear(hint) ?? normalizeYear(filename);
     const directDoc: ResolvedDocument = {
+      candidate_kind: "single_document",
       url: hint,
       cds_year: year ?? UNKNOWN_YEAR_SENTINEL,
       filename,
@@ -962,7 +1035,7 @@ export async function resolveCdsForSchool(
       : [];
 
     // Merge direct + siblings + fallback, dedupe by URL.
-    const byUrl = new Map<string, ResolvedDocument>();
+    const byUrl = new Map<string, ResolvedCandidate>();
     byUrl.set(directDoc.url.split("#")[0], directDoc);
     for (const d of [...siblings, ...fallback]) {
       const key = d.url.split("#")[0];
@@ -1019,6 +1092,7 @@ export async function resolveCdsForSchool(
     return {
       kind: "resolved",
       docs: [{
+        candidate_kind: "single_document",
         url: landing.finalUrl,
         cds_year: year ?? UNKNOWN_YEAR_SENTINEL,
         filename,

--- a/supabase/migrations/20260604170000_sectionized_cds_source_artifacts.sql
+++ b/supabase/migrations/20260604170000_sectionized_cds_source_artifacts.sql
@@ -1,0 +1,21 @@
+-- Allow the archive pipeline to preserve sectionized CDS source PDFs
+-- alongside the derived merged source artifact that extraction consumes.
+--
+-- source_part: original A/B/C/... section PDF bytes.
+-- source_bundle: reserved for future explicit bundle manifests. The current
+-- archive path stores the merged PDF as kind='source' so existing extraction
+-- workers keep consuming the latest source artifact unchanged.
+
+alter table public.cds_artifacts
+  drop constraint if exists cds_artifacts_kind_valid,
+  add constraint cds_artifacts_kind_valid
+    check (kind in (
+      'source',
+      'source_part',
+      'source_bundle',
+      'canonical',
+      'raw_docling',
+      'raw_reducto',
+      'cleaned',
+      'schema_v1_normalized'
+    ));

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -29,7 +29,7 @@ from supabase import create_client
 
 C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
 C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
-OCR_PRODUCER_VERSION = "0.3.8"
+OCR_PRODUCER_VERSION = "0.3.12"
 
 
 def parse_year_start(year: str | None) -> int | None:

--- a/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c1_c2.py
@@ -371,6 +371,37 @@ C3   High school completion requirement
         self.assertEqual(values["C.203"]["value"], "344")
         self.assertEqual(values["C.204"]["value"], "157")
 
+    def test_valdosta_visual_ocr_c1_lines(self):
+        supplemental = """
+C. FIRST-TIME, FIRST-YEAR ADMISSION
+FIRST-TIME, FIRST-YEAR STUDENT APPLICANTS TOTAL
+Total first-time, first-year men who applied 1655
+Total first-time, first-year women who applied 3836
+Total first-time, first-year unknown sex who applied 0
+FIRST-TIME, FIRST-YEAR STUDENT ADMITS TOTAL
+Total first-time, first-year men who were admitted 1232
+Total first-time, first-year women who were admitted 3034
+Total first-time, first-year unknown sex who were admitted 0
+FIRST-TIME, FIRST-YEAR STUDENT ENROLLEES TOTAL
+Total first-time, first-year men who enrolled 411
+Total first-time, first-year women who enrolled 814
+Total first-time, first-year unknown sex who enrolled 0
+"""
+
+        values = clean(
+            "",
+            supplemental_text=supplemental,
+            schema=SchemaIndex(REPO_ROOT / "schemas" / "cds_schema_2025_26.json"),
+        )
+
+        self.assertEqual(values["C.101"]["value"], "1655")
+        self.assertEqual(values["C.102"]["value"], "3836")
+        self.assertEqual(values["C.104"]["value"], "1232")
+        self.assertEqual(values["C.105"]["value"], "3034")
+        self.assertEqual(values["C.116"]["value"], "5491")
+        self.assertEqual(values["C.117"]["value"], "4266")
+        self.assertEqual(values["C.118"]["value"], "1225")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_cleaner_c9.py
+++ b/tools/extraction_worker/test_tier4_cleaner_c9.py
@@ -118,6 +118,40 @@ ACT Reading 21 25 30
         self.assertEqual(values["C.915"]["value"], "24")
         self.assertEqual(values["C.916"]["value"], "28")
 
+    def test_valdosta_visual_ocr_c9_lines(self):
+        markdown = """
+C9. Percent and number of first-time, first-year students enrolled in Fall 2025 who submitted national standardized (SAT/ACT) test scores.
+
+Percent Number
+Submitting SAT Scores 23.93 303
+Submitting ACT Scores 6.56 83
+
+Assessment 25th Percentile 50th Percentile 75th Percentile
+Score Score Score
+
+SAT Composite 920 1000 1080
+SAT Evidence-Based Reading and Writing 480 530 570
+SAT Math 440 480 540
+ACT Composite 15 17 20
+ACT Math 15 16 18
+ACT English 13 15 19
+ACT Science 15 17 21
+ACT Reading 15 19 23
+"""
+
+        values = clean(markdown)
+
+        self.assertEqual(values["C.901"]["value"], "23.93")
+        self.assertEqual(values["C.902"]["value"], "6.56")
+        self.assertEqual(values["C.903"]["value"], "303")
+        self.assertEqual(values["C.904"]["value"], "83")
+        self.assertEqual(values["C.905"]["value"], "920")
+        self.assertEqual(values["C.906"]["value"], "1000")
+        self.assertEqual(values["C.907"]["value"], "1080")
+        self.assertEqual(values["C.914"]["value"], "15")
+        self.assertEqual(values["C.915"]["value"], "17")
+        self.assertEqual(values["C.916"]["value"], "20")
+
     def test_c9_form_style_submission_values_on_following_lines(self):
         markdown = """
 Score that represents the 25th and 75th percentile score for students who enrolled in Fall 2024 (CDS C9)
@@ -233,6 +267,24 @@ Submitting ACT Scores
         self.assertEqual(values["C.957"]["value"], "3")
         self.assertNotIn("C.958", values)
         self.assertEqual(values["C.959"]["value"], "100.00")
+
+    def test_c9_blank_below_6_row_followed_by_unlabeled_total(self):
+        markdown = """
+| Score Range   | ACT Composite   | ACT English   | ACT Math   | ACT Reading   | ACT Science   |
+|---------------|-----------------|---------------|------------|---------------|---------------|
+| 30-36         |                 |               |            |               |               |
+| 24-29         |                 |               |            |               |               |
+| 18-23         |                 |               |            |               |               |
+| 12-17         |                 |               |            |               |               |
+| 6-11          |                 |               |            |               |               |
+| Below 6       |                 |               |            |               |               |
+|               | 100%            | 100%          | 100%       | 100%          | 100%          |
+"""
+
+        values = clean(markdown)
+
+        self.assertNotIn("C.958", values)
+        self.assertEqual(values["C.959"]["value"], "100")
 
     def test_c9_percentile_table_uses_header_order(self):
         markdown = """

--- a/tools/extraction_worker/test_tier4_cleaner_h13_h15.py
+++ b/tools/extraction_worker/test_tier4_cleaner_h13_h15.py
@@ -112,6 +112,19 @@ CDS-H
         self.assertNotIn("H.1411", values)
         self.assertEqual(values["H.1501"]["value"], "Automatic Scholarship for Ohio Residents")
 
+    def test_h15_empty_value_stops_before_compact_section_i(self):
+        markdown = """
+H15. If your institution has recently implemented any major financial aid policy, program, or initiative to make your
+institution more affordable to incoming students such as replacing loans with grants, or waiving costs for families
+below a certain income level please provide details below:
+I.INSTRUCTIONALFACULTYANDCLASSSIZE I-1. Please report the number of instructional faculty members
+J.DisciplinaryareasofDEGREESCONFERRED
+"""
+
+        values = clean(markdown)
+
+        self.assertNotIn("H.1501", values)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
+++ b/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import tier4_extractor
@@ -13,6 +14,21 @@ class Tier4ExtractorVisualOcrTest(unittest.TestCase):
         text = "Percent  Number\nSubmitting SAT  Scores\nSubmitting ACT Scores"
 
         self.assertTrue(tier4_extractor._matches_visual_ocr_trigger(text))
+
+    def test_visual_ocr_candidates_include_neighbor_pages(self):
+        class FakeReader:
+            pages = [
+                SimpleNamespace(extract_text=lambda: "Common Data Set"),
+                SimpleNamespace(extract_text=lambda: "C. FIRST-TIME, FIRST-YEAR ADMISSION"),
+                SimpleNamespace(extract_text=lambda: "Common Data Set"),
+                SimpleNamespace(extract_text=lambda: "Submitting SAT Scores"),
+            ]
+
+        fake_pypdf = SimpleNamespace(PdfReader=lambda _path: FakeReader())
+        with patch.dict("sys.modules", {"pypdf": fake_pypdf}):
+            pages = tier4_extractor._visual_ocr_candidate_pages(Path("fake.pdf"))
+
+        self.assertEqual(pages, [1, 2, 3, 4])
 
     def test_scanned_fallback_pages_when_text_layer_has_no_candidates(self):
         calls: list[list[str]] = []

--- a/tools/extraction_worker/test_worker_projection_refresh.py
+++ b/tools/extraction_worker/test_worker_projection_refresh.py
@@ -7,6 +7,7 @@ from worker import (
     annotate_tier2_unmapped_fields,
     artifact_already_extracted,
     attach_source_metadata,
+    extraction_quality_flag,
     extraction_no_project,
     extraction_success,
     is_failure_action,
@@ -71,6 +72,37 @@ class WorkerProjectionRefreshTests(unittest.TestCase):
         self.assertEqual(low_field_quality_flag(0), "blank_template")
         self.assertEqual(low_field_quality_flag(24), "low_coverage")
         self.assertIsNone(low_field_quality_flag(25))
+
+    def test_extraction_quality_flags_missing_admissions_anchors(self):
+        canonical = {
+            "stats": {"schema_fields_populated": 43},
+            "markdown": "C9. Percent and number\nSubmitting SAT Scores\nSubmitting ACT Scores",
+            "values": {"A.501": {"value": "X"}},
+        }
+
+        self.assertEqual(extraction_quality_flag(canonical), "low_coverage")
+
+    def test_extraction_quality_flags_sparse_long_documents(self):
+        canonical = {
+            "stats": {"schema_fields_populated": 87, "page_count": 40},
+            "markdown": "",
+            "values": {},
+        }
+
+        self.assertEqual(extraction_quality_flag(canonical), "low_coverage")
+
+    def test_extraction_quality_flags_section_swallow(self):
+        canonical = {
+            "stats": {"schema_fields_populated": 43},
+            "markdown": "",
+            "values": {
+                "H.1501": {
+                    "value": "x" * 5001 + " I.INSTRUCTIONALFACULTYANDCLASSSIZE",
+                },
+            },
+        }
+
+        self.assertEqual(extraction_quality_flag(canonical), "low_coverage")
 
     def test_attach_source_metadata_records_latest_source(self):
         canonical = {}

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -3702,10 +3702,23 @@ def resolve_c9_score_distributions(
 
         previous_single_role = roles[0][1] if len(roles) == 1 else None
         matched_any = False
+        previous_range_key: str | None = None
         for row in table["rows"]:
             range_key = _c9_range_key(_normalize_label(row["label"]))
             if not range_key:
                 continue
+            values_with_numbers = [
+                _extract_number(value)
+                for value in row.get("values", [])
+                if _extract_number(value) is not None
+            ]
+            if (
+                range_key == previous_range_key
+                and values_with_numbers
+                and all(value in {"100", "100.00"} for value in values_with_numbers)
+            ):
+                range_key = "total"
+            previous_range_key = range_key
             for col_idx, role in roles:
                 qn = _C9_DISTRIBUTION_QNS.get(role, {}).get(range_key)
                 if not qn or col_idx >= len(row["values"]):
@@ -5038,14 +5051,19 @@ def resolve_h_financial_aid(
                 out[non_need_qn] = {"value": "X", "source": "tier4_cleaner"}
 
         if match := re.search(
-            r"H15\b.*?please\s+provide\s+details\s+below:\s*(.+?)\s*(?:CDS-H|I\.\s*INSTRUCTIONAL FACULTY|$)",
+            r"H15\b.*?please\s+provide\s+details\s+below:\s*(.+?)\s*(?:CDS-H|I\.?\s*INSTRUCTIONAL\s*FACULTY|J\.?\s*Disciplinary|$)",
             h_block,
             re.IGNORECASE | re.DOTALL,
         ):
             text = re.sub(r"\s+", " ", match.group(1)).strip()
             text = text.replace("on- campus", "on-campus")
             text = re.sub(r"\bW e\b", "We", text)
-            text = re.split(r"\s+(?:-\s+\[|Students must reply by|H1[234]\b|##\s+)", text, maxsplit=1)[0].strip()
+            text = re.split(
+                r"\s+(?:-\s+\[|Students must reply by|H1[234]\b|##\s+)|I\.?\s*INSTRUCTIONAL\s*FACULTY|J\.?\s*Disciplinary",
+                text,
+                maxsplit=1,
+                flags=re.IGNORECASE,
+            )[0].strip()
             if (
                 re.fullmatch(r"Common Data Set\s+20\d{2}-\s*20\d{2}", text, re.IGNORECASE)
                 or "Non-Need Based" in text

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.11"
+PRODUCER_VERSION = "0.3.12"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35
@@ -40,7 +40,11 @@ def _matches_visual_ocr_trigger(text: str) -> bool:
     normalized = re.sub(r"\s+", " ", text.lower())
     triggers = (
         "c1. first-time",
+        "c. first-time, first-year admission",
+        "first-time, first-year admission",
         "first-time, first-year student applicants",
+        "first-time, first-year student admits",
+        "first-time, first-year student enrollees",
         "residency breakdowns for total applicants",
         "total first-time, first-year (degree-seeking) who applied",
         "c2. first time",
@@ -84,13 +88,16 @@ def _visual_ocr_candidate_pages(pdf_path: Path) -> list[int]:
 
         reader = pypdf.PdfReader(str(pdf_path))
         pages: set[int] = set()
+        page_count = len(reader.pages)
         for idx, page in enumerate(reader.pages, start=1):
             try:
                 text = page.extract_text() or ""
             except Exception:
                 text = ""
             if _matches_visual_ocr_trigger(text):
-                pages.add(idx)
+                for page_no in (idx - 1, idx, idx + 1):
+                    if 1 <= page_no <= page_count and page_no <= SCANNED_ADMISSIONS_OCR_MAX_PAGE:
+                        pages.add(page_no)
         return sorted(pages)
     except Exception:
         return []

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -162,6 +162,50 @@ def low_field_quality_flag(fields: int, threshold: int = MIN_TIER4_FIELDS) -> st
     return "blank_template" if fields == 0 else "low_coverage"
 
 
+def extraction_quality_flag(canonical: dict, threshold: int = MIN_TIER4_FIELDS) -> str | None:
+    """Return a recoverable extraction quality flag for weak canonical artifacts."""
+    stats = canonical.get("stats") or {}
+    fields = int(stats.get("schema_fields_populated") or 0)
+    flag = low_field_quality_flag(fields, threshold)
+    if flag:
+        return flag
+    page_count = int(stats.get("page_count") or 0)
+    if page_count >= 20 and fields < 100:
+        return "low_coverage"
+
+    values = canonical.get("values") or {}
+    markdown = str(canonical.get("markdown") or "")
+    markdown_lower = markdown.lower()
+    if fields < 150:
+        has_c1_anchor = (
+            "c1. first-time" in markdown_lower
+            or "first-time, first-year student applicants" in markdown_lower
+            or "first-time, first-year admission" in markdown_lower
+        )
+        has_c9_anchor = (
+            "submitting sat scores" in markdown_lower
+            or "c9. percent and number" in markdown_lower
+        )
+        c1_keys = {"C.101", "C.102", "C.104", "C.105", "C.116", "C.117", "C.118", "C.119"}
+        c9_keys = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
+        if (has_c1_anchor and not c1_keys.intersection(values)) or (
+            has_c9_anchor and not c9_keys.intersection(values)
+        ):
+            return "low_coverage"
+
+    for qn in ("H.1501",):
+        rec = values.get(qn) or {}
+        text = str(rec.get("value") or "")
+        compact = re.sub(r"\s+", "", text).lower()
+        if len(text) > 5000 and (
+            "instructionalfacultyandclasssize" in compact
+            or "disciplinaryareasofdegreesconferred" in compact
+        ):
+            return "low_coverage"
+
+    return None
+
+
 def mean_or_none(values: list[int]) -> float | None:
     if not values:
         return None
@@ -893,7 +937,7 @@ def _run_tier6(
     producer_version = canonical["producer_version"]
     stats = canonical.get("stats", {})
     fields = int(stats.get("schema_fields_populated") or 0)
-    quality_flag = low_field_quality_flag(fields)
+    quality_flag = extraction_quality_flag(canonical)
 
     if not dry_run:
         if not force_reextract and artifact_already_extracted(
@@ -964,7 +1008,7 @@ def _run_tier4(
     producer_version = canonical["producer_version"]
     stats = canonical.get("stats", {})
     fields = int(stats.get("schema_fields_populated") or 0)
-    quality_flag = low_field_quality_flag(fields)
+    quality_flag = extraction_quality_flag(canonical)
 
     if not dry_run:
         if not force_reextract and artifact_already_extracted(


### PR DESCRIPTION
## Summary
- expand visual OCR recovery for sparse long CDS PDFs and keep weak extractions flagged
- fix C9/H15 cleaner regressions surfaced by sparse extracts
- add sectionized CDS source packages: archive original section PDFs as source_part artifacts and merge them into a source bundle for extraction
- document the sectionized CDS archive flow

## Verification
- deno test supabase/functions/_shared/resolve.test.ts supabase/functions/_shared/storage.test.ts supabase/functions/archive-process/queue.test.ts supabase/functions/archive-enqueue/schedule.test.ts supabase/functions/_shared/hosting.test.ts supabase/functions/_shared/probe_outcome.test.ts supabase/functions/_shared/year.test.ts
- deno check supabase/functions/archive-process/index.ts supabase/functions/discover/index.ts supabase/functions/archive-upload/index.ts
- cd tools/extraction_worker && python3 -m unittest test_tier4_extractor_visual_ocr.py test_tier4_cleaner_c1_c2.py test_tier4_cleaner_c9.py test_tier4_cleaner_h13_h15.py test_worker_projection_refresh.py
- git diff --check