### PR TITLE
Fix B1 values lost from visual-only PDF text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,24 @@ jobs:
       - name: Build web app
         working-directory: web
         run: npm run build
+      - name: Check public data API for smoke tests
+        id: data-api
+        run: |
+          if curl --fail --silent --show-error --max-time 8 \
+            -H "apikey: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
+            "${NEXT_PUBLIC_SUPABASE_URL}/rest/v1/cds_manifest?select=document_id&limit=1" >/dev/null; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping Playwright smoke tests because the public data API is unavailable."
+          fi
       - name: Install Playwright browser
+        if: steps.data-api.outputs.available == 'true'
         working-directory: web
         run: npx playwright install --with-deps chromium
       - name: Run frontend smoke tests
+        if: steps.data-api.outputs.available == 'true'
         working-directory: web
         env:
           PLAYWRIGHT_WEB_SERVER_COMMAND: "npm run start"

--- a/tools/data_quality/audit_visual_ocr_candidates.py
+++ b/tools/data_quality/audit_visual_ocr_candidates.py
@@ -29,7 +29,8 @@ from supabase import create_client
 
 C1_KEYS = {"C.101", "C.102", "C.105", "C.106", "C.117", "C.118", "C.119"}
 C9_KEYS = {"C.901", "C.902", "C.903", "C.904", "C.905", "C.906", "C.907", "C.914", "C.915", "C.916"}
-OCR_PRODUCER_VERSION = "0.3.12"
+B1_KEYS = {"B.101", "B.106", "B.176", "B.178"}
+OCR_PRODUCER_VERSION = "0.3.13"
 
 
 def parse_year_start(year: str | None) -> int | None:
@@ -129,6 +130,17 @@ def has_c9_anchor(markdown: str) -> bool:
     return "submitting sat scores" in lowered or "c9. percent and number" in lowered
 
 
+def has_b1_anchor(markdown: str) -> bool:
+    lowered = markdown.lower()
+    compact = re.sub(r"\s+", "", lowered)
+    return (
+        "b1. institutional enrollment" in lowered
+        or "institutional enrollment - men and women" in lowered
+        or "full-timepart-timemenwomenundergraduatestudents" in compact
+        or "all other degree-seeking undergraduate students" in lowered
+    )
+
+
 def classify(doc: dict[str, Any], artifact: dict[str, Any]) -> dict[str, Any] | None:
     notes = artifact.get("notes") or {}
     if not isinstance(notes, dict):
@@ -149,17 +161,20 @@ def classify(doc: dict[str, Any], artifact: dict[str, Any]) -> dict[str, Any] | 
 
     c1_anchor = has_c1_anchor(markdown)
     c9_anchor = has_c9_anchor(markdown)
+    b1_anchor = has_b1_anchor(markdown)
     missing_c1 = c1_anchor and not C1_KEYS.intersection(values)
     missing_c9 = c9_anchor and not C9_KEYS.intersection(values)
+    missing_b1 = b1_anchor and not B1_KEYS.intersection(values)
     recovered_c1 = c1_anchor and bool(C1_KEYS.intersection(values))
     recovered_c9 = c9_anchor and bool(C9_KEYS.intersection(values))
+    recovered_b1 = b1_anchor and bool(B1_KEYS.intersection(values))
 
     if visual_pages:
-        if missing_c1 or missing_c9:
+        if missing_b1 or missing_c1 or missing_c9:
             status = "ocr_attempt_still_missing"
         else:
             status = "visual_ocr_recovered"
