### PR TITLE
Add friendly API usage attribution

### DIFF
--- a/packages/cli/bin/collegedata.js
+++ b/packages/cli/bin/collegedata.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 const API_BASE = (process.env.COLLEGEDATA_API_BASE ?? "https://www.collegedata.fyi").replace(/\/$/, "");
+const CLIENT_NAME = "cli";
+const CLIENT_VERSION = "0.1.0";
 
 function usage() {
   console.error(`Usage:
@@ -32,8 +34,22 @@ function parseOptions(args) {
   return out;
 }
 
-async function getJson(path) {
-  const res = await fetch(`${API_BASE}${path}`);
+function withClientParams(path, command) {
+  const url = new URL(path, "https://collegedata.fyi");
+  url.searchParams.set("cd_client", CLIENT_NAME);
+  url.searchParams.set("cd_client_version", CLIENT_VERSION);
+  if (command) url.searchParams.set("cd_command", command);
+  return `${url.pathname}?${url.searchParams.toString()}`;
+}
+
+async function getJson(path, command) {
+  const res = await fetch(`${API_BASE}${withClientParams(path, command)}`, {
+    headers: {
+      "X-CollegeData-Client": CLIENT_NAME,
+      "X-CollegeData-Client-Version": CLIENT_VERSION,
+      ...(command ? { "X-CollegeData-CLI-Command": command } : {}),
+    },
+  });
   const text = await res.text();
   let payload;
   try {
@@ -98,7 +114,7 @@ async function main() {
   if (command === "search") {
     const q = opts._.join(" ");
     if (!q) throw new Error("search requires a query");
-    const payload = await getJson(`/api/schools/search?q=${encodeURIComponent(q)}`);
+    const payload = await getJson(`/api/schools/search?q=${encodeURIComponent(q)}`, command);
     if (format === "json") return printJson(payload);
     return printTable(payload.results, ["school_id", "school_name", "city", "state", "coverage_status"]);
   }
@@ -108,7 +124,7 @@ async function main() {
     if (!school) throw new Error("facts requires a school_id");
     const params = new URLSearchParams();
     if (opts.categories) params.set("categories", opts.categories);
-    const payload = await getJson(`/api/schools/${encodeURIComponent(school)}/facts${params.size ? `?${params}` : ""}`);
+    const payload = await getJson(`/api/schools/${encodeURIComponent(school)}/facts${params.size ? `?${params}` : ""}`, command);
     if (format === "json") return printJson(payload);
     return printTable(
       payload.facts.map((fact) => ({
@@ -127,7 +143,7 @@ async function main() {
     const params = new URLSearchParams({ schools: schools.join(",") });
     if (opts.categories) params.set("categories", opts.categories);
     if (opts.fields) params.set("fields", opts.fields);
-    const payload = await getJson(`/api/compare?${params}`);
+    const payload = await getJson(`/api/compare?${params}`, command);
     if (format === "json") return printJson(payload);
     const columns = ["school", ...payload.columns.map((column) => column.key)];
     const rows = payload.rows.map((row) => ({
@@ -143,14 +159,14 @@ async function main() {
   if (command === "sources") {
     const school = opts._[0];
     if (!school) throw new Error("sources requires a school_id");
-    const payload = await getJson(`/api/schools/${encodeURIComponent(school)}/sources`);
+    const payload = await getJson(`/api/schools/${encodeURIComponent(school)}/sources`, command);
     return printJson(payload);
   }
 
   if (command === "fields") {
     const params = new URLSearchParams();
     if (opts.category) params.set("category", opts.category);
-    const payload = await getJson(`/api/fields${params.size ? `?${params}` : ""}`);
+    const payload = await getJson(`/api/fields${params.size ? `?${params}` : ""}`, command);
     if (format === "json") return printJson(payload);
     return printTable(payload.fields, ["key", "label", "category", "source_layer"]);
   }
@@ -173,4 +189,3 @@ main().catch((error) => {
   console.error(error.message);
   process.exit(1);
 });
-

--- a/packages/mcp-server/bin/collegedata-mcp.js
+++ b/packages/mcp-server/bin/collegedata-mcp.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 const API_BASE = (process.env.COLLEGEDATA_API_BASE ?? "https://www.collegedata.fyi").replace(/\/$/, "");
+const CLIENT_NAME = "mcp";
+const CLIENT_VERSION = "0.1.0";
 
 const tools = [
   {
@@ -59,8 +61,22 @@ const tools = [
   },
 ];
 
-async function getJson(path) {
-  const res = await fetch(`${API_BASE}${path}`);
+function withClientParams(path, toolName) {
+  const url = new URL(path, "https://collegedata.fyi");
+  url.searchParams.set("cd_client", CLIENT_NAME);
+  url.searchParams.set("cd_client_version", CLIENT_VERSION);
+  if (toolName) url.searchParams.set("cd_tool", toolName);
+  return `${url.pathname}?${url.searchParams.toString()}`;
+}
+
+async function getJson(path, toolName) {
+  const res = await fetch(`${API_BASE}${withClientParams(path, toolName)}`, {
+    headers: {
+      "X-CollegeData-Client": CLIENT_NAME,
+      "X-CollegeData-Client-Version": CLIENT_VERSION,
+      ...(toolName ? { "X-CollegeData-MCP-Tool": toolName } : {}),
+    },
+  });
   const payload = await res.json();
   if (!res.ok) throw new Error(payload?.message ?? payload?.error ?? `HTTP ${res.status}`);
   return payload;
@@ -70,26 +86,26 @@ async function callTool(name, args) {
   if (name === "search_schools") {
     const params = new URLSearchParams({ q: args.query });
     if (args.limit) params.set("limit", String(args.limit));
-    return getJson(`/api/schools/search?${params}`);
+    return getJson(`/api/schools/search?${params}`, name);
   }
   if (name === "get_school_facts") {
     const params = new URLSearchParams();
     if (args.categories) params.set("categories", args.categories);
-    return getJson(`/api/schools/${encodeURIComponent(args.school_id)}/facts${params.size ? `?${params}` : ""}`);
+    return getJson(`/api/schools/${encodeURIComponent(args.school_id)}/facts${params.size ? `?${params}` : ""}`, name);
   }
   if (name === "compare_schools") {
     const params = new URLSearchParams({ schools: args.school_ids.join(",") });
     if (args.categories) params.set("categories", args.categories);
     if (args.fields) params.set("fields", args.fields);
-    return getJson(`/api/compare?${params}`);
+    return getJson(`/api/compare?${params}`, name);
   }
   if (name === "get_source_documents") {
-    return getJson(`/api/schools/${encodeURIComponent(args.school_id)}/sources`);
+    return getJson(`/api/schools/${encodeURIComponent(args.school_id)}/sources`, name);
   }
   if (name === "get_field_dictionary") {
     const params = new URLSearchParams();
     if (args.category) params.set("category", args.category);
-    return getJson(`/api/fields${params.size ? `?${params}` : ""}`);
+    return getJson(`/api/fields${params.size ? `?${params}` : ""}`, name);
   }
   throw new Error(`Unknown tool: ${name}`);
 }

--- a/supabase/migrations/20260625120000_api_usage_events.sql
+++ b/supabase/migrations/20260625120000_api_usage_events.sql
@@ -1,0 +1,57 @@
+-- Lightweight public API usage attribution.
+--
+-- This table intentionally stores coarse request metadata only: endpoint
+-- family, self-declared client labels, referrer host, country, and public
+-- school identifiers. It does not store IP addresses, full user agents,
+-- search queries, full query strings, request bodies, or profile inputs.
+
+create table if not exists public.api_usage_events (
+  id bigserial primary key,
+  occurred_at timestamptz not null default now(),
+  request_source text not null default 'friendly_api',
+  route_path text not null,
+  route_kind text not null,
+  http_method text not null,
+  client_family text not null default 'unknown',
+  client_name text,
+  client_version text,
+  client_tool text,
+  user_agent_family text not null default 'unknown',
+  referer_host text,
+  country text,
+  school_id text,
+  school_count integer,
+  created_at timestamptz not null default now(),
+  constraint api_usage_events_method_valid check (
+    http_method in ('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS')
+  ),
+  constraint api_usage_events_school_count_valid check (
+    school_count is null or school_count >= 0
+  )
+);
+
+comment on table public.api_usage_events is
+  'Low-PII server-side usage events for the public friendly API. Used to distinguish first-party MCP/CLI calls, cooperative app integrations, and unknown script/browser traffic.';
+
+comment on column public.api_usage_events.client_name is
+  'Self-declared client marker from X-CollegeData-Client or cd_client. Sanitized before insert; untrusted and advisory only.';
+
+comment on column public.api_usage_events.client_tool is
+  'MCP tool or CLI command marker when supplied by first-party clients. Sanitized before insert; untrusted and advisory only.';
+
+comment on column public.api_usage_events.user_agent_family is
+  'Coarse user-agent bucket only, not the raw User-Agent header.';
+
+alter table public.api_usage_events enable row level security;
+
+create index if not exists api_usage_events_occurred_at_idx
+  on public.api_usage_events (occurred_at desc);
+
+create index if not exists api_usage_events_route_kind_occurred_at_idx
+  on public.api_usage_events (route_kind, occurred_at desc);
+
+create index if not exists api_usage_events_client_family_occurred_at_idx
+  on public.api_usage_events (client_family, occurred_at desc);
+
+grant all on public.api_usage_events to service_role;
+grant usage, select on sequence public.api_usage_events_id_seq to service_role;

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -99,6 +99,18 @@ curl 'https://www.collegedata.fyi/openapi.json'`}</CodeBlock>
         </code>
         . Both wrap the simple endpoints rather than reimplementing query logic.
       </p>
+      <p className="mt-3 text-sm leading-relaxed text-gray-700">
+        If you build on these endpoints, send a short{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+          X-CollegeData-Client
+        </code>{" "}
+        header such as{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+          my-app-name
+        </code>
+        . It helps us understand API usage and keep the free public surface
+        healthy without requiring API keys.
+      </p>
 
       <h2 className="mt-10 text-xl font-semibold text-gray-900">
         Runbook

--- a/web/src/lib/api-usage.test.ts
+++ b/web/src/lib/api-usage.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildApiUsageEvent,
+  clientFamily,
+  routeKindFromPath,
+  userAgentFamily,
+} from "./api-usage";
+
+describe("api usage attribution", () => {
+  it("classifies first-party MCP calls from headers and query markers", () => {
+    const request = new Request(
+      "https://www.collegedata.fyi/api/schools/mit/facts?cd_client=mcp&cd_tool=get_school_facts&cd_client_version=0.1.0",
+      {
+        headers: {
+          "user-agent": "node",
+          "x-vercel-ip-country": "US",
+        },
+      },
+    );
+
+    expect(buildApiUsageEvent(request)).toMatchObject({
+      route_kind: "school_facts",
+      client_family: "mcp",
+      client_name: "mcp",
+      client_tool: "get_school_facts",
+      client_version: "0.1.0",
+      user_agent_family: "node_fetch",
+      country: "US",
+      school_id: "mit",
+    });
+  });
+
+  it("keeps search queries out of logged events", () => {
+    const request = new Request("https://www.collegedata.fyi/api/schools/search?q=stanford");
+    expect(buildApiUsageEvent(request)).toMatchObject({
+      route_path: "/api/schools/search",
+      route_kind: "schools_search",
+      school_id: null,
+    });
+    expect(JSON.stringify(buildApiUsageEvent(request))).not.toContain("stanford");
+  });
+
+  it("records compare school counts without storing the full query string", () => {
+    const request = new Request("https://www.collegedata.fyi/api/compare?schools=mit,yale,stanford");
+    expect(buildApiUsageEvent(request)).toMatchObject({
+      route_kind: "compare",
+      school_count: 3,
+      school_id: null,
+    });
+  });
+
+  it("classifies common clients conservatively", () => {
+    expect(clientFamily("my-app", "node")).toBe("integration");
+    expect(clientFamily(null, "Mozilla/5.0")).toBe("browser");
+    expect(clientFamily(null, "curl/8.0")).toBe("script");
+    expect(clientFamily(null, "ClaudeBot")).toBe("ai_agent");
+    expect(userAgentFamily("python-requests/2.32")).toBe("python");
+  });
+
+  it("normalizes public API route kinds", () => {
+    expect(routeKindFromPath("/api/schools/search")).toBe("schools_search");
+    expect(routeKindFromPath("/api/schools/mit/sources")).toBe("school_sources");
+    expect(routeKindFromPath("/api/facts/mit")).toBe("legacy_school_facts");
+  });
+});

--- a/web/src/lib/api-usage.ts
+++ b/web/src/lib/api-usage.ts
@@ -1,0 +1,154 @@
+export type ApiUsageEvent = {
+  request_source: "friendly_api";
+  route_path: string;
+  route_kind: string;
+  http_method: string;
+  client_family: string;
+  client_name: string | null;
+  client_version: string | null;
+  client_tool: string | null;
+  user_agent_family: string;
+  referer_host: string | null;
+  country: string | null;
+  school_id: string | null;
+  school_count: number | null;
+};
+
+const MAX_TOKEN_LENGTH = 80;
+
+function firstValue(headers: Headers, name: string): string | null {
+  const value = headers.get(name);
+  return value && value.trim() ? value.trim() : null;
+}
+
+function cleanToken(value: string | null, maxLength = MAX_TOKEN_LENGTH): string | null {
+  if (!value) return null;
+  const cleaned = value
+    .trim()
+    .slice(0, maxLength)
+    .replace(/[^a-zA-Z0-9._:/@+-]/g, "-")
+    .replace(/-+/g, "-");
+  return cleaned || null;
+}
+
+function refererHost(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    return cleanToken(new URL(value).hostname.toLowerCase(), 160);
+  } catch {
+    return null;
+  }
+}
+
+export function userAgentFamily(userAgent: string | null): string {
+  const ua = userAgent?.toLowerCase() ?? "";
+  if (!ua) return "unknown";
+  if (ua.includes("claude") || ua.includes("anthropic")) return "ai_agent";
+  if (ua.includes("chatgpt") || ua.includes("openai")) return "ai_agent";
+  if (ua.includes("perplexity") || ua.includes("copilot")) return "ai_agent";
+  if (ua.includes("curl/")) return "curl";
+  if (ua.includes("python-requests") || ua.includes("aiohttp")) return "python";
+  if (ua === "node" || ua.includes("node-fetch") || ua.includes("undici")) return "node_fetch";
+  if (ua.includes("mozilla/")) return "browser";
+  return "script";
+}
+
+export function clientFamily(clientName: string | null, userAgent: string | null): string {
+  const marker = clientName?.toLowerCase() ?? "";
+  if (marker.includes("mcp")) return "mcp";
+  if (marker.includes("cli")) return "cli";
+  if (marker) return "integration";
+
+  const uaFamily = userAgentFamily(userAgent);
+  if (uaFamily === "browser") return "browser";
+  if (uaFamily === "ai_agent") return "ai_agent";
+  if (["curl", "python", "node_fetch", "script"].includes(uaFamily)) return "script";
+  return "unknown";
+}
+
+function schoolIdFromPath(parts: string[]): string | null {
+  if (parts[0] === "api" && parts[1] === "schools" && parts[2] && parts[2] !== "search") {
+    return cleanToken(decodeURIComponent(parts[2]), 160);
+  }
+  if (parts[0] === "api" && parts[1] === "facts" && parts[2]) {
+    return cleanToken(decodeURIComponent(parts[2]), 160);
+  }
+  return null;
+}
+
+function schoolCount(url: URL, routeKind: string): number | null {
+  if (routeKind !== "compare") return null;
+  return (
+    url.searchParams
+      .get("schools")
+      ?.split(",")
+      .map((school) => school.trim())
+      .filter(Boolean).length ?? 0
+  );
+}
+
+export function routeKindFromPath(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  if (pathname === "/api/schools/search") return "schools_search";
+  if (parts[0] === "api" && parts[1] === "schools" && parts[3] === "facts") return "school_facts";
+  if (parts[0] === "api" && parts[1] === "schools" && parts[3] === "sources") return "school_sources";
+  if (parts[0] === "api" && parts[1] === "facts" && parts[2]) return "legacy_school_facts";
+  if (pathname === "/api/compare") return "compare";
+  if (pathname === "/api/fields") return "fields";
+  if (pathname === "/api/snapshots") return "snapshots";
+  return "other_api";
+}
+
+export function buildApiUsageEvent(request: Request): ApiUsageEvent {
+  const url = new URL(request.url);
+  const routeKind = routeKindFromPath(url.pathname);
+  const clientName = cleanToken(
+    firstValue(request.headers, "x-collegedata-client") ?? url.searchParams.get("cd_client"),
+  );
+  const userAgent = firstValue(request.headers, "user-agent");
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  return {
+    request_source: "friendly_api",
+    route_path: url.pathname,
+    route_kind: routeKind,
+    http_method: request.method.toUpperCase(),
+    client_family: clientFamily(clientName, userAgent),
+    client_name: clientName,
+    client_version: cleanToken(
+      firstValue(request.headers, "x-collegedata-client-version") ?? url.searchParams.get("cd_client_version"),
+    ),
+    client_tool: cleanToken(
+      firstValue(request.headers, "x-collegedata-mcp-tool") ??
+        firstValue(request.headers, "x-collegedata-cli-command") ??
+        url.searchParams.get("cd_tool") ??
+        url.searchParams.get("cd_command"),
+    ),
+    user_agent_family: userAgentFamily(userAgent),
+    referer_host: refererHost(firstValue(request.headers, "referer")),
+    country: cleanToken(firstValue(request.headers, "x-vercel-ip-country"), 8),
+    school_id: schoolIdFromPath(parts),
+    school_count: schoolCount(url, routeKind),
+  };
+}
+
+export async function recordApiUsageEvent(event: ApiUsageEvent): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) return;
+
+  try {
+    await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/api_usage_events`, {
+      method: "POST",
+      headers: {
+        apikey: serviceKey,
+        authorization: `Bearer ${serviceKey}`,
+        "content-type": "application/json",
+        prefer: "return=minimal",
+      },
+      body: JSON.stringify(event),
+    });
+  } catch {
+    // Usage telemetry must never affect the public API response path.
+  }
+}

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,0 +1,18 @@
+import type { NextFetchEvent, NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { buildApiUsageEvent, recordApiUsageEvent } from "@/lib/api-usage";
+
+export function proxy(request: NextRequest, event: NextFetchEvent) {
+  event.waitUntil(recordApiUsageEvent(buildApiUsageEvent(request)));
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/api/compare",
+    "/api/fields",
+    "/api/facts/:path*",
+    "/api/schools/:path*",
+    "/api/snapshots",
+  ],
+};


### PR DESCRIPTION
## Summary
- add a private api_usage_events table for low-PII friendly API usage telemetry
- record friendly API calls from Next proxy with route/client/tool/referrer/country buckets
- tag MCP and CLI calls with CollegeData client headers and cd_* query markers
- document X-CollegeData-Client for external API builders

## Deployment notes
- Supabase migration 20260625120000_api_usage_events.sql has already been applied to production.
- The logger no-ops/fails closed if service-role env is unavailable, so API responses are not blocked by telemetry.

## Tests
- npm test
- npm run typecheck
- npm run build
- node --check packages/mcp-server/bin/collegedata-mcp.js
- node --check packages/cli/bin/collegedata.js
- git diff --check origin/main...HEAD
- supabase db push --dry-run --linked