### PR TITLE
Quarantine bad archived HTML sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Raw PostgREST remains available for power users:
 ```bash
 ANON_KEY="<copy the public anon key from https://www.collegedata.fyi/api>"
 
-# List all schools in the manifest
-curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?select=school_id,school_name,canonical_year&order=school_name' \
+# List all live schools in the manifest
+curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?removed_at=is.null&select=school_id,school_name,canonical_year&order=school_name' \
   -H "apikey: $ANON_KEY" \
   -H "Authorization: Bearer $ANON_KEY"
 
 # Find a specific school's documents
-curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?school_id=eq.yale&order=canonical_year.desc' \
+curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?school_id=eq.yale&removed_at=is.null&order=canonical_year.desc' \
   -H "apikey: $ANON_KEY" \
   -H "Authorization: Bearer $ANON_KEY"
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -37,10 +37,11 @@ with coverage badges as well as schools with archived CDS data. Below it, a
 stats bar shows live corpus numbers pulled from the API (institutions, documents,
 field rows, extraction %).
 
-**Data flow:** `fetchManifest()` returns all rows from `cds_manifest` via
-paginated range queries (PostgREST caps at 1,000 rows per request).
-Client-side aggregation computes school summaries and corpus stats. ISR
-revalidates every hour.
+**Data flow:** `fetchManifest()` returns live rows from `cds_manifest` via
+paginated range queries (PostgREST caps at 1,000 rows per request), filtering
+out `removed_at` rows and excluded public participation statuses. Client-side
+aggregation computes school summaries and corpus stats. ISR revalidates every
+hour.
 
 ### `/schools` School directory (`web/src/app/schools/page.tsx`)
 
@@ -217,9 +218,9 @@ paths.
 
 | Page | Query | Notes |
 |------|-------|-------|
-| Landing + Directory | `cds_manifest` (all rows, paginated) | Range-based pagination to work around PostgREST 1,000-row cap |
-| School detail | `cds_manifest WHERE school_id = ?` | Ordered by canonical_year DESC |
-| Year detail | `cds_manifest WHERE school_id = ? AND canonical_year = ?` | Returns all sub-institutional variants |
+| Landing + Directory | `cds_manifest WHERE removed_at IS NULL` (paginated) | Range-based pagination to work around PostgREST 1,000-row cap |
+| School detail | `cds_manifest WHERE school_id = ? AND removed_at IS NULL` | Ordered by canonical_year DESC |
+| Year detail | `cds_manifest WHERE school_id = ? AND canonical_year = ? AND removed_at IS NULL` | Returns all sub-institutional variants |
 | Year detail (fields) | `cds_artifacts WHERE document_id = ?` | Loads canonical + `tier4_llm_fallback`, then merges cleaner-wins |
 | Queryable browser | `browser-search` Edge Function | Ranked latest-per-school search over `school_browser_rows` with answerability metadata, including SAT/ACT submit-rate companion metadata for active score filters |
 | School positioning/admission cards | `school_browser_rows WHERE school_id = ?` | Latest primary row with SAT/ACT, admissions, ED/EA, wait-list, and C7/app-fee columns |

--- a/supabase/functions/_shared/archive.ts
+++ b/supabase/functions/_shared/archive.ts
@@ -16,6 +16,7 @@ import {
   USER_AGENT,
 } from "./resolve.ts";
 import { inferHosting, inferWaf, type HostingInference } from "./hosting.ts";
+import { rejectableHtmlSourceOutcome } from "./html_source_guard.ts";
 import {
   ARCHIVER_PRODUCER,
   ARCHIVER_VERSION,
@@ -805,6 +806,16 @@ async function archiveOneCandidate(
       `unknown content type for ${finalUrl}: ${contentType || "(none)"}, bytes do not match PDF/XLSX/DOCX magic`,
       "wrong_content_type",
     );
+  }
+
+  if (ext === "html") {
+    const rejectOutcome = rejectableHtmlSourceOutcome(bytes, finalUrl);
+    if (rejectOutcome) {
+      throw new PermanentError(
+        `rejecting non-CDS HTML source at ${finalUrl}: ${rejectOutcome}`,
+        rejectOutcome,
+      );
+    }
   }
 
   // Use the post-redirect URL when persisting provenance. A school may

--- a/supabase/functions/_shared/html_source_guard.test.ts
+++ b/supabase/functions/_shared/html_source_guard.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "jsr:@std/assert";
+import { rejectableHtmlSourceOutcome } from "./html_source_guard.ts";
+
+const encode = (html: string) => new TextEncoder().encode(html);
+
+Deno.test("rejectableHtmlSourceOutcome: Microsoft sign-in body is auth-walled", () => {
+  assertEquals(
+    rejectableHtmlSourceOutcome(
+      encode("<!-- Copyright (C) Microsoft Corporation. --><title>Sign in to your account</title>"),
+      "https://fs.example.edu/adfs/ls/",
+    ),
+    "auth_walled_microsoft",
+  );
+});
+
+Deno.test("rejectableHtmlSourceOutcome: WAF challenge is bot_challenge", () => {
+  assertEquals(
+    rejectableHtmlSourceOutcome(
+      encode("<html><title>Just a moment...</title><script>__cf_chl_tk='x'</script></html>"),
+      "https://example.edu/cds",
+    ),
+    "bot_challenge",
+  );
+});
+
+Deno.test("rejectableHtmlSourceOutcome: non-CDS error page is wrong_content_type", () => {
+  assertEquals(
+    rejectableHtmlSourceOutcome(
+      encode("<html><h1>Page not found</h1><p>The page you requested could not be found.</p></html>"),
+      "https://example.edu/cds",
+    ),
+    "wrong_content_type",
+  );
+});
+
+Deno.test("rejectableHtmlSourceOutcome: CDS landing page without tables is wrong_content_type", () => {
+  assertEquals(
+    rejectableHtmlSourceOutcome(
+      encode("<html><h1>Common Data Set PDF downloads</h1><a href='/files/cds.pdf'>2025-26 PDF</a></html>"),
+      "https://example.edu/common-data-set/pdf",
+    ),
+    "wrong_content_type",
+  );
+});
+
+Deno.test("rejectableHtmlSourceOutcome: CDS-like HTML is accepted", () => {
+  assertEquals(
+    rejectableHtmlSourceOutcome(
+      encode("<html><h1>Common Data Set 2025-2026</h1><table><tr><th>B1</th><th>Men</th><th>Women</th></tr></table></html>"),
+      "https://example.edu/cds",
+    ),
+    null,
+  );
+});

--- a/supabase/functions/_shared/html_source_guard.ts
+++ b/supabase/functions/_shared/html_source_guard.ts
@@ -1,0 +1,111 @@
+import { authWallOutcome, type ProbeOutcome } from "./probe_outcome.ts";
+
+function htmlPreview(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: false })
+    .decode(bytes.slice(0, 64 * 1024))
+    .toLowerCase();
+}
+
+function hasAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+export function rejectableHtmlSourceOutcome(
+  bytes: Uint8Array,
+  finalUrl: string,
+): ProbeOutcome | null {
+  const finalUrlOutcome = authWallOutcome(finalUrl);
+  if (finalUrlOutcome) return finalUrlOutcome;
+
+  let host = "";
+  try {
+    host = new URL(finalUrl).hostname.toLowerCase();
+  } catch {
+    // Continue with body classification.
+  }
+
+  const text = htmlPreview(bytes);
+  const haystack = `${host}\n${text}`;
+
+  if (
+    hasAny(haystack, [
+      "login.microsoftonline.com",
+      "sign in to your account",
+      "aadcdn",
+      "samlrequest",
+      "microsoft corporation. all rights reserved",
+    ])
+  ) {
+    return "auth_walled_microsoft";
+  }
+
+  if (
+    hasAny(haystack, [
+      "accounts.google.com",
+      "service_login",
+      "google accounts",
+      "google sign in",
+      "identifierid",
+    ])
+  ) {
+    return "auth_walled_google";
+  }
+
+  if (host.endsWith(".okta.com") || hasAny(haystack, ["okta sign in", "okta-signin"])) {
+    return "auth_walled_okta";
+  }
+
+  if (
+    hasAny(haystack, [
+      "cloudflare",
+      "just a moment",
+      "cf-mitigated",
+      "cf-chl-",
+      "__cf_chl_",
+      "captcha",
+      "incapsula incident",
+      "imperva",
+      "perfdrive",
+      "validate.perfdrive.com",
+      "access denied",
+      "request unsuccessful",
+    ])
+  ) {
+    return "bot_challenge";
+  }
+
+  const cdsLike = hasAny(text, [
+    "common data set",
+    "common dataset",
+    "cds",
+    "b1 men women another gender",
+    "first-time, first-year",
+    "degree-seeking undergraduate",
+  ]);
+  const hasTableMarkup = text.includes("<table") && (
+    text.includes("<td") || text.includes("<th")
+  );
+
+  if (
+    hasAny(text, [
+      "404 not found",
+      "404 error",
+      "page not found",
+      "file not found",
+      "the page you requested could not be found",
+      "server error",
+      "temporarily unavailable",
+      "please sign in",
+      "single sign-on",
+      "single sign on",
+    ])
+  ) {
+    return "wrong_content_type";
+  }
+
+  if (cdsLike && !hasTableMarkup) {
+    return "wrong_content_type";
+  }
+
+  return null;
+}

--- a/tools/data_quality/cleanup_bad_html_sources.py
+++ b/tools/data_quality/cleanup_bad_html_sources.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Audit and quarantine archived HTML sources that are not CDS documents.
+
+HTML is a valid source format for schools that publish CDS pages as static
+tables. The bad cases are login walls, WAF challenges, and generic error pages
+that were archived before the TypeScript guard rejected them. By default this
+script only prints candidates. With --write, it marks the document removed and
+flags it as wrong_file. With --delete-storage, it also removes the public
+Storage object so the archived login/challenge page is no longer downloadable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import requests
+from supabase import create_client
+
+
+SOURCES_BUCKET = "sources"
+MAX_PREVIEW_BYTES = 64 * 1024
+
+
+@dataclass
+class Candidate:
+    row: dict[str, Any]
+    outcome: str
+    markers: list[str]
+    http_status: int | None
+
+
+def env(name: str) -> str | None:
+    value = os.environ.get(name)
+    return value if value else None
+
+
+def supabase_client():
+    url = env("SUPABASE_URL") or env("NEXT_PUBLIC_SUPABASE_URL")
+    key = env("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise SystemExit("SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required")
+    return create_client(url, key), url
+
+
+def fetch_manifest(sb) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    start = 0
+    while True:
+        batch = (
+            sb.table("cds_manifest")
+            .select(
+                "document_id,school_id,school_name,canonical_year,cds_year,"
+                "source_url,source_format,extraction_status,data_quality_flag,"
+                "removed_at,source_storage_path"
+            )
+            .range(start, start + 999)
+            .execute()
+            .data
+            or []
+        )
+        rows.extend(batch)
+        if len(batch) < 1000:
+            return rows
+        start += 1000
+
+
+def is_html_source(row: dict[str, Any]) -> bool:
+    path = (row.get("source_storage_path") or "").lower().split("?", 1)[0]
+    return row.get("source_format") == "html" or path.endswith((".html", ".htm"))
+
+
+def storage_url(base_url: str, path: str) -> str:
+    return f"{base_url}/storage/v1/object/public/{SOURCES_BUCKET}/{quote(path, safe='/')}"
+
+
+def fetch_preview(base_url: str, row: dict[str, Any]) -> tuple[str, int | None]:
+    path = row.get("source_storage_path")
+    if not path:
+        return row.get("source_url") or "", None
+    response = requests.get(storage_url(base_url, path), timeout=15)
+    text = response.content[:MAX_PREVIEW_BYTES].decode("utf-8", errors="ignore")
+    return text, response.status_code
+
+
+def has_any(value: str, needles: list[str]) -> list[str]:
+    return [needle for needle in needles if needle in value]
+
+
+def classify(row: dict[str, Any], text: str) -> tuple[str | None, list[str]]:
+    host = urlparse(row.get("source_url") or "").netloc.lower()
+    haystack = f"{host}\n{text.lower()}"
+
+    marker_groups: list[tuple[str, str, list[str]]] = [
+        (
+            "auth_walled_microsoft",
+            "auth_walled_microsoft",
+            [
+                "login.microsoftonline.com",
+                "sign in to your account",
+                "aadcdn",
+                "samlrequest",
+                "microsoft corporation. all rights reserved",
+            ],
+        ),
+        (
+            "auth_walled_google",
+            "auth_walled_google",
+            [
+                "accounts.google.com",
+                "service_login",
+                "google accounts",
+                "google sign in",
+                "identifierid",
+            ],
+        ),
+        (
+            "auth_walled_okta",
+            "auth_walled_okta",
+            ["okta sign in", "okta-signin", ".okta.com"],
+        ),
+        (
+            "bot_challenge",
+            "bot_challenge",
+            [
+                "cloudflare",
+                "just a moment",
+                "cf-mitigated",
+                "cf-chl-",
+                "__cf_chl_",
+                "captcha",
+                "incapsula incident",
+                "imperva",
+                "perfdrive",
+                "validate.perfdrive.com",
+                "access denied",
+                "request unsuccessful",
+            ],
+        ),
+    ]
+
+    for outcome, marker_label, needles in marker_groups:
+        hits = has_any(haystack, needles)
+        if hits:
+            return outcome, [marker_label, *hits[:3]]
+
+    cds_like = bool(
+        re.search(
+            r"common data set|common dataset|\bcds\b|first-time, first-year|degree-seeking undergraduate",
+            haystack,
+            re.I,
+        )
+    )
+    has_table_markup = "<table" in haystack and ("<td" in haystack or "<th" in haystack)
+    error_hits = has_any(
+        haystack,
+        [
+            "404 not found",
+            "404 error",
+            "page not found",
+            "file not found",
+            "the page you requested could not be found",
+            "server error",
+            "temporarily unavailable",
+            "please sign in",
+            "single sign-on",
+            "single sign on",
+        ],
+    )
+    if error_hits:
+        return "wrong_content_type", ["error_page", *error_hits[:3]]
+
+    if cds_like and not has_table_markup:
+        return "wrong_content_type", ["cds_landing_without_tables"]
+
+    return None, []
+
+
+def suspicious_html_rows(sb, base_url: str) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for row in fetch_manifest(sb):
+        if row.get("removed_at") or not is_html_source(row):
+            continue
+        text, status = fetch_preview(base_url, row)
+        outcome, markers = classify(row, text)
+        if not outcome and row.get("extraction_status") == "failed":
+            outcome = "failed_html_source"
+            markers = ["extraction_failed"]
+        if outcome:
+            candidates.append(Candidate(row=row, outcome=outcome, markers=markers, http_status=status))
+    return candidates
+
+
+def mark_removed(sb, candidate: Candidate) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    (
+        sb.table("cds_documents")
+        .update({"removed_at": now, "data_quality_flag": "wrong_file"})
+        .eq("id", candidate.row["document_id"])
+        .execute()
+    )
+
+
+def delete_storage(sb, path: str) -> None:
+    sb.storage.from_(SOURCES_BUCKET).remove([path])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true", help="mark suspicious rows removed/wrong_file")
+    parser.add_argument(
+        "--delete-storage",
+        action="store_true",
+        help="also delete the public Storage object; requires --write",
+    )
+    args = parser.parse_args()
+
+    if args.delete_storage and not args.write:
+        parser.error("--delete-storage requires --write")
+
+    sb, base_url = supabase_client()
+    candidates = suspicious_html_rows(sb, base_url)
+
+    print(f"suspicious active HTML sources: {len(candidates)}")
+    for candidate in candidates:
+        row = candidate.row
+        print(
+            "|".join(
+                [
+                    row.get("school_id") or "",
+                    row.get("canonical_year") or row.get("cds_year") or "",
+                    row.get("source_format") or "",
+                    row.get("extraction_status") or "",
+                    candidate.outcome,
+                    ",".join(candidate.markers),
+                    str(candidate.http_status),
+                    row.get("source_storage_path") or "",
+                ]
+            )
+        )
+
+    if not args.write:
+        print("dry run only; pass --write to mark rows removed")
+        return 0
+
+    for candidate in candidates:
+        mark_removed(sb, candidate)
+        path = candidate.row.get("source_storage_path")
+        if args.delete_storage and path:
+            delete_storage(sb, path)
+
+    print(
+        f"updated {len(candidates)} row(s)"
+        + (" and deleted storage objects" if args.delete_storage else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -946,14 +946,14 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
       <h3 className="mt-6 text-base font-semibold text-gray-900">
         List the most recent year for every school
       </h3>
-      <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?select=school_id,school_name,canonical_year&order=canonical_year.desc&limit=10' \\
+      <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?removed_at=is.null&select=school_id,school_name,canonical_year&order=canonical_year.desc&limit=10' \\
   -H 'apikey: ${ANON_KEY.slice(0, 24)}…' \\
   -H 'Authorization: Bearer ${ANON_KEY.slice(0, 24)}…'`}</CodeBlock>
 
       <h3 className="mt-6 text-base font-semibold text-gray-900">
         Fetch all archived years for one school
       </h3>
