### PR TITLE
Fix historical schema registry filtering

### DIFF
--- a/tools/extraction_worker/test_schema_dispatch.py
+++ b/tools/extraction_worker/test_schema_dispatch.py
@@ -1,5 +1,7 @@
 import unittest
+import json
 import sys
+import tempfile
 from pathlib import Path
 
 TOOLS_ROOT = Path(__file__).resolve().parents[1]
@@ -76,6 +78,38 @@ class MultiTableFakeClient:
 
 
 class SchemaDispatchTest(unittest.TestCase):
+    def test_schema_registry_ignores_overlay_files_without_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_dir = Path(tmp)
+            (schema_dir / "cds_schema_2023_24.core_table_overlay.json").write_text(
+                json.dumps({
+                    "schema_version": "2023-24",
+                    "overlay_version": "core_table_v1",
+                    "mappings": [],
+                })
+            )
+            (schema_dir / "cds_schema_2025_26.json").write_text(
+                json.dumps({
+                    "schema_version": "2025-26",
+                    "fields": [
+                        {
+                            "question_number": "A.001",
+                            "question": "First Name:",
+                            "section": "General Information",
+                            "subsection": "Respondent Information",
+                        }
+                    ],
+                })
+            )
+
+            registry = load_schema_registry(schema_dir)
+            resolution = resolve_schema_for_year("2023-24", registry)
+
+        self.assertNotIn("2023-24", registry)
+        self.assertEqual(resolution.schema_version, "2025-26")
+        self.assertTrue(resolution.fallback_used)
+        self.assertEqual(resolution.fallback_reason, "no_schema_for_2023-24")
+
     def test_resolve_schema_uses_matching_year(self):
         registry = load_schema_registry()
         resolution = resolve_schema_for_year("2024-25", registry)

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -267,10 +267,11 @@ def load_env(env_path: Path) -> dict[str, str]:
 
 
 def canonical_schema_paths(schema_dir: Path = SCHEMA_DIR) -> list[Path]:
+    canonical_name_re = re.compile(r"^cds_schema_\d{4}_\d{2}\.json$")
     return [
         path
         for path in sorted(schema_dir.glob("cds_schema_*.json"))
-        if "-to-" not in path.name and not path.name.endswith(".structural.json")
+        if canonical_name_re.match(path.name)
     ]
 
 
@@ -279,7 +280,7 @@ def load_schema_registry(schema_dir: Path = SCHEMA_DIR) -> dict[str, tuple[Path,
     for path in canonical_schema_paths(schema_dir):
         schema = load_schema(path)
         version = schema.get("schema_version")
-        if version:
+        if version and isinstance(schema.get("fields"), list):
             registry[str(version)] = (path, schema)
     if not registry:
         raise RuntimeError(f"no canonical schemas found in {schema_dir}")


### PR DESCRIPTION
## Summary
- restrict extraction worker schema discovery to exact canonical schema files
- require loaded schema JSON to contain a top-level fields array before registering it
- add regression coverage for 2023-24 overlay files being ignored and falling back to the latest full schema

## Validation
- python3 -m unittest tools/extraction_worker/test_schema_dispatch.py
- python3 -m unittest discover -s tools/extraction_worker -p "test_*.py"
- python3 -m unittest tools.browser_backend.project_browser_data_test
- dry-run worker against Wilkes 2023-24 document 2760300b-21b4-488f-b8d8-53e4422408fa: tier4_extracted (236 fields, 144371 chars, 57 pages)