### PR TITLE
feat(finder): refresh CDS seed URLs for CSUN, Houston CC, UT Rio Grande Valley

### DIFF
--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -4058,7 +4058,7 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.csun.edu/node/65206
+  discovery_seed_url: https://www.csun.edu/institutional-research/explore-csun-data/common-data-set
 - id: california-state-university-sacramento
   name: California State University-Sacramento
   domain: csus.edu
@@ -9718,7 +9718,7 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.hccs.edu/media/houston-community-college/district/pdf/HCC-Common-Data-Set-2023-2024.pdf
+  discovery_seed_url: https://www.hccs.edu/about-us/institutional-data/common-data-set/
 - id: houston-graduate-school-of-theology
   name: Houston Graduate School of Theology
   domain: hgst.edu
@@ -21455,7 +21455,7 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.utrgv.edu/sair/data-reports/cds_2020-2021.pdf
+  discovery_seed_url: https://www.utrgv.edu/sair/_files/documents/data-and-reports/cds_2023-2024_utrgv-2.xlsx
 - id: the-university-of-texas-system-office
   name: The University of Texas System Office
   domain: utsystem.edu


### PR DESCRIPTION
Three seed URLs updated to the schools' current CDS publications. Each was found while auditing our own downstream mirror of the archive; every URL below was verified by downloading and parsing the actual bytes.

- **california-state-university-northridge**: old seed (`/node/65206`) is a stale landing page. New seed is the current IR CDS page: https://www.csun.edu/institutional-research/explore-csun-data/common-data-set — which links the document on the Pantheon backend (`.../sites/default/files/2026-04/CDS%202025%20v2.pdf`, HTTP 200, 847 KB, verified "Common Data Set 2024-2025" + section A/C content via pdftotext). Note: the page labels it "CDS 2025-2026" but the document itself says 2024-2025 — school-side mislabel, may be worth a per-school note.
- **houston-community-college**: old seed was the 2023-2024 PDF. New seed is the current CDS landing page: https://www.hccs.edu/about-us/institutional-data/common-data-set/ — which hosts the 2024-2025 edition as **XLSX** (`HCC_Common-Data-Set_2024-2025.xlsx`, 799 KB, verified CDS-A…CDS-J tabs + "For the Fall 2024 entering class"). Upstream coverage status was `no_public_cds_found`, so this should be a genuine coverage gain.
- **the-university-of-texas-rio-grande-valley**: old seed was the 2020-2021 PDF. New seed is the school's canonical latest: https://www.utrgv.edu/sair/_files/documents/data-and-reports/cds_2023-2024_utrgv-2.xlsx (793 KB, verified "Common Data Set" + C1-C2/B22 content). Also **XLSX** — likely explains this school's `extract_failed` status, and should extract cleanly via the Tier 1 XLSX path.

Happy to split into per-school PRs if preferred, or adjust seed style (landing page vs direct file) — I used landing pages where a stable one exists, matching what the discovery crawler follows. `identity_guard.py` and `school_redirect_guard.py` both pass (0 errors; the 26 warnings are pre-existing and unrelated).

And a thank-you: this project makes college data meaningfully more accessible. The public archive with verifiable source bytes, the canonical-schema extraction, and the no-auth API are exactly the infrastructure this space has been missing. We mirror the archive downstream for a school-research project of our own, and finding these felt like the least we could send back.
