### PR TITLE
Profile strip + spotlight attribution for discovery rounds (PRD 026)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -75,7 +75,12 @@ Sections are ordered **Open → Resolved → Strategic context**. Every open ite
   (c) grow CDS-backed evidence matchers as extraction coverage expands — the
   v1 bundle leans on IPEDS completions, directory, and Scorecard fields, and
   the policy's matcher layer is where CDS fields plug in without a bundle
-  format change. **Effort:** (b) is ~30 min; (a) and (c) are focused
+  format change; each new resolver also moves its matcher-backed deck keys
+  out of the profile strip's disclosed "Recorded, not yet matching" group
+  (keys outside `ACTIONABLE_KEYS` in `web/src/lib/discovery/matchers.ts`)
+  into real steering; (d) the profile-strip v2 tap-to-retune interaction (chips that
+  re-tune future rounds), designed but held until dogfooding validates the
+  read-only strip. **Effort:** (b) is ~30 min; (a), (c), and (d) are focused
   follow-up slices.
 
 - **Academic positioning v1.1 follow-ups from pre-merge review.** Confirm

--- a/docs/prd/026-guided-college-discovery.md
+++ b/docs/prd/026-guided-college-discovery.md
@@ -1111,6 +1111,27 @@ Owner decisions after acceptance, superseding the corresponding sections above:
   domain), regenerated bit-identically by
   `tools/discovery/build_zip3_centroids.py`. No server endpoint; the full ZIP
   never leaves the device.
+- **Profile strip + spotlight attribution shipped (2026-07-12).** The rounds
+  view gains a fixed bottom profile strip (hidden when no round is on screen
+  or nothing steers): steering counts (strong / away / tensions) with the
+  strongest chips inline, expanding to a drawer grouped in
+  steering language — never bucket names, since reactions can push a card past
+  its sorted bucket and quoting the bucket would misquote the sort. Positive,
+  matcher-supported chips are spotlight toggles that highlight every rendered
+  reason they caused across the round (pure view-state; school order untouched
+  by construction); away/tension/unsupported chips are non-toggles with honest
+  per-class copy. Reasons carry "Because you said: '<card statement>'"
+  attribution — the card is quoted only while an active card signal exists;
+  reaction-only aggregates say "Because you asked for more like this" instead
+  of misquoting a withdrawn card. Steering counts are truthful: deck keys
+  outside `ACTIONABLE_KEYS` (`web/src/lib/discovery/matchers.ts`) — the 12
+  of 24 whose matcher evidence has no bundle resolver yet, plus the two with
+  no policy matcher at all — surface in a disclosed "Recorded, not yet
+  matching" drawer group rather than posing as active steering;
+  matcher-backed keys move into real steering automatically as resolvers
+  land. The v2 tap-to-retune interaction (chips that re-tune future rounds)
+  is designed but deliberately not built, gated on dogfooding the read-only
+  strip first.
 
 ## The Assignment
 

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -111,12 +111,21 @@
 }
 
 /* Discovery rounds: a reason spotlit by an active profile-strip chip. The
-   wash reuses the established forest tint (see --match-fit-bg). */
+   wash reuses the established forest tint (see --match-fit-bg). The negative
+   margin cancels the border+padding so text never reflows on toggle — the
+   rule sits in the card's gutter. */
 .discover-spotlit {
   border-left: 3px solid var(--forest);
   background: rgba(63, 91, 58, 0.07);
   padding-left: 10px;
+  margin-left: -13px;
 }
+
+/* Profile-strip interactive affordances: chips and drawer rows are buttons
+   and need hover feedback like every other interactive element. Inline
+   active-state styles (solid forest) win over these. */
+.discover-chip:hover { border-color: var(--forest); color: var(--forest-ink); }
+.discover-drawer-toggle:hover { background: rgba(63, 91, 58, 0.05); }
 
 /* Button text color and underline reset for anchor variants. The
    `.cd-theme a { color: var(--ink); text-decoration: underline; }` rule

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -110,6 +110,14 @@
   .cd-btn { transition: none; }
 }
 
+/* Discovery rounds: a reason spotlit by an active profile-strip chip. The
+   wash reuses the established forest tint (see --match-fit-bg). */
+.discover-spotlit {
+  border-left: 3px solid var(--forest);
+  background: rgba(63, 91, 58, 0.07);
+  padding-left: 10px;
+}
+
 /* Button text color and underline reset for anchor variants. The
    `.cd-theme a { color: var(--ink); text-decoration: underline; }` rule
    above has specificity (0,1,1), which beats a bare `.cd-btn` at (0,1,0)

--- a/web/src/components/discover/ProfileStrip.tsx
+++ b/web/src/components/discover/ProfileStrip.tsx
@@ -7,15 +7,16 @@
 // reasons they caused across the round. The ledger stays the only editing
 // surface — "Edit profile" navigates there.
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   NON_TOGGLE_COPY,
+  STRIP_BAR_MIN_HEIGHT,
   type ProfileStripModel,
   type StripEntry,
 } from "@/lib/discovery/profile-strip";
 
 const GROUPS: {
-  field: "strong" | "gentle" | "away" | "tensions";
+  field: "strong" | "gentle" | "away" | "tensions" | "recorded";
   label: string;
   blurb: string;
 }[] = [
@@ -23,6 +24,7 @@ const GROUPS: {
   { field: "gentle", label: "Steering gently", blurb: "These nudge, they don't drive." },
   { field: "away", label: "Steering away", blurb: "Schools like this lose ground." },
   { field: "tensions", label: "Tensions", blurb: "Pulling both ways — counting for nothing until resolved." },
+  { field: "recorded", label: "Recorded, not yet matching", blurb: "No public data can check these yet — they don't pick schools." },
 ];
 
 export function ProfileStrip({
@@ -44,6 +46,14 @@ export function ProfileStrip({
   const [open, setOpen] = useState(false);
   const [announcement, setAnnouncement] = useState("");
   const disclosureRef = useRef<HTMLButtonElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  // A keyboard user who opens the drawer must land inside it: the drawer
+  // renders before the trigger in DOM order, so without this, Tab exits the
+  // strip without ever reaching the content just opened.
+  useEffect(() => {
+    if (open) drawerRef.current?.focus();
+  }, [open]);
 
   function toggleSpotlight(key: string) {
     if (spotlightKey === key) {
@@ -76,7 +86,7 @@ export function ProfileStrip({
   // text-overflow on the box itself).
   const chipStyle = (active: boolean) =>
     ({
-      minHeight: 32,
+      minHeight: 44,
       cursor: "pointer",
       background: active ? "var(--forest)" : undefined,
       color: active ? "var(--paper)" : undefined,
@@ -89,28 +99,43 @@ export function ProfileStrip({
     }) as const;
 
   return (
-    <div data-testid="profile-strip">
+    // One fixed container, drawer above bar in normal flow: the bar can wrap
+    // taller without ever painting over the drawer, and Escape works from
+    // anywhere in the strip (trigger included). z-index sits BELOW the
+    // header search dropdown (40) and nav popover — bottom chrome yields to
+    // top-of-page overlays.
+    <div
+      data-testid="profile-strip"
+      onKeyDown={(e) => {
+        if (e.key === "Escape" && open) closeDrawer(true);
+      }}
+      style={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 38,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       <p className="sr-only" aria-live="polite">
         {announcement}
       </p>
 
       {open && (
         <div
+          id="profile-strip-drawer"
+          ref={drawerRef}
+          tabIndex={-1}
           role="region"
           aria-label="Your answers"
-          onKeyDown={(e) => {
-            if (e.key === "Escape") closeDrawer(true);
-          }}
           style={{
-            position: "fixed",
-            left: 0,
-            right: 0,
-            bottom: 56,
-            zIndex: 40,
             background: "var(--paper)",
             borderTop: "1px solid var(--rule-strong)",
             maxHeight: "70dvh",
             overflowY: "auto",
+            overscrollBehavior: "contain",
           }}
         >
           <div className="mx-auto max-w-3xl px-4 sm:px-6" style={{ padding: "14px 16px 18px" }}>
@@ -159,16 +184,13 @@ export function ProfileStrip({
 
       <div
         style={{
-          position: "fixed",
-          left: 0,
-          right: 0,
-          bottom: 0,
-          zIndex: 41,
           background: "var(--paper)",
           borderTop: "1px solid var(--rule-strong)",
-          minHeight: 56,
+          minHeight: STRIP_BAR_MIN_HEIGHT,
           display: "flex",
           alignItems: "center",
+          // Notched phones: keep the touch targets above the home indicator.
+          paddingBottom: "env(safe-area-inset-bottom)",
         }}
       >
         <div
@@ -184,7 +206,7 @@ export function ProfileStrip({
               <button
                 key={e.key}
                 type="button"
-                className="cd-chip"
+                className="cd-chip discover-chip"
                 aria-pressed={spotlightKey === e.key}
                 onClick={() => toggleSpotlight(e.key)}
                 style={chipStyle(spotlightKey === e.key)}
@@ -207,6 +229,7 @@ export function ProfileStrip({
             type="button"
             className="cd-btn cd-btn--ghost"
             aria-expanded={open}
+            aria-controls="profile-strip-drawer"
             style={{ minHeight: 44, marginLeft: "auto", whiteSpace: "nowrap" }}
             onClick={() => (open ? closeDrawer(false) : setOpen(true))}
           >
@@ -216,6 +239,14 @@ export function ProfileStrip({
       </div>
     </div>
   );
+}
+
+// A withdrawn card (reaction-only aggregate) must not be quoted as the
+// student's answer — same truthfulness rule the glosses follow.
+function entryLabel(entry: StripEntry): string {
+  return entry.quoted
+    ? `“${entry.statement}”`
+    : `${entry.statement} — via your round reactions`;
 }
 
 function DrawerEntry({
@@ -230,10 +261,13 @@ function DrawerEntry({
   if (entry.kind !== "spotlight") {
     return (
       <li style={{ padding: "8px 2px", borderBottom: "1px dashed var(--rule)", fontSize: 14 }}>
-        “{entry.statement}”{" "}
-        <span style={{ color: "var(--ink-3)", fontSize: 13 }}>
-          — {NON_TOGGLE_COPY[entry.kind]}
-        </span>
+        {entryLabel(entry)}
+        {/* the recorded group's blurb already explains unsupported entries */}
+        {entry.kind !== "unsupported" && (
+          <span style={{ color: "var(--ink-3)", fontSize: 13 }}>
+            {" "}— {NON_TOGGLE_COPY[entry.kind]}
+          </span>
+        )}
       </li>
     );
   }
