### PR TITLE
Fix visual OCR tooling in extraction drains

### DIFF
--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -92,7 +92,15 @@ jobs:
           cache-dependency-path: tools/extraction_worker/requirements.txt
 
       - name: Install extraction worker dependencies
-        run: python -m pip install -r tools/extraction_worker/requirements.txt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends poppler-utils tesseract-ocr
+          python -m pip install -r tools/extraction_worker/requirements.txt
+
+      - name: Verify visual OCR tooling
+        run: |
+          pdftoppm -h >/dev/null 2>&1
+          tesseract --version
 
       - name: Run bounded pending-row drain
         shell: bash

--- a/tools/extraction_worker/tier4_extractor.py
+++ b/tools/extraction_worker/tier4_extractor.py
@@ -30,10 +30,15 @@ from pathlib import Path
 
 
 PRODUCER_NAME = "tier4_docling"
-PRODUCER_VERSION = "0.3.13"
+PRODUCER_VERSION = "0.3.14"
 DOCLING_CONFIG_NAME = "production-fast-no-orphan-clusters"
 DOCLING_NATIVE_TABLES_VERSION = "docling_table_cells_compact_v1"
 SCANNED_ADMISSIONS_OCR_MAX_PAGE = 35
+VISUAL_OCR_TOOLS = ("pdftoppm", "tesseract")
+
+
+def _missing_visual_ocr_tools() -> list[str]:
+    return [tool for tool in VISUAL_OCR_TOOLS if not shutil.which(tool)]
 
 
 def _matches_visual_ocr_trigger(text: str) -> bool:
@@ -113,7 +118,7 @@ def _extract_visual_ocr_text(
     fallback_page_count: int | None = None,
 ) -> tuple[str, list[int]]:
     """Best-effort Tesseract supplement for visually rendered table values."""
-    if not shutil.which("pdftoppm") or not shutil.which("tesseract"):
+    if _missing_visual_ocr_tools():
         return "", []
 
     pages = _visual_ocr_candidate_pages(pdf_path)
@@ -239,7 +244,9 @@ def extract(
     values = clean(markdown, schema=schema, supplemental_text=supplemental_text)
     visual_ocr_text = ""
     visual_ocr_pages: list[int] = []
+    visual_ocr_missing_tools: list[str] = []
     if _needs_visual_ocr_supplement(markdown, values):
+        visual_ocr_missing_tools = _missing_visual_ocr_tools()
         # Scanned PDFs have no embedded text layer for pypdf to select pages
         # from. If Docling's full-page OCR still left admissions values blank,
         # use a bounded Tesseract pass over the front CDS sections instead of
@@ -283,6 +290,7 @@ def extract(
             "pdf_layout_text_length": len(pdf_layout_text),
             "visual_ocr_text_length": len(visual_ocr_text),
             "visual_ocr_pages": visual_ocr_pages,
+            "visual_ocr_missing_tools": visual_ocr_missing_tools,
         },
         "markdown": markdown,
         "native_tables": native_tables,


### PR DESCRIPTION
## Summary

- Install `poppler-utils` and `tesseract-ocr` in the ops extraction worker before Docling drains run.
- Add a visual-OCR tool availability helper and record `visual_ocr_missing_tools` in Tier 4 artifact stats.
- Bump `tier4_docling` producer to `0.3.14` so targeted redrains write fresh artifacts.

## Live Data Repair

Scanned 35 live low-coverage `pdf_flat` rows and found 3 with the missing-visual-OCR signature. Locally redrained those with Docling and projection refresh:

- Lake Superior State 2025-26: 25 -> 117 fields, OCR pages populated.
- Old Dominion 2024-25 and Eastern Virginia Medical School 2024-25: OCR now runs, but both remain low because they point at the same Old Dominion BigFuture profile export rather than a normal CDS template.

Post-redrain scan: 0 remaining live low-coverage rows with the original missing-OCR signature.

## Verification

- `python3 -m unittest discover -s tools/extraction_worker -p 'test_*.py'` — 167 tests OK
- `git diff --check`
- local `pdftoppm`/`tesseract` command availability checks