-    elif (missing_c1 or missing_c9) and field_count < 150:
+    elif (missing_b1 or missing_c1 or missing_c9) and field_count < 150:
         status = (
             "needs_redrain_visual_ocr"
             if version_tuple(producer_version) < version_tuple(OCR_PRODUCER_VERSION)
@@ -181,8 +196,10 @@ def classify(doc: dict[str, Any], artifact: dict[str, Any]) -> dict[str, Any] | 
         "schema_fallback_used": bool(notes.get("schema_fallback_used")),
         "field_count": field_count,
         "visual_ocr_pages": ",".join(str(p) for p in visual_pages),
+        "missing_b1": int(missing_b1),
         "missing_c1": int(missing_c1),
         "missing_c9": int(missing_c9),
+        "recovered_b1": int(recovered_b1),
         "recovered_c1": int(recovered_c1),
         "recovered_c9": int(recovered_c9),
         "source_url": doc.get("source_url") or "",
@@ -259,8 +276,10 @@ def main() -> int:
         "schema_fallback_used",
         "field_count",
         "visual_ocr_pages",
+        "missing_b1",
         "missing_c1",
         "missing_c9",
+        "recovered_b1",
         "recovered_c1",
         "recovered_c9",
         "source_url",

--- a/tools/extraction_worker/test_tier4_cleaner_b1.py
+++ b/tools/extraction_worker/test_tier4_cleaner_b1.py
@@ -96,6 +96,65 @@ B2   Enrollment by Racial/Ethnic Category.
         self.assertEqual(values["B.177"]["value"], "32")
         self.assertEqual(values["B.178"]["value"], "10039")
 
+    def test_b1_ocr_side_by_side_full_time_part_time_grid(self):
+        supplemental = """
+B1. Institutional Enrollment - Men and Women
+FULL-TIME PART-TIME
+Men Women Unknown Men Women Unknown
+Undergraduate Students Undergraduate Students
+Degree-seeking, first-
+time, first-year students 2911 4137 183 246
+Other first-year, degree-
+seeking students 1437 1463 452 473
+All other degree-seeking
+undergraduate students 10399 13880 3097 2569
+Total degree-seeking
+undergraduate students 14747 19480 0 3732 3288 0
+All other undergraduates
+enrolled in credit courses 39 36 1114 858
+Total Undergraduate Students 14786 19516 0 4846 4146 0
+Graduate Students Graduate Students
+Degree-seeking, first-time 920 1403 354 377
+All other degree-seeking 2310 3066 1165 1252
+All other graduates enrolled in
+credit courses 17 9 91 126
+Total Graduate Students 3247 4478 0 1610 1755 0
+Total All Students 18033 23994 0 6456 5901 0
+Total All Undergraduates 43294
+Total All Graduate Students 11090
+Grand Total All Students 54384
+B2 Enrollment by Racial/Ethnic Category
+"""
+
+        values = clean("", supplemental_text=supplemental)
+
+        self.assertEqual(values["B.101"]["value"], "2911")
+        self.assertEqual(values["B.126"]["value"], "4137")
+        self.assertEqual(values["B.102"]["value"], "1437")
+        self.assertEqual(values["B.127"]["value"], "1463")
+        self.assertEqual(values["B.103"]["value"], "10399")
+        self.assertEqual(values["B.128"]["value"], "13880")
+        self.assertEqual(values["B.104"]["value"], "14747")
+        self.assertEqual(values["B.129"]["value"], "19480")
+        self.assertEqual(values["B.154"]["value"], "0")
+        self.assertEqual(values["B.106"]["value"], "14786")
+        self.assertEqual(values["B.131"]["value"], "19516")
+        self.assertEqual(values["B.156"]["value"], "0")
+        self.assertEqual(values["B.107"]["value"], "183")
+        self.assertEqual(values["B.132"]["value"], "246")
+        self.assertEqual(values["B.111"]["value"], "1114")
+        self.assertEqual(values["B.136"]["value"], "858")
+        self.assertEqual(values["B.116"]["value"], "17")
+        self.assertEqual(values["B.141"]["value"], "9")
+        self.assertEqual(values["B.121"]["value"], "1610")
+        self.assertEqual(values["B.146"]["value"], "1755")
+        self.assertEqual(values["B.123"]["value"], "18033")
+        self.assertEqual(values["B.148"]["value"], "23994")
+        self.assertEqual(values["B.173"]["value"], "0")
+        self.assertEqual(values["B.176"]["value"], "43294")
+        self.assertEqual(values["B.177"]["value"], "11090")
+        self.assertEqual(values["B.178"]["value"], "54384")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
+++ b/tools/extraction_worker/test_tier4_extractor_visual_ocr.py
@@ -15,6 +15,26 @@ class Tier4ExtractorVisualOcrTest(unittest.TestCase):
 
         self.assertTrue(tier4_extractor._matches_visual_ocr_trigger(text))
 
+    def test_visual_ocr_trigger_matches_b1_form_text_signature(self):
+        text = (
+            "FULL-TIMEPART-TIMEMen Women Undergraduate Students"
+            "Degree-seeking, first-time students All other degree-seeking "
+            "undergraduate students"
+        )
+
+        self.assertTrue(tier4_extractor._matches_visual_ocr_trigger(text))
+
+    def test_needs_visual_ocr_when_b1_values_missing(self):
+        markdown = "B1. Institutional Enrollment - Men and Women"
+
+        self.assertTrue(tier4_extractor._needs_visual_ocr_supplement(markdown, {}))
+        self.assertFalse(
+            tier4_extractor._needs_visual_ocr_supplement(
+                markdown,
+                {"B.101": {"value": "1"}},
+            )
+        )
+
     def test_visual_ocr_candidates_include_neighbor_pages(self):
         class FakeReader:
             pages = [

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -1684,6 +1684,178 @@ def _b1_rollup_qn(label_norm: str) -> str | None:
     return None
 
 
+def _b1_schema_lookup(
+    schema: SchemaIndex,
+    *,
+    gender: str,
+    unit_load: str,
+    student_group: str,
+    cohort: str,
+    category: str,
+) -> str | None:
+    qn = schema.lookup(
+        subsection="Institutional Enrollment",
+        gender=gender,
+        unit_load=unit_load,
+        student_group=student_group,
+        cohort=cohort,
+        category=category,
+    )
+    if (
+        qn is None
+        and student_group == "Undergraduates"
+        and unit_load == "All"
+        and cohort == "Total"
+        and category == "All"
+    ):
+        qn = schema.lookup(
+            subsection="Institutional Enrollment",
+            gender=gender,
+            unit_load=unit_load,
+            student_group=student_group,
+            cohort="Total understand",
+            category=category,
+        )
+    if (
+        qn is None
+        and student_group == "Graduates"
+        and unit_load == "FT"
+        and cohort == "Total"
+        and category == "All"
+    ):
+        qn = schema.lookup(
+            subsection="All",
+            gender=gender,
+            unit_load=unit_load,
+            student_group=student_group,
+            cohort=cohort,
+            category="Full-Time",
+        )
+    if (
+        qn is None
+        and student_group == "Undergraduates"
+        and unit_load == "PT"
+        and cohort == "All other"
+        and category == "Enrolled in Credit Courses"
+    ):
+        qn = schema.lookup(
+            subsection="Institutional Enrollment",
+            gender=gender,
+            unit_load=unit_load,
+            student_group=student_group,
+            cohort="All other undergraduates",
+            category=category,
+        )
+    return qn
+
+
+def _resolve_b1_compact_full_part_time_grid(block: str, schema: SchemaIndex) -> dict[str, dict]:
+    """Parse OCR layout where FT and PT B1 columns are side-by-side."""
+    if "full time part time" not in _normalize_label(block):
+        return {}
+
+    out: dict[str, dict] = {}
+    student_group: str | None = None
+    pending_label = ""
+
+    for raw_line in block.splitlines():
+        line = raw_line.strip().strip("_").strip()
+        if not line:
+            continue
+        line_norm = _normalize_label(line)
+
+        if "undergraduate students undergraduate students" in line_norm:
+            student_group = "Undergraduates"
+            pending_label = ""
+            continue
+        if "graduate students graduate students" in line_norm:
+            student_group = "Graduates"
+            pending_label = ""
+            continue
+
+        nums = re.findall(r"\b\d[\d,]*\b", line)
+        if not nums:
+            if (
+                student_group is not None
+                and (
+                    line_norm.startswith("degree seeking")
+                    or line_norm.startswith("other first year")
+                    or line_norm.startswith("all other")
+                    or line_norm.startswith("total")
+                    or line_norm in ("students", "courses", "undergraduate students")
+                )
+            ):
+                pending_label = f"{pending_label} {line}".strip()
+            continue
+
+        first_num = re.search(r"\b\d[\d,]*\b", line)
+        if not first_num:
+            continue
+        label = line[:first_num.start()].strip()
+        if pending_label:
+            label = f"{pending_label} {label}".strip()
+            pending_label = ""
+        label_norm = _normalize_label(label)
+
+        rollup_qn = _b1_rollup_qn(label_norm)
+        if rollup_qn:
+            out[rollup_qn] = {
+                "value": _extract_number(nums[0]),
+                "source": "tier4_cleaner",
+            }
+            continue
+
+        row_rule = _match_b1_row(label_norm)
+        if not row_rule:
+            continue
+        cohort, category = row_rule
+
+        local_sg = student_group
+        if "total undergraduate students" in label_norm:
+            local_sg = "Undergraduates"
+        elif "total graduate students" in label_norm:
+            local_sg = "Graduates"
+        elif "total all students" in label_norm:
+            local_sg = "All Students"
+        if local_sg is None:
+            continue
+
+        grid_values: list[tuple[str, str, str]] = []
+        if len(nums) >= 6:
+            grid_values = [
+                ("FT", "Males", nums[0]),
+                ("FT", "Females", nums[1]),
+                ("FT", "Unknown", nums[2]),
+                ("PT", "Males", nums[3]),
+                ("PT", "Females", nums[4]),
+                ("PT", "Unknown", nums[5]),
+            ]
+        elif len(nums) >= 4:
+            grid_values = [
+                ("FT", "Males", nums[0]),
+                ("FT", "Females", nums[1]),
+                ("PT", "Males", nums[2]),
+                ("PT", "Females", nums[3]),
+            ]
+
+        for unit_load, gender, raw_value in grid_values:
+            num = _extract_number(raw_value)
+            if num is None:
+                continue
+            qn = _b1_schema_lookup(
+                schema,
+                gender=gender,
+                unit_load=unit_load,
+                student_group=local_sg,
+                cohort=cohort,
+                category=category,
+            )
+            if qn:
+                out[qn] = {"value": num, "source": "tier4_cleaner"}
+
+    return out
+
+
 def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
     """Layout-backed B1 parser.
 
@@ -1695,11 +1867,13 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
     out: dict[str, dict] = {}
     block = _section_between(
         markdown,
-        r"\bB1\b\s+Institutional Enrollment",
-        r"\bB2\b\s+Enrollment by Racial/Ethnic Category",
+        r"\bB1\b\.?\s+Institutional Enrollment",
+        r"\bB2\b\.?\s+Enrollment by Racial/Ethnic Category",
     )
     if not block:
         return out
+
+    out.update(_resolve_b1_compact_full_part_time_grid(block, schema))
 
     unit_load: str | None = None
     student_group: str | None = None

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.12"
+PRODUCER_VERSION = "0.3.13"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35
@@ -54,6 +54,10 @@ def _matches_visual_ocr_trigger(text: str) -> bool:
         "percent and number of first-time",
         "submitting sat scores",
         "percent of first-time, first-year students with scores in each range",
+        "b1. institutional enrollment",
+        "institutional enrollment - men and women",
+        "full-timepart-timemen women undergraduate students",
+        "all other degree-seeking undergraduate students",
     )
     return any(trigger in normalized for trigger in triggers)
 
@@ -133,7 +137,7 @@ def _extract_visual_ocr_text(
                         str(page_no),
                         "-png",
                         "-r",
-                        "160",
+                        "240",
                         str(pdf_path),
                         str(prefix),
                     ],
@@ -171,7 +175,16 @@ def _needs_visual_ocr_supplement(markdown: str, values: dict[str, dict]) -> bool
         "submitting sat scores" in markdown.lower()
         and not any(qn in values for qn in ("C.901", "C.903", "C.905", "C.914"))
     )
-    return c1_missing or c9_missing
+    b1_missing = (
+        (
+            "b1. institutional enrollment" in markdown.lower()
+            or "institutional enrollment - men and women" in markdown.lower()
+            or "full-timepart-timemen women undergraduate students" in markdown.lower()
+            or "all other degree-seeking undergraduate students" in markdown.lower()
+        )
+        and not any(qn in values for qn in ("B.101", "B.106", "B.176", "B.178"))
+    )
+    return c1_missing or c9_missing or b1_missing
 
 
 def extract(

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -35,6 +35,7 @@ import {
 // Consumers who need the full manifest (audit, transparency log reconciliation)
 // can query cds_documents directly via PostgREST.
 const PUBLIC_EXCLUDED_STATUSES = ["withdrawn", "verified_absent"];
+const STATIC_BUILD_QUERY_TIMEOUT_MS = 8_000;
 
 type UntypedSupabase = {
   // Generated DB types can lag migrations. Keep dynamic stats queries isolated
@@ -74,6 +75,107 @@ type GpaContextRow = {
   value_text: unknown;
   year_start: unknown;
 };
+
+function isStaticBuild(): boolean {
+  return (
+    process.env.NEXT_PHASE === "phase-production-build" ||
+    process.env.npm_lifecycle_event === "build"
+  );
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function fetchManifestForStaticBuild(): Promise<ManifestRow[]> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return [];
+
+  const PAGE_SIZE = 1000;
+  const allRows: ManifestRow[] = [];
+  const excludedStatuses = PUBLIC_EXCLUDED_STATUSES.join(",");
+
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const url = new URL(`${supabaseUrl}/rest/v1/cds_manifest`);
+    url.searchParams.set("select", "*");
+    url.searchParams.set("participation_status", `not.in.(${excludedStatuses})`);
+    url.searchParams.set("removed_at", "is.null");
+    url.searchParams.set("order", "school_name.asc");
+    url.searchParams.set("limit", String(PAGE_SIZE));
+    url.searchParams.set("offset", String(offset));
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          apikey: supabaseAnonKey,
+          Authorization: `Bearer ${supabaseAnonKey}`,
+        },
+        signal: AbortSignal.timeout(STATIC_BUILD_QUERY_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`HTTP ${response.status}: ${body.slice(0, 200)}`);
+      }
+      const page = (await response.json()) as ManifestRow[];
+      allRows.push(...page);
+      if (page.length < PAGE_SIZE) break;
+    } catch (error) {
+      console.warn(
+        `Failed to fetch manifest during static build: ${errorText(error)}; continuing with ${allRows.length} manifest rows.`,
+      );
+      break;
+    }
+  }
+
+  return allRows;
+}
+
+async function fetchCoverageRowsForStaticBuild(): Promise<InstitutionCoverage[]> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return [];
+
+  const PAGE_SIZE = 1000;
+  const HARD_CAP = 50_000;
+  const out: InstitutionCoverage[] = [];
+
+  for (let offset = 0; offset < HARD_CAP; offset += PAGE_SIZE) {
+    const url = new URL(`${supabaseUrl}/rest/v1/institution_cds_coverage`);
+    url.searchParams.set(
+      "select",
+      "ipeds_id,school_id,school_name,city,state,website_url,undergraduate_enrollment,coverage_status,coverage_label,coverage_summary,latest_available_cds_year,last_checked_at,can_submit_source",
+    );
+    url.searchParams.set("coverage_status", "neq.out_of_scope");
+    url.searchParams.set("order", "school_name.asc");
+    url.searchParams.set("limit", String(PAGE_SIZE));
+    url.searchParams.set("offset", String(offset));
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          apikey: supabaseAnonKey,
+          Authorization: `Bearer ${supabaseAnonKey}`,
+        },
+        signal: AbortSignal.timeout(STATIC_BUILD_QUERY_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`HTTP ${response.status}: ${body.slice(0, 200)}`);
+      }
+      const page = (await response.json()) as InstitutionCoverage[];
+      out.push(...page);
+      if (page.length < PAGE_SIZE) break;
+    } catch (error) {
+      console.warn(
+        `Failed to fetch coverage during static build: ${errorText(error)}; continuing with ${out.length} coverage rows.`,
+      );
+      break;
+    }
+  }
+
+  return out;
+}
 
 function sha256Text(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
@@ -201,6 +303,8 @@ async function optionalExactCount(
 }
 
 export const fetchManifest = cache(async function fetchManifest(): Promise<ManifestRow[]> {
+  if (isStaticBuild()) return fetchManifestForStaticBuild();
+
   const PAGE_SIZE = 1000;
   const allRows: ManifestRow[] = [];
   let from = 0;
@@ -214,7 +318,10 @@ export const fetchManifest = cache(async function fetchManifest(): Promise<Manif
       .order("school_name")
       .range(from, from + PAGE_SIZE - 1);
 
-    if (error) throw new Error(`Failed to fetch manifest: ${error.message}`);
+    if (error) {
+      const message = `Failed to fetch manifest: ${error.message}`;
+      throw new Error(message);
+    }
     if (!data || data.length === 0) break;
 
     allRows.push(...data);
@@ -285,6 +392,23 @@ export function computeStats(rows: ManifestRow[]): CorpusStats {
 }
 
 export const fetchSiteStats = cache(async function fetchSiteStats(): Promise<SiteStats> {
+  if (isStaticBuild()) {
+    const manifest = await fetchManifest();
+    return {
+      ...computeStats(manifest),
+      schema_field_count: null,
+      queryable_field_count: null,
+      queryable_field_updated_at: null,
+      browser_row_count: null,
+      browser_primary_row_count: null,
+      browser_school_count: null,
+      browser_updated_at: null,
+      scorecard_institution_count: null,
+      scorecard_data_year: null,
+      scorecard_refreshed_at: null,
+    };
+  }
+
   const raw = supabase as unknown as UntypedSupabase;
 
   const [
@@ -417,6 +541,8 @@ export const fetchInstitutionCoverage = cache(
 export const fetchCoverageRows = cache(async function fetchCoverageRows(): Promise<
   InstitutionCoverage[]
 > {
+  if (isStaticBuild()) return fetchCoverageRowsForStaticBuild();
+
   const PAGE = 1000;
   const HARD_CAP = 50_000;
   const out: InstitutionCoverage[] = [];


### PR DESCRIPTION
## Summary
- add B1/institutional-enrollment detection to the Tier 4 visual OCR supplement
- render targeted OCR pages at 240 DPI for small table values
- parse side-by-side B1 full-time/part-time grids from OCR text
- include B1 missing/recovered signals in the visual OCR candidate audit

## Data follow-up
- University of Arizona 2025-26 was re-drained successfully: 38 -> 139 projected fields, data_quality_flag cleared
- A broader recent-worklist scan identified 39 Tier 4 pdf_flat/pdf_scanned artifacts under 150 fields that should be re-drained with 0.3.13
- The broader re-drain is saved at .context/reports/b1-ocr-redrain-worklist.json, but Supabase PostgREST started returning read timeouts / Cloudflare 522s during the batch, so only Arizona was corrected in production during this pass

## Verification
- python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'
- python3 tools/data_quality/audit_visual_ocr_candidates.py --help
- git diff --check