@@ -241,6 +275,7 @@ function DrawerEntry({
     <li style={{ borderBottom: "1px dashed var(--rule)" }}>
       <button
         type="button"
+        className="discover-drawer-toggle"
         aria-pressed={active}
         onClick={() => onToggle(entry.key)}
         style={{
@@ -270,7 +305,7 @@ function DrawerEntry({
             background: active ? "var(--forest)" : "transparent",
           }}
         />
-        “{entry.statement}”
+        {entryLabel(entry)}
         {active && (
           <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--forest)", whiteSpace: "nowrap" }}>
             spotlighting

--- a/web/src/components/discover/ProfileStrip.tsx
+++ b/web/src/components/discover/ProfileStrip.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+// Floating preference-profile strip for discovery rounds (design doc:
+// preference profile strip + spotlight attribution). Read-only v1: the
+// collapsed bar keeps the profile's shape ambient while scanning schools;
+// the drawer shows the full steering picture; positive chips spotlight the
+// reasons they caused across the round. The ledger stays the only editing
+// surface — "Edit profile" navigates there.
+
+import { useRef, useState } from "react";
+import {
+  NON_TOGGLE_COPY,
+  type ProfileStripModel,
+  type StripEntry,
+} from "@/lib/discovery/profile-strip";
+
+const GROUPS: {
+  field: "strong" | "gentle" | "away" | "tensions";
+  label: string;
+  blurb: string;
+}[] = [
+  { field: "strong", label: "Steering strongly", blurb: "These pull hardest on every round." },
+  { field: "gentle", label: "Steering gently", blurb: "These nudge, they don't drive." },
+  { field: "away", label: "Steering away", blurb: "Schools like this lose ground." },
+  { field: "tensions", label: "Tensions", blurb: "Pulling both ways — counting for nothing until resolved." },
+];
+
+export function ProfileStrip({
+  model,
+  spotlightKey,
+  onSpotlight,
+  spotlightCounts,
+  onEditProfile,
+}: {
+  model: ProfileStripModel;
+  spotlightKey: string | null;
+  onSpotlight: (key: string | null) => void;
+  // how many rendered reasons / schools the given key would highlight in the
+  // round currently on screen (the strip and the reasons share the same live
+  // session snapshot, so these counts are exact)
+  spotlightCounts: (key: string) => { reasons: number; schools: number };
+  onEditProfile: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
+  const disclosureRef = useRef<HTMLButtonElement>(null);
+
+  function toggleSpotlight(key: string) {
+    if (spotlightKey === key) {
+      onSpotlight(null);
+      setAnnouncement("Highlight cleared.");
+      return;
+    }
+    onSpotlight(key);
+    const { reasons, schools } = spotlightCounts(key);
+    setAnnouncement(
+      reasons > 0
+        ? `Highlighting ${reasons} reason${reasons === 1 ? "" : "s"} across ${schools} school${schools === 1 ? "" : "s"}.`
+        : "No shown reasons come from this in this round — it still shapes scoring.",
+    );
+  }
+
+  // One rule, no special cases: closing the drawer clears any active
+  // spotlight (inline chips can immediately re-activate it).
+  function closeDrawer(returnFocus: boolean) {
+    setOpen(false);
+    if (spotlightKey) {
+      onSpotlight(null);
+      setAnnouncement("Highlight cleared.");
+    }
+    if (returnFocus) disclosureRef.current?.focus();
+  }
+
+  // Statements are sentences, not labels — keep the chip box but drop the
+  // uppercase treatment, and ellipsize inside (inline-flex swallows
+  // text-overflow on the box itself).
+  const chipStyle = (active: boolean) =>
+    ({
+      minHeight: 32,
+      cursor: "pointer",
+      background: active ? "var(--forest)" : undefined,
+      color: active ? "var(--paper)" : undefined,
+      borderColor: active ? "var(--forest)" : undefined,
+      maxWidth: "26ch",
+      minWidth: 0,
+      textTransform: "none",
+      letterSpacing: 0,
+      fontSize: 11.5,
+    }) as const;
+
+  return (
+    <div data-testid="profile-strip">
+      <p className="sr-only" aria-live="polite">
+        {announcement}
+      </p>
+
+      {open && (
+        <div
+          role="region"
+          aria-label="Your answers"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") closeDrawer(true);
+          }}
+          style={{
+            position: "fixed",
+            left: 0,
+            right: 0,
+            bottom: 56,
+            zIndex: 40,
+            background: "var(--paper)",
+            borderTop: "1px solid var(--rule-strong)",
+            maxHeight: "70dvh",
+            overflowY: "auto",
+          }}
+        >
+          <div className="mx-auto max-w-3xl px-4 sm:px-6" style={{ padding: "14px 16px 18px" }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+              <div className="meta">§ Your answers, steering this round</div>
+              <button
+                type="button"
+                className="cd-btn cd-btn--ghost"
+                style={{ minHeight: 44, marginLeft: "auto" }}
+                onClick={onEditProfile}
+              >
+                Edit profile
+              </button>
+            </div>
+            <p style={{ margin: "6px 0 2px", fontSize: 13, color: "var(--ink-3)" }}>
+              Tap a preference to spotlight the reasons it caused below.
+              Reactions change which schools appear starting next round.
+            </p>
+            {GROUPS.map(({ field, label, blurb }) => {
+              const entries = model[field];
+              if (entries.length === 0) return null;
+              return (
+                <div key={field} style={{ margin: "12px 0 0" }}>
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                    <h2 className="serif" style={{ fontSize: 17, fontWeight: 400, margin: 0 }}>
+                      {label}
+                    </h2>
+                    <span style={{ fontSize: 12, color: "var(--ink-3)" }}>{blurb}</span>
+                  </div>
+                  <ul style={{ listStyle: "none", margin: "6px 0 0", padding: 0 }}>
+                    {entries.map((e) => (
+                      <DrawerEntry
+                        key={e.key}
+                        entry={e}
+                        active={spotlightKey === e.key}
+                        onToggle={toggleSpotlight}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div
+        style={{
+          position: "fixed",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 41,
+          background: "var(--paper)",
+          borderTop: "1px solid var(--rule-strong)",
+          minHeight: 56,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <div
+          className="mx-auto max-w-3xl px-4 sm:px-6"
+          style={{ display: "flex", alignItems: "center", gap: 10, width: "100%" }}
+        >
+          <span className="meta nums" style={{ minWidth: 0, lineHeight: 1.5 }}>
+            Steering: {model.counts.strong} strong · {model.counts.away} away ·{" "}
+            {model.counts.tensions} tension{model.counts.tensions === 1 ? "" : "s"}
+          </span>
+          <span className="hidden sm:flex" style={{ gap: 6, minWidth: 0, overflow: "hidden" }}>
+            {model.inline.map((e) => (
+              <button
+                key={e.key}
+                type="button"
+                className="cd-chip"
+                aria-pressed={spotlightKey === e.key}
+                onClick={() => toggleSpotlight(e.key)}
+                style={chipStyle(spotlightKey === e.key)}
+                title={e.statement}
+              >
+                <span
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {e.statement}
+                </span>
+              </button>
+            ))}
+          </span>
+          <button
+            ref={disclosureRef}
+            type="button"
+            className="cd-btn cd-btn--ghost"
+            aria-expanded={open}
+            style={{ minHeight: 44, marginLeft: "auto", whiteSpace: "nowrap" }}
+            onClick={() => (open ? closeDrawer(false) : setOpen(true))}
+          >
+            Your answers {open ? "▾" : "▴"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DrawerEntry({
+  entry,
+  active,
+  onToggle,
+}: {
+  entry: StripEntry;
+  active: boolean;
+  onToggle: (key: string) => void;
+}) {
+  if (entry.kind !== "spotlight") {
+    return (
+      <li style={{ padding: "8px 2px", borderBottom: "1px dashed var(--rule)", fontSize: 14 }}>
+        “{entry.statement}”{" "}
+        <span style={{ color: "var(--ink-3)", fontSize: 13 }}>
+          — {NON_TOGGLE_COPY[entry.kind]}
+        </span>
+      </li>
+    );
+  }
+  return (
+    <li style={{ borderBottom: "1px dashed var(--rule)" }}>
+      <button
+        type="button"
+        aria-pressed={active}
+        onClick={() => onToggle(entry.key)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          width: "100%",
+          minHeight: 44,
+          padding: "8px 2px",
+          background: "none",
+          border: "none",
+          font: "inherit",
+          fontSize: 14,
+          color: "var(--ink)",
+          textAlign: "left",
+          cursor: "pointer",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 10,
+            height: 10,
+            flexShrink: 0,
+            borderRadius: 1,
+            border: "1px solid var(--forest)",
+            background: active ? "var(--forest)" : "transparent",
+          }}
+        />
+        “{entry.statement}”
+        {active && (
+          <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--forest)", whiteSpace: "nowrap" }}>
+            spotlighting
+          </span>
+        )}
+      </button>
+    </li>
+  );
+}

--- a/web/src/components/discover/RoundsStep.tsx
+++ b/web/src/components/discover/RoundsStep.tsx
@@ -11,7 +11,11 @@ import { useEffect, useMemo, useState } from "react";
 import { trackEvent } from "@/lib/analytics";
 import { getCachedBundle, loadBundle } from "@/lib/discovery/bundle";
 import { DECK_VERSION } from "@/lib/discovery/content";
-import { buildProfileStripModel } from "@/lib/discovery/profile-strip";
+import {
+  buildProfileStripModel,
+  spotlightCountsForRound,
+  STRIP_CLEARANCE,
+} from "@/lib/discovery/profile-strip";
 import {
   cardStatementForKey,
   composeNextRound,
@@ -97,15 +101,31 @@ export function RoundsStep({
     round && round.schools.length > 0 && !stripModel.empty,
   );
 
-  // Keyboard focus must never land hidden behind the fixed strip
-  // (WCAG focus-not-obscured).
+  // A reaction can invalidate the active spotlight mid-round (e.g. Not-for-me
+  // on the spotlit key makes it conflicted; its chip becomes non-toggle and
+  // its reasons vanish). Reconcile at render: an invalid key highlights
+  // nothing and no chip reads pressed — same live snapshot everywhere.
+  const spotlightableKeys = useMemo(
+    () => new Set([...stripModel.strong, ...stripModel.gentle].map((e) => e.key)),
+    [stripModel],
+  );
+  const activeSpotlight =
+    spotlightKey && spotlightableKeys.has(spotlightKey) ? spotlightKey : null;
+
+  // Keyboard focus must never land hidden behind the fixed strip (WCAG
+  // focus-not-obscured), and the document itself needs bottom clearance —
+  // padding only the step content would leave the global footer's last row
+  // permanently under the bar at full scroll.
   useEffect(() => {
     if (!stripVisible) return;
     const root = document.documentElement;
-    const prev = root.style.scrollPaddingBottom;
-    root.style.scrollPaddingBottom = "88px";
+    const prevScroll = root.style.scrollPaddingBottom;
+    const prevPad = document.body.style.paddingBottom;
+    root.style.scrollPaddingBottom = `${STRIP_CLEARANCE}px`;
+    document.body.style.paddingBottom = `${STRIP_CLEARANCE}px`;
     return () => {
-      root.style.scrollPaddingBottom = prev;
+      root.style.scrollPaddingBottom = prevScroll;
+      document.body.style.paddingBottom = prevPad;
     };
   }, [stripVisible]);
 
@@ -150,7 +170,7 @@ export function RoundsStep({
   ).length;
 
   return (
-    <StepShell style={stripVisible ? { paddingBottom: 88 } : undefined}>
+    <StepShell style={stripVisible ? { paddingBottom: STRIP_CLEARANCE } : undefined}>
       {round.zip_unresolved && (
         <div className="cd-card" style={{ padding: "12px 16px", margin: "0 0 16px", maxWidth: "64ch" }}>
           <p style={{ margin: 0, fontSize: 14, color: "var(--ink-2)" }}>
@@ -194,7 +214,7 @@ export function RoundsStep({
             roundIndex={round.round_index}
             alreadyReacted={reactedIds.has(s.school.school_id)}
             onReact={onReact}
-            spotlightKey={spotlightKey}
+            spotlightKey={activeSpotlight}
             glosses={stripModel.glosses}
           />
         ))}
@@ -234,23 +254,12 @@ export function RoundsStep({
         ranking, an application list, or an admissions prediction.
       </p>
 
-      {stripVisible && round && (
+      {stripVisible && (
         <ProfileStrip
           model={stripModel}
-          spotlightKey={spotlightKey}
+          spotlightKey={activeSpotlight}
           onSpotlight={setSpotlightKey}
-          spotlightCounts={(key) => {
-            let reasons = 0;
-            let schools = 0;
-            for (const sch of round.schools) {
-              const hits = sch.reasons.filter((r) => r.tunable_key === key).length;
-              if (hits > 0) {
-                reasons += hits;
-                schools += 1;
-              }
-            }
-            return { reasons, schools };
-          }}
+          spotlightCounts={(key) => spotlightCountsForRound(round.schools, key)}
           onEditProfile={onBackToLedger}
         />
       )}

--- a/web/src/components/discover/RoundsStep.tsx
+++ b/web/src/components/discover/RoundsStep.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from "react";
 import { trackEvent } from "@/lib/analytics";
 import { getCachedBundle, loadBundle } from "@/lib/discovery/bundle";
 import { DECK_VERSION } from "@/lib/discovery/content";
+import { buildProfileStripModel } from "@/lib/discovery/profile-strip";
 import {
   cardStatementForKey,
   composeNextRound,
@@ -23,6 +24,7 @@ import type {
   RoundSchool,
   SchoolReaction,
 } from "@/lib/discovery/types";
+import { ProfileStrip } from "./ProfileStrip";
 
 const CONTROL_LABELS: Record<number, string> = {
   1: "public",
@@ -60,6 +62,9 @@ export function RoundsStep({
 }) {
   const [bundle, setBundle] = useState<EvidenceBundle | null>(getCachedBundle());
   const [loadError, setLoadError] = useState(false);
+  // Spotlight is view-state only — it highlights, never recomposes. Cleared
+  // on drawer close (inside ProfileStrip) and on round advance (below).
+  const [spotlightKey, setSpotlightKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (bundle || loadError) return;
@@ -86,6 +91,23 @@ export function RoundsStep({
       ? renderStoredRound(session, bundle, storedEntry)
       : composeNextRound(session, bundle);
   }, [bundle, session, storedEntry]);
+
+  const stripModel = useMemo(() => buildProfileStripModel(session), [session]);
+  const stripVisible = Boolean(
+    round && round.schools.length > 0 && !stripModel.empty,
+  );
+
+  // Keyboard focus must never land hidden behind the fixed strip
+  // (WCAG focus-not-obscured).
+  useEffect(() => {
+    if (!stripVisible) return;
+    const root = document.documentElement;
+    const prev = root.style.scrollPaddingBottom;
+    root.style.scrollPaddingBottom = "88px";
+    return () => {
+      root.style.scrollPaddingBottom = prev;
+    };
+  }, [stripVisible]);
 
   // Persist a freshly composed round exactly once (drives cooldowns).
   useEffect(() => {
@@ -128,7 +150,7 @@ export function RoundsStep({
   ).length;
 
   return (
-    <StepShell>
+    <StepShell style={stripVisible ? { paddingBottom: 88 } : undefined}>
       {round.zip_unresolved && (
         <div className="cd-card" style={{ padding: "12px 16px", margin: "0 0 16px", maxWidth: "64ch" }}>
           <p style={{ margin: 0, fontSize: 14, color: "var(--ink-2)" }}>
@@ -172,13 +194,26 @@ export function RoundsStep({
             roundIndex={round.round_index}
             alreadyReacted={reactedIds.has(s.school.school_id)}
             onReact={onReact}
+            spotlightKey={spotlightKey}
+            glosses={stripModel.glosses}
           />
         ))}
       </ol>
 
       <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 20 }}>
         {round.schools.length > 0 && (
-          <button type="button" className="cd-btn" style={{ minHeight: 44 }} onClick={onAdvanceRound}>
+          <button
+            type="button"
+            className="cd-btn"
+            style={{ minHeight: 44 }}
+            onClick={() => {
+              // A spotlight surviving the transition would describe the
+              // previous round — clear it with the same one-rule semantics
+              // as drawer close.
+              setSpotlightKey(null);
+              onAdvanceRound();
+            }}
+          >
             Next round →
           </button>
         )}
@@ -198,6 +233,27 @@ export function RoundsStep({
         These are research suggestions with their evidence shown — not a
         ranking, an application list, or an admissions prediction.
       </p>
+
+      {stripVisible && round && (
+        <ProfileStrip
+          model={stripModel}
+          spotlightKey={spotlightKey}
+          onSpotlight={setSpotlightKey}
+          spotlightCounts={(key) => {
+            let reasons = 0;
+            let schools = 0;
+            for (const sch of round.schools) {
+              const hits = sch.reasons.filter((r) => r.tunable_key === key).length;
+              if (hits > 0) {
+                reasons += hits;
+                schools += 1;
+              }
+            }
+            return { reasons, schools };
+          }}
+          onEditProfile={onBackToLedger}
+        />
+      )}
     </StepShell>
   );
 }
@@ -262,9 +318,15 @@ function ChangeNote({
   );
 }
 
-function StepShell({ children }: { children: React.ReactNode }) {
+function StepShell({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
   return (
-    <div>
+    <div style={style}>
       <div className="meta">§ Discovery round</div>
       <h1 className="serif" style={{ fontSize: 32, margin: "8px 0 12px" }}>
         Schools worth a look — with receipts.
@@ -279,11 +341,15 @@ function RoundCard({
   roundIndex,
   alreadyReacted,
   onReact,
+  spotlightKey,
+  glosses,
 }: {
   entry: RoundSchool;
   roundIndex: number;
   alreadyReacted: boolean;
   onReact: (r: SchoolReaction) => void;
+  spotlightKey: string | null;
+  glosses: Record<string, string>;
 }) {
   const [panel, setPanel] = useState<"none" | "save" | "more" | "not">("none");
   const [chosenReason, setChosenReason] = useState<number | null>(null);
@@ -333,9 +399,22 @@ function RoundCard({
       </p>
 
       <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-        {entry.reasons.map((r, i) => (
-          <li key={r.ref} style={{ padding: "6px 0", borderTop: i > 0 ? "1px dashed var(--rule)" : "none" }}>
+        {entry.reasons.map((r, i) => {
+          const spotlit = Boolean(r.tunable_key && r.tunable_key === spotlightKey);
+          const gloss = r.tunable_key ? glosses[r.tunable_key] : undefined;
+          return (
+          <li
+            key={r.ref}
+            data-spotlit={spotlit || undefined}
+            className={spotlit ? "discover-spotlit" : undefined}
+            style={{ padding: "6px 0", borderTop: i > 0 ? "1px dashed var(--rule)" : "none" }}
+          >
             <p style={{ margin: 0, fontSize: 15, lineHeight: 1.5 }}>{r.text}</p>
+            {gloss && (
+              <p style={{ margin: "2px 0 0", fontSize: 13, color: "var(--ink-3)" }}>
+                {gloss}
+              </p>
+            )}
             <details>
               <summary
                 className="meta"
@@ -348,7 +427,8 @@ function RoundCard({
               </p>
             </details>
           </li>
-        ))}
+          );
+        })}
       </ul>
 
       {alreadyReacted ? (

--- a/web/src/lib/discovery/matchers.ts
+++ b/web/src/lib/discovery/matchers.ts
@@ -37,6 +37,18 @@ export function bandTest(value: number, band: Record<string, number>): boolean {
 
 export const SUPPORTED_KEYS = new Set(Object.keys(POLICY.matchers));
 
+// Keys whose matcher can actually resolve evidence from the current bundle.
+// A spec whose evidence keys all lack resolvers (cds.*, ipeds.ic.*,
+// distance.*) is policy-supported but not yet actionable — matcher() always
+// returns 0 for it, so it neither scores nor produces reasons. UI that
+// claims such a key "shapes scoring" would be lying; use this set to tell
+// the truth.
+export const ACTIONABLE_KEYS = new Set(
+  Object.keys(POLICY.matchers).filter((k) =>
+    POLICY.matchers[k].evidence_keys.some((ek) => ek in FIELD_RESOLVERS),
+  ),
+);
+
 /** Execute the policy matcher for a preference key → -1 | 0 | +1. */
 export function matcher(key: string, school: EvidenceSchool): -1 | 0 | 1 {
   const spec: MatcherSpec | undefined = POLICY.matchers[key];

--- a/web/src/lib/discovery/profile-strip-edges.test.ts
+++ b/web/src/lib/discovery/profile-strip-edges.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { AGGREGATE_CLAMP } from "./content";
+import { buildProfileStripModel } from "./profile-strip";
+import { newSession } from "./session";
+import type { DiscoverySessionV1, SchoolReaction } from "./types";
+
+// Edge coverage for the profile-strip model: group ordering, mixed
+// supported/unsupported inline selection, the away/unsupported kind
+// combination, the fresh-session state, and clamp interplay. Companion to
+// profile-strip.test.ts (grouping, glosses, drift guards).
+
+const NOW = new Date("2026-07-12T12:00:00Z");
+
+function session(over: Partial<DiscoverySessionV1> = {}): DiscoverySessionV1 {
+  return { ...newSession(NOW), step: "rounds", concepts: ["environment-climate"], ...over };
+}
+
+function reaction(over: Partial<SchoolReaction>): SchoolReaction {
+  return {
+    school_id: "s1",
+    reaction: "more_like_this",
+    key: "cost.low_debt",
+    saved_reason_text: null,
+    familiarity: null,
+    round_index: 0,
+    ...over,
+  };
+}
+
+describe("buildProfileStripModel ordering", () => {
+  it("orders the away group most-negative first, then key ascending on ties", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "big-school-energy": "not_for_me", // scale.large -3
+          "city-as-campus": "not_for_me", // place.big_city -3 (key tie with above)
+        },
+        // Reaction-only avoid: out.retention -1, weaker than the -3 pair.
+        reactions: [reaction({ reaction: "not_for_me", key: "out.retention" })],
+      }),
+    );
+    expect(m.away.map((e) => e.key)).toEqual([
+      "place.big_city",
+      "scale.large",
+      "out.retention",
+    ]);
+    expect(m.away.map((e) => e.total)).toEqual([-3, -3, -1]);
+  });
+
+  it("orders the gentle group strongest first, then key ascending on ties", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "graduate-low-debt": "interesting", // +1 card
+          "students-return": "interesting", // +1
+          "four-year-finish": "interesting", // +1
+        },
+        // One more_like_this lifts cost.low_debt to +2 — still under the
+        // essential threshold, so it stays gentle but leads the group.
+        reactions: [reaction({})],
+      }),
+    );
+    expect(m.gentle.map((e) => e.key)).toEqual([
+      "cost.low_debt",
+      "out.four_year_grad",
+      "out.retention",
+    ]);
+    expect(m.gentle.map((e) => e.total)).toEqual([2, 1, 1]);
+  });
+});
+
+describe("buildProfileStripModel kind/group edges", () => {
+  it("non-actionable entries go to recorded; inline comes from actionable positives", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "collaborative-culture": "essential", // spirit.collaborative +3, no matcher
+          "graduate-low-debt": "interesting", // cost.low_debt +1, actionable
+        },
+      }),
+    );
+    // Non-actionable keys never inflate the steering groups or counts —
+    // scoreSchool ignores them, so "Steering strongly" would be a lie.
+    expect(m.strong).toEqual([]);
+    expect(m.counts.strong).toBe(0);
+    expect(m.recorded.map((e) => e.key)).toEqual(["spirit.collaborative"]);
+    expect(m.inline.map((e) => e.key)).toEqual(["cost.low_debt"]);
+    expect(m.inline[0].kind).toBe("spotlight");
+  });
+
+  it("a negative non-actionable key is recorded, not away", () => {
+    // The away copy "shapes scoring" would overstate what an unmatched key
+    // does — it shapes nothing until its evidence ships.
+    const m = buildProfileStripModel(
+      session({ card_responses: { "collaborative-culture": "not_for_me" } }),
+    );
+    expect(m.away).toEqual([]);
+    expect(m.counts.away).toBe(0);
+    expect(m.recorded.map((e) => e.key)).toEqual(["spirit.collaborative"]);
+    expect(m.recorded[0].kind).toBe("unsupported");
+  });
+
+  it("a tension entry carries total 0 and appears in no steering group", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: { "students-return": "essential" },
+        reactions: [reaction({ reaction: "not_for_me", key: "out.retention" })],
+      }),
+    );
+    expect(m.tensions.map((e) => e.key)).toEqual(["out.retention"]);
+    expect(m.tensions[0].total).toBe(0);
+    expect(m.strong).toEqual([]);
+    expect(m.gentle).toEqual([]);
+    expect(m.away).toEqual([]);
+  });
+});
+
+describe("buildProfileStripModel boundary states", () => {
+  it("a fresh session (no responses, no reactions) is empty with zeroed counts", () => {
+    const m = buildProfileStripModel(session());
+    expect(m.empty).toBe(true);
+    expect(m.counts).toEqual({ strong: 0, away: 0, tensions: 0 });
+    expect(m.inline).toEqual([]);
+    expect(m.glosses).toEqual({});
+  });
+
+  it("entry totals respect the policy aggregate clamp", () => {
+    // Essential card (+3) plus three more_like_this reactions on distinct
+    // schools (+1 each) sums to 6 raw; the strip must show the clamped
+    // steering value the engine actually uses, not the raw sum.
+    const [, hi] = AGGREGATE_CLAMP;
+    const m = buildProfileStripModel(
+      session({
+        card_responses: { "graduate-low-debt": "essential" },
+        reactions: [
+          reaction({ school_id: "s1" }),
+          reaction({ school_id: "s2" }),
+          reaction({ school_id: "s3" }),
+        ],
+      }),
+    );
+    const entry = m.strong.find((e) => e.key === "cost.low_debt");
+    expect(entry).toBeTruthy();
+    expect(entry!.total).toBe(hi);
+  });
+});

--- a/web/src/lib/discovery/profile-strip.test.ts
+++ b/web/src/lib/discovery/profile-strip.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { DECK_CARDS, ESSENTIAL_THRESHOLD } from "./content";
+import { SUPPORTED_KEYS } from "./matchers";
+import { buildProfileStripModel } from "./profile-strip";
+import { newSession } from "./session";
+import type { DiscoverySessionV1, SchoolReaction } from "./types";
+
+const NOW = new Date("2026-07-12T12:00:00Z");
+
+function session(over: Partial<DiscoverySessionV1> = {}): DiscoverySessionV1 {
+  return { ...newSession(NOW), step: "rounds", concepts: ["environment-climate"], ...over };
+}
+
+function reaction(over: Partial<SchoolReaction>): SchoolReaction {
+  return {
+    school_id: "s1",
+    reaction: "more_like_this",
+    key: "cost.low_debt",
+    saved_reason_text: null,
+    familiarity: null,
+    round_index: 0,
+    ...over,
+  };
+}
+
+describe("buildProfileStripModel grouping", () => {
+  it("groups by steering strength, direction, and conflict", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "small-school-known": "essential", // +3 -> strong
+          "graduate-low-debt": "interesting", // +1 -> gentle
+          "big-school-energy": "not_for_me", // -3 -> away
+          "students-return": "essential", // +3, opposed by reaction -> tension
+        },
+        reactions: [
+          reaction({ reaction: "not_for_me", key: "out.retention" }),
+        ],
+      }),
+    );
+    expect(m.strong.map((e) => e.key)).toEqual(["scale.small"]);
+    expect(m.gentle.map((e) => e.key)).toEqual(["cost.low_debt"]);
+    expect(m.away.map((e) => e.key)).toEqual(["scale.large"]);
+    expect(m.tensions.map((e) => e.key)).toEqual(["out.retention"]);
+    expect(m.counts).toEqual({ strong: 1, away: 1, tensions: 1 });
+    expect(m.empty).toBe(false);
+  });
+
+  it("an Interesting-sorted card pushed past the threshold by reactions lands in Steering strongly", () => {
+    // Weight 1 from the card + two more_like_this reactions (+1 each,
+    // distinct schools) = 3 = ESSENTIAL_THRESHOLD. The group is steering
+    // language on purpose — the student never marked this card Essential.
+    const m = buildProfileStripModel(
+      session({
+        card_responses: { "graduate-low-debt": "interesting" },
+        reactions: [
+          reaction({ school_id: "s1" }),
+          reaction({ school_id: "s2" }),
+        ],
+      }),
+    );
+    const entry = m.strong.find((e) => e.key === "cost.low_debt");
+    expect(entry).toBeTruthy();
+    expect(entry!.total).toBe(ESSENTIAL_THRESHOLD);
+    expect(m.gentle).toEqual([]);
+  });
+
+  it("marks unsupported keys non-toggle even when steering positively", () => {
+    const m = buildProfileStripModel(
+      session({ card_responses: { "collaborative-culture": "essential" } }),
+    );
+    const entry = m.strong.find((e) => e.key === "spirit.collaborative");
+    expect(entry).toBeTruthy();
+    expect(entry!.kind).toBe("unsupported");
+    // Non-toggle entries never reach the collapsed inline chips.
+    expect(m.inline).toEqual([]);
+  });
+
+  it("away and tension entries are never spotlight toggles", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "big-school-energy": "not_for_me",
+          "students-return": "essential",
+        },
+        reactions: [reaction({ reaction: "not_for_me", key: "out.retention" })],
+      }),
+    );
+    expect(m.away.every((e) => e.kind === "away")).toBe(true);
+    expect(m.tensions.every((e) => e.kind === "tension")).toBe(true);
+  });
+
+  it("inline chips are the strongest supported positives, capped at 3", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "small-school-known": "essential", // scale.small +3
+          "students-return": "essential", // out.retention +3
+          "four-year-finish": "essential", // out.four_year_grad +3
+          "graduate-low-debt": "interesting", // cost.low_debt +1
+        },
+      }),
+    );
+    expect(m.inline).toHaveLength(3);
+    // total desc, then key asc: three +3 keys sort alphabetically.
+    expect(m.inline.map((e) => e.key)).toEqual([
+      "out.four_year_grad",
+      "out.retention",
+      "scale.small",
+    ]);
+    expect(m.inline.every((e) => e.kind === "spotlight" && SUPPORTED_KEYS.has(e.key))).toBe(true);
+  });
+
+  it("is empty when nothing steers (all cards Not important, no reactions)", () => {
+    const responses: Record<string, "not_important"> = {};
+    for (const c of DECK_CARDS) responses[c.card_id] = "not_important";
+    const m = buildProfileStripModel(session({ card_responses: responses }));
+    expect(m.empty).toBe(true);
+  });
+
+  it("fails closed on keys without a card statement", () => {
+    const m = buildProfileStripModel(
+      session({ reactions: [reaction({ key: "no.such_key" })] }),
+    );
+    const everywhere = [...m.strong, ...m.gentle, ...m.away, ...m.tensions];
+    expect(everywhere.find((e) => e.key === "no.such_key")).toBeUndefined();
+  });
+});
+
+describe("attribution glosses", () => {
+  it("quotes the card while an active card signal exists", () => {
+    const m = buildProfileStripModel(
+      session({ card_responses: { "small-school-known": "essential" } }),
+    );
+    expect(m.glosses["scale.small"]).toMatch(/^Because you said: “/);
+    expect(m.glosses["scale.small"]).toMatch(/small enough/);
+  });
+
+  it("uses the reaction wording when the aggregate is reaction-only", () => {
+    // Ledger edit moved the card to "Not important" (writes no signal); a
+    // prior More-like-this reaction keeps the key alive. Quoting the card
+    // would misstate what the student currently says.
+    const m = buildProfileStripModel(
+      session({
+        card_responses: { "graduate-low-debt": "not_important" },
+        reactions: [reaction({})],
+      }),
+    );
+    expect(m.glosses["cost.low_debt"]).toBe("Because you asked for more like this.");
+  });
+
+  it("writes no gloss for away or conflicted keys", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "big-school-energy": "not_for_me",
+          "students-return": "essential",
+        },
+        reactions: [reaction({ reaction: "not_for_me", key: "out.retention" })],
+      }),
+    );
+    expect(m.glosses["scale.large"]).toBeUndefined();
+    expect(m.glosses["out.retention"]).toBeUndefined();
+  });
+});
+
+describe("content-drift guards", () => {
+  it("every deck card maps to exactly one key and no two cards share one", () => {
+    // The strip dedupes chips by key; today that path is vacuously safe
+    // because the deck is strictly 1 card : 1 key. This pins that fact so a
+    // future content change re-opens the design question consciously.
+    const seen = new Map<string, string>();
+    for (const c of DECK_CARDS) {
+      expect(c.preference_keys).toHaveLength(1);
+      const key = c.preference_keys[0];
+      expect(seen.has(key), `${c.card_id} shares ${key} with ${seen.get(key)}`).toBe(false);
+      seen.set(key, c.card_id);
+    }
+  });
+});

--- a/web/src/lib/discovery/profile-strip.test.ts
+++ b/web/src/lib/discovery/profile-strip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DECK_CARDS, ESSENTIAL_THRESHOLD } from "./content";
-import { SUPPORTED_KEYS } from "./matchers";
-import { buildProfileStripModel } from "./profile-strip";
+import { ACTIONABLE_KEYS } from "./matchers";
+import { buildProfileStripModel, spotlightCountsForRound } from "./profile-strip";
 import { newSession } from "./session";
 import type { DiscoverySessionV1, SchoolReaction } from "./types";
 
@@ -65,15 +65,40 @@ describe("buildProfileStripModel grouping", () => {
     expect(m.gentle).toEqual([]);
   });
 
-  it("marks unsupported keys non-toggle even when steering positively", () => {
+  it("keeps non-actionable keys out of the steering groups and counts", () => {
+    // spirit.collaborative has no matcher; life.greek_scene has a matcher
+    // whose cds.* evidence has no resolver yet. Neither can score or produce
+    // reasons — counting them as "strong" would claim influence scoreSchool
+    // never applies. They live in the disclosed "recorded" group instead.
     const m = buildProfileStripModel(
-      session({ card_responses: { "collaborative-culture": "essential" } }),
+      session({
+        card_responses: {
+          "collaborative-culture": "essential",
+          "greek-scene": "essential",
+        },
+      }),
     );
-    const entry = m.strong.find((e) => e.key === "spirit.collaborative");
-    expect(entry).toBeTruthy();
-    expect(entry!.kind).toBe("unsupported");
+    expect(m.strong).toEqual([]);
+    expect(m.counts.strong).toBe(0);
+    expect(m.recorded.map((e) => e.key).sort()).toEqual([
+      "life.greek_scene",
+      "spirit.collaborative",
+    ]);
+    expect(m.recorded.every((e) => e.kind === "unsupported")).toBe(true);
     // Non-toggle entries never reach the collapsed inline chips.
     expect(m.inline).toEqual([]);
+    // The strip still shows (the profile isn't empty, it's just not
+    // matchable yet).
+    expect(m.empty).toBe(false);
+  });
+
+  it("routes negative non-actionable keys to recorded, not away", () => {
+    const m = buildProfileStripModel(
+      session({ card_responses: { "collaborative-culture": "not_for_me" } }),
+    );
+    expect(m.away).toEqual([]);
+    expect(m.counts.away).toBe(0);
+    expect(m.recorded.map((e) => e.key)).toEqual(["spirit.collaborative"]);
   });
 
   it("away and tension entries are never spotlight toggles", () => {
@@ -108,7 +133,7 @@ describe("buildProfileStripModel grouping", () => {
       "out.retention",
       "scale.small",
     ]);
-    expect(m.inline.every((e) => e.kind === "spotlight" && SUPPORTED_KEYS.has(e.key))).toBe(true);
+    expect(m.inline.every((e) => e.kind === "spotlight" && ACTIONABLE_KEYS.has(e.key))).toBe(true);
   });
 
   it("is empty when nothing steers (all cards Not important, no reactions)", () => {
@@ -161,6 +186,51 @@ describe("attribution glosses", () => {
     );
     expect(m.glosses["scale.large"]).toBeUndefined();
     expect(m.glosses["out.retention"]).toBeUndefined();
+  });
+});
+
+describe("quoted flag and spotlight counts", () => {
+  it("marks reaction-only entries unquoted so the UI never quotes a withdrawn card", () => {
+    const m = buildProfileStripModel(
+      session({
+        card_responses: {
+          "graduate-low-debt": "not_important", // withdrawn in the ledger
+          "small-school-known": "essential",
+        },
+        reactions: [reaction({})], // keeps cost.low_debt alive at +1
+      }),
+    );
+    const reactionOnly = m.gentle.find((e) => e.key === "cost.low_debt");
+    expect(reactionOnly!.quoted).toBe(false);
+    const cardBacked = m.strong.find((e) => e.key === "scale.small");
+    expect(cardBacked!.quoted).toBe(true);
+  });
+
+  it("writes no gloss for non-actionable keys (no reason can ever carry them)", () => {
+    const m = buildProfileStripModel(
+      session({ card_responses: { "greek-scene": "essential" } }),
+    );
+    expect(m.glosses["life.greek_scene"]).toBeUndefined();
+  });
+
+  it("counts spotlight hits per reason and per school", () => {
+    const schools = [
+      { reasons: [{ tunable_key: "scale.small" }, { tunable_key: "scale.small" }] },
+      { reasons: [{ tunable_key: "scale.small" }, { tunable_key: null }] },
+      { reasons: [{ tunable_key: "cost.low_debt" }] },
+    ];
+    expect(spotlightCountsForRound(schools, "scale.small")).toEqual({
+      reasons: 3,
+      schools: 2,
+    });
+    expect(spotlightCountsForRound(schools, "cost.low_debt")).toEqual({
+      reasons: 1,
+      schools: 1,
+    });
+    expect(spotlightCountsForRound(schools, "no.match")).toEqual({
+      reasons: 0,
+      schools: 0,
+    });
   });
 });
 

--- a/web/src/lib/discovery/profile-strip.ts
+++ b/web/src/lib/discovery/profile-strip.ts
@@ -1,0 +1,116 @@
+// Profile strip model (design doc: preference profile strip + spotlight
+// attribution). Pure data selection over the same combined card+reaction
+// signal pipeline the engine and ledger use, grouped in STEERING language —
+// never bucket names, because an "Interesting"-sorted card can cross the
+// essential threshold via reactions, and labeling that group "Essential"
+// would misquote the student's sort.
+
+import { DECK_CARDS, ESSENTIAL_THRESHOLD } from "./content";
+import { SUPPORTED_KEYS } from "./matchers";
+import { cardStatementForKey } from "./round-session";
+import { aggregateKeys, buildReactionSignals, buildSignals } from "./signals";
+import type { DiscoverySessionV1 } from "./types";
+
+// Chip interaction class. Only "spotlight" entries are toggles: rendered
+// reasons exist only for keys with a positive aggregate and a firing matcher,
+// so away/tension/unsupported chips can never match a reason — a dead toggle
+// that always announces zero would be a lie in a product built on receipts.
+export type StripEntryKind = "spotlight" | "away" | "tension" | "unsupported";
+
+export interface StripEntry {
+  key: string;
+  statement: string;
+  total: number;
+  kind: StripEntryKind;
+}
+
+export interface ProfileStripModel {
+  strong: StripEntry[]; // total >= ESSENTIAL_THRESHOLD
+  gentle: StripEntry[]; // 0 < total < ESSENTIAL_THRESHOLD
+  away: StripEntry[]; // total < 0
+  tensions: StripEntry[]; // conflicted (contribute zero until resolved)
+  // 2-3 strongest positive, matcher-supported chips for the collapsed bar —
+  // never away/tension/unsupported (non-toggle) entries.
+  inline: StripEntry[];
+  counts: { strong: number; away: number; tensions: number };
+  // Attribution gloss per positive key, source-precedence so the gloss can
+  // never misquote: card statement only while an active CARD signal exists;
+  // a reaction-only positive aggregate (possible after a ledger edit) gets
+  // the reaction wording instead.
+  glosses: Record<string, string>;
+  // Zero aggregates and zero tensions — an all-zeros strip would be noise.
+  empty: boolean;
+}
+
+export const NON_TOGGLE_COPY: Record<Exclude<StripEntryKind, "spotlight">, string> = {
+  away: "shapes scoring, not the reasons shown",
+  tension: "pulls both ways and counts for nothing until you resolve it in your profile",
+  unsupported: "recorded in your profile — not yet used for matching",
+};
+
+export function buildProfileStripModel(
+  session: DiscoverySessionV1,
+): ProfileStripModel {
+  const cardSignals = buildSignals(session.card_responses, DECK_CARDS);
+  const cardKeys = new Set(cardSignals.map((s) => s.key));
+  const aggregates = aggregateKeys([
+    ...cardSignals,
+    ...buildReactionSignals(session.reactions),
+  ]);
+
+  const strong: StripEntry[] = [];
+  const gentle: StripEntry[] = [];
+  const away: StripEntry[] = [];
+  const tensions: StripEntry[] = [];
+  const glosses: Record<string, string> = {};
+
+  for (const agg of aggregates) {
+    const statement = cardStatementForKey(agg.key);
+    if (!statement) continue; // fail closed — a chip we can't caption is no chip
+    const kind: StripEntryKind = agg.conflicted
+      ? "tension"
+      : !SUPPORTED_KEYS.has(agg.key)
+        ? "unsupported"
+        : agg.total > 0
+          ? "spotlight"
+          : "away";
+    const entry: StripEntry = { key: agg.key, statement, total: agg.total, kind };
+    if (agg.conflicted) tensions.push(entry);
+    else if (agg.total >= ESSENTIAL_THRESHOLD) strong.push(entry);
+    else if (agg.total > 0) gentle.push(entry);
+    else if (agg.total < 0) away.push(entry);
+    // non-conflicted total of exactly 0 cannot occur (same-direction signals
+    // only), but if it ever did, it steers nothing and is omitted
+
+    if (!agg.conflicted && agg.total > 0) {
+      glosses[agg.key] = cardKeys.has(agg.key)
+        ? `Because you said: “${statement}”`
+        : "Because you asked for more like this.";
+    }
+  }
+
+  const byStrength = (a: StripEntry, b: StripEntry) =>
+    b.total - a.total || (a.key < b.key ? -1 : 1);
+  strong.sort(byStrength);
+  gentle.sort(byStrength);
+  away.sort((a, b) => a.total - b.total || (a.key < b.key ? -1 : 1));
+
+  const inline = [...strong, ...gentle]
+    .filter((e) => e.kind === "spotlight")
+    .slice(0, 3);
+
+  return {
+    strong,
+    gentle,
+    away,
+    tensions,
+    inline,
+    counts: { strong: strong.length, away: away.length, tensions: tensions.length },
+    glosses,
+    empty:
+      strong.length === 0 &&
+      gentle.length === 0 &&
+      away.length === 0 &&
+      tensions.length === 0,
+  };
+}

--- a/web/src/lib/discovery/profile-strip.ts
+++ b/web/src/lib/discovery/profile-strip.ts
@@ -6,7 +6,7 @@
 // would misquote the student's sort.
 
 import { DECK_CARDS, ESSENTIAL_THRESHOLD } from "./content";
-import { SUPPORTED_KEYS } from "./matchers";
+import { ACTIONABLE_KEYS } from "./matchers";
 import { cardStatementForKey } from "./round-session";
 import { aggregateKeys, buildReactionSignals, buildSignals } from "./signals";
 import type { DiscoverySessionV1 } from "./types";
@@ -15,6 +15,10 @@ import type { DiscoverySessionV1 } from "./types";
 // reasons exist only for keys with a positive aggregate and a firing matcher,
 // so away/tension/unsupported chips can never match a reason — a dead toggle
 // that always announces zero would be a lie in a product built on receipts.
+// "Unsupported" here means not ACTIONABLE: a key with no matcher at all OR a
+// matcher whose evidence has no resolver yet (12 of 24 deck keys today —
+// cds.*, ipeds.ic.*, distance.*) — either way it can't score or produce
+// reasons, and its honest copy is "not yet used for matching."
 export type StripEntryKind = "spotlight" | "away" | "tension" | "unsupported";
 
 export interface StripEntry {
@@ -22,13 +26,22 @@ export interface StripEntry {
   statement: string;
   total: number;
   kind: StripEntryKind;
+  // An active CARD signal backs this entry. When false (reaction-only after
+  // a ledger edit), the statement must NOT be rendered in quotes as "your
+  // answer" — the student withdrew it.
+  quoted: boolean;
 }
 
 export interface ProfileStripModel {
-  strong: StripEntry[]; // total >= ESSENTIAL_THRESHOLD
-  gentle: StripEntry[]; // 0 < total < ESSENTIAL_THRESHOLD
-  away: StripEntry[]; // total < 0
+  strong: StripEntry[]; // total >= ESSENTIAL_THRESHOLD (actionable only)
+  gentle: StripEntry[]; // 0 < total < ESSENTIAL_THRESHOLD (actionable only)
+  away: StripEntry[]; // total < 0 (actionable only)
   tensions: StripEntry[]; // conflicted (contribute zero until resolved)
+  // Non-actionable keys (no matcher, or matcher without resolvable evidence)
+  // regardless of sign. They steer NOTHING today — putting them in a
+  // steering group would make the counts lie, so they get their own
+  // disclosed group instead.
+  recorded: StripEntry[];
   // 2-3 strongest positive, matcher-supported chips for the collapsed bar —
   // never away/tension/unsupported (non-toggle) entries.
   inline: StripEntry[];
@@ -62,6 +75,7 @@ export function buildProfileStripModel(
   const gentle: StripEntry[] = [];
   const away: StripEntry[] = [];
   const tensions: StripEntry[] = [];
+  const recorded: StripEntry[] = [];
   const glosses: Record<string, string> = {};
 
   for (const agg of aggregates) {
@@ -69,21 +83,30 @@ export function buildProfileStripModel(
     if (!statement) continue; // fail closed — a chip we can't caption is no chip
     const kind: StripEntryKind = agg.conflicted
       ? "tension"
-      : !SUPPORTED_KEYS.has(agg.key)
+      : !ACTIONABLE_KEYS.has(agg.key)
         ? "unsupported"
         : agg.total > 0
           ? "spotlight"
           : "away";
-    const entry: StripEntry = { key: agg.key, statement, total: agg.total, kind };
-    if (agg.conflicted) tensions.push(entry);
+    const entry: StripEntry = {
+      key: agg.key,
+      statement,
+      total: agg.total,
+      kind,
+      quoted: cardKeys.has(agg.key),
+    };
+    if (kind === "tension") tensions.push(entry);
+    // Non-actionable keys steer nothing — counting them as strong/away would
+    // claim influence scoreSchool never applies.
+    else if (kind === "unsupported") recorded.push(entry);
     else if (agg.total >= ESSENTIAL_THRESHOLD) strong.push(entry);
     else if (agg.total > 0) gentle.push(entry);
     else if (agg.total < 0) away.push(entry);
     // non-conflicted total of exactly 0 cannot occur (same-direction signals
     // only), but if it ever did, it steers nothing and is omitted
 
-    if (!agg.conflicted && agg.total > 0) {
-      glosses[agg.key] = cardKeys.has(agg.key)
+    if (kind === "spotlight") {
+      glosses[agg.key] = entry.quoted
         ? `Because you said: “${statement}”`
         : "Because you asked for more like this.";
     }
@@ -94,16 +117,18 @@ export function buildProfileStripModel(
   strong.sort(byStrength);
   gentle.sort(byStrength);
   away.sort((a, b) => a.total - b.total || (a.key < b.key ? -1 : 1));
+  recorded.sort(byStrength);
 
-  const inline = [...strong, ...gentle]
-    .filter((e) => e.kind === "spotlight")
-    .slice(0, 3);
+  // strong/gentle are actionable-positive by construction, so every entry
+  // here is a spotlight toggle.
+  const inline = [...strong, ...gentle].slice(0, 3);
 
   return {
     strong,
     gentle,
     away,
     tensions,
+    recorded,
     inline,
     counts: { strong: strong.length, away: away.length, tensions: tensions.length },
     glosses,
@@ -111,6 +136,32 @@ export function buildProfileStripModel(
       strong.length === 0 &&
       gentle.length === 0 &&
       away.length === 0 &&
-      tensions.length === 0,
+      tensions.length === 0 &&
+      recorded.length === 0,
   };
+}
+
+// Strip geometry, shared between ProfileStrip (bar/drawer) and RoundsStep
+// (content clearance) so a resize is a one-line change. CLEARANCE must stay
+// >= BAR_MIN_HEIGHT + breathing room.
+export const STRIP_BAR_MIN_HEIGHT = 56;
+export const STRIP_CLEARANCE = 88;
+
+// How many rendered reasons (and schools) an active spotlight key would
+// highlight in the round on screen. Pure so the announcement copy can be
+// unit-tested against the same numbers the UI shows.
+export function spotlightCountsForRound(
+  schools: { reasons: { tunable_key: string | null }[] }[],
+  key: string,
+): { reasons: number; schools: number } {
+  let reasons = 0;
+  let hitSchools = 0;
+  for (const s of schools) {
+    const hits = s.reasons.filter((r) => r.tunable_key === key).length;
+    if (hits > 0) {
+      reasons += hits;
+      hitSchools += 1;
+    }
+  }
+  return { reasons, schools: hitSchools };
 }

--- a/web/tests/discover.spec.ts
+++ b/web/tests/discover.spec.ts
@@ -19,6 +19,36 @@ async function expectAxeClean(page: Page) {
   expect(results.violations).toEqual([]);
 }
 
+const BUCKETS = [/^Essential/, /^Interesting/, /^Not important/, /^Not for me/];
+
+// Shared funnel: fresh session → sorted deck → interests → first round.
+// The mixed sort (buckets cycling across all 24 cards) guarantees strong,
+// gentle, away, tension-free, and recorded entries all exist.
+async function reachFirstRound(
+  page: Page,
+  opts: { zip?: { zip: string; preferred: string; maximum: string } } = {},
+) {
+  await page.goto("/discover");
+  await page.getByRole("button", { name: /start sorting/i }).click();
+  if (opts.zip) {
+    await page.getByLabel(/home zip/i).fill(opts.zip.zip);
+    await page.getByLabel(/prefer within/i).fill(opts.zip.preferred);
+    await page.getByRole("textbox", { name: /never beyond/i }).fill(opts.zip.maximum);
+    await page.getByRole("checkbox", { name: /occasional wildcard/i }).check();
+    await page.getByRole("button", { name: /continue to the cards/i }).click();
+  } else {
+    await page.getByRole("button", { name: /skip — no distance limits/i }).click();
+  }
+  for (let i = 0; i < 24; i++) {
+    await page.getByRole("button", { name: BUCKETS[i % 4] }).press("Enter");
+  }
+  await page.getByRole("button", { name: /see my preference profile/i }).click();
+  await page.getByRole("button", { name: /continue to discovery rounds/i }).click();
+  await page.getByRole("button", { name: /environment & climate/i }).click();
+  await page.getByRole("button", { name: /see my first round/i }).click();
+  await expect(page.locator("ol > li.cd-card").first()).toBeVisible();
+}
+
 test("discover flow: boundaries → card sort → ledger", async ({ page }) => {
   await page.goto("/discover");
 
@@ -51,12 +81,11 @@ test("discover flow: boundaries → card sort → ledger", async ({ page }) => {
   await expect(page.getByText("Card 1 of 24")).toBeVisible();
   await expectAxeClean(page);
 
-  const buckets = [/^Essential/, /^Interesting/, /^Not important/, /^Not for me/];
   for (let i = 0; i < 24; i++) {
     // Keyboard operation: focus the bucket button and press Enter.
     // press() is keyboard-operated AND actionability-checked, so a swallowed
     // keystroke fails at the card that stalled instead of 5 lines later.
-    await page.getByRole("button", { name: buckets[i % 4] }).press("Enter");
+    await page.getByRole("button", { name: BUCKETS[i % 4] }).press("Enter");
   }
 
   // The live region announced the final sort.
@@ -161,9 +190,8 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
   await page.getByLabel(/prefer within/i).fill("300");
   await page.getByRole("textbox", { name: /never beyond/i }).fill("800");
   await page.getByRole("button", { name: /continue to the cards/i }).click();
-  const buckets = [/^Essential/, /^Interesting/, /^Not important/, /^Not for me/];
   for (let i = 0; i < 24; i++) {
-    await page.getByRole("button", { name: buckets[i % 4] }).press("Enter");
+    await page.getByRole("button", { name: BUCKETS[i % 4] }).press("Enter");
   }
   await page.getByRole("button", { name: /see my preference profile/i }).click();
 
@@ -198,21 +226,42 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
   const drawer = page.getByRole("region", { name: /your answers/i });
   await expect(drawer.getByText(/steering strongly/i)).toBeVisible();
   await expectAxeClean(page);
-  const toggle = drawer.locator("button[aria-pressed]").first();
+  // Deterministic spotlight: derive the toggle from a rendered gloss, so the
+  // highlight branch always exercises real matches (a regression that makes
+  // every toggle match zero can't slip through the zero-match copy).
+  const glossText = await page
+    .getByText(/^Because you said: “/)
+    .first()
+    .textContent();
+  const statement = glossText!.slice("Because you said: “".length).replace(/”$/, "");
+  const toggle = drawer
+    .locator("button[aria-pressed]", { hasText: statement.slice(0, 30) })
+    .first();
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
   const spotlitCount = await page.locator("[data-spotlit]").count();
+  expect(spotlitCount).toBeGreaterThan(0);
   const announcement = await strip.locator("[aria-live]").textContent();
-  if (spotlitCount > 0) {
-    expect(announcement).toMatch(
-      new RegExp(`Highlighting ${spotlitCount} reason`),
-    );
-  } else {
-    expect(announcement).toMatch(/No shown reasons come from this/);
-  }
+  expect(announcement).toMatch(new RegExp(`Highlighting ${spotlitCount} reason`));
   const orderAfter = await page.locator("ol > li.cd-card h2").allTextContents();
   expect(orderAfter).toEqual(orderBefore);
   await expectAxeClean(page);
+  // Non-toggle entries explain themselves instead of pretending to be
+  // spotlights: away entries carry their copy, and non-actionable keys sit
+  // in the disclosed "Recorded, not yet matching" group (never inflating
+  // the steering counts).
+  await expect(
+    drawer.getByText(/shapes scoring, not the reasons shown/).first(),
+  ).toBeVisible();
+  await expect(drawer.getByText(/recorded, not yet matching/i)).toBeVisible();
+  // Toggling the same chip off clears the spotlight and announces it.
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(page.locator("[data-spotlit]")).toHaveCount(0);
+  expect(await strip.locator("[aria-live]").textContent()).toBe("Highlight cleared.");
+  // Re-arm so Escape below demonstrably clears an active spotlight.
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
   // Escape closes the drawer and clears the spotlight (one rule).
   await page.keyboard.press("Escape");
   await expect(drawer).toBeHidden();
@@ -233,8 +282,22 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
   await second.getByRole("radio", { name: /something else/i }).check();
   await second.getByRole("button", { name: /set it aside/i }).click();
 
+  // Advancing rounds clears any active spotlight — a highlight surviving the
+  // transition would describe the previous round. Inline collapsed-bar chips
+  // exist only at sm+ widths, so this leg runs on the desktop project.
+  const inlineChip = strip.locator(".cd-chip[aria-pressed]").first();
+  const inlineChipVisible = await inlineChip.isVisible();
+  if (inlineChipVisible) {
+    await inlineChip.click();
+    await expect(inlineChip).toHaveAttribute("aria-pressed", "true");
+  }
+
   // Next round: saved + rejected schools never reappear.
   await page.getByRole("button", { name: /next round/i }).click();
+  if (inlineChipVisible) {
+    await expect(page.locator("[data-spotlit]")).toHaveCount(0);
+    await expect(inlineChip).toHaveAttribute("aria-pressed", "false");
+  }
   await expect(
     page.locator("ol > li.cd-card h2", { hasText: firstSchool ?? "" }),
   ).toHaveCount(0);
@@ -260,18 +323,7 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
 
 test("discovery rounds with profile strip reflow at 320px", async ({ page }) => {
   await page.setViewportSize({ width: 320, height: 800 });
-  await page.goto("/discover");
-  await page.getByRole("button", { name: /start sorting/i }).click();
-  await page.getByRole("button", { name: /skip — no distance limits/i }).click();
-  const buckets = [/^Essential/, /^Interesting/, /^Not important/, /^Not for me/];
-  for (let i = 0; i < 24; i++) {
-    await page.getByRole("button", { name: buckets[i % 4] }).press("Enter");
-  }
-  await page.getByRole("button", { name: /see my preference profile/i }).click();
-  await page.getByRole("button", { name: /continue to discovery rounds/i }).click();
-  await page.getByRole("button", { name: /environment & climate/i }).click();
-  await page.getByRole("button", { name: /see my first round/i }).click();
-  await expect(page.locator("ol > li.cd-card").first()).toBeVisible();
+  await reachFirstRound(page);
 
   const strip = page.getByTestId("profile-strip");
   await expect(strip.getByText(/Steering: \d+ strong/)).toBeVisible();
@@ -287,6 +339,17 @@ test("discovery rounds with profile strip reflow at 320px", async ({ page }) => 
   await lastCard.getByRole("button", { name: /not for me/i }).click();
   await expect(lastCard.getByText(/not for you because of/i)).toBeVisible();
   await expectAxeClean(page);
+
+  // "Edit profile" in the drawer routes back to the ledger — the strip is
+  // read-only by design and the ledger stays the only editing surface.
+  await strip.getByRole("button", { name: /your answers/i }).click();
+  await page
+    .getByRole("region", { name: /your answers/i })
+    .getByRole("button", { name: /edit profile/i })
+    .click();
+  await expect(
+    page.getByRole("button", { name: /continue to discovery rounds/i }),
+  ).toBeVisible();
 });
 
 test("discover card sort reflows at 320px without horizontal scroll", async ({ page }) => {

--- a/web/tests/discover.spec.ts
+++ b/web/tests/discover.spec.ts
@@ -185,6 +185,40 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
   await expectAxeClean(page);
   const firstSchool = await cards.first().getByRole("heading").textContent();
 
+  // Profile strip: collapsed bar is present with steering counts, and every
+  // reason that traces to a preference carries its attribution gloss.
+  const strip = page.getByTestId("profile-strip");
+  await expect(strip.getByText(/Steering: \d+ strong/)).toBeVisible();
+  await expect(page.getByText(/Because you (said|asked)/).first()).toBeVisible();
+
+  // Expand the drawer, spotlight a preference, and verify the round is a
+  // pure render under it: same schools, same order.
+  const orderBefore = await page.locator("ol > li.cd-card h2").allTextContents();
+  await strip.getByRole("button", { name: /your answers/i }).click();
+  const drawer = page.getByRole("region", { name: /your answers/i });
+  await expect(drawer.getByText(/steering strongly/i)).toBeVisible();
+  await expectAxeClean(page);
+  const toggle = drawer.locator("button[aria-pressed]").first();
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  const spotlitCount = await page.locator("[data-spotlit]").count();
+  const announcement = await strip.locator("[aria-live]").textContent();
+  if (spotlitCount > 0) {
+    expect(announcement).toMatch(
+      new RegExp(`Highlighting ${spotlitCount} reason`),
+    );
+  } else {
+    expect(announcement).toMatch(/No shown reasons come from this/);
+  }
+  const orderAfter = await page.locator("ol > li.cd-card h2").allTextContents();
+  expect(orderAfter).toEqual(orderBefore);
+  await expectAxeClean(page);
+  // Escape closes the drawer and clears the spotlight (one rule).
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden();
+  await expect(page.locator("[data-spotlit]")).toHaveCount(0);
+  await expect(strip.getByRole("button", { name: /your answers/i })).toBeFocused();
+
   // Research next: must pick a reason and answer familiarity (PRD §10).
   await cards.first().getByRole("button", { name: /research next/i }).click();
   await expect(page.getByText(/which reason are you saving/i)).toBeVisible();
@@ -222,6 +256,37 @@ test("discovery rounds: interests → round with reasons → reactions → shelf
   // Session (with rounds state) survives a reload.
   await page.reload();
   await expect(page.getByRole("heading", { name: /shortlist/i })).toBeVisible();
+});
+
+test("discovery rounds with profile strip reflow at 320px", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto("/discover");
+  await page.getByRole("button", { name: /start sorting/i }).click();
+  await page.getByRole("button", { name: /skip — no distance limits/i }).click();
+  const buckets = [/^Essential/, /^Interesting/, /^Not important/, /^Not for me/];
+  for (let i = 0; i < 24; i++) {
+    await page.getByRole("button", { name: buckets[i % 4] }).press("Enter");
+  }
+  await page.getByRole("button", { name: /see my preference profile/i }).click();
+  await page.getByRole("button", { name: /continue to discovery rounds/i }).click();
+  await page.getByRole("button", { name: /environment & climate/i }).click();
+  await page.getByRole("button", { name: /see my first round/i }).click();
+  await expect(page.locator("ol > li.cd-card").first()).toBeVisible();
+
+  const strip = page.getByTestId("profile-strip");
+  await expect(strip.getByText(/Steering: \d+ strong/)).toBeVisible();
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(1);
+
+  // The fixed strip must not obscure the reaction buttons: the last card's
+  // panel still opens from a real click.
+  const lastCard = page.locator("ol > li.cd-card").last();
+  await lastCard.getByRole("button", { name: /not for me/i }).scrollIntoViewIfNeeded();
+  await lastCard.getByRole("button", { name: /not for me/i }).click();
+  await expect(lastCard.getByText(/not for you because of/i)).toBeVisible();
+  await expectAxeClean(page);
 });
 
 test("discover card sort reflows at 320px without horizontal scroll", async ({ page }) => {


### PR DESCRIPTION
## Summary

Adds a **floating profile strip with spotlight attribution** to the `/discover` rounds page — the fix for the dogfooding finding that you lose track of your card-sort answers while scanning schools. Built from an office-hours design doc (adversarially reviewed ×3 before a line was written).

**Profile strip + spotlight** (`7141e64`)
- Fixed bottom bar on the rounds view: steering counts (`Steering: N strong · N away · N tensions`) plus the strongest preference chips inline; expands to a drawer grouped in **steering language** — never bucket names, because reactions can push an "Interesting" card past the essential threshold and calling that group "Essential" would misquote the sort.
- **Spotlight**: positive, matcher-actionable chips are `aria-pressed` toggles that highlight every rendered reason they caused across the six schools (forest left rule + tint) — pure view-state; school order provably untouched. Zero-match announces honestly via a polite live region.
- **Attribution**: reasons gain `Because you said: "<card statement>"` with source precedence — card quote only while an active card signal exists; reaction-only aggregates say "Because you asked for more like this" instead of quoting a withdrawn card.
- Strip hides in loading/error/zero-schools/empty-profile states; ledger stays the only editing surface; zero new analytics; session schema unchanged (spotlight is never persisted).

**Cross-model review fixes** (`d2c156b`)
- **Truthful steering counts** (Codex adversarial + Claude adversarial, strongest finding): 12 of 24 deck keys have matcher specs whose `cds.*`/`ipeds.ic.*`/`distance.*` evidence has no resolver yet — `matcher()` always returns 0 for them. New `ACTIONABLE_KEYS` set routes every non-actionable key to a disclosed **"Recorded, not yet matching"** drawer group instead of letting them pose as spotlight toggles or inflate the strong/away counts.
- **Stale spotlight reconciliation** (Codex + Red Team): a reaction can invalidate the spotlit key mid-round (Not-for-me → conflicted); the active spotlight now derives from the live model, so an invalid key highlights nothing and no chip reads pressed.
- **Drawer keyboard access** (Codex structured P2 + Red Team): opening the drawer moves focus into it (it renders before the trigger in DOM order — Tab used to exit without reaching it); Escape handled on the whole strip; `aria-controls` links trigger to region.
- **Geometry**: single fixed container (a wrapping bar can never paint over the drawer), shared `STRIP_*` constants, `env(safe-area-inset-bottom)`, z-index below the header search dropdown, `overscroll-behavior: contain`, document-body bottom padding so the global footer's last links aren't stuck under the bar.
- Design polish: 44px chip hit areas, hover states, reflow-free spotlight highlight (rule sits in the card gutter).

**Docs** (`94e1379`): PRD 026 addendum entry + backlog follow-ups (v2 tap-to-retune tracked as designed-not-built, gated on dogfooding).

## Test Coverage

Coverage audit (fresh-context subagent): **95% — PASS** (39/41 paths; the two accepted gaps are the disclosure-button close path, whose clear logic the Escape path fully covers, and staging network-error strip-hide states). Tests: 36 → 38 files; 254 → 265 vitest.

## Pre-Landing Review

22 findings (2 critical) from 4 specialists + Red Team + Claude adversarial + Codex adversarial + Codex structured — **all fixed** in `d2c156b`; none skipped. Codex structured P1 gate: **PASS** (one P2, fixed). Performance specialist: no findings (memo deps and effect hygiene verified). One informational Red Team note carried, not fixed: the repo has no documented z-index scale — the strip now slots under the header dropdowns, but a scale in tokens.css would prevent the next collision.

## Design Review

Design Review (lite): 5 findings — 5 auto-fixed (touch targets, hover states, spotlight reflow, safe-area, drawer/bar overlap eliminated by the container refactor).

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — all files map to the approved design doc; no v2/retuning code, no schema changes, no analytics.

## Plan Completion

**20/27 done, 5 changed, 0 deferred** against the approved design doc. The 5 CHANGED are honest deviations: bar is 56px min-height (not the specced ≤48px) to hold 44px touch targets; E2E chip activation via click (Escape/focus keyboard paths covered); the zero-match announcement is unit-covered rather than E2E-staged; plus the review-driven "recorded" group supersedes the doc's original unsupported-copy placement. The two originally unverifiable items (full suites green) were verified in this ship run.

## Verification Results

- 265 vitest (all green, incl. 29 profile-strip model tests) · 36 pytest · 27 Playwright ×(chromium + mobile-chrome) with axe scans on collapsed/expanded/spotlight states and a 320px rounds test proving no overflow and unobscured reaction buttons
- Deterministic spotlight E2E: the toggled chip is derived from a rendered gloss, so a highlighting regression can no longer hide behind the zero-match branch
- Clean `tsc` and production build

## Documentation

- **docs/prd/026-guided-college-discovery.md** — new dated Implementation Addendum entry for the profile strip + spotlight attribution slice: hide conditions, steering-language drawer groups (never bucket names), spotlight as pure view-state, "Because you said" quote-precedence attribution, truthful steering counts (keys outside `ACTIONABLE_KEYS` surface in the disclosed "Recorded, not yet matching" group), and v2 tap-to-retune noted as designed-not-built, gated on dogfooding.
- **docs/backlog.md** — "PRD 026 discovery rounds follow-ups": slice (c) now names the resolver payoff (matcher-backed keys leave "Recorded, not yet matching"); new slice (d) tracks the held v2 tap-to-retune interaction. No items marked done.
- **docs/ARCHITECTURE.md**, **web/DESIGN_SYSTEM.md** — reviewed, no changes needed.

## Test plan
- [x] All vitest pass (265)
- [x] All pytest pass (36)
- [x] All Playwright pass (27, axe-clean in all strip states)
- [x] Production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
