### PR TITLE
Fix Dataset structured data metadata

### DIFF
--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -245,8 +245,13 @@ export default async function SchoolDetailPage({
       dataset: uniqueYears.map((year) => ({
         "@type": "Dataset",
         name: `${name} Common Data Set ${year}`,
+        description: `Common Data Set ${year} for ${name}, containing admissions, enrollment, financial aid, and other institutional data extracted by collegedata.fyi.`,
         url: `https://www.collegedata.fyi/schools/${school_id}/${year}`,
+        creator: { "@type": "Organization", name },
+        provider: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
         temporalCoverage: year,
+        license: "https://opensource.org/licenses/MIT",
+        isAccessibleForFree: true,
       })),
     },
   ];


### PR DESCRIPTION
## Summary
- add required Dataset descriptions to school archive nested year datasets
- add creator, provider, license, and free-access metadata to satisfy Search Console recommendations

## Verification
- npm run typecheck
- npm run build
- git diff --check