### PR TITLE
Fix source download labels for auth-wall HTML

### DIFF
--- a/supabase/functions/_shared/archive.ts
+++ b/supabase/functions/_shared/archive.ts
@@ -635,6 +635,13 @@ async function archiveSectionPackage(
   const parts: DownloadedSectionPart[] = [];
   for (const part of pkg.parts) {
     const downloaded = await downloadWithCaps(part.url);
+    const authCategory = authWallOutcome(downloaded.finalUrl);
+    if (authCategory) {
+      throw new PermanentError(
+        `auth-walled: section ${part.section} for ${part.url} redirected to ${downloaded.finalUrl}`,
+        authCategory,
+      );
+    }
     const ext = extForResponse(downloaded.contentType, downloaded.finalUrl, downloaded.bytes);
     if (ext !== "pdf") {
       throw new PermanentError(
@@ -779,26 +786,21 @@ async function archiveOneCandidate(
   // Download with a hard memory + wall clock cap.
   const { bytes, sha256, contentType, finalUrl, httpLastModified } =
     await downloadWithCaps(resolved.url);
+
+  const authCategory = authWallOutcome(finalUrl);
+  if (authCategory) {
+    throw new PermanentError(
+      `auth-walled: download for ${resolved.url} redirected to ${finalUrl}`,
+      authCategory,
+    );
+  }
+
   // extForResponse tries content-type → URL suffix → magic-byte sniff.
   // The magic-byte path is what rescues Google Drive (serves everything
   // as application/octet-stream) and any other host whose download
   // endpoint doesn't set a canonical Content-Type.
   const ext = extForResponse(contentType, finalUrl, bytes);
   if (!ext) {
-    // Auth-wall detection: when a school's CDS lives behind SSO, the
-    // download follow-redirects path lands on an SSO HTML page (e.g.,
-    // login.microsoftonline.com/<tenant>/saml2). The bytes are HTML, not
-    // PDF, so extForResponse rejects them — but the *reason* matters.
-    // An auth-walled school is structurally different from a school
-    // whose link 404s, and downstream cooldown / hosting policy needs
-    // to distinguish them.
-    const authCategory = authWallOutcome(finalUrl);
-    if (authCategory) {
-      throw new PermanentError(
-        `auth-walled: download for ${resolved.url} redirected to ${finalUrl}`,
-        authCategory,
-      );
-    }
     throw new PermanentError(
       `unknown content type for ${finalUrl}: ${contentType || "(none)"}, bytes do not match PDF/XLSX/DOCX magic`,
       "wrong_content_type",

--- a/supabase/functions/_shared/storage.test.ts
+++ b/supabase/functions/_shared/storage.test.ts
@@ -1,9 +1,28 @@
 import { assertEquals } from "jsr:@std/assert";
-import { extForResponse } from "./storage.ts";
+import { extForResponse, sniffBytesForExt } from "./storage.ts";
 
 Deno.test("extForResponse: rejects HTML challenge bytes at PDF URL", () => {
   const bytes = new TextEncoder().encode(
     "<!DOCTYPE html><html><title>Just a moment...</title></html>",
+  );
+
+  assertEquals(
+    extForResponse("text/html; charset=UTF-8", "https://example.edu/cds.pdf", bytes),
+    null,
+  );
+});
+
+Deno.test("sniffBytesForExt: detects HTML after leading comments", () => {
+  const bytes = new TextEncoder().encode(
+    "<!-- Copyright (C) Example. --><!DOCTYPE html><html><title>Sign in</title></html>",
+  );
+
+  assertEquals(sniffBytesForExt(bytes), "html");
+});
+
+Deno.test("extForResponse: rejects comment-prefixed HTML challenge bytes at PDF URL", () => {
+  const bytes = new TextEncoder().encode(
+    "<!-- Copyright (C) Example. --><!DOCTYPE html><html><title>Sign in</title></html>",
   );
 
   assertEquals(

--- a/supabase/functions/_shared/storage.ts
+++ b/supabase/functions/_shared/storage.ts
@@ -40,6 +40,16 @@ export function extForContentType(contentType: string | null, fallbackUrl: strin
   return extForContentTypeOnly(contentType) ?? extForUrl(fallbackUrl);
 }
 
+function stripLeadingHtmlNoise(fragment: string): string {
+  let head = fragment.replace(/^\uFEFF/, "").trimStart();
+  while (head.startsWith("<!--")) {
+    const end = head.indexOf("-->");
+    if (end < 0) return head;
+    head = head.slice(end + 3).trimStart();
+  }
+  return head;
+}
+
 // Magic-byte sniffer. Used as a last-resort fallback when content-type
 // and URL extension both fail to identify the file — most commonly
 // for Google Drive direct-download URLs which serve every file as
@@ -83,13 +93,13 @@ export function sniffBytesForExt(bytes: Uint8Array): "pdf" | "xlsx" | "docx" | "
   // document. Case-insensitive. Tolerates leading whitespace / BOM.
   const head = new TextDecoder("utf-8", { fatal: false })
     .decode(bytes.slice(0, 512))
-    .toLowerCase()
-    .trimStart();
+    .toLowerCase();
+  const normalizedHead = stripLeadingHtmlNoise(head);
   if (
-    head.startsWith("<!doctype html") ||
-    head.startsWith("<html") ||
-    head.startsWith("<head") ||
-    head.startsWith("<?xml") && head.includes("<html")
+    normalizedHead.startsWith("<!doctype html") ||
+    normalizedHead.startsWith("<html") ||
+    normalizedHead.startsWith("<head") ||
+    normalizedHead.startsWith("<?xml") && normalizedHead.includes("<html")
   ) {
     return "html";
   }

--- a/tools/extraction_worker/test_docx_sniff.py
+++ b/tools/extraction_worker/test_docx_sniff.py
@@ -102,6 +102,14 @@ class SniffFormatFromBytesTest(unittest.TestCase):
             "html",
         )
 
+    def test_html_with_leading_comment_routes_html(self):
+        self.assertEqual(
+            sniff_format_from_bytes(
+                b"<!-- Copyright (C) Example. --><!DOCTYPE html><html><body>sign in</body></html>"
+            ),
+            "html",
+        )
+
     def test_unknown_bytes_route_other(self):
         self.assertEqual(sniff_format_from_bytes(b"\x00\x01garbage"), "other")
 

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -633,6 +633,16 @@ def sniff_zip_inner_format(data: bytes) -> str:
     return "other"
 
 
+def strip_leading_html_noise(head: str) -> str:
+    head = head.lstrip("\ufeff").lstrip()
+    while head.startswith("<!--"):
+        end = head.find("-->")
+        if end < 0:
+            return head
+        head = head[end + 3 :].lstrip()
+    return head
+
+
 def sniff_format_from_bytes(data: bytes) -> str:
     """Best-effort format detection when cds_documents.source_format is null.
     Returns one of the extraction_status enum values the migration allows
@@ -663,7 +673,9 @@ def sniff_format_from_bytes(data: bytes) -> str:
     # stray "<html" byte sequence doesn't mis-route. Matches the
     # storage.ts sniffBytesForExt logic on the discovery side.
     try:
-        head = data[:512].decode("utf-8", errors="ignore").lower().lstrip()
+        head = strip_leading_html_noise(
+            data[:512].decode("utf-8", errors="ignore").lower()
+        )
     except Exception:
         head = ""
     if (

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -8,7 +8,7 @@ import {
   fetchScorecardByIpedsId,
 } from "@/lib/queries";
 import type { FieldValue, ArtifactNotes } from "@/lib/types";
-import { storageUrl, formatBadgeLabel } from "@/lib/format";
+import { storageUrl, formatBadgeLabel, sourceDownloadLabel } from "@/lib/format";
 import { Badge } from "@/components/Badge";
 import { KeyStats } from "@/components/KeyStats";
 import { FieldsView } from "@/components/FieldsView";
@@ -140,7 +140,7 @@ async function DocumentVariant({
   doc: Awaited<ReturnType<typeof fetchDocumentsBySchoolAndYear>>[number];
   scorecard: Awaited<ReturnType<typeof fetchScorecardByIpedsId>>;
 }) {
-  const pdfUrl = storageUrl(doc.source_storage_path);
+  const sourceDownloadUrl = storageUrl(doc.source_storage_path);
   const isExtracted = doc.extraction_status === "extracted";
 
   let values: Record<string, FieldValue> = {};
@@ -179,14 +179,14 @@ async function DocumentVariant({
             className="bg-gray-100 text-gray-700"
           />
         )}
-        {pdfUrl && (
+        {sourceDownloadUrl && (
           <a
-            href={pdfUrl}
+            href={sourceDownloadUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-blue-600 hover:text-blue-800"
           >
-            Download source PDF
+            {sourceDownloadLabel(doc.source_format, doc.source_storage_path)}
           </a>
         )}
       </div>
@@ -201,7 +201,7 @@ async function DocumentVariant({
       {admissionStrategy && (
         <AdmissionStrategyCard
           school={admissionStrategy}
-          sourceHref={pdfUrl ?? admissionStrategy.archiveUrl}
+          sourceHref={sourceDownloadUrl ?? admissionStrategy.archiveUrl}
         />
       )}
 
@@ -239,7 +239,7 @@ async function DocumentVariant({
       ) : (
         <div className="mt-4 rounded-lg border border-yellow-200 bg-yellow-50 p-6 text-center text-yellow-800">
           <p>
-            Structured data coming soon. The source PDF is available for
+            Structured data coming soon. The source document is available for
             download above.
           </p>
         </div>

--- a/web/src/components/DocumentCard.tsx
+++ b/web/src/components/DocumentCard.tsx
@@ -6,6 +6,7 @@ import {
   formatExtractionStatus,
   storageUrl,
   dataQualityLabel,
+  sourceDownloadLabel,
 } from "@/lib/format";
 import { trackSourceOpened, trackEvent } from "@/lib/analytics";
 import type { ManifestRow } from "@/lib/types";
@@ -26,23 +27,6 @@ function statusChipClass(status: string): string {
   }
 }
 
-function downloadLabel(format: string | null): string {
-  switch (format) {
-    case "xlsx":
-      return "Download XLSX";
-    case "docx":
-      return "Download DOCX";
-    case "html":
-      return "Download HTML";
-    case "pdf_fillable":
-    case "pdf_flat":
-    case "pdf_scanned":
-      return "Download PDF";
-    default:
-      return "Download source";
-  }
-}
-
 // One row of the documents ledger. Year sits in display serif; the format
 // and status are mono chips; download/view actions are right-aligned. Last
 // row drops the dashed separator so the ledger ends on a hairline rule.
@@ -53,7 +37,7 @@ export function DocumentCard({
   doc: ManifestRow;
   isLast?: boolean;
 }) {
-  const pdfUrl = storageUrl(doc.source_storage_path);
+  const sourceDownloadUrl = storageUrl(doc.source_storage_path);
   const sourceUrl = doc.source_url;
   const status = doc.extraction_status ?? "discovered";
   const isExtracted = status === "extracted";
@@ -128,9 +112,9 @@ export function DocumentCard({
             View fields →
           </Link>
         )}
-        {pdfUrl ? (
+        {sourceDownloadUrl ? (
           <a
-            href={pdfUrl}
+            href={sourceDownloadUrl}
             target="_blank"
             rel="noopener noreferrer"
             onClick={() =>
@@ -143,7 +127,7 @@ export function DocumentCard({
               })
             }
           >
-            {downloadLabel(doc.source_format)}
+            {sourceDownloadLabel(doc.source_format, doc.source_storage_path)}
           </a>
         ) : sourceUrl ? (
           <a

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { sourceDownloadLabel } from "./format";
+
+describe("sourceDownloadLabel", () => {
+  it("uses the storage extension when the stored source format is stale", () => {
+    expect(
+      sourceDownloadLabel(
+        "pdf_flat",
+        "mississippi-state-university/2022-23/hash.html",
+      ),
+    ).toBe("Download HTML");
+  });
+
+  it("labels PDF source variants as PDFs", () => {
+    expect(sourceDownloadLabel("pdf_scanned", "school/2025-26/hash.pdf")).toBe(
+      "Download PDF",
+    );
+  });
+});

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -19,6 +19,39 @@ export function formatBadgeLabel(format: string | null): string {
   }
 }
 
+function sourcePathExtension(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const cleanPath = path.split(/[?#]/)[0]?.toLowerCase() ?? "";
+  const lastDot = cleanPath.lastIndexOf(".");
+  if (lastDot < 0) return null;
+  return cleanPath.slice(lastDot + 1);
+}
+
+export function sourceDownloadLabel(
+  format: string | null,
+  storagePath?: string | null,
+): string {
+  const pathExt = sourcePathExtension(storagePath);
+  const effectiveFormat = pathExt ?? format;
+
+  switch (effectiveFormat) {
+    case "xlsx":
+      return "Download XLSX";
+    case "docx":
+      return "Download DOCX";
+    case "html":
+    case "htm":
+      return "Download HTML";
+    case "pdf":
+    case "pdf_fillable":
+    case "pdf_flat":
+    case "pdf_scanned":
+      return "Download PDF";
+    default:
+      return "Download source";
+  }
+}
+
 export function formatExtractionStatus(status: string): string {
   switch (status) {
     case "extracted":


### PR DESCRIPTION
## Summary
- make source download labels format-aware and prefer the stored object extension when source_format is stale
- stop calling failed/non-PDF source objects "source PDF" on school year pages
- reject auth-wall final URLs before archiving and detect comment-prefixed HTML in both archive and extraction sniffers
- add regression tests for comment-prefixed HTML and stale PDF-vs-HTML labels

## Data audit
- checked 4,016 manifest rows
- found 19 rows with HTML source objects or source_format = html
- found 10 rows with auth/challenge/error markers among those HTML objects
- only one active row has a persisted login.microsoftonline.com source URL: suny-college-at-geneseo 2025-26

## Tests
- deno test supabase/functions/_shared/storage.test.ts
- python3 -m unittest test_docx_sniff.py
- npm run test -- src/lib/format.test.ts
- deno check supabase/functions/_shared/archive.ts
- npm run typecheck
- npm run build
- git diff --check

## Follow-up
Existing suspicious historical HTML source rows still need data cleanup or replacement with real public CDS sources. This PR fixes the misleading UI and prevents future auth-wall archives.