### PR TITLE
fix: harden IPEDS publication and reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ SUPABASE_DB_PASSWORD=
 # Dashboard: Settings > Database > Connection String > URI
 DATABASE_URL=
 
+# Dedicated direct or Supavisor session-mode URI for long IPEDS publication
+# refreshes. `load_release.py --apply` intentionally does not use PostgREST or
+# a transaction-mode pooler for these administrative calls.
+IPEDS_ADMIN_DATABASE_URL=
+
 # ─── Supabase access token (optional) ───────────────────────────────────────
 # Personal access token for `supabase` CLI commands that hit the Management API
 # (e.g., creating/deleting projects via CLI). Not required for routine migration

--- a/docs/prd/027-endowment-financial-health.md
+++ b/docs/prd/027-endowment-financial-health.md
@@ -473,6 +473,18 @@ Validation checks:
   fixtures match exactly under FY-correct alignment (Scorecard's current file is FY2024).
   Gate: ≥99% exact match over the full correctly-aligned FASB population, with the discovered
   alignment documented.
+  **Observed after the Phase 1 production backfill (June 10, 2026 Scorecard file):** the best
+  alignment is FY2024. There are 1,110 in-scope private-nonprofit Scorecard rows with both
+  values; 1,079 have complete F2 beginning/end fact pairs. Direct UNITID matches account for
+  1,060. Of 19 reporting entities needing consolidation, 16 reconcile through exact OPEID6
+  allocation rollups and two through unique exact beginning-and-ending residual matches.
+  The Chicago School remains the one unreconciled entity because its Dallas branch has `NA`
+  Scorecard values. Correct reporting-entity result: 1,078/1,079 = 99.907% (pass); the 31
+  in-scope rows without F2 pairs are reported separately, not counted as independent F2
+  reporters. That is 97.207% coverage of the in-scope Scorecard population, above the tool's
+  95% anti-sparsity floor. All five corrected fixtures match both values exactly. The
+  reproducible command is `tools/ipeds/reconcile_endowment_scorecard.py`; its JSON output lists
+  every member UNITID and method and does not use fuzzy names.
 - **Accounting identity:** `(F2H02 − F2H01) = F2H03A+F2H03B+F2H03C+F2H03D` per year via the
   analysis script (`F2H03` itself is not loaded — it is the calculated difference). Verified
   FY2023 baseline: identity holds 1318/1318. FY2020–21 checks run per-release during the M1

--- a/tools/ipeds/README.md
+++ b/tools/ipeds/README.md
@@ -10,6 +10,12 @@ As of the June 2026 backfill, the pipeline supports historical releases from
 `ipeds_current_facts_cache`; historical analysis should query `ipeds_facts`
 with `ipeds_id`, `field_key`, and a bounded `data_year` range.
 
+Install the IPEDS tool dependencies before downloading or applying a release:
+
+```bash
+python3 -m pip install -r tools/ipeds/requirements.txt
+```
+
 ## Workflow
 
 Run IPEDS loads from a fresh `main` checkout after the corresponding migrations
@@ -78,22 +84,58 @@ python tools/ipeds/load_release.py \
 ```
 
 3. After reviewing the report and after the migration has landed/applied from
-   `main`, re-run with `--apply`. This requires `SUPABASE_URL` and
-   `SUPABASE_SERVICE_ROLE_KEY` in `.env`.
+   `main`, re-run with `--apply`. This requires `SUPABASE_URL`,
+   `SUPABASE_SERVICE_ROLE_KEY`, and `IPEDS_ADMIN_DATABASE_URL` in `.env`.
+   `IPEDS_ADMIN_DATABASE_URL` must be a direct PostgreSQL or Supavisor
+   **session-mode** URI copied from the target project's database connection
+   settings. Do not substitute a transaction-mode pooler URI.
 
 ```bash
 python tools/ipeds/load_release.py ... --apply
 ```
 
-The loader refreshes `ipeds_current_facts_cache` after fact upserts, then
-refreshes browser source-mode flags that depend on current facts. If an
-operator applies rows manually, run these RPCs with service-role credentials in
-the same order:
+The loader preflights the administrative session before writing. Normal release
+metadata, raw-row, fact, pruning, and supersession writes continue through
+PostgREST with the service role. Publication then uses the dedicated database
+session, sets a 10-minute statement timeout, refreshes
+`ipeds_current_facts_cache`, and finally refreshes browser source-mode flags.
+The current-facts cache is required; browser source modes remain best-effort.
+The loader prints `applied release ...` only after the required cache refresh
+succeeds.
+
+The split is intentional. The cache refresh scans millions of historical facts
+and takes about 65–71 seconds in production. PostgREST's service-role requests
+inherit the `authenticator` role's 8-second statement timeout, so the ordinary
+API path cannot complete this administrative operation. There is no PostgREST
+fallback for either post-load refresh: retrying the same known-short path would
+only repeat the timeout. If an operator applies rows manually, run these
+functions through a direct or session-mode database connection in this order:
 
 ```sql
 select public.refresh_ipeds_current_facts_cache();
 select public.refresh_ipeds_browser_source_modes();
 ```
+
+### Apply failure and recovery semantics
+
+- Missing, malformed, or unreachable `IPEDS_ADMIN_DATABASE_URL` fails the
+  preflight before release writes begin. Connection errors identify the config
+  name and safe error class/SQLSTATE only; the URI and password are never
+  printed.
+- A PostgREST write failure is a data-load failure. The loader does not print
+  `release data writes completed` or `applied release`; correct the write error
+  and rerun the exact command.
+- If the required cache refresh fails after writes, the loader exits 4 and says
+  `release data writes completed, but required publication failed`. It does not
+  claim success. Correct the administrative session or timeout issue and rerun
+  the exact `--apply` command. Upserts, stale-row pruning, release-priority
+  checks, and supersession are idempotent at the same release/mapping scope.
+- If only `refresh_ipeds_browser_source_modes()` fails, the loader warns after
+  confirming that the current-facts cache was published, then completes. Rerun
+  the function later through the same administrative session if browser badges
+  need recovery.
+- Dry runs do not connect to either Supabase path and do not require
+  `IPEDS_ADMIN_DATABASE_URL`.
 
 For a targeted backfill after adding table aliases, restrict projection to one
 or more display groups:
@@ -228,6 +270,38 @@ curl "$SUPABASE_URL/rest/v1/ipeds_facts?field_key=in.(endowment_value_begin,endo
   -H "apikey: $SUPABASE_ANON_KEY" \
   -H "Authorization: Bearer $SUPABASE_ANON_KEY"
 ```
+
+Run the checked-in reconciliation command against the untouched Scorecard CSV
+or ZIP. It loads `.env`, uses the anon key in both required headers, paginates
+both PostgREST tables, and writes no database data:
+
+```bash
+python -m tools.ipeds.reconcile_endowment_scorecard \
+  /path/to/Most-Recent-Cohorts-Institution_06102026.zip \
+  --min-year 2020 \
+  --max-year 2024 \
+  --threshold 0.99 \
+  --min-reporting-coverage 0.95 \
+  --out scratch/ipeds/endowment-scorecard-reconciliation-06102026.json
+```
+
+The June 10, 2026 Scorecard file empirically aligns to FY2024. Of 1,110
+in-scope private-nonprofit Scorecard rows with both values, 1,079 have a
+complete F2 fact pair. Direct UNITID comparison matches 1,060. The remaining 19
+are reporting-entity consolidations: 16 exact OPEID6 allocation rollups and two
+unique exact beginning-and-ending residual matches reconcile; the Chicago
+School remains visible and unreconciled because its Dallas branch has `NA`
+Scorecard values. The reporting-entity gate is therefore 1,078/1,079 = 99.907%
+(pass). The 31 in-scope rows without a complete F2 pair are reported separately,
+not counted as independent F2 reporters, and leave 97.207% population coverage,
+above the command's default 95% anti-sparsity floor. All five corrected fixtures
+(201195, 148131, 231420, 203580, and 152080) match both values exactly.
+
+The consolidation detail in the JSON report is deliberately auditable. Every
+member UNITID, OPEID6, value pair, inclusion flag, and matching method is
+listed. The tool never uses fuzzy names, never discards ambiguous residual
+matches, and never promotes a Scorecard branch without direct F2 facts into the
+reporting-entity denominator.
 
 ## Source discipline
 

--- a/tools/ipeds/load_release.py
+++ b/tools/ipeds/load_release.py
@@ -13,11 +13,12 @@ import csv
 import json
 import os
 import sys
+import urllib.parse
 import zipfile
 from dataclasses import asdict
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -29,6 +30,24 @@ from tools.ipeds.project import project_rows_to_facts
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT_DIR = REPO_ROOT / "scratch" / "ipeds"
 ACCESS_PAGE_URL = "https://nces.ed.gov/ipeds/use-the-data/download-access-database"
+ADMIN_DATABASE_URL_ENV = "IPEDS_ADMIN_DATABASE_URL"
+ADMIN_REFRESH_TIMEOUT_MS = 600_000
+
+
+class AdminRefreshConfigurationError(RuntimeError):
+    """Raised before writes when the administrative session DSN is unusable."""
+
+
+class AdminRefreshConnectionError(RuntimeError):
+    """Raised when the administrative database session cannot be opened."""
+
+
+class RequiredCacheRefreshError(RuntimeError):
+    """Raised when the required current-facts publication step fails."""
+
+
+class PublicationRefreshError(RuntimeError):
+    """Raised after loader writes commit but required publication does not."""
 
 
 def main() -> int:
@@ -107,14 +126,33 @@ def main() -> int:
         return 2
 
     if args.apply:
-        apply_to_supabase(
-            args,
-            tablesdoc,
-            rows_by_table,
-            table_sources,
-            facts,
-            fact_mappings,
-        )
+        try:
+            apply_to_supabase(
+                args,
+                tablesdoc,
+                rows_by_table,
+                table_sources,
+                facts,
+                fact_mappings,
+            )
+        except (AdminRefreshConfigurationError, AdminRefreshConnectionError) as exc:
+            print(
+                f"error: apply stopped before release writes: {exc}",
+                file=sys.stderr,
+            )
+            return 3
+        except PublicationRefreshError as exc:
+            print(
+                "error: release data writes completed, but required publication failed: "
+                f"{exc}",
+                file=sys.stderr,
+            )
+            print(
+                "Re-run the exact same --apply command after fixing the administrative "
+                "database connection; upserts and pruning are idempotent.",
+                file=sys.stderr,
+            )
+            return 4
     else:
         print("dry run only; re-run with --apply to write Supabase")
     return 0
@@ -316,6 +354,8 @@ def apply_to_supabase(
     fact_mappings: tuple[Any, ...],
 ) -> None:
     load_env(REPO_ROOT / ".env")
+    admin_database_url = require_admin_database_url()
+    preflight_admin_database(admin_database_url)
     try:
         from supabase import create_client
     except ImportError as exc:
@@ -444,7 +484,10 @@ def apply_to_supabase(
         release_type=args.release_type,
         field_keys={mapping.field_key for mapping in loaded_fact_mappings},
     )
-    refresh_post_load_serving_views(client)
+    try:
+        refresh_post_load_serving_views(admin_database_url)
+    except (AdminRefreshConnectionError, RequiredCacheRefreshError) as exc:
+        raise PublicationRefreshError(str(exc)) from None
     print(f"applied release {release_id}: {len(raw_payloads)} raw rows, {len(fact_payloads)} facts")
 
 
@@ -508,14 +551,163 @@ def build_loaded_table_payloads(
     return payloads
 
 
-def refresh_post_load_serving_views(client: Any) -> None:
-    refreshed = client.rpc("refresh_ipeds_current_facts_cache").execute()
-    print(f"refreshed current IPEDS facts cache: {refreshed.data}")
+def require_admin_database_url(
+    env: Mapping[str, str] | None = None,
+) -> str:
+    source = os.environ if env is None else env
+    value = source.get(ADMIN_DATABASE_URL_ENV, "").strip()
+    if not value:
+        raise AdminRefreshConfigurationError(
+            f"{ADMIN_DATABASE_URL_ENV} is required for --apply; configure a direct "
+            "or Supavisor session-mode PostgreSQL URI, not the ordinary API URL"
+        )
     try:
-        browser_modes = client.rpc("refresh_ipeds_browser_source_modes").execute()
-        print(f"refreshed browser source modes: {browser_modes.data}")
-    except Exception as exc:  # pragma: no cover - optional browser metadata helper.
-        print(f"warning: could not refresh browser source modes: {exc}", file=sys.stderr)
+        parsed = urllib.parse.urlsplit(value)
+        _ = parsed.port
+    except ValueError:
+        raise AdminRefreshConfigurationError(
+            f"{ADMIN_DATABASE_URL_ENV} must be a valid PostgreSQL URI"
+        ) from None
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or not parsed.hostname
+        or not parsed.path.lstrip("/")
+    ):
+        raise AdminRefreshConfigurationError(
+            f"{ADMIN_DATABASE_URL_ENV} must be a PostgreSQL URI with a host and database name"
+        )
+    return value
+
+
+def database_error_label(exc: Exception) -> str:
+    """Return diagnostics that cannot contain a password, URI, or auth header."""
+    label = type(exc).__name__
+    sqlstate = getattr(exc, "sqlstate", None)
+    return f"{label} (SQLSTATE {sqlstate})" if sqlstate else label
+
+
+def connect_admin_database(admin_database_url: str) -> Any:
+    try:
+        import psycopg  # type: ignore
+    except ImportError:
+        raise AdminRefreshConnectionError(
+            "psycopg is required for administrative refreshes; install "
+            "tools/ipeds/requirements.txt"
+        ) from None
+    try:
+        return psycopg.connect(
+            admin_database_url,
+            autocommit=True,
+            connect_timeout=20,
+            application_name="collegedata_ipeds_loader",
+        )
+    except Exception as exc:
+        raise AdminRefreshConnectionError(
+            f"could not connect using {ADMIN_DATABASE_URL_ENV}; verify that it is a "
+            "reachable direct or session-mode DSN ({database_error_label(exc)})"
+        ) from None
+
+
+def execute_admin_scalar(connection: Any, sql: str, params: tuple[Any, ...] = ()) -> Any:
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def preflight_admin_database(
+    admin_database_url: str,
+    *,
+    connect: Any = connect_admin_database,
+) -> None:
+    """Fail before PostgREST writes when the admin session is not reachable."""
+    try:
+        with connect(admin_database_url) as connection:
+            function_name = "public.refresh_ipeds_current_facts_cache()"
+            can_refresh = execute_admin_scalar(
+                connection,
+                """
+                select to_regprocedure(%s) is not null
+                   and has_function_privilege(
+                     current_user,
+                     to_regprocedure(%s),
+                     'EXECUTE'
+                   )
+                """,
+                (function_name, function_name),
+            )
+            if can_refresh is not True:
+                raise AdminRefreshConfigurationError(
+                    f"{ADMIN_DATABASE_URL_ENV} connects, but its database role cannot "
+                    "execute refresh_ipeds_current_facts_cache()"
+                )
+    except AdminRefreshConfigurationError:
+        raise
+    except AdminRefreshConnectionError:
+        raise
+    except Exception as exc:
+        raise AdminRefreshConnectionError(
+            f"could not verify {ADMIN_DATABASE_URL_ENV}; verify that it is a reachable "
+            f"direct or session-mode DSN ({database_error_label(exc)})"
+        ) from None
+
+
+def refresh_post_load_serving_views(
+    admin_database_url: str,
+    *,
+    connect: Any = connect_admin_database,
+) -> None:
+    """Publish loader writes through a long-lived administrative DB session."""
+    try:
+        connection_context = connect(admin_database_url)
+    except AdminRefreshConnectionError:
+        raise
+    except Exception as exc:
+        raise AdminRefreshConnectionError(
+            f"could not connect using {ADMIN_DATABASE_URL_ENV} for publication "
+            f"({database_error_label(exc)})"
+        ) from None
+
+    try:
+        with connection_context as connection:
+            try:
+                execute_admin_scalar(
+                    connection,
+                    "select set_config('statement_timeout', %s, false)",
+                    (str(ADMIN_REFRESH_TIMEOUT_MS),),
+                )
+                refreshed_count = execute_admin_scalar(
+                    connection,
+                    "select public.refresh_ipeds_current_facts_cache()",
+                )
+            except Exception as exc:
+                raise RequiredCacheRefreshError(
+                    "refresh_ipeds_current_facts_cache() failed through the "
+                    "administrative database session "
+                    f"({database_error_label(exc)})"
+                ) from None
+
+            print(f"refreshed current IPEDS facts cache: {refreshed_count}")
+            try:
+                browser_count = execute_admin_scalar(
+                    connection,
+                    "select public.refresh_ipeds_browser_source_modes()",
+                )
+                print(f"refreshed browser source modes: {browser_count}")
+            except Exception as exc:  # Best-effort metadata; cache publication is durable.
+                print(
+                    "warning: current facts cache published, but "
+                    "refresh_ipeds_browser_source_modes() failed "
+                    f"({database_error_label(exc)})",
+                    file=sys.stderr,
+                )
+    except RequiredCacheRefreshError:
+        raise
+    except Exception as exc:
+        raise AdminRefreshConnectionError(
+            "administrative database session failed during publication "
+            f"({database_error_label(exc)})"
+        ) from None
 
 
 def prune_release_scope(

--- a/tools/ipeds/reconcile_endowment_scorecard.py
+++ b/tools/ipeds/reconcile_endowment_scorecard.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""Reproduce PRD 027's College Scorecard endowment reconciliation gate.
+
+The comparison is exact and reporting-entity aware. It never uses fuzzy school
+names: direct UNITID matches come first, followed by exact OPEID6 allocation
+rollups and then unique two-value residual matches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from tools.ipeds.load_release import load_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENDOWMENT_FIELDS = ("endowment_value_begin", "endowment_value_end")
+DEFAULT_FIXTURE_UNITIDS = (201195, 148131, 231420, 203580, 152080)
+DEFAULT_PAGE_SIZE = 1000
+DEFAULT_MIN_REPORTING_COVERAGE = Decimal("0.95")
+METHOD_DIRECT_UNITID = "direct_unitid"
+METHOD_OPEID6_ROLLUP = "opeid6_rollup"
+METHOD_UNIQUE_RESIDUAL = "unique_residual_match"
+
+
+@dataclass(frozen=True)
+class ScorecardRow:
+    unitid: int
+    opeid6: str
+    institution_name: str
+    control: int | None
+    main_campus: bool | None
+    endowment_begin: Decimal | None
+    endowment_end: Decimal | None
+
+    @property
+    def pair(self) -> tuple[Decimal, Decimal] | None:
+        if self.endowment_begin is None or self.endowment_end is None:
+            return None
+        return self.endowment_begin, self.endowment_end
+
+
+@dataclass(frozen=True)
+class FactPair:
+    unitid: int
+    data_year: int
+    endowment_begin: Decimal
+    endowment_end: Decimal
+
+    @property
+    def pair(self) -> tuple[Decimal, Decimal]:
+        return self.endowment_begin, self.endowment_end
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scorecard", type=Path, help="Raw Scorecard institution CSV or ZIP")
+    parser.add_argument("--min-year", type=int, default=2020)
+    parser.add_argument("--max-year", type=int, default=2024)
+    parser.add_argument("--threshold", type=Decimal, default=Decimal("0.99"))
+    parser.add_argument(
+        "--min-reporting-coverage",
+        type=Decimal,
+        default=DEFAULT_MIN_REPORTING_COVERAGE,
+        help="Minimum share of in-scope Scorecard rows that must have complete F2 facts",
+    )
+    parser.add_argument("--out", type=Path, help="Optional machine-readable JSON report")
+    args = parser.parse_args()
+
+    if args.min_year > args.max_year:
+        parser.error("--min-year must be less than or equal to --max-year")
+    if not args.threshold.is_finite() or args.threshold < 0 or args.threshold > 1:
+        parser.error("--threshold must be between 0 and 1")
+    if (
+        not args.min_reporting_coverage.is_finite()
+        or args.min_reporting_coverage < 0
+        or args.min_reporting_coverage > 1
+    ):
+        parser.error("--min-reporting-coverage must be between 0 and 1")
+
+    load_env(REPO_ROOT / ".env")
+    supabase_url = os.environ.get("SUPABASE_URL", "").strip()
+    api_key = (
+        os.environ.get("SUPABASE_ANON_KEY", "").strip()
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY", "").strip()
+    )
+    if not supabase_url or not api_key:
+        print(
+            "error: SUPABASE_URL and SUPABASE_ANON_KEY (or "
+            "NEXT_PUBLIC_SUPABASE_ANON_KEY) are required",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        scorecard_rows = read_scorecard_rows(args.scorecard)
+        fact_rows = fetch_ipeds_endowment_facts(
+            supabase_url,
+            api_key,
+            min_year=args.min_year,
+            max_year=args.max_year,
+        )
+        directory_rows = fetch_in_scope_private_nonprofit_directory(
+            supabase_url,
+            api_key,
+        )
+        report = reconcile_scorecard(
+            scorecard_rows,
+            fact_rows,
+            directory_rows,
+            min_year=args.min_year,
+            max_year=args.max_year,
+            threshold=args.threshold,
+            min_reporting_coverage=args.min_reporting_coverage,
+        )
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        print(f"error: reconciliation failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"wrote {args.out}")
+    print_summary(report)
+    return 0 if report["gate"]["passed"] else 1
+
+
+def parse_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text.lower() in {"", "na", "null", "privacysuppressed"}:
+        return None
+    try:
+        parsed = Decimal(text)
+    except InvalidOperation:
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def parse_int(value: Any) -> int | None:
+    parsed = parse_decimal(value)
+    if parsed is None or parsed != parsed.to_integral_value():
+        return None
+    return int(parsed)
+
+
+def normalize_opeid6(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    parsed = parse_decimal(text)
+    if parsed is None or parsed != parsed.to_integral_value():
+        return text
+    return f"{int(parsed):06d}"
+
+
+def scorecard_row(raw: Mapping[str, Any]) -> ScorecardRow | None:
+    unitid = parse_int(raw.get("UNITID"))
+    if unitid is None:
+        return None
+    main = parse_int(raw.get("MAIN"))
+    return ScorecardRow(
+        unitid=unitid,
+        opeid6=normalize_opeid6(raw.get("OPEID6")),
+        institution_name=str(raw.get("INSTNM") or "").strip(),
+        control=parse_int(raw.get("CONTROL")),
+        main_campus=None if main is None else main == 1,
+        endowment_begin=parse_decimal(raw.get("ENDOWBEGIN")),
+        endowment_end=parse_decimal(raw.get("ENDOWEND")),
+    )
+
+
+def read_scorecard_rows(path: Path) -> list[ScorecardRow]:
+    if not path.exists():
+        raise ValueError(f"Scorecard source does not exist: {path}")
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path) as archive:
+            members = [
+                name
+                for name in archive.namelist()
+                if name.lower().endswith(".csv") and not name.startswith("__MACOSX/")
+            ]
+            if len(members) != 1:
+                raise ValueError(
+                    f"Scorecard ZIP must contain exactly one CSV; found {len(members)}"
+                )
+            with archive.open(members[0]) as raw:
+                with io.TextIOWrapper(raw, encoding="utf-8-sig", newline="") as text:
+                    return parse_scorecard_reader(csv.DictReader(text))
+    with path.open("r", encoding="utf-8-sig", newline="") as source:
+        return parse_scorecard_reader(csv.DictReader(source))
+
+
+def parse_scorecard_reader(reader: csv.DictReader[str]) -> list[ScorecardRow]:
+    required = {"UNITID", "OPEID6", "INSTNM", "MAIN", "CONTROL", "ENDOWBEGIN", "ENDOWEND"}
+    missing = sorted(required - set(reader.fieldnames or []))
+    if missing:
+        raise ValueError("Scorecard source is missing columns: " + ", ".join(missing))
+    parsed = [row for raw in reader if (row := scorecard_row(raw)) is not None]
+    if not parsed:
+        raise ValueError("Scorecard source contains no valid UNITID rows")
+    return parsed
+
+
+def rest_url(base_url: str, table: str, params: Mapping[str, str]) -> str:
+    return (
+        base_url.rstrip("/")
+        + "/rest/v1/"
+        + table
+        + "?"
+        + urllib.parse.urlencode(params, safe="(),.*")
+    )
+
+
+def postgrest_get_all(
+    base_url: str,
+    api_key: str,
+    table: str,
+    params: Mapping[str, str],
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> list[dict[str, Any]]:
+    if page_size <= 0 or page_size > 1000:
+        raise ValueError("PostgREST page size must be between 1 and 1000")
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page_params = dict(params)
+        page_params.update({"limit": str(page_size), "offset": str(offset)})
+        request = urllib.request.Request(
+            rest_url(base_url, table, page_params),
+            headers={"apikey": api_key, "Authorization": f"Bearer {api_key}"},
+        )
+        try:
+            with opener(request, timeout=60) as response:
+                page = json.load(response)
+        except urllib.error.HTTPError as exc:
+            raise ValueError(
+                f"PostgREST {table} request failed with HTTP {exc.code}"
+            ) from None
+        except urllib.error.URLError:
+            raise ValueError(f"PostgREST {table} request could not connect") from None
+        if not isinstance(page, list) or any(not isinstance(row, dict) for row in page):
+            raise ValueError(f"PostgREST {table} returned a non-row response")
+        if not page:
+            return rows
+        rows.extend(page)
+        offset += len(page)
+
+
+def fetch_ipeds_endowment_facts(
+    base_url: str,
+    api_key: str,
+    *,
+    min_year: int,
+    max_year: int,
+) -> list[dict[str, Any]]:
+    return postgrest_get_all(
+        base_url,
+        api_key,
+        "ipeds_facts",
+        {
+            "select": (
+                "release_id,ipeds_id,unitid,data_year,field_key,value_numeric,"
+                "source_table,source_variable"
+            ),
+            "field_key": "in.(endowment_value_begin,endowment_value_end)",
+            "data_year": f"gte.{min_year}",
+            "and": f"(data_year.lte.{max_year},source_table.like.F*_F2)",
+            "public_visible": "eq.true",
+            "order": (
+                "data_year.asc,unitid.asc,field_key.asc,source_table.asc,"
+                "source_variable.asc,release_id.asc"
+            ),
+        },
+    )
+
+
+def fetch_in_scope_private_nonprofit_directory(
+    base_url: str,
+    api_key: str,
+) -> list[dict[str, Any]]:
+    return postgrest_get_all(
+        base_url,
+        api_key,
+        "institution_directory",
+        {
+            "select": "ipeds_id,school_name,control,in_scope,main_campus,branch_count",
+            "control": "eq.2",
+            "in_scope": "eq.true",
+            "order": "ipeds_id.asc",
+        },
+    )
+
+
+def build_fact_pairs(rows: Iterable[Mapping[str, Any]]) -> dict[int, dict[int, FactPair]]:
+    values: dict[tuple[int, int, str], Decimal] = {}
+    for row in rows:
+        unitid = parse_int(row.get("unitid")) or parse_int(row.get("ipeds_id"))
+        year = parse_int(row.get("data_year"))
+        field = str(row.get("field_key") or "")
+        value = parse_decimal(row.get("value_numeric"))
+        if unitid is None or year is None or field not in ENDOWMENT_FIELDS or value is None:
+            continue
+        key = (year, unitid, field)
+        if key in values and values[key] != value:
+            raise ValueError(
+                f"Conflicting public IPEDS values for FY{year} UNITID {unitid} {field}"
+            )
+        values[key] = value
+
+    pairs: dict[int, dict[int, FactPair]] = defaultdict(dict)
+    unit_years = {(year, unitid) for year, unitid, _field in values}
+    for year, unitid in sorted(unit_years):
+        beginning = values.get((year, unitid, ENDOWMENT_FIELDS[0]))
+        ending = values.get((year, unitid, ENDOWMENT_FIELDS[1]))
+        if beginning is None or ending is None:
+            continue
+        pairs[year][unitid] = FactPair(unitid, year, beginning, ending)
+    return dict(pairs)
+
+
+def member_report(row: ScorecardRow, *, included: bool) -> dict[str, Any]:
+    return {
+        "unitid": row.unitid,
+        "institution_name": row.institution_name,
+        "opeid6": row.opeid6,
+        "main_campus": row.main_campus,
+        "endowment_begin": decimal_json(row.endowment_begin),
+        "endowment_end": decimal_json(row.endowment_end),
+        "included_in_sum": included,
+    }
+
+
+def reconcile_entity(
+    reporter: ScorecardRow,
+    fact: FactPair,
+    *,
+    opeid_groups: Mapping[str, list[ScorecardRow]],
+    residual_candidates: Mapping[tuple[Decimal, Decimal], list[ScorecardRow]],
+    reporting_unitids: set[int] | frozenset[int] = frozenset(),
+) -> dict[str, Any]:
+    direct_pair = reporter.pair
+    base = {
+        "reporter_unitid": reporter.unitid,
+        "reporter_name": reporter.institution_name,
+        "opeid6": reporter.opeid6,
+        "ipeds": {
+            "endowment_begin": decimal_json(fact.endowment_begin),
+            "endowment_end": decimal_json(fact.endowment_end),
+        },
+    }
+    if direct_pair == fact.pair:
+        return {
+            **base,
+            "matched": True,
+            "method": METHOD_DIRECT_UNITID,
+            "members": [member_report(reporter, included=True)],
+        }
+
+    group = (
+        [
+            row
+            for row in opeid_groups.get(reporter.opeid6, [])
+            if row.unitid == reporter.unitid or row.unitid not in reporting_unitids
+        ]
+        if reporter.opeid6
+        else []
+    )
+    complete_group = [row for row in group if row.pair is not None]
+    if len(group) > 1 and complete_group:
+        rollup_pair = (
+            sum(
+                (
+                    row.endowment_begin
+                    for row in complete_group
+                    if row.endowment_begin is not None
+                ),
+                Decimal(0),
+            ),
+            sum(
+                (
+                    row.endowment_end
+                    for row in complete_group
+                    if row.endowment_end is not None
+                ),
+                Decimal(0),
+            ),
+        )
+        if rollup_pair == fact.pair:
+            return {
+                **base,
+                "matched": True,
+                "method": METHOD_OPEID6_ROLLUP,
+                "scorecard_rollup": {
+                    "endowment_begin": decimal_json(rollup_pair[0]),
+                    "endowment_end": decimal_json(rollup_pair[1]),
+                },
+                "allocation_member_unitids": sorted(
+                    row.unitid
+                    for row in complete_group
+                    if row.unitid != reporter.unitid
+                ),
+                "members": [
+                    member_report(row, included=row.pair is not None)
+                    for row in sorted(group, key=lambda item: item.unitid)
+                ],
+            }
+
+    candidates: list[ScorecardRow] = []
+    residual_pair: tuple[Decimal, Decimal] | None = None
+    if direct_pair is not None:
+        residual_pair = (
+            fact.endowment_begin - direct_pair[0],
+            fact.endowment_end - direct_pair[1],
+        )
+        candidates = [
+            row
+            for row in residual_candidates.get(residual_pair, [])
+            if row.unitid != reporter.unitid
+        ]
+        if len(candidates) == 1:
+            return {
+                **base,
+                "matched": True,
+                "method": METHOD_UNIQUE_RESIDUAL,
+                "residual_candidate_unitid": candidates[0].unitid,
+                "allocation_member_unitids": [candidates[0].unitid],
+                "residual": {
+                    "endowment_begin": decimal_json(residual_pair[0]),
+                    "endowment_end": decimal_json(residual_pair[1]),
+                },
+                "members": [
+                    member_report(reporter, included=True),
+                    member_report(candidates[0], included=True),
+                ],
+            }
+
+    method = "ambiguous_residual" if len(candidates) > 1 else "unreconciled"
+    return {
+        **base,
+        "matched": False,
+        "method": method,
+        "direct_scorecard": {
+            "endowment_begin": decimal_json(reporter.endowment_begin),
+            "endowment_end": decimal_json(reporter.endowment_end),
+        },
+        "residual": {
+            "endowment_begin": decimal_json(residual_pair[0]),
+            "endowment_end": decimal_json(residual_pair[1]),
+        }
+        if residual_pair is not None
+        else None,
+        "members": [
+            member_report(row, included=row.pair is not None)
+            for row in sorted(group or [reporter], key=lambda item: item.unitid)
+        ],
+        "residual_candidates": [
+            member_report(row, included=False)
+            for row in sorted(candidates, key=lambda item: item.unitid)
+        ],
+    }
+
+
+def reconcile_year(
+    year: int,
+    in_scope_rows: Iterable[ScorecardRow],
+    facts: Mapping[int, FactPair],
+    all_private_nonprofit_rows: Iterable[ScorecardRow],
+) -> dict[str, Any]:
+    scorecard_rows = sorted(in_scope_rows, key=lambda row: row.unitid)
+    private_rows = list(all_private_nonprofit_rows)
+    opeid_groups: dict[str, list[ScorecardRow]] = defaultdict(list)
+    residual_candidates: dict[tuple[Decimal, Decimal], list[ScorecardRow]] = defaultdict(list)
+    for row in private_rows:
+        if row.opeid6:
+            opeid_groups[row.opeid6].append(row)
+        if row.pair is not None and row.unitid not in facts:
+            residual_candidates[row.pair].append(row)
+
+    entities: list[dict[str, Any]] = []
+    no_f2_rows: list[dict[str, Any]] = []
+    for row in scorecard_rows:
+        fact = facts.get(row.unitid)
+        if fact is None:
+            no_f2_rows.append({
+                "unitid": row.unitid,
+                "institution_name": row.institution_name,
+                "opeid6": row.opeid6,
+                "reason": "no_complete_f2_fact_pair",
+            })
+            continue
+        entities.append(
+            reconcile_entity(
+                row,
+                fact,
+                opeid_groups=opeid_groups,
+                residual_candidates=residual_candidates,
+                reporting_unitids=set(facts),
+            )
+        )
+
+    allocation_claims: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for entity in entities:
+        if not entity["matched"]:
+            continue
+        for member_unitid in entity.get("allocation_member_unitids", []):
+            allocation_claims[int(member_unitid)].append(entity)
+    conflicting_members_by_reporter: dict[int, set[int]] = defaultdict(set)
+    for member_unitid, claims in allocation_claims.items():
+        if len(claims) <= 1:
+            continue
+        for entity in claims:
+            conflicting_members_by_reporter[int(entity["reporter_unitid"])].add(
+                member_unitid
+            )
+    for entity in entities:
+        conflicts = conflicting_members_by_reporter.get(int(entity["reporter_unitid"]))
+        if not conflicts:
+            continue
+        entity["matched"] = False
+        entity["method"] = "ambiguous_branch_allocation"
+        entity["members"] = [
+            {
+                **member,
+                "included_in_sum": (
+                    member["included_in_sum"] and member["unitid"] not in conflicts
+                ),
+            }
+            for member in entity["members"]
+        ]
+        entity["conflicting_allocation_unitids"] = sorted(conflicts)
+
+    direct_exact = sum(entity["method"] == METHOD_DIRECT_UNITID for entity in entities)
+    consolidation_required = len(entities) - direct_exact
+    consolidation_matched = sum(
+        entity["matched"] and entity["method"] != METHOD_DIRECT_UNITID
+        for entity in entities
+    )
+    matched = sum(entity["matched"] for entity in entities)
+    denominator = len(entities)
+    rate = Decimal(matched) / Decimal(denominator) if denominator else Decimal(0)
+    return {
+        "data_year": year,
+        "reporting_entities": denominator,
+        "matched_reporting_entities": matched,
+        "reporting_entity_rate": decimal_json(rate),
+        "direct_exact_unitid_rows": direct_exact,
+        "direct_exact_rate": decimal_json(
+            Decimal(direct_exact) / Decimal(denominator) if denominator else Decimal(0)
+        ),
+        "consolidation_required": consolidation_required,
+        "consolidation_matched": consolidation_matched,
+        "unreconciled_count": sum(not entity["matched"] for entity in entities),
+        "entities": entities,
+        "no_f2_rows": no_f2_rows,
+    }
+
+
+def alignment_sort_key(alignment: Mapping[str, Any]) -> tuple[Decimal, int, int, int]:
+    reporting_entities = int(alignment["reporting_entities"])
+    rate = (
+        Decimal(int(alignment["matched_reporting_entities"]))
+        / Decimal(reporting_entities)
+        if reporting_entities
+        else Decimal(0)
+    )
+    return (
+        rate,
+        int(alignment["matched_reporting_entities"]),
+        int(alignment["reporting_entities"]),
+        int(alignment["data_year"]),
+    )
+
+
+def fixture_results(
+    fixture_unitids: Iterable[int],
+    scorecard_by_unitid: Mapping[int, ScorecardRow],
+    facts: Mapping[int, FactPair],
+) -> list[dict[str, Any]]:
+    results = []
+    for unitid in fixture_unitids:
+        scorecard = scorecard_by_unitid.get(unitid)
+        fact = facts.get(unitid)
+        matched = scorecard is not None and fact is not None and scorecard.pair == fact.pair
+        results.append({
+            "unitid": unitid,
+            "institution_name": scorecard.institution_name if scorecard else None,
+            "matched": matched,
+            "scorecard": {
+                "endowment_begin": decimal_json(scorecard.endowment_begin),
+                "endowment_end": decimal_json(scorecard.endowment_end),
+            }
+            if scorecard
+            else None,
+            "ipeds": {
+                "endowment_begin": decimal_json(fact.endowment_begin),
+                "endowment_end": decimal_json(fact.endowment_end),
+            }
+            if fact
+            else None,
+        })
+    return results
+
+
+def reconcile_scorecard(
+    scorecard_rows: Iterable[ScorecardRow],
+    fact_rows: Iterable[Mapping[str, Any]],
+    directory_rows: Iterable[Mapping[str, Any]],
+    *,
+    min_year: int,
+    max_year: int,
+    threshold: Decimal,
+    min_reporting_coverage: Decimal = DEFAULT_MIN_REPORTING_COVERAGE,
+) -> dict[str, Any]:
+    all_rows = list(scorecard_rows)
+    private_with_values = [row for row in all_rows if row.control == 2 and row.pair is not None]
+    private_rows = [row for row in all_rows if row.control == 2]
+    directory_unitids = {
+        unitid
+        for row in directory_rows
+        if (unitid := parse_int(row.get("ipeds_id"))) is not None
+        and parse_int(row.get("control")) == 2
+        and row.get("in_scope") is True
+    }
+    in_scope = [row for row in private_with_values if row.unitid in directory_unitids]
+    excluded = [
+        {
+            "unitid": row.unitid,
+            "institution_name": row.institution_name,
+            "reason": "not_in_current_in_scope_private_nonprofit_directory",
+        }
+        for row in private_with_values
+        if row.unitid not in directory_unitids
+    ]
+    pairs_by_year = build_fact_pairs(fact_rows)
+    alignments = [
+        reconcile_year(year, in_scope, pairs_by_year.get(year, {}), private_rows)
+        for year in range(min_year, max_year + 1)
+    ]
+    if not alignments:
+        raise ValueError("No candidate data years were requested")
+    in_scope_count = len(in_scope)
+    coverage_by_year: dict[int, Decimal] = {}
+    for alignment in alignments:
+        year = int(alignment["data_year"])
+        coverage = (
+            Decimal(int(alignment["reporting_entities"])) / Decimal(in_scope_count)
+            if in_scope_count
+            else Decimal(0)
+        )
+        coverage_by_year[year] = coverage
+        alignment["scorecard_population_coverage"] = decimal_json(coverage)
+    population_eligible = [
+        alignment
+        for alignment in alignments
+        if coverage_by_year[int(alignment["data_year"])] >= min_reporting_coverage
+    ]
+    best = max(population_eligible or alignments, key=alignment_sort_key)
+    best_year = int(best["data_year"])
+    scorecard_by_unitid = {row.unitid: row for row in all_rows}
+    fixtures = fixture_results(
+        DEFAULT_FIXTURE_UNITIDS,
+        scorecard_by_unitid,
+        pairs_by_year.get(best_year, {}),
+    )
+    best_denominator = int(best["reporting_entities"])
+    best_rate = (
+        Decimal(int(best["matched_reporting_entities"]))
+        / Decimal(best_denominator)
+        if best_denominator
+        else Decimal(0)
+    )
+    best_coverage = coverage_by_year[best_year]
+    return {
+        "methodology": {
+            "population": (
+                "Current in-scope private-nonprofit Scorecard rows with both ENDOWBEGIN "
+                "and ENDOWEND, restricted to UNITIDs with a complete F2 fact pair"
+            ),
+            "matching_order": [
+                METHOD_DIRECT_UNITID,
+                METHOD_OPEID6_ROLLUP,
+                METHOD_UNIQUE_RESIDUAL,
+            ],
+            "fuzzy_name_matching": False,
+        },
+        "candidate_years": list(range(min_year, max_year + 1)),
+        "scorecard_private_nonprofit_rows_with_values": len(private_with_values),
+        "in_scope_private_nonprofit_rows_with_values": len(in_scope),
+        "excluded_scorecard_rows": excluded,
+        "alignments": alignments,
+        "best_alignment": best,
+        "fixtures": fixtures,
+        "fixtures_all_match": all(item["matched"] for item in fixtures),
+        "gate": {
+            "threshold": decimal_json(threshold),
+            "rate": decimal_json(best_rate),
+            "rate_passed": best_rate >= threshold,
+            "min_reporting_coverage": decimal_json(min_reporting_coverage),
+            "reporting_coverage": decimal_json(best_coverage),
+            "reporting_coverage_passed": best_coverage >= min_reporting_coverage,
+            "passed": (
+                best_rate >= threshold and best_coverage >= min_reporting_coverage
+            ),
+        },
+    }
+
+
+def decimal_json(value: Decimal | None) -> int | float | None:
+    if value is None:
+        return None
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)
+
+
+def print_summary(report: Mapping[str, Any]) -> None:
+    best = report["best_alignment"]
+    gate = report["gate"]
+    print(
+        f"Best alignment: FY{best['data_year']} | in-scope Scorecard rows with values: "
+        f"{report['in_scope_private_nonprofit_rows_with_values']}"
+    )
+    print(
+        f"Direct exact UNITID: {best['direct_exact_unitid_rows']}/{best['reporting_entities']} | "
+        f"consolidated: {best['consolidation_matched']}/{best['consolidation_required']}"
+    )
+    print(
+        f"Reporting entities: {best['matched_reporting_entities']}/{best['reporting_entities']} "
+        f"= {float(best['reporting_entity_rate']):.3%} | gate "
+        f"{float(gate['threshold']):.3%}: {'PASS' if gate['passed'] else 'FAIL'}"
+    )
+    print(
+        f"F2 reporting coverage: {float(gate['reporting_coverage']):.3%} | minimum "
+        f"{float(gate['min_reporting_coverage']):.3%}: "
+        f"{'PASS' if gate['reporting_coverage_passed'] else 'FAIL'}"
+    )
+    print(
+        f"Excluded/no-F2: {len(report['excluded_scorecard_rows'])}/"
+        f"{len(best['no_f2_rows'])} | fixtures: "
+        f"{sum(item['matched'] for item in report['fixtures'])}/{len(report['fixtures'])}"
+    )
+    for entity in best["entities"]:
+        if not entity["matched"]:
+            print(
+                f"Unreconciled: {entity['reporter_unitid']} {entity['reporter_name']} "
+                f"({entity['method']})"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ipeds/requirements.txt
+++ b/tools/ipeds/requirements.txt
@@ -1,0 +1,3 @@
+openpyxl>=3.1
+psycopg[binary]>=3.2,<4
+supabase>=2.9

--- a/tools/ipeds/test_project.py
+++ b/tools/ipeds/test_project.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import sys
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tools.ipeds.load_release import (
+    ADMIN_DATABASE_URL_ENV,
+    AdminRefreshConnectionError,
+    AdminRefreshConfigurationError,
+    PublicationRefreshError,
+    RequiredCacheRefreshError,
+    apply_to_supabase,
     build_loaded_table_payloads,
     build_release_notes,
     data_url_for_table,
     dedupe_rows,
     find_table_zip,
+    preflight_admin_database,
     read_release_manifest,
     read_table_zip,
     refresh_post_load_serving_views,
+    require_admin_database_url,
     prune_release_scope,
     supersede_lower_priority_facts,
     validate_release_priority,
@@ -28,6 +39,71 @@ from tools.ipeds.load_release import (
 from tools.ipeds.mappings import FactMapping, fact_mappings_for_data_year, resolve_fact_mappings_for_columns, table_name_for_data_year
 from tools.ipeds.metadata import IpedsColumn, IpedsTable, IpedsValueLabel, TablesDoc
 from tools.ipeds.project import project_rows_to_facts, quality_from_label
+
+
+class FakeDatabaseError(RuntimeError):
+    sqlstate = "57014"
+
+
+class FakeAdminCursor:
+    def __init__(self, connection: "FakeAdminConnection") -> None:
+        self.connection = connection
+        self.sql = ""
+
+    def __enter__(self) -> "FakeAdminCursor":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[object, ...] = ()) -> None:
+        self.sql = sql
+        self.connection.calls.append((sql, params))
+        if self.connection.fail_on and self.connection.fail_on in sql:
+            raise self.connection.error
+
+    def fetchone(self) -> tuple[object]:
+        if "has_function_privilege" in self.sql:
+            return (self.connection.preflight_allowed,)
+        if "refresh_ipeds_current_facts_cache" in self.sql:
+            return (8244,)
+        if "refresh_ipeds_browser_source_modes" in self.sql:
+            return (100,)
+        return (1,)
+
+
+class FakeAdminConnection:
+    def __init__(
+        self,
+        *,
+        fail_on: str | None = None,
+        error: Exception | None = None,
+        preflight_allowed: bool = True,
+    ) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fail_on = fail_on
+        self.error = error or RuntimeError("database failure")
+        self.preflight_allowed = preflight_allowed
+
+    def __enter__(self) -> "FakeAdminConnection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def cursor(self) -> FakeAdminCursor:
+        return FakeAdminCursor(self)
+
+
+class FailingAdminConnectionContext:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def __enter__(self) -> None:
+        raise self.error
+
+    def __exit__(self, *_args: object) -> None:
+        return None
 
 
 class IpedsProjectionTests(unittest.TestCase):
@@ -257,44 +333,139 @@ class IpedsProjectionTests(unittest.TestCase):
         self.assertEqual(next(mapping for mapping in resolved if mapping.field_key == "room_and_board_on_campus").table_name, "IC2019")
         self.assertEqual(next(mapping for mapping in resolved if mapping.field_key == "total_price_in_state_on_campus").table_name, "DRVIC2019")
 
-    def test_post_load_refreshes_current_cache_before_browser_modes(self) -> None:
-        class FakeRpc:
-            def __init__(self, calls: list[str], name: str) -> None:
-                self.calls = calls
-                self.name = name
-                self.data = 1
+    def test_direct_post_load_refreshes_required_cache_before_browser_modes(self) -> None:
+        connection = FakeAdminConnection()
+        stdout = io.StringIO()
 
-            def execute(self) -> "FakeRpc":
-                self.calls.append(self.name)
-                return self
-
-        class FakeClient:
-            def __init__(self) -> None:
-                self.calls: list[str] = []
-
-            def rpc(self, name: str) -> FakeRpc:
-                return FakeRpc(self.calls, name)
-
-        client = FakeClient()
-
-        refresh_post_load_serving_views(client)
+        with contextlib.redirect_stdout(stdout):
+            refresh_post_load_serving_views(
+                "postgresql://admin:secret@example.test/postgres",
+                connect=lambda _dsn: connection,
+            )
 
         self.assertEqual(
-            client.calls,
-            ["refresh_ipeds_current_facts_cache", "refresh_ipeds_browser_source_modes"],
+            [call[0] for call in connection.calls],
+            [
+                "select set_config('statement_timeout', %s, false)",
+                "select public.refresh_ipeds_current_facts_cache()",
+                "select public.refresh_ipeds_browser_source_modes()",
+            ],
+        )
+        self.assertEqual(connection.calls[0][1], ("600000",))
+        self.assertIn("refreshed current IPEDS facts cache: 8244", stdout.getvalue())
+        self.assertIn("refreshed browser source modes: 100", stdout.getvalue())
+
+    def test_required_current_cache_refresh_failure_propagates_without_secret(self) -> None:
+        secret = "do-not-leak"
+        connection = FakeAdminConnection(
+            fail_on="refresh_ipeds_current_facts_cache",
+            error=FakeDatabaseError(f"{secret} postgresql://admin:{secret}@host/db"),
         )
 
-    def test_required_current_cache_refresh_failure_propagates(self) -> None:
-        class FailingRpc:
-            def execute(self) -> None:
-                raise RuntimeError("refresh failed")
+        with self.assertRaises(RequiredCacheRefreshError) as caught:
+            refresh_post_load_serving_views(
+                f"postgresql://admin:{secret}@example.test/postgres",
+                connect=lambda _dsn: connection,
+            )
 
-        class FakeClient:
-            def rpc(self, _name: str) -> FailingRpc:
-                return FailingRpc()
+        self.assertIn("SQLSTATE 57014", str(caught.exception))
+        self.assertNotIn(secret, str(caught.exception))
+        self.assertEqual(
+            [call[0] for call in connection.calls],
+            [
+                "select set_config('statement_timeout', %s, false)",
+                "select public.refresh_ipeds_current_facts_cache()",
+            ],
+        )
 
-        with self.assertRaisesRegex(RuntimeError, "refresh failed"):
-            refresh_post_load_serving_views(FakeClient())
+    def test_browser_source_mode_refresh_is_best_effort_and_redacted(self) -> None:
+        secret = "browser-secret"
+        connection = FakeAdminConnection(
+            fail_on="refresh_ipeds_browser_source_modes",
+            error=RuntimeError(f"bad DSN postgresql://admin:{secret}@host/db"),
+        )
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            refresh_post_load_serving_views(
+                f"postgresql://admin:{secret}@example.test/postgres",
+                connect=lambda _dsn: connection,
+            )
+
+        self.assertIn("current facts cache published", stderr.getvalue())
+        self.assertNotIn(secret, stderr.getvalue())
+
+    def test_publication_connection_lifecycle_failure_is_redacted(self) -> None:
+        secret = "lifecycle-secret"
+
+        with self.assertRaises(AdminRefreshConnectionError) as caught:
+            refresh_post_load_serving_views(
+                f"postgresql://admin:{secret}@example.test/postgres",
+                connect=lambda _dsn: FailingAdminConnectionContext(
+                    RuntimeError(f"could not enter with {secret}")
+                ),
+            )
+
+        self.assertIn("session failed during publication", str(caught.exception))
+        self.assertNotIn(secret, str(caught.exception))
+
+    def test_admin_database_url_is_required_and_validated_without_echoing_it(self) -> None:
+        with self.assertRaisesRegex(
+            AdminRefreshConfigurationError,
+            ADMIN_DATABASE_URL_ENV,
+        ):
+            require_admin_database_url({})
+
+        secret = "invalid-secret"
+        with self.assertRaises(AdminRefreshConfigurationError) as caught:
+            require_admin_database_url(
+                {ADMIN_DATABASE_URL_ENV: f"https://admin:{secret}@example.test/project"}
+            )
+        self.assertNotIn(secret, str(caught.exception))
+
+        valid = "postgresql://admin:secret@example.test/postgres?sslmode=require"
+        self.assertEqual(
+            require_admin_database_url({ADMIN_DATABASE_URL_ENV: valid}),
+            valid,
+        )
+
+    def test_admin_preflight_requires_cache_refresh_execute_privilege(self) -> None:
+        connection = FakeAdminConnection(preflight_allowed=False)
+
+        with self.assertRaisesRegex(
+            AdminRefreshConfigurationError,
+            "cannot execute refresh_ipeds_current_facts_cache",
+        ):
+            preflight_admin_database(
+                "postgresql://admin:secret@example.test/postgres",
+                connect=lambda _dsn: connection,
+            )
+
+        self.assertEqual(len(connection.calls), 1)
+        self.assertIn("has_function_privilege", connection.calls[0][0])
+
+    def test_apply_preflight_failure_happens_before_supabase_client_creation(self) -> None:
+        create_client_calls: list[tuple[object, ...]] = []
+        fake_supabase = SimpleNamespace(
+            create_client=lambda *args: create_client_calls.append(args)
+        )
+
+        with (
+            patch("tools.ipeds.load_release.load_env"),
+            patch(
+                "tools.ipeds.load_release.require_admin_database_url",
+                return_value="postgresql://admin:secret@example.test/postgres",
+            ),
+            patch(
+                "tools.ipeds.load_release.preflight_admin_database",
+                side_effect=AdminRefreshConnectionError("unreachable"),
+            ),
+            patch.dict(sys.modules, {"supabase": fake_supabase}),
+        ):
+            with self.assertRaises(AdminRefreshConnectionError):
+                apply_to_supabase(None, None, {}, {}, [], ())
+
+        self.assertEqual(create_client_calls, [])
 
     def test_release_scope_prunes_stale_rows_after_upsert_at_mapping_scope(self) -> None:
         deletes: list[tuple[str, list[tuple[str, object]]]] = []
@@ -730,6 +901,50 @@ class IpedsProjectionTests(unittest.TestCase):
             ):
                 self.assertEqual(load_release_main(), 0)
                 apply_mock.assert_called_once()
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                patch.object(sys, "argv", argv),
+                patch("tools.ipeds.load_release.parse_tablesdoc", return_value=tablesdoc),
+                patch(
+                    "tools.ipeds.load_release.resolve_fact_mappings_for_columns",
+                    return_value=(mapping,),
+                ),
+                patch("tools.ipeds.load_release.project_rows_to_facts", return_value=facts),
+                patch(
+                    "tools.ipeds.load_release.apply_to_supabase",
+                    side_effect=PublicationRefreshError("required cache refresh failed"),
+                ),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(load_release_main(), 4)
+
+            self.assertNotIn("applied release", stdout.getvalue())
+            self.assertIn("release data writes completed", stderr.getvalue())
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                patch.object(sys, "argv", argv),
+                patch("tools.ipeds.load_release.parse_tablesdoc", return_value=tablesdoc),
+                patch(
+                    "tools.ipeds.load_release.resolve_fact_mappings_for_columns",
+                    return_value=(mapping,),
+                ),
+                patch("tools.ipeds.load_release.project_rows_to_facts", return_value=facts),
+                patch(
+                    "tools.ipeds.load_release.apply_to_supabase",
+                    side_effect=AdminRefreshConnectionError("unreachable"),
+                ),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(load_release_main(), 3)
+
+            self.assertNotIn("applied release", stdout.getvalue())
+            self.assertIn("stopped before release writes", stderr.getvalue())
 
     def test_release_manifest_reader_handles_absent_invalid_and_valid_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/ipeds/test_reconcile_endowment_scorecard.py
+++ b/tools/ipeds/test_reconcile_endowment_scorecard.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import tempfile
+import unittest
+import urllib.parse
+import zipfile
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.ipeds.reconcile_endowment_scorecard import (
+    FactPair,
+    ScorecardRow,
+    alignment_sort_key,
+    fetch_in_scope_private_nonprofit_directory,
+    fetch_ipeds_endowment_facts,
+    fixture_results,
+    parse_decimal,
+    postgrest_get_all,
+    read_scorecard_rows,
+    reconcile_entity,
+    reconcile_scorecard,
+    reconcile_year,
+)
+
+
+def scorecard(
+    unitid: int,
+    begin: int | None,
+    end: int | None,
+    *,
+    opeid6: str = "001234",
+    name: str | None = None,
+    control: int = 2,
+    main: bool = True,
+) -> ScorecardRow:
+    return ScorecardRow(
+        unitid=unitid,
+        opeid6=opeid6,
+        institution_name=name or f"School {unitid}",
+        control=control,
+        main_campus=main,
+        endowment_begin=None if begin is None else Decimal(begin),
+        endowment_end=None if end is None else Decimal(end),
+    )
+
+
+def fact(unitid: int, year: int, begin: int, end: int) -> FactPair:
+    return FactPair(unitid, year, Decimal(begin), Decimal(end))
+
+
+class FakeResponse(io.StringIO):
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class ReconcileEndowmentScorecardTests(unittest.TestCase):
+    def test_non_finite_numbers_are_rejected_at_the_input_boundary(self) -> None:
+        for value in ("NaN", "sNaN", "Infinity", "-Infinity"):
+            with self.subTest(value=value):
+                self.assertIsNone(parse_decimal(value))
+
+    def test_postgrest_paginates_and_sends_both_auth_headers(self) -> None:
+        requests = []
+
+        def opener(request: object, *, timeout: int) -> FakeResponse:
+            requests.append((request, timeout))
+            offset = urllib.parse.parse_qs(
+                urllib.parse.urlsplit(request.full_url).query
+            )["offset"][0]
+            page = {
+                "0": [{"id": 1}, {"id": 2}],
+                "2": [{"id": 3}],
+            }.get(offset, [])
+            return FakeResponse(json.dumps(page))
+
+        rows = postgrest_get_all(
+            "https://project.example",
+            "test-api-key",
+            "ipeds_facts",
+            {"select": "unitid"},
+            page_size=2,
+            opener=opener,
+        )
+
+        self.assertEqual(rows, [{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(len(requests), 3)
+        for request, timeout in requests:
+            self.assertEqual(request.get_header("Apikey"), "test-api-key")
+            self.assertEqual(request.get_header("Authorization"), "Bearer test-api-key")
+            self.assertEqual(timeout, 60)
+
+    def test_fact_and_directory_queries_bound_the_audit_population(self) -> None:
+        with patch(
+            "tools.ipeds.reconcile_endowment_scorecard.postgrest_get_all",
+            return_value=[],
+        ) as get_all:
+            fetch_ipeds_endowment_facts(
+                "https://project.example",
+                "test-api-key",
+                min_year=2020,
+                max_year=2024,
+            )
+            fetch_in_scope_private_nonprofit_directory(
+                "https://project.example",
+                "test-api-key",
+            )
+
+        fact_call, directory_call = get_all.call_args_list
+        self.assertEqual(fact_call.args[2], "ipeds_facts")
+        self.assertEqual(
+            fact_call.args[3],
+            {
+                "select": (
+                    "release_id,ipeds_id,unitid,data_year,field_key,value_numeric,"
+                    "source_table,source_variable"
+                ),
+                "field_key": "in.(endowment_value_begin,endowment_value_end)",
+                "data_year": "gte.2020",
+                "and": "(data_year.lte.2024,source_table.like.F*_F2)",
+                "public_visible": "eq.true",
+                "order": (
+                    "data_year.asc,unitid.asc,field_key.asc,source_table.asc,"
+                    "source_variable.asc,release_id.asc"
+                ),
+            },
+        )
+        self.assertEqual(directory_call.args[2], "institution_directory")
+        self.assertEqual(directory_call.args[3]["control"], "eq.2")
+        self.assertEqual(directory_call.args[3]["in_scope"], "eq.true")
+
+    def test_opeid6_rollup_reports_every_member_including_missing_values(self) -> None:
+        reporter = scorecard(100001, 60, 70)
+        branch = scorecard(100002, 40, 50, main=False)
+        missing_branch = scorecard(100003, None, None, main=False)
+
+        result = reconcile_entity(
+            reporter,
+            fact(100001, 2024, 100, 120),
+            opeid_groups={reporter.opeid6: [reporter, branch, missing_branch]},
+            residual_candidates={},
+        )
+
+        self.assertTrue(result["matched"])
+        self.assertEqual(result["method"], "opeid6_rollup")
+        self.assertEqual(
+            [member["unitid"] for member in result["members"]],
+            [100001, 100002, 100003],
+        )
+        self.assertFalse(result["members"][2]["included_in_sum"])
+
+    def test_unique_residual_handles_cross_opeid_allocation(self) -> None:
+        reporter = scorecard(100001, 60, 70, opeid6="001111")
+        acquired = scorecard(200001, 40, 50, opeid6="009999")
+
+        result = reconcile_entity(
+            reporter,
+            fact(100001, 2024, 100, 120),
+            opeid_groups={reporter.opeid6: [reporter]},
+            residual_candidates={acquired.pair: [acquired]},  # type: ignore[dict-item]
+        )
+
+        self.assertTrue(result["matched"])
+        self.assertEqual(result["method"], "unique_residual_match")
+        self.assertEqual(
+            [member["unitid"] for member in result["members"]],
+            [100001, 200001],
+        )
+
+    def test_ambiguous_residual_is_visible_and_does_not_match(self) -> None:
+        reporter = scorecard(100001, 60, 70)
+        candidate_a = scorecard(200001, 40, 50, opeid6="002000")
+        candidate_b = scorecard(200002, 40, 50, opeid6="003000")
+
+        result = reconcile_entity(
+            reporter,
+            fact(100001, 2024, 100, 120),
+            opeid_groups={reporter.opeid6: [reporter]},
+            residual_candidates={candidate_a.pair: [candidate_a, candidate_b]},  # type: ignore[dict-item]
+        )
+
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["method"], "ambiguous_residual")
+        self.assertEqual(
+            [member["unitid"] for member in result["residual_candidates"]],
+            [200001, 200002],
+        )
+
+    def test_branch_without_f2_fact_is_not_an_independent_reporter(self) -> None:
+        reporter = scorecard(100001, 60, 70)
+        branch = scorecard(100002, 40, 50, main=False)
+
+        result = reconcile_year(
+            2024,
+            [reporter, branch],
+            {100001: fact(100001, 2024, 100, 120)},
+            [reporter, branch],
+        )
+
+        self.assertEqual(result["reporting_entities"], 1)
+        self.assertEqual(result["consolidation_required"], 1)
+        self.assertEqual(result["consolidation_matched"], 1)
+        self.assertEqual(
+            [row["unitid"] for row in result["no_f2_rows"]],
+            [100002],
+        )
+
+    def test_independent_f2_reporter_cannot_be_used_as_a_residual_branch(self) -> None:
+        reporter = scorecard(100001, 60, 70, opeid6="001111")
+        independent = scorecard(200001, 40, 50, opeid6="001111")
+
+        result = reconcile_year(
+            2024,
+            [reporter, independent],
+            {
+                100001: fact(100001, 2024, 100, 120),
+                200001: fact(200001, 2024, 40, 50),
+            },
+            [reporter, independent],
+        )
+
+        by_unitid = {entity["reporter_unitid"]: entity for entity in result["entities"]}
+        self.assertFalse(by_unitid[100001]["matched"])
+        self.assertEqual(by_unitid[100001]["method"], "unreconciled")
+        self.assertEqual(by_unitid[200001]["method"], "direct_unitid")
+
+    def test_one_residual_branch_cannot_be_allocated_to_two_reporters(self) -> None:
+        reporter_a = scorecard(100001, 60, 70, opeid6="001111")
+        reporter_b = scorecard(100002, 60, 70, opeid6="002222")
+        branch = scorecard(200001, 40, 50, opeid6="003333", main=False)
+
+        result = reconcile_year(
+            2024,
+            [reporter_a, reporter_b, branch],
+            {
+                100001: fact(100001, 2024, 100, 120),
+                100002: fact(100002, 2024, 100, 120),
+            },
+            [reporter_a, reporter_b, branch],
+        )
+
+        reporters = [
+            entity for entity in result["entities"]
+            if entity["reporter_unitid"] in {100001, 100002}
+        ]
+        self.assertEqual(
+            [entity["method"] for entity in reporters],
+            ["ambiguous_branch_allocation", "ambiguous_branch_allocation"],
+        )
+        self.assertTrue(all(not entity["matched"] for entity in reporters))
+        self.assertTrue(
+            all(
+                next(
+                    member["included_in_sum"]
+                    for member in entity["members"]
+                    if member["unitid"] == branch.unitid
+                )
+                is False
+                for entity in reporters
+            )
+        )
+
+    def test_one_branch_cannot_be_shared_by_rollup_and_residual_matches(self) -> None:
+        rollup_reporter = scorecard(100001, 60, 70, opeid6="001111")
+        residual_reporter = scorecard(100002, 60, 70, opeid6="002222")
+        branch = scorecard(200001, 40, 50, opeid6="001111", main=False)
+
+        result = reconcile_year(
+            2024,
+            [rollup_reporter, residual_reporter, branch],
+            {
+                100001: fact(100001, 2024, 100, 120),
+                100002: fact(100002, 2024, 100, 120),
+            },
+            [rollup_reporter, residual_reporter, branch],
+        )
+
+        reporters = [
+            entity for entity in result["entities"]
+            if entity["reporter_unitid"] in {100001, 100002}
+        ]
+        self.assertEqual(
+            [entity["method"] for entity in reporters],
+            ["ambiguous_branch_allocation", "ambiguous_branch_allocation"],
+        )
+        self.assertTrue(all(not entity["matched"] for entity in reporters))
+        self.assertTrue(
+            all(
+                entity["conflicting_allocation_unitids"] == [branch.unitid]
+                for entity in reporters
+            )
+        )
+
+    def test_alignment_prefers_highest_rate_then_larger_and_newer_population(self) -> None:
+        candidates = [
+            {"reporting_entity_rate": 0.9, "matched_reporting_entities": 9, "reporting_entities": 10, "data_year": 2023},
+            {"reporting_entity_rate": 0.9, "matched_reporting_entities": 18, "reporting_entities": 20, "data_year": 2024},
+            {"reporting_entity_rate": 0.8, "matched_reporting_entities": 80, "reporting_entities": 100, "data_year": 2022},
+        ]
+
+        self.assertEqual(max(candidates, key=alignment_sort_key)["data_year"], 2024)
+
+    def test_fixture_results_require_exact_beginning_and_end_values(self) -> None:
+        rows = {
+            201195: scorecard(201195, 100, 120, name="Baldwin Wallace"),
+            148131: scorecard(148131, 50, 60, name="Quincy"),
+        }
+        facts = {
+            201195: fact(201195, 2024, 100, 120),
+            148131: fact(148131, 2024, 50, 61),
+        }
+
+        results = fixture_results([201195, 148131, 231420], rows, facts)
+
+        self.assertEqual([item["matched"] for item in results], [True, False, False])
+
+    def test_gate_passes_and_fails_at_configured_threshold(self) -> None:
+        rows = [scorecard(201195, 100, 120)]
+        directory = [{"ipeds_id": "201195", "control": 2, "in_scope": True}]
+        facts = [
+            {"unitid": 201195, "data_year": 2024, "field_key": "endowment_value_begin", "value_numeric": 100},
+            {"unitid": 201195, "data_year": 2024, "field_key": "endowment_value_end", "value_numeric": 120},
+        ]
+
+        passing = reconcile_scorecard(
+            rows,
+            facts,
+            directory,
+            min_year=2024,
+            max_year=2024,
+            threshold=Decimal("1"),
+        )
+        failing_facts = [
+            {"unitid": 201195, "data_year": 2024, "field_key": "endowment_value_begin", "value_numeric": 100},
+            {"unitid": 201195, "data_year": 2024, "field_key": "endowment_value_end", "value_numeric": 121},
+        ]
+        failing = reconcile_scorecard(
+            rows,
+            failing_facts,
+            directory,
+            min_year=2024,
+            max_year=2024,
+            threshold=Decimal("0.99"),
+        )
+
+        self.assertTrue(passing["gate"]["passed"])
+        self.assertFalse(failing["gate"]["passed"])
+
+    def test_sparse_exact_alignment_fails_reporting_coverage_gate(self) -> None:
+        rows = [
+            scorecard(
+                200000 + index,
+                100,
+                120,
+                opeid6=f"{index:06d}",
+            )
+            for index in range(100)
+        ]
+        directory = [
+            {"ipeds_id": str(row.unitid), "control": 2, "in_scope": True}
+            for row in rows
+        ]
+        facts = [
+            {
+                "unitid": rows[0].unitid,
+                "data_year": 2024,
+                "field_key": "endowment_value_begin",
+                "value_numeric": 100,
+            },
+            {
+                "unitid": rows[0].unitid,
+                "data_year": 2024,
+                "field_key": "endowment_value_end",
+                "value_numeric": 120,
+            },
+        ]
+
+        result = reconcile_scorecard(
+            rows,
+            facts,
+            directory,
+            min_year=2024,
+            max_year=2024,
+            threshold=Decimal("0.99"),
+            min_reporting_coverage=Decimal("0.95"),
+        )
+
+        self.assertTrue(result["gate"]["rate_passed"])
+        self.assertEqual(result["gate"]["reporting_coverage"], 0.01)
+        self.assertFalse(result["gate"]["reporting_coverage_passed"])
+        self.assertFalse(result["gate"]["passed"])
+
+    def test_alignment_selection_rejects_higher_rate_sparse_year(self) -> None:
+        rows = [
+            scorecard(
+                300000 + index,
+                100,
+                120,
+                opeid6=f"{index:06d}",
+            )
+            for index in range(100)
+        ]
+        directory = [
+            {"ipeds_id": str(row.unitid), "control": 2, "in_scope": True}
+            for row in rows
+        ]
+        facts = [
+            {
+                "unitid": rows[0].unitid,
+                "data_year": 2023,
+                "field_key": field_key,
+                "value_numeric": value,
+            }
+            for field_key, value in zip(
+                ("endowment_value_begin", "endowment_value_end"),
+                (100, 120),
+            )
+        ]
+        for index, row in enumerate(rows[:95]):
+            facts.extend([
+                {
+                    "unitid": row.unitid,
+                    "data_year": 2024,
+                    "field_key": "endowment_value_begin",
+                    "value_numeric": 100,
+                },
+                {
+                    "unitid": row.unitid,
+                    "data_year": 2024,
+                    "field_key": "endowment_value_end",
+                    "value_numeric": 121 if index == 94 else 120,
+                },
+            ])
+
+        result = reconcile_scorecard(
+            rows,
+            facts,
+            directory,
+            min_year=2023,
+            max_year=2024,
+            threshold=Decimal("0.99"),
+            min_reporting_coverage=Decimal("0.95"),
+        )
+
+        by_year = {
+            alignment["data_year"]: alignment for alignment in result["alignments"]
+        }
+        self.assertEqual(by_year[2023]["reporting_entity_rate"], 1)
+        self.assertEqual(by_year[2023]["scorecard_population_coverage"], 0.01)
+        self.assertEqual(result["best_alignment"]["data_year"], 2024)
+        self.assertEqual(result["gate"]["reporting_coverage"], 0.95)
+
+    def test_exact_decimal_reporting_coverage_boundary_passes(self) -> None:
+        rows = [
+            scorecard(400000 + index, 100, 120, opeid6=f"{index:06d}")
+            for index in range(3)
+        ]
+        directory = [
+            {"ipeds_id": str(row.unitid), "control": 2, "in_scope": True}
+            for row in rows
+        ]
+        facts = [
+            {
+                "unitid": rows[0].unitid,
+                "data_year": 2024,
+                "field_key": "endowment_value_begin",
+                "value_numeric": 100,
+            },
+            {
+                "unitid": rows[0].unitid,
+                "data_year": 2024,
+                "field_key": "endowment_value_end",
+                "value_numeric": 120,
+            },
+        ]
+        exact_one_third = Decimal(1) / Decimal(3)
+
+        result = reconcile_scorecard(
+            rows,
+            facts,
+            directory,
+            min_year=2024,
+            max_year=2024,
+            threshold=Decimal("1"),
+            min_reporting_coverage=exact_one_third,
+        )
+
+        self.assertTrue(result["gate"]["reporting_coverage_passed"])
+        self.assertTrue(result["gate"]["passed"])
+
+    def test_csv_and_zip_fixture_parsing_preserves_na_branch_values(self) -> None:
+        header = ["UNITID", "OPEID6", "INSTNM", "MAIN", "CONTROL", "ENDOWBEGIN", "ENDOWEND"]
+        rows = [
+            ["143978", "021553", "The Chicago School at Chicago", "0", "2", "14163764", "8540268"],
+            ["501549", "021553", "The Chicago School at Dallas", "0", "2", "NA", "NA"],
+        ]
+        text = io.StringIO()
+        writer = csv.writer(text)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "scorecard.csv"
+            zip_path = Path(tmp) / "scorecard.zip"
+            csv_path.write_text(text.getvalue(), encoding="utf-8")
+            with zipfile.ZipFile(zip_path, "w") as archive:
+                archive.writestr("scorecard.csv", text.getvalue())
+
+            csv_rows = read_scorecard_rows(csv_path)
+            zip_rows = read_scorecard_rows(zip_path)
+
+        self.assertEqual(csv_rows, zip_rows)
+        self.assertEqual(csv_rows[1].institution_name, "The Chicago School at Dallas")
+        self.assertIsNone(csv_rows[1].pair)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Route the required `refresh_ipeds_current_facts_cache()` publication step through an explicit direct or Supavisor session database connection with a 10-minute statement timeout, while preserving PostgREST for all normal IPEDS writes.
- Preflight the administrative connection before writes, redact database errors, distinguish pre-write configuration failures from post-write publication failures, and keep browser source-mode refresh best-effort.
- Add a read-only, paginated College Scorecard reconciliation command with deterministic UNITID, OPEID6 rollup, and unique exact two-value residual matching plus auditable JSON output.
- Document dependency installation, `IPEDS_ADMIN_DATABASE_URL`, safe apply/recovery semantics, and the reproduced PRD 027 baseline.

## Test Coverage

- `python3 -m unittest discover -s tools/ipeds -p 'test_*.py'`: 71 passed, 0 failed.
- `python3 -m compileall -q tools/ipeds`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Added focused tests for direct refresh success, required and best-effort failures, redaction, preflight ordering, bounded REST queries, server-capped pagination, deterministic consolidation, allocation ambiguity, anti-sparsity coverage, exact Decimal boundaries, fixtures, and gate outcomes.

## Pre-Landing Review

No issues found after resolving all testing, maintainability, red-team, and cross-model review findings. Structured Codex P1 gate: pass.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

The bounded PRD 027 reliability/reproducibility brief is complete. No Phase 2 UI/view, FY2015-19 backfill, recipe, deployment, or schema migration work is included.

## Verification Results

Read-only reconciliation against `Most-Recent-Cohorts-Institution_06102026.zip` and the production public API reproduced:

- Best alignment: FY2024.
- In-scope Scorecard rows with both values: 1,110.
- Direct exact UNITID matches: 1,060 / 1,079 F2 reporters.
- Consolidated matches: 18 / 19 (16 OPEID6 rollups, 2 unique residuals).
- Reporting-entity gate: 1,078 / 1,079 = 99.907% (pass at 99%).
- F2 reporting coverage: 97.207% (pass at the 95% anti-sparsity floor).
- Corrected fixtures: 5 / 5 exact.
- Remaining unreconciled entity: The Chicago School, whose Dallas branch has `NA` Scorecard values.

No production writes, administrative refreshes, migrations, or deployments were performed from this branch.

## Test plan

- [x] Full IPEDS unit suite passes (71 tests).
- [x] Read-only Scorecard reconciliation reproduces 99.907%.
- [x] All five corrected fixtures match exactly.
- [x] Secret scan found no configured environment values or production Supabase hosts in the diff and no auth/DSN markers in the audit JSON.