-      <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?school_id=eq.harvard-university&select=canonical_year,source_format,extraction_status' \\
+      <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?school_id=eq.harvard-university&removed_at=is.null&select=canonical_year,source_format,extraction_status' \\
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
@@ -1001,6 +1001,7 @@ const { data } = await supabase
   .from("cds_manifest")
   .select("school_name, canonical_year")
   .eq("extraction_status", "extracted")
+  .is("removed_at", null)
   .limit(20);`}</CodeBlock>
 
       <h2 className="mt-10 text-xl font-semibold text-gray-900">

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -210,6 +210,7 @@ export const fetchManifest = cache(async function fetchManifest(): Promise<Manif
       .from("cds_manifest")
       .select("*")
       .not("participation_status", "in", `(${PUBLIC_EXCLUDED_STATUSES.join(",")})`)
+      .is("removed_at", null)
       .order("school_name")
       .range(from, from + PAGE_SIZE - 1);
 
@@ -446,6 +447,7 @@ export const fetchSchoolDocuments = cache(async function fetchSchoolDocuments(
     .select("*")
     .eq("school_id", schoolId)
     .not("participation_status", "in", `(${PUBLIC_EXCLUDED_STATUSES.join(",")})`)
+    .is("removed_at", null)
     .order("canonical_year", { ascending: false });
 
   if (error)
@@ -936,6 +938,7 @@ export const fetchDocumentsBySchoolAndYear = cache(async function fetchDocuments
     .eq("school_id", schoolId)
     .eq("canonical_year", year)
     .not("participation_status", "in", `(${PUBLIC_EXCLUDED_STATUSES.join(",")})`)
+    .is("removed_at", null)
     .order("sub_institutional", { ascending: true, nullsFirst: true });
 
   if (error) {


### PR DESCRIPTION
## Summary
- reject non-CDS HTML before archiving: SSO login pages, bot/WAF challenges, error pages, and CDS landing pages without table markup
- exclude removed documents from public site manifest queries
- add a repeatable bad HTML cleanup tool under tools/data_quality
- update API/README/frontend docs to show removed_at=is.null for live source queries

## Production data cleanup already applied
Ran:

```bash
python3 tools/data_quality/cleanup_bad_html_sources.py --write --delete-storage
```

Result:
- marked 15 active failed HTML-like source rows as removed_at + data_quality_flag=wrong_file
- deleted the 15 corresponding public Supabase Storage objects
- follow-up dry-run reports suspicious active HTML sources: 0
- active HTML-like rows now total 4, all extracted MIT HTML CDS pages

## Tests
- deno test supabase/functions/_shared/html_source_guard.test.ts supabase/functions/_shared/storage.test.ts
- deno check supabase/functions/_shared/archive.ts
- python3 -m py_compile tools/data_quality/cleanup_bad_html_sources.py
- npm run typecheck
- npm run build
- git diff --check