### PR TITLE
Advertise the endowment finance category across agent surfaces (PRD 027)

### DIFF
--- a/docs/prd/027-endowment-financial-health.md
+++ b/docs/prd/027-endowment-financial-health.md
@@ -292,6 +292,13 @@ the site's contact path must be referenced near the panel so a school can disput
   - Known, accepted gaps (pre-existing, documented not fixed here): snapshots exclude IPEDS
     facts entirely; `/api/fields` and `field_dictionary.json` list only the static friendly
     fields; `/api/compare` cannot select IPEDS fields.
+  - **Amendment (2026-08-05), agent-surface discoverability:** the `/api/fields` gap is closed
+    for this family — documentation-only `ipeds.endowment_*` entries (with the sign and
+    residual caveats) join the field dictionary and snapshot `field_dictionary.json`, while
+    the `fields=` selector list stays friendly-fields-only. The MCP server tool descriptions,
+    `llms.txt`, and the OpenAPI spec enumerate valid categories including `finance` (and note
+    that compare excludes it). No new MCP tools: the server stays a thin generic wrapper per
+    PRD 022, and agent-facing caveats continue to travel inside each fact payload.
 - **Phase 2 panel:** compact endowment card on the school page — end value, 5-year sparkline or
   delta, draw rate with the qualified threshold copy — per `web/DESIGN_SYSTEM.md` and dataviz
   guidance. Private nonprofits only until F1A lands; publics get a "reports under different

--- a/packages/mcp-server/bin/collegedata-mcp.js
+++ b/packages/mcp-server/bin/collegedata-mcp.js
@@ -2,7 +2,10 @@
 
 const API_BASE = (process.env.COLLEGEDATA_API_BASE ?? "https://www.collegedata.fyi").replace(/\/$/, "");
 const CLIENT_NAME = "mcp";
-const CLIENT_VERSION = "0.1.0";
+const CLIENT_VERSION = "0.1.1";
+
+const FACT_CATEGORIES = "identity, admissions, enrollment, cost, aid, finance, outcomes, sources";
+const COMPARE_CATEGORIES = "identity, admissions, enrollment, cost, aid, outcomes, sources";
 
 const tools = [
   {
@@ -24,7 +27,10 @@ const tools = [
       type: "object",
       properties: {
         school_id: { type: "string" },
-        categories: { type: "string", description: "Optional comma-separated categories." },
+        categories: {
+          type: "string",
+          description: `Optional comma-separated categories. Valid: ${FACT_CATEGORIES}. Use "finance" for endowment values and spending (IPEDS Part H, fiscal years 2020+). Unknown categories are silently ignored.`,
+        },
       },
       required: ["school_id"],
     },
@@ -36,7 +42,10 @@ const tools = [
       type: "object",
       properties: {
         school_ids: { type: "array", items: { type: "string" } },
-        categories: { type: "string" },
+        categories: {
+          type: "string",
+          description: `Optional comma-separated categories. Valid for compare: ${COMPARE_CATEGORIES}. The finance category is facts-only; use get_school_facts for endowment data.`,
+        },
         fields: { type: "string" },
       },
       required: ["school_ids"],
@@ -53,10 +62,16 @@ const tools = [
   },
   {
     name: "get_field_dictionary",
-    description: "List V1 friendly fact field definitions.",
+    description:
+      "List friendly fact field definitions, including federal endowment fields (category: finance).",
     inputSchema: {
       type: "object",
-      properties: { category: { type: "string" } },
+      properties: {
+        category: {
+          type: "string",
+          description: `Optional single-category filter. Valid: ${FACT_CATEGORIES}.`,
+        },
+      },
     },
   },
 ];

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@collegedata-fyi/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "bin": {
     "collegedata-mcp": "./bin/collegedata-mcp.js"

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -9,10 +9,17 @@ Use these no-auth JSON endpoints for agent and CLI workflows:
 
 - Search schools: https://www.collegedata.fyi/api/schools/search?q=mit
 - School facts: https://www.collegedata.fyi/api/schools/mit/facts
+- School facts by category: https://www.collegedata.fyi/api/schools/mit/facts?categories=finance
+  (categories: identity, admissions, enrollment, cost, aid, finance, outcomes, sources)
 - School sources: https://www.collegedata.fyi/api/schools/mit/sources
 - Compare schools: https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chicago
 - Field dictionary: https://www.collegedata.fyi/api/fields
 - OpenAPI: https://www.collegedata.fyi/openapi.json
+
+Endowment health (IPEDS Finance Part H, fiscal years 2020+): request categories=finance for
+per-school endowment values, gifts, investment return, spending distribution, and the residual
+change line. Caveats travel inside each fact's quality.note — keep them when citing. Sector
+methodology and a worked example: https://www.collegedata.fyi/recipes/endowment-draw-rate
 
 When summarizing values, preserve the source metadata in each fact. Do not blend CDS, IPEDS, and Scorecard values without naming the source layer. Use source.url or source.archive_url for citations when available.
 `;

--- a/web/src/app/openapi.json/route.ts
+++ b/web/src/app/openapi.json/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
-import { publicFieldDefinitions } from "@/lib/public-data";
+import { selectableFactKeys } from "@/lib/public-data";
 
 export const revalidate = 3600;
 
+const FACT_CATEGORIES = "identity, admissions, enrollment, cost, aid, finance, outcomes, sources";
+const COMPARE_CATEGORIES = "identity, admissions, enrollment, cost, aid, outcomes, sources";
+
 export async function GET() {
-  const factKeys = publicFieldDefinitions().map((field) => field.key);
+  const factKeys = selectableFactKeys();
   return NextResponse.json(
     {
       openapi: "3.1.0",
@@ -31,7 +34,15 @@ export async function GET() {
             summary: "Get source-labeled school facts",
             parameters: [
               { name: "school_id", in: "path", required: true, schema: { type: "string" } },
-              { name: "categories", in: "query", required: false, schema: { type: "string" } },
+              {
+                name: "categories",
+                in: "query",
+                required: false,
+                schema: {
+                  type: "string",
+                  description: `Comma-separated categories. Valid: ${FACT_CATEGORIES}. Use finance for endowment values and spending (IPEDS Part H, fiscal years 2020+); unknown categories are ignored.`,
+                },
+              },
               {
                 name: "fields",
                 in: "query",
@@ -54,7 +65,15 @@ export async function GET() {
             summary: "Compare schools across friendly fact fields",
             parameters: [
               { name: "schools", in: "query", required: true, schema: { type: "string" } },
-              { name: "categories", in: "query", required: false, schema: { type: "string" } },
+              {
+                name: "categories",
+                in: "query",
+                required: false,
+                schema: {
+                  type: "string",
+                  description: `Comma-separated categories. Valid for compare: ${COMPARE_CATEGORIES}. The finance category is facts-only (per-school endpoint), not comparable.`,
+                },
+              },
               { name: "fields", in: "query", required: false, schema: { type: "string" } },
             ],
             responses: { "200": { description: "Sparse comparison matrix" } },
@@ -63,7 +82,14 @@ export async function GET() {
         "/api/fields": {
           get: {
             summary: "List V1 friendly field definitions",
-            parameters: [{ name: "category", in: "query", required: false, schema: { type: "string" } }],
+            parameters: [
+              {
+                name: "category",
+                in: "query",
+                required: false,
+                schema: { type: "string", description: `Single category filter. Valid: ${FACT_CATEGORIES}.` },
+              },
+            ],
             responses: { "200": { description: "Field dictionary" } },
           },
         },

--- a/web/src/lib/endowment-field-docs.test.ts
+++ b/web/src/lib/endowment-field-docs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+// public-data.ts transitively initializes the supabase client at module load,
+// so the env must exist before a dynamic import (a static import would hoist
+// above these assignments and crash).
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://localhost:54321";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+
+const { FEDERAL_ENDOWMENT_FIELD_DOCS, publicFieldDefinitions, selectableFactKeys } =
+  await import("./public-data");
+
+describe("federal endowment field docs", () => {
+  it("documents all six endowment facts under the finance category", () => {
+    expect(FEDERAL_ENDOWMENT_FIELD_DOCS).toHaveLength(6);
+    for (const field of FEDERAL_ENDOWMENT_FIELD_DOCS) {
+      expect(field.key).toMatch(/^ipeds\.endowment_/);
+      expect(field.category).toBe("finance");
+      expect(field.source_layer).toBe("ipeds");
+      expect(field.definition.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("appears in the public field dictionary", () => {
+    const keys = new Set(publicFieldDefinitions().map((field) => field.key));
+    for (const field of FEDERAL_ENDOWMENT_FIELD_DOCS) {
+      expect(keys.has(field.key)).toBe(true);
+    }
+  });
+
+  it("is excluded from the fields= selector key list", () => {
+    const selectable = new Set(selectableFactKeys());
+    expect(selectable.size).toBeGreaterThan(0);
+    for (const field of FEDERAL_ENDOWMENT_FIELD_DOCS) {
+      expect(selectable.has(field.key)).toBe(false);
+    }
+  });
+
+  it("carries the sign and residual caveats on the two hazardous fields", () => {
+    const byKey = new Map(FEDERAL_ENDOWMENT_FIELD_DOCS.map((field) => [field.key, field]));
+    expect(byKey.get("ipeds.endowment_spending_distribution")?.caveat).toMatch(/sign/i);
+    expect(byKey.get("ipeds.endowment_other_change")?.caveat).toMatch(/not a measure of borrowing/i);
+  });
+});

--- a/web/src/lib/public-data.ts
+++ b/web/src/lib/public-data.ts
@@ -389,8 +389,90 @@ export const FRIENDLY_FACT_FIELDS: FactDefinitionInput[] = [
 
 const FIELD_BY_KEY = new Map(FRIENDLY_FACT_FIELDS.map((field) => [field.key, field]));
 
+// Documentation-only definitions for the federal endowment facts (PRD 027).
+// These facts are assembled from school_facts_unified, not from a `path`
+// lookup, so they are listed in the field dictionary for discoverability but
+// are not addressable via the `fields=` selector — request them with
+// `categories=finance`. Available for fiscal years 2020 onward (FASB F2
+// filers; the change components do not exist in federal data before FY2020).
+export const FEDERAL_ENDOWMENT_FIELD_DOCS: PublicFieldDefinition[] = [
+  {
+    key: "ipeds.endowment_value_begin",
+    label: "Endowment net assets, beginning of fiscal year",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "Value of endowment net assets at the beginning of the fiscal year (IPEDS Finance Part H, F2H01).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+  },
+  {
+    key: "ipeds.endowment_value_end",
+    label: "Endowment net assets, end of fiscal year",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "Value of endowment net assets at the end of the fiscal year (IPEDS Finance Part H, F2H02).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+  },
+  {
+    key: "ipeds.endowment_new_gifts",
+    label: "Endowment new gifts and additions",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "New gifts and additions to endowment net assets during the fiscal year (IPEDS Finance Part H, F2H03A).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+  },
+  {
+    key: "ipeds.endowment_investment_return",
+    label: "Endowment net investment return",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "Net investment return on endowment net assets during the fiscal year (IPEDS Finance Part H, F2H03B).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+  },
+  {
+    key: "ipeds.endowment_spending_distribution",
+    label: "Endowment spending distribution for current use",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "Spending distributed from the endowment for current use during the fiscal year (IPEDS Finance Part H, F2H03C).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+    caveat:
+      "Reported as a negative value when funds leave the endowment under the modern convention; fiscal years 2020 and 2021 mix sign conventions.",
+  },
+  {
+    key: "ipeds.endowment_other_change",
+    label: "Other changes in endowment net assets",
+    category: "finance",
+    source_layer: "ipeds",
+    unit: "USD",
+    value_type: "money",
+    definition: "Residual change in endowment net assets not attributed to gifts, investment return, or spending (IPEDS Finance Part H, F2H03D).",
+    derivation_note: "Served per fiscal year via categories=finance; not selectable via fields=.",
+    caveat:
+      "Residual line that absorbs transfers, reclassifications, and reporting noise; it is not a measure of borrowing.",
+  },
+];
+
 export function publicFieldDefinitions(): PublicFieldDefinition[] {
-  return FRIENDLY_FACT_FIELDS.map(({ path: _path, ...field }) => field);
+  return [
+    ...FRIENDLY_FACT_FIELDS.map(({ path: _path, ...field }) => field),
+    ...FEDERAL_ENDOWMENT_FIELD_DOCS,
+  ];
+}
+
+// Keys addressable via the `fields=` selector on /api/schools/{id}/facts and
+// /api/compare. Documentation-only federal entries are excluded on purpose.
+export function selectableFactKeys(): string[] {
+  return FRIENDLY_FACT_FIELDS.map((field) => field.key);
 }
 
 export function fieldsForCategories(categories: PublicFactCategory[]): string[] {


### PR DESCRIPTION
## Summary

Closes the agent-discoverability gap for the endowment fact family (PRD 027 follow-up). Before this PR, `categories=finance` worked end-to-end but nothing advertised it: the MCP tool descriptions didn't enumerate categories, `/api/fields` listed zero endowment fields (so the MCP field-dictionary tool was blind to the family), and `llms.txt`/OpenAPI never mentioned finance. An agent methodically using our own discovery tools would conclude the endowment data doesn't exist.

Changes (all thin-wrapper discipline, no new MCP tools per PRD 022):

- **`web/src/lib/public-data.ts`** — new `FEDERAL_ENDOWMENT_FIELD_DOCS` (6 documentation-only entries for `ipeds.endowment_*`, carrying the sign-convention and residual-not-borrowing caveats) merged into `publicFieldDefinitions()`; new `selectableFactKeys()` keeps the `fields=` selector list friendly-fields-only so the OpenAPI spec doesn't advertise unselectable keys.
- **`packages/mcp-server`** — `get_school_facts` and `compare_schools` descriptions enumerate valid categories (finance included; compare notes it's facts-only); `get_field_dictionary` mentions the finance category. Version 0.1.0 → 0.1.1.
- **`llms.txt`** — categories list, a `categories=finance` example, and an endowment note pointing at the recipe, with an instruction to preserve `quality.note` caveats when citing.
- **`openapi.json`** — category enumerations on the facts/compare/fields parameters; `fields=` key list now sourced from `selectableFactKeys()`.
- **PRD 027** — amendment bullet recording the decision (no new tools; caveats stay in-band in fact payloads).

## Concurrency

No overlap with the Phase 2 worktree (its branch touches only PRD sections elsewhere) or with PR #118 (recipe amendment section). The PRD edit here is a single appended bullet in the Frontend and API surface section.

## Pre-Landing Review

Small diff; inline checklist pass clean (no data-path changes — `FIELD_BY_KEY`, compare filtering, and fact assembly are untouched; verified the docs-only list cannot leak into value resolution because entries carry no `path`). New vitest guards: 6 entries under finance, present in the dictionary, excluded from the selector list, caveats present on the two hazardous fields.

## Test plan

- [x] web vitest: 25 files, 277 tests pass (4 new)
- [x] `tsc --noEmit` clean
- [x] `node --check` on the MCP server entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
