### PR TITLE
feat: ship PRD 028 organic search for CDS queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This project uses four-part semantic versioning.
 
+## [Unreleased]
+
+### Added
+
+- Show a data-generated Common Data Set archive lead on school hubs and year pages, including an official IR link when we have a usable HTML URL, and gated-request copy only for schools we have actually read (Virginia Tech).
+- Publish three source-literacy pages under `/about` (Common Data Set, College Scorecard, IPEDS) and link them from About, the footer, and `/llms.txt`.
+- Record the August 2026 Search Console CDS-query export next to PRD 028, including URL inspection of the Virginia Tech and Harvey Mudd canaries.
+
+### Changed
+
+- Replace the About page’s three-paragraph source gloss with a short hub that points at the longer CDS, Scorecard, and IPEDS notes.
+
 ## [0.5.1.0] - 2026-08-10
 
 ### Added

--- a/docs/prd/028-gsc-cds-queries-2026-08.md
+++ b/docs/prd/028-gsc-cds-queries-2026-08.md
@@ -1,0 +1,285 @@
+# GSC memo: `[school] Common Data Set` queries (PRD 028)
+
+**Date:** 2026-08-17
+**Property:** Search Console, collegedata.fyi (www canonical)
+**Window:** last 3 months (chart 2026-05-18 → 2026-08-15), Search type = Web
+**Related:** [PRD 028](028-organic-search-cds-queries.md)
+
+This memo freezes the operator exports that PRD 028 M0 asked for, plus
+the reading of them. Raw CSVs live in gitignored `scratch/seo/` on the
+machine that pulled them. The numbers that should survive a laptop are
+here.
+
+---
+
+## What was checked
+
+URL Inspection, 2026-08-17 — all four canaries **URL is on Google**:
+
+- `https://www.collegedata.fyi/schools/virginia-tech`
+- `https://www.collegedata.fyi/schools/virginia-tech/2025-26`
+- `https://www.collegedata.fyi/schools/harvey-mudd`
+- `https://www.collegedata.fyi/schools/harvey-mudd/2025-26`
+
+Indexing is not the failure. Harvey Mudd’s absence from the head-term
+SERP is competition, not a crawl bug.
+
+Exports (same session, same date filter):
+
+| Tab | What it gave us |
+|-----|-----------------|
+| Queries | 1,000 rows: query, clicks, impressions, CTR, average position |
+| Pages | 505 rows: URL, impressions (no clicks/position in this dump) |
+| Chart | Daily impressions only |
+| Countries / Devices | Impression mix for the filtered slice |
+
+The Pages and Queries totals do not match each other (GSC tables and
+charts often disagree). Treat them as two views of one slice, not a
+reconciliation.
+
+---
+
+## The slice, not the whole site
+
+PRD 028’s site-wide screenshot was **236K impressions / 1.6K clicks /
+0.7% CTR / position 12.2**. This export is the CDS neighborhood, not
+that report.
+
+| View | Impressions | Notes |
+|------|-------------:|-------|
+| Chart | 1,720 | 90 days |
+| Pages table | 1,767 | 505 URLs |
+| Queries, CDS-shaped only | ~14.3K | after dropping brand-collision, quoted IPEDS, snapshot URLs |
+| Queries, CDS-shaped clicks | 668 | see school rollup below |
+
+Daily impressions sit near zero through May, move in June, jump in
+early July, and hold a higher August baseline (peak 83 on 2026-08-11).
+Same shape as the PRD, smaller because this is the CDS filter.
+
+**Countries (this slice):** United States 1,406 (~82%). Singapore is 5.
+The site-wide 21% Singapore share is not CDS searchers. Keep writing
+for U.S. college search.
+
+**Devices (this slice):** Desktop 1,051 / mobile 644 / tablet 25.
+More mobile than the site-wide 89% desktop mix. Still design the
+About-tree as desktop reading; don’t break phones.
+
+---
+
+## Finding 1 — Virginia Tech is still the business
+
+CDS-shaped query rollup for Virginia Tech:
+
+| Query | Clicks | Impr | CTR | Pos |
+|-------|-------:|-----:|----:|----:|
+| virginia tech common data set | 277 | 721 | 38.4% | 3.58 |
+| virginia tech cds | 72 | 168 | 42.9% | 3.84 |
+| common data set virginia tech | 58 | 161 | 36.0% | 3.91 |
+| virginia tech common data set 2026 | 33 | 65 | 50.8% | 2.60 |
+| virginia tech common data set 2025 | 23 | 51 | 45.1% | 4.00 |
+| va tech common data set | 19 | 40 | 47.5% | 5.20 |
+| vt cds | 12 | 39 | 30.8% | 3.10 |
+| vt common data set | 7 | 34 | 20.6% | 3.47 |
+| virginia tech common data set pdf | 7 | 30 | 23.3% | 4.27 |
+| vtech common data set | 7 | 16 | 43.8% | 6.88 |
+| *(plus a few 2024–25 PDF variants with 0 clicks)* | | | | |
+
+**517 clicks / 1,367 impressions / 37.8% CTR / position ~3.8** on the
+school as a whole. That is ~77% of CDS-query clicks in this export.
+
+People searching `… 2026` mean academic year 2025-26. We are at
+position 2.6 with 51% CTR on that query. Do not change VT titles,
+H1s, or year slugs to chase a calendar year.
+
+Pages tab agrees on the landing URL: `/schools/virginia-tech/2025-26`
+(116) then the hub (83). Year page first. PRD 002 was right.
+
+Official source, re-fetched 2026-08-17: still the email gate at
+`aie.vt.edu/analytics-and-ai/common-data-set.html`. Protect this ranking.
+
+---
+
+## Finding 2 — VT is no longer the only school that pays
+
+PRD 028’s 90-day success line was “VT is no longer the only school in
+the top-10 query report.” It isn’t. CDS-shaped clicks outside VT:
+
+| School | Clicks | Impr | CTR | Pos | Official source (yaml / fetch) |
+|--------|-------:|-----:|----:|----:|--------------------------------|
+| Haverford | 23 | 240 | 9.6% | 4.7 | Direct PDF (`CDS_2023-2034.pdf`) |
+| Brown | 20 | 461 | 4.3% | 8.8 | HTML CDS URL, 0 PDF hrefs in static source |
+| UC Santa Barbara | 12 | 248 | 4.8% | 4.8 | IR research page, not a year index |
+| WashU | 9 | 645 | 1.4% | 7.8 | CDS buried on a consumer-info page |
+| UW Seattle | 9 | 422 | 2.1% | 6.9 | Public PDF index |
+| Florida | 6 | 419 | 1.4% | 6.7 | Direct PDF seed |
+| Bowdoin | 5 | 305 | 1.6% | 5.7 | IR home, not a CDS index |
+| Elon | 5 | 197 | 2.5% | 6.0 | Direct upload-path seed |
+| UW–Madison | 4 | 296 | 1.4% | 8.0 | HTML page, 0 PDF hrefs in static source |
+| UC Merced | 4 | 18 | 22.2% | 4.3 | Small volume, already page-ish one |
+| Stony Brook | 3 | 216 | 1.4% | 7.8 | Fact-book CDS directory |
+| CU Boulder | 3 | 168 | 1.8% | 5.9 | Reports listing |
+| Davidson | 3 | 141 | 2.1% | 4.4 | Dedicated CDS page |
+| Skidmore | 3 | 126 | 2.4% | 4.8 | `facts/common/` listing |
+| Gonzaga | 3 | 13 | 23.1% | 3.9 | Tiny volume, high CTR |
+| Notre Dame | 2 | 224 | 0.9% | 7.5 | Seed PDF **403s** |
+| Alabama | 2 | 281 | 0.7% | 8.2 | Direct PDF seed |
+| Penn State | 2 | 153 | 1.3% | 6.9 | Excellent public PDF index (100+ files) |
+| Howard | 1 | 290 | 0.3% | 6.8 | Public PDF index |
+| Wellesley | 1 | 137 | 0.7% | 6.4 | Direct PDF seed |
+
+Harvey Mudd does not appear as a real query. One page impression on
+the hub. Indexed, not the business, not a go/no-go.
+
+**Haverford is the second school.** Head query `haverford college
+common data set`: 14 clicks, 20.6% CTR, position 4. The official file
+is a PDF (mis-dated filename). Google is already treating our year
+page as a usable HTML answer, and people click it. That is the VT
+pattern at smaller scale.
+
+**Brown is demand we have not converted.** Current-year queries
+(`… common data set 2026`) do better (position ~6.3, ~10% CTR) than
+the un-yeared head term (position ~9–10, near-zero CTR). The official
+CDS URL is HTML that does not link files in the static source.
+
+---
+
+## Finding 3 — An indexed `.edu` PDF is not a good product
+
+PRD 028 split schools by official-source quality: compete when the
+`.edu` is an email gate; cite and do not fight when it is a
+well-published PDF index (Harvey Mudd, Penn State, UVA). That split
+is still the right way to **prioritize** (VT-shaped gates first). It
+is the wrong way to **underrate our offer**.
+
+A public PDF on `school.edu` is often Google’s correct *navigational*
+result for “the document the school published.” It is a poor
+*session*. The searcher gets a 47-page print form, no extracted
+tables, no prior years in one place, no comparison, and usually no
+accessible HTML. collegedata.fyi’s year page is the opposite of that:
+source-linked extract, spreadsheet, archived years, and the rest of
+the library one click away.
+
+Haverford is the measured version of that argument. Their `.edu` PDF
+exists and is fetchable. We still get position 4 and 20% CTR on the
+head query, because the HTML archive is the better click for anyone
+who wants to *use* the file rather than prove it exists.
+
+So:
+
+- **Do not impersonate IR.** Keep the official link above the fold.
+  Copy must not say we host “the official” CDS.
+- **Do not treat “PDF is indexed” as “we cannot win.”** We can win
+  historical years, spreadsheet intent, comparison, and a share of
+  the head term when the PDF is a bad reading experience.
+- **Do not spend H1 experiments on Penn State / Howard** while VT is
+  the only 38% CTR query. Freshness and the archive lead are the
+  lever. GradGPT is already on the VT SERP; speed still matters more
+  than heading tags for that slice.
+- **Do not use Harvey Mudd head-term rank as go/no-go.** Their IR
+  page is a real year-by-year HTML index. That is a different object
+  from “a PDF exists at some DAM path.”
+
+Notre Dame is the other pole: the yaml seed PDF **403s**. There is no
+usable official HTML. That is a second VT if we keep the year page
+fresh.
+
+---
+
+## Pages tab (where those queries land)
+
+Year pages 1,308 impressions / hubs 376 / homepage 51 / `/about` 15 /
+apex host 4.
+
+Top landing URLs in the CDS slice:
+
+| Impr | URL |
+|-----:|-----|
+| 116 | `/schools/virginia-tech/2025-26` |
+| 109 | `/schools/penn-state/2025-26` |
+| 83 | `/schools/virginia-tech` |
+| 56 | `/schools/bowdoin/2025-26` |
+| 51 | `/` |
+| 47 | `/schools/university-of-notre-dame/2025-26` |
+| 36 | `/schools/haverford-college/2025-26` |
+| 36 | `/schools/uw/2025-26` |
+| 35 | `/schools/washington-university-in-st-louis/2025-26` |
+| 32 | `/schools/howard-university/2025-26` |
+| 30 | `/schools/brown/2025-26` |
+| 15 | `/about` |
+
+Penn State’s year page is #2 by *impressions* and almost unused by
+*clicks* (2 clicks, 1.3% CTR, position 6.9 on the query rollup). That
+is leftover page-two inventory above a real `.edu` index, not a
+second VT. Do not read the Pages tab without the Queries tab.
+
+Homepage 51 CDS-query impressions: the query is a school CDS search
+and Google showed `/`. The school/year lead copy is the fix.
+
+`/about` already has 15 impressions in this slice. The three
+`/about/…` source pages are not starting from zero.
+
+Apex (`https://collegedata.fyi/…`) still has 4 leftover impressions.
+The 301 pin in Next.js is correct; live `curl -I` already 301s.
+
+Stanford and Texas A&M are thin in *this Google CDS-query slice*
+(1–2 impressions per URL). They remain large in Vercel because Bing /
+DDG / ChatGPT are in the mix. Do not let a Google-only title tweak
+wreck those year pages.
+
+---
+
+## Noise to ignore in the 1,000-row query export
+
+| Bucket | Approx. impressions | What it is |
+|--------|--------------------:|------------|
+| Not CDS | 2,699 | Acceptance-rate, tuition, enrollment, “is duke test-optional” |
+| Quoted Ferris State / IPEDS | 1,500+ | Filename and field-dump searches |
+| `college data` / `collegedata` | 510 | CollegeData.com collision (ADR 0004). 0 clicks, position 13–16 |
+| Snapshot JSONL URLs | 332 | `collegedata.fyi/snapshots/latest/*.jsonl` at position ~1, 0 clicks. Crawlers |
+| `"3,695" admitted 2020` | ~400 | People or tools searching a CDS cell value |
+
+None of that is a school-page SEO program.
+
+---
+
+## Attention list (not an H1 backlog)
+
+1. **Virginia Tech** — protect. 38% CTR, position ~3.8.
+2. **Haverford** — already converting against a PDF official. Closest
+   second VT. Freshness, then leave the copy honest.
+3. **Brown** — demand at position 6–9; official HTML is thin/JS.
+   Current-year query is the wedge.
+4. **UCSB** — real CTR at position ~5. Smaller than Brown, healthier.
+5. **Notre Dame** — official seed 403s. `… 2026` is closer (pos 4.8)
+   than the un-yeared head term (pos 9).
+6. **WashU / Florida / UW Seattle** — large impression piles, page-two
+   CTR. UF `… 2026` is already position 3.8. Freshness before copy.
+7. **Bowdoin / Elon / Davidson / Skidmore** — small but real clicks
+   from position ~4–6.
+8. **Alabama / Wellesley / Richmond / Duke / BC** — PDF-only or stale
+   official files. Historical years + extract are the honest unique
+   offer; the PDF may still own “download the form.”
+9. **Penn State / Howard** — impressions without clicks, strong `.edu`
+   indexes. Cite them. Still ship the archive lead: prior years and
+   comparison are the product, not a war with `psu.edu`.
+10. **Harvey Mudd** — ignore as go/no-go.
+
+Operator next, not engineering: SERP check the first eight, archive
+pass if our latest year is behind a *linked* official file, then stop.
+M3 (Show HN, citations) is still off-page.
+
+---
+
+## What this does not change in the product
+
+M0–M2 still ship for every school: path-specific canonicals, 301 apex
+→ www, sitemap gaps, data-generated archive lead, year-page headings,
+three `/about` source pages. Unique copy stays generated from
+manifest facts. No prestige adjectives. No parallel `/cds/` tree.
+
+The lead may say the school currently asks the public to request the
+file **only when that is true of the URL we link** (Virginia Tech
+today). For everyone else, the honest sentence is years archived,
+formats, and a link labeled as the school’s own CDS page when we have
+an HTML landing URL. Direct PDF seeds are not “the school’s own CDS
+page.”

--- a/docs/prd/028-organic-search-cds-queries.md
+++ b/docs/prd/028-organic-search-cds-queries.md
@@ -1,0 +1,924 @@
+# PRD 028: Organic search for school CDS queries
+
+**Status:** M0–M2 implemented (2026-08-17). GSC URL inspect is green on all four canaries. Query × page readout is in [028-gsc-cds-queries-2026-08.md](028-gsc-cds-queries-2026-08.md). M3 is off-page.
+**Created:** 2026-08-17
+**Author:** Anthony Showalter (with Claude)
+**Related:** [PRD 002](002-frontend.md) (frontend SEO primitives), [PRD 009](009-last-mile-ci-and-preservation.md) (distribution push), [PRD 015](015-institution-directory-and-cds-coverage.md) (school identity pages), [PRD 019](019-cds-change-intelligence.md) (year-over-year deltas), [PRD 021](021-ipeds-coverage-layer.md) (IPEDS baseline), [PRD 024](024-share-button.md) (share / unfurls), [ADR 0004](../decisions/0004-canonical-domain-collegedata-fyi.md) (naming / CollegeData.com collision), [CDS vs Scorecard research](../research/cds-vs-college-scorecard.md), [GSC CDS memo (2026-08-17)](028-gsc-cds-queries-2026-08.md)
+
+---
+
+## Executive summary
+
+The head query `[school] Common Data Set` is winnable. Google Search
+Console for 16 May–14 Aug 2026 shows Virginia Tech variants as the
+site's actual organic business: `#2` for `virginia tech common data set`
+at ~38% CTR, and the top four queries are all VT. Harvey Mudd, with
+the same templates, titles, sitemap, and JSON-LD, does not appear in
+the first ten pages for the same query shape.
+
+The difference is not on-page SEO. It is **whether the official `.edu`
+is a usable answer**.
+
+- Harvey Mudd's IR page lists recent PDFs by year, titled "Common Data
+  Set", on `hmc.edu`. Google's correct result is that page.
+- Virginia Tech's IR page
+  (`aie.vt.edu/analytics-and-ai/common-data-set.html`) explains what a
+  CDS is, then says files are "**available via request to
+  aiesupport@vt.edu**." The PDFs exist in a DAM path Google can
+  sometimes find; the landing page is a dead end. We are the first
+  public HTML answer that actually hands over the extracted file.
+
+Rev 1 of this PRD treated Harvey Mudd as the canary and told us not to
+chase the head term. GSC falsifies that as a universal rule. The
+canary is **Virginia Tech**: protect that ranking, then find other
+high-demand schools whose official CDS is gated, thin, JS-only, or
+email-only. Harvey Mudd remains the hard case because IR publishes a
+real year-by-year HTML index, not because a PDF exists.
+
+An indexed `.edu` PDF is Google's navigational answer for "the file
+the school published." It is not a usable session. collegedata.fyi
+still wins the *use* of that file: accessible HTML, extracted tables,
+prior years in one place, and comparison. Cite the official link
+above the fold; do not treat "PDF is indexed" as "we cannot rank."
+Haverford already converts against a public PDF (see the
+[August 2026 GSC memo](028-gsc-cds-queries-2026-08.md)).
+
+The other GSC number that matters: **236K impressions, 0.7% CTR,
+average position 12.2**. Almost all impressions are page-two-or-worse
+queries. VT proves what happens when one school-query moves to
+position 2. The work is to repeat VT, not to beat HMC.
+
+Vercel Analytics for the same window (17 May–16 Aug 2026) shows the
+demand side of that: **17.5K visitors, 30.7K pageviews**, a July 5
+spike to ~1,000 visitors/day, then a new baseline of roughly 250–500
+visitors/day and another lift in early August. Google is the largest
+referrer (2.7K), but Bing (1.4K), DuckDuckGo (581), Yahoo (491),
+cn.bing (220), and ChatGPT (188) are already in the room. Discovery
+is working. **`/about` is not in the top pages.** People land on a
+year page or the homepage, take the file or bounce (77%), and never
+hear why the archive exists. The story pages are how we convert an
+already-rising crawl into a library people stay in — and how Bing,
+DDG, and ChatGPT, which do not share GSC, still get a document they
+can cite.
+
+A second, smaller ranking surface is **source literacy**. `/about`
+already publishes the Uncommon Data Set framing, but it glosses CDS,
+Scorecard, and IPEDS in three paragraphs. CollegeVine owns
+`what is a Common Data Set`; `collegescorecard.ed.gov` owns the
+navigational Scorecard query. Three deep `/about/…` pages will not
+displace those official/navigational results. They can rank for the
+comparison and explainer queries the About page currently cannot
+support (`common data set vs college scorecard`, `what is IPEDS`,
+`IPEDS vs CDS`), and they give every school page a unique prose hub
+to link to. That is the SEO side-effect, not the reason to write
+them. The reason to write them is that the product story is currently
+too thin for the rigor of the archive.
+
+## What we have today (measured)
+
+Checked 2026-08-17 against live pages, Google results, a Search
+Console Performance screenshot (16 May–14 Aug 2026), and a Vercel
+Analytics screenshot (17 May–16 Aug 2026).
+
+### Search Console (site-wide, last 3 months)
+
+| Metric | Value |
+|--------|--------|
+| Clicks | 1.6K |
+| Impressions | 236K |
+| Average CTR | 0.7% |
+| Average position | 12.2 |
+
+Clicks were flat (under ~20/day) through mid-July, then rose sharply
+and peaked near ~90/day in early August. Impressions ran ~2.5–5K/day
+with an upward drift from late July.
+
+Top queries in that export (all Virginia Tech):
+
+| Query | Clicks | Impressions | CTR (approx.) |
+|-------|--------|-------------|---------------|
+| `virginia tech common data set` | 277 | 721 | 38% |
+| `virginia tech cds` | 72 | 168 | 43% |
+| `common data set virginia tech` | 58 | 161 | 36% |
+| `virginia tech common data set 2024` | 33 | 65 | 51% |
+
+Those four queries are ~440 clicks, roughly **a quarter of all organic
+clicks**, from ~0.5% of impressions. Harvey Mudd does not appear in
+the top-query list.
+
+Search Console is verified. M0's "is GSC set up?" question is closed.
+
+### Vercel Analytics (17 May–16 Aug 2026)
+
+GSC is Google-only. Vercel is what actually arrived.
+
+| Metric | Value |
+|--------|--------|
+| Visitors | 17,474 (+5.1K% vs prior period — prior was near-zero) |
+| Page views | 30,696 (+2.2K%) |
+| Bounce rate | 77% (up 20 points) |
+| Pages / visitor | ~1.75 |
+
+Daily visitors sat near zero through June, spiked around **5 July**
+(~1,000), then held a much higher baseline (~250–500) with another
+rise in early August. That lines up with GSC clicks leaving the
+sub-20/day floor in mid-July.
+
+Top pages (visitors):
+
+| Path | Visitors |
+|------|----------|
+| `/schools/virginia-tech/2025-26` | 1,000 |
+| `/` | 959 |
+| `/schools/stanford` | 357 |
+| `/schools` | 339 |
+| `/schools/stanford/2017-18` | 333 |
+| `/schools/texas-a-and-m-university-college-station/2023-24` | 294 |
+| `/api` | 291 |
+
+`/about` does not appear. The year page is the working SEO unit (PRD
+002 was right). Historical years already convert: Stanford **2017-18**
+is a top-five URL. Texas A&M 2023-24 is a second large-public year
+page in the same list. Repeat-VT is not a theory.
+
+Top referrers:
+
+| Referrer | Visitors |
+|----------|----------|
+| google.com | 2.7K |
+| bing.com | 1.4K |
+| duckduckgo.com | 581 |
+| search.yahoo.com | 491 |
+| cn.bing.com | 220 |
+| chatgpt.com | 188 |
+| ecosia.org | 44 |
+
+Google is not the only crawler that matters. Bing + Yahoo + DDG
+together are in the same order of magnitude as Google. ChatGPT is
+already a referrer; PRD 009's "LLM citability" is not hypothetical.
+Story pages, `/llms.txt`, and Dataset JSON-LD have to be written for
+that set, not for GSC alone.
+
+Other notes, not to over-read:
+
+- **89% desktop.** These are research sessions. Long-form About-tree
+  pages should be designed as desktop reading (the design system
+  already is). Do not ship a marketing-mobile layout. Still don't
+  break 11% mobile.
+- **US 58% / Singapore 21% / China 7%.** Singapore-at-21% is
+  unexplained (VPN, crawlers, international students — do not treat
+  it as a product-market signal until it is checked). US remaining
+  majority is enough to keep writing for U.S. college search.
+- **77% bounce / 1.75 pages per visitor.** Consistent with "landed,
+  grabbed the PDF, left." Telling the source story is also an
+  engagement bet: a year-page lead plus an About-tree link should
+  raise pages/visitor. Do not chase bounce rate with popups or
+  related-school carousels.
+
+### Virginia Tech vs Harvey Mudd (the ranking experiment)
+
+Same product, same metadata template, opposite SERPs.
+
+| | Virginia Tech | Harvey Mudd |
+|---|---|---|
+| Our hub | `/schools/virginia-tech` | `/schools/harvey-mudd` |
+| Our title | `{name} Common Data Set (CDS) Archive` | same template |
+| Our latest year | 2025-26 (Excel, extracted) | 2025-26 (fillable PDF, extracted) |
+| Docs on our hub | 14 | 16 |
+| Head-query rank | **#2** (operator + GSC CTR) | **not in first 10 pages** |
+| Official IR page | [aie.vt.edu/.../common-data-set.html](https://aie.vt.edu/analytics-and-ai/common-data-set.html) — CDS definition, then **email to request files** | [hmc.edu/.../common-data-set/](https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/) — year-by-year **linked** PDFs through 2025-26; a 2026-27 heading exists without an href |
+| Applicant-scale (our 2025-26 extract) | 57,755 applied | 5,217 applied |
+| Other HTML competitors | GradGPT visualized CDS page already ranks | CollegeVine "how to get in" essay |
+
+Official VT copy, verbatim: "Current and historical CDS files for
+Virginia Tech are available via request to aiesupport@vt.edu."
+
+That is the product. For VT, we are not a third copy of a public PDF
+index. We are the public index. For HMC, we are a third copy of a
+well-published `.edu` PDF index. Latest **linked** year on both sides
+is 2025-26 (checked 2026-08-17). HMC's page also has an unlinked
+"2026-2027" heading; there is no PDF. That is not an archive lag.
+
+Demand also differs: a large public flagship generates more
+`[school] common data set` searches than a 900-student college. Even a
+#2 Harvey Mudd rank would be small traffic. VT is both **winnable**
+and **worth winning**.
+
+### Indexing is not the failure
+
+| Check | Result |
+|-------|--------|
+| Live school URL | `https://www.collegedata.fyi/schools/harvey-mudd` |
+| Live year URL | `https://www.collegedata.fyi/schools/harvey-mudd/2025-26` |
+| `<title>` (school) | `Harvey Mudd College Common Data Set (CDS) Archive \| collegedata.fyi` |
+| `<title>` (year) | `Harvey Mudd College Common Data Set 2025-26 \| collegedata.fyi` |
+| Canonical | `https://www.collegedata.fyi/schools/harvey-mudd` (www host) |
+| `robots.txt` | `Allow: /`, sitemap pointer |
+| Sitemap | School hub + extracted year pages included (`web/src/app/sitemap.ts`) |
+| Rendering | Next.js App Router SSR / ISR (`revalidate = 3600`) |
+| JSON-LD | `CollegeOrUniversity` + `DataCatalog` on school; `Dataset` + `BreadcrumbList` on year |
+| `site:collegedata.fyi Harvey Mudd Common Data Set` | Returns the year page as result 1 |
+
+PRD 002 already shipped the technical SEO primitives: unique titles,
+descriptions, canonicals, OG images, sitemap, robots, Dataset markup. Those
+are doing their job. Google can fetch both school pages. It ranks VT
+because the official alternative fails the click; it skips HMC because
+the official alternative is a better click.
+
+### What Google ranks instead
+
+For `Harvey Mudd Common Data Set`, page one is owned by:
+
+1. Harvey Mudd IR: `/institutional-research/institutional-statistics/common-data-set/`
+2. Harvey Mudd IR parent page and Fast Facts PDFs
+3. Direct `hmc.edu` CDS PDF URLs (Google indexes the PDFs themselves)
+4. Long-form admissions explainers that *cite* the CDS (CollegeVine's
+   "How to Get Into Harvey Mudd") rather than hosting it
+
+This is the expected SERP for a named institutional document. The official
+`.edu` is the publisher. The PDFs contain the query phrase on every page
+header. CollegeVine wins leftover intent with unique editorial. A new
+archive of the same PDFs is, to Google, a third copy.
+
+### Unique value Google cannot currently see
+
+HMC's public IR page lists four **linked** recent years (2022-23
+through 2025-26), plus an unlinked 2026-27 heading with no PDF, and
+says older files are "archived in OIRE, and available on request."
+collegedata.fyi currently shows **16 CDS documents** for Harvey Mudd,
+latest **2025-26** — the same latest linked year as HMC. The gap that
+matters is historical files the school no longer lists, plus extracted
+fields / XLSX / CSV / API. It is not stated as crawlable unique prose
+on the school page. The H1 is `Harvey Mudd College`. The visible page
+is product cards and tables. The "16 documents, 2009–2025, including
+years the school no longer publishes" sentence does not exist as a
+first-screen paragraph.
+
+One related content gap (the other was a false freshness alarm):
+
+- **`/about` is live** ([The Uncommon Data Set](https://www.collegedata.fyi/about)).
+  Rev 1 of this PRD wrongly called the essay unpublished. What is
+  still missing is depth: About summarizes CDS, Scorecard, and IPEDS
+  in one section each and then moves on. There is no annotated walk
+  through a real CDS PDF, no Scorecard history, no IPEDS survey-component
+  explainer. `/methodology` is the wrong tree — it documents how the
+  product *cards* are built, not what the underlying federal and
+  school-authored sources are. The Show HN draft
+  (`docs/blog/show-hn-draft.md`) remains unposted.
+
+### Authority and brand (off-page)
+
+- Domain registered / first commit: **2026-04-11**. Four months old as of
+  this PRD. Google treats new domains conservatively for competitive
+  queries.
+- TLD is `.fyi`. Honest per ADR 0004; it does not inherit `.edu` trust.
+- ADR 0004 already recorded the **CollegeData.com** collision: a
+  decades-old commercial college-search brand owns the generic "college
+  data" query class. Unbranded searches for college data do not accrue to
+  us.
+- Inbound links are thin. PRD 009 already named this: "Archive usefulness
+  ∝ discoverability" and scoped a Show HN / GSC distribution push. The
+  Show HN draft is still unposted.
+- No public author byline on school/year pages. E-E-A-T for a data archive
+  is "who extracted this, from which file, when" — we have provenance in
+  the product, but the first screen does not say it in English.
+
+### On-page specifics that make the loss worse (not the root cause)
+
+These would not beat `hmc.edu` by themselves. They do make it harder to
+rank for adjacent queries and for Google to understand the unique offer.
+
+1. **H1 does not contain "Common Data Set."** School H1 is the institution
+   name; year H1 is the institution name with "Common Data Set {year}" as
+   a `<p>`, not an H1. Titles are good; headings are not aligned.
+2. **No unique intro copy.** Every school page is the same widget stack.
+   Near-duplicate templates at corpus scale look like a scraper, not a
+   library.
+3. **URL does not contain the query phrase.** `/schools/harvey-mudd` is
+   correct identity design (PRD 015). It is a weaker exact-match URL than
+   HMC's `/common-data-set/`. Do not rename school slugs to chase this.
+4. **Apex → www is a 307.** `layout.tsx` documents it. For SEO this should
+   be a 301. Minor, but free.
+5. **Sitemap gaps.** `/browse` and some recipes (`waitlist-odds`,
+   `endowment-draw-rate`) are indexable but omitted from `sitemap.ts`.
+6. **Internal links are nav, not topical.** Recipes mention Harvey Mudd
+   (acceptance-vs-yield) but do not systematically point at the year page
+   with descriptive anchors. No "Common Data Set" concept hub. No Claremont
+   Colleges cluster.
+7. **Root layout sets `alternates.canonical: "/"`.** Child
+   `generateMetadata` overrides it today (verified live). Keep that
+   contract tested; a merge bug here would canonicalize every school to
+   the homepage.
+
+## Problem
+
+Parents, counselors, journalists, and IR staff search `[school] Common Data
+Set` when they want the document.
+
+When the school publishes it well, they get the `.edu` and never see us
+(Harvey Mudd). When the school gates the file behind email, a JS app, or
+a DAM path with no indexable landing page, Google will rank a public
+HTML archive **second** — and people click it (Virginia Tech, ~38% CTR).
+
+Today almost all of that second case is accidental. One school produces
+a quarter of clicks. 236K impressions at average position 12.2 are
+sitting on page two. We do not yet know which of those impressions are
+VT-shaped (gated official source + real search demand) versus HMC-shaped
+(excellent official source we should not fight).
+
+## Goals
+
+1. **Protect Virginia Tech.** Do not regress `/schools/virginia-tech`
+   or its year pages. It is the existence proof and the current
+   organic business.
+2. **Repeat VT.** Find high-demand schools whose official CDS is
+   gated, email-only, JS-only, or otherwise a poor Google result, and
+   make our hub the obvious public HTML answer — still citing the
+   official page.
+3. Put a crawlable, source-linked explanation of *what this page is* on
+   every school hub and year page: years archived, extract/download
+   formats, link to the official IR source, and (when true) that the
+   school currently asks the public to email for the file.
+4. Branch `/about` into three long, source-rigorous pages — Common Data
+   Set, College Scorecard, IPEDS — that show the silo problem with
+   annotated real documents rather than glossing it. Rank for the
+   explainer/comparison queries those pages honestly answer. Do not
+   treat them as a blog.
+5. Use Search Console as the operator loop: query × page × position,
+   starting with `common data set` / `cds` filters, not a marketing
+   suite.
+
+## Non-goals
+
+- **Do not try to outrank a well-published official `.edu` PDF index**
+  (Harvey Mudd, Penn State, UVA, and similar). Cite and link those.
+  Do **compete** when the official page is an email gate or otherwise
+  fails the searcher.
+- **Do not rename the domain, drop `.fyi`, or collide with CollegeData.com
+  trademarks.** ADR 0004 stands. Brand-query work is "collegedata.fyi",
+  not "college data".
+- **Do not manufacture per-school SEO essays** or spun "How to get into X"
+  content. That is CollegeVine's game and it fights the source-linked
+  posture.
+- **Do not add `/common-data-set/[school]` duplicates** of existing school
+  URLs. Identity stays `/schools/{school_id}`. Optional redirects from
+  well-known aliases are fine; a second canonical is not.
+- **Do not buy links, guest-post networks, or directory spam.**
+- **Do not noindex year pages** to "consolidate" onto the school hub.
+  Year pages are the SEO answer pages (PRD 002).
+- **Do not wait on LLM-citation work as a substitute.** `/llms.txt` and
+  facts endpoints remain useful; they do not fix this Google SERP.
+- **Do not outrank `collegescorecard.ed.gov` or `nces.ed.gov/ipeds`**
+  for the navigational queries `college scorecard` and `IPEDS`. Cite
+  them. Compete for `what is the common data set`, `CDS vs Scorecard`,
+  `IPEDS vs CDS`, and similar literacy queries.
+- **Do not put the source-story pages under `/methodology`.** That
+  index is "how the cards are built." Source literacy hangs off
+  `/about`.
+- **Do not ship a blog index, CMS, or authoring workflow.** Three
+  static App Router pages plus About as the hub.
+- **Not a Search Console product.** Use the existing Google Search Console
+  property as an operator tool; do not build a GSC clone.
+
+## Users and jobs
+
+### Parent or student
+
+"I searched Harvey Mudd Common Data Set because someone told me that's
+where the real numbers live. I want the latest admit rate, SAT band, and
+a file I can download — and I would stay if the page also showed last
+year and a spreadsheet."
+
+### Counselor
+
+"I want one URL I can send a family that has the extracted tables, not a
+47-page PDF, and that still links to the official source so I am not
+the one vouching for a scrape."
+
+### Journalist or researcher
+
+"I need the 2015 CDS and the school no longer lists it. Search should
+find the archive year page, not a 'contact IR' note. If I am writing
+about the data system itself, I want one durable URL that explains
+CDS vs Scorecard vs IPEDS with examples, not a vendor blog."
+
+### IR professional
+
+"If this archive ranks, it must not impersonate my office. Link to my
+page, label the extract, show the archived original."
+
+## Product principles
+
+1. **Cite the official source above the fold.** Every school hub and year
+   page that has a known IR URL must link it. We are an archive and
+   extract, not the publisher.
+2. **Unique copy must be true of this school, generated from data we
+   already have.** Counts, year spans, "school currently lists N years;
+   we archive M", format list, last-verified date. No invented narrative.
+3. **Gated official pages are the wedge, then historical files.** When
+   the school tells Google "email us," we should be result two (or one).
+   When the school lists fewer years than we archive, say so. Both are
+   true unique value; VT shows the first one already converts.
+4. **Freshness is a ranking feature when a newer file actually exists.**
+   If the school has published a newer CDS than we have extracted, the
+   page should say that rather than imply we are current. Do not treat
+   an IR heading without an href as a published year. HMC's 2026-27
+   heading (checked 2026-08-17) is that case: no PDF, archive current.
+5. **No prestige copy.** Do not write "elite STEM college" filler to pick
+   up CollegeVine-style queries.
+6. **Do not impersonate IR.** Ranking for VT because they hide the file
+   is complementary. Copy must still say the numbers are the school's,
+   with a link to `aie.vt.edu` (or whoever), not "the official Virginia
+   Tech Common Data Set hosted here."
+
+## Query taxonomy (what we will and will not chase)
+
+Split by **official-source quality**, not by school prestige.
+
+| Query class | Example | Should we win? | Why |
+|-------------|---------|----------------|-----|
+| Head term, gated official page | `virginia tech common data set` | **Yes — already #2. Protect and repeat.** | Official result fails the searcher |
+| Head term, excellent official page | `Harvey Mudd Common Data Set` | No (cite them) | `.edu` PDF index is correct |
+| Current-year file, gated official | `virginia tech cds 2025-26` | Yes | We host XLSX/PDF they make you email for |
+| Historical year | `Harvey Mudd Common Data Set 2015` / `virginia tech common data set 2024` | Yes | VT 2024 already converts in GSC (33 clicks). Stanford `/2017-18` is a top Vercel URL (333 visitors). |
+| Extract / spreadsheet | `{school} CDS excel` | Yes | Official pages are usually PDF-only or email-only |
+| Specific fact + CDS | `{school} waitlist CDS` | Yes, over time | Year page headings |
+| Comparison | `{school} vs {school} CDS` | Yes, later | No official page does this |
+| Concept, CDS | `what is the common data set` | Yes — `/about/common-data-set` | CollegeVine owns a thin explainer; we can be the rigorous one |
+| Concept, Scorecard | `college scorecard vs common data set` | Yes — `/about/college-scorecard` | Do not chase navigational `college scorecard` (ed.gov) |
+| Concept, IPEDS | `what is IPEDS` / `IPEDS vs CDS` | Yes — `/about/ipeds` | Do not chase navigational `IPEDS` (nces.ed.gov) |
+| Brand | `collegedata.fyi …` | Yes, already | |
+
+M1 on-page copy still ships for every school. **Prioritization of
+attention and internal links** follows VT-shaped schools (gated or
+thin official source × search demand), not Harvey Mudd.
+
+## What ships
+
+### M0 — Operator baseline (no product UI)
+
+1. Search Console is verified (screenshot 2026-08-17). Remaining:
+   URL inspect `/schools/virginia-tech`, `/schools/virginia-tech/2025-26`,
+   `/schools/harvey-mudd`, `/schools/harvey-mudd/2025-26`. Export
+   queries matching `common data set|cds` for 3 months, sorted by
+   impressions, with page and average position. That export is the
+   VT-shaped opportunity list.
+2. Change apex → www from **307 to 301** (Vercel / DNS / middleware —
+   wherever the 307 is currently issued).
+3. Add missing indexable URLs to `sitemap.ts`: `/browse`,
+   `/recipes/waitlist-odds`, `/recipes/endowment-draw-rate`, and any
+   other public recipe already routed. M2 pages join the sitemap when
+   they ship (`/about/common-data-set`, `/about/college-scorecard`,
+   `/about/ipeds`).
+4. Add a regression test that school and year `generateMetadata`
+   emit a path-specific canonical, so the root `canonical: "/"` cannot
+   leak. Include `virginia-tech` in that fixture.
+
+### M1 — Make the unique offer crawlable (the actual ranking work)
+
+**School hub** (`/schools/[school_id]`):
+
+- Keep the school name as the visual headline if design requires it.
+  Add a visible H1 or H1-equivalent that includes "Common Data Set"
+  without becoming keyword soup. Preferred pattern: H1 remains
+  `{name}`; an immediately following `h2` or lead sentence is
+  `{name} Common Data Set archive, {first}–{latest} ({n} documents).`
+  Implementation should follow `web/DESIGN_SYSTEM.md`; this PRD does
+  not restyle the page.
+- Add a short **source-linked lead** (2–4 sentences, data-generated,
+  no editorial flourish) covering: years archived, latest extracted
+  year, download formats (PDF / XLSX / CSV), and a link labeled as
+  the school's own CDS page when `discovery_seed_url` (or equivalent)
+  is known.
+- When we can detect it cheaply, mention that the school currently
+  lists fewer public years than we archive. Do not scrape HMC's IR
+  page on every request; a static comparison is not required in M1
+  if we can only truthfully say "n archived years, {range}."
+- If a newer **linked** official file is known-missing, show
+  coverage-honest copy ("latest archived year is {year}") rather
+  than implying currency. An unlinked year heading is not a miss
+  (HMC 2026-27 as of 2026-08-17).
+- For VT-shaped schools, the lead may say the school's own page
+  currently asks the public to request the file, and that this page
+  is the archived source plus extract. Only if that is true of the
+  seed URL we link. Do not guess.
+
+**Year page** (`/schools/[school_id]/[year]`):
+
+- Promote "Common Data Set {year}" into the heading structure so the
+  H1 or a single H1+subtitle pairing contains both the school name
+  and the phrase. Do not ship two H1s.
+- Add one lead sentence: this is the archived source file plus the
+  extracted field tables, with a download link and a link back to the
+  official IR page.
+- Add in-page headings for the high-demand CDS slices already
+  rendered (admissions, testing, waitlist, aid) so queries like
+  `Harvey Mudd waitlist CDS` have a fragment to rank. Reuse existing
+  section labels; do not invent new analysis.
+
+**Copy rules:** every sentence must be generable from manifest /
+coverage / document rows. If a fact is missing, omit the sentence.
+No "prestigious," no "top STEM," no admissions advice.
+
+### M2 — Three source-story pages off `/about`
+
+`/about` stays the product narrative ([live](https://www.collegedata.fyi/about)).
+It currently spends one paragraph each on CDS, Scorecard, and IPEDS,
+then pivots to "what you can do now." That gloss is the problem. Branch
+three long static App Router pages from it. `/methodology` is
+untouched: those URLs stay "how the cards are built."
+
+| URL | Title pattern | Primary queries |
+|-----|---------------|-----------------|
+| `/about/common-data-set` | What is the Common Data Set | `what is the common data set`, `common data set explained` |
+| `/about/college-scorecard` | College Scorecard, and why it is not a CDS | `college scorecard vs common data set`, `college scorecard vs IPEDS` |
+| `/about/ipeds` | What IPEDS is, and what it cannot replace | `what is IPEDS`, `IPEDS vs CDS`, `IPEDS vs college scorecard` |
+
+Writing standard: the rigor of [PRD 021](021-ipeds-coverage-layer.md)
+and the original Uncommon Data Set essay
+(`docs/blog/the-uncommon-data-set.md`), not marketing. Measured claims,
+named schools, named field IDs, named federal tables. Every screenshot
+captions the archived source file it came from and links to the live
+year page. No prestige adjectives. No "chance me."
+
+**About becomes the hub.** Replace the three gloss paragraphs with a
+short "three sources" block that links to these pages. Keep the rest of
+About (what you can do, what makes it different, open source, credits).
+Do not paste the long pages back into About.
+
+#### a) `/about/common-data-set`
+
+Job: make a reader *feel* why a 47-page PDF on a random IR URL is not
+a data system, then show the canonical template and what this archive
+does with it.
+
+Must include:
+
+1. What the CDS Initiative is (College Board, Peterson's, U.S. News;
+   link `commondataset.org`). Sections A–J in one table, in English.
+2. **Annotated screenshots of real archived PDFs**, not stock. Minimum
+   set, all from files we host:
+   - A fillable AcroForm page (Harvey Mudd 2025-26 is the documented
+     ground-truth case — named fields, deterministic extract).
+   - The same *kind* of table after flattening / scan / kerned year
+     numerals, so the reader sees why Docling-on-the-wrong-file
+     corrupts C1. Use `docs/known-issues/harvey-mudd-2025-26.md` as
+     the caption source; do not re-litigate it as if the live extract
+     is still wrong.
+   - A school that publishes XLSX (Virginia Tech 2025-26) next to a
+     school that hides the file behind email (same school's IR page).
+   - A page-header that repeats "Common Data Set 2025-2026" five times
+     so the silo is visible: the document is a print form, not a
+     database.
+3. The publishing mess, with real examples we already have in the
+   essay draft: fillable PDF, flattened PDF, scan, XLSX, DOCX, HTML,
+   Box/SharePoint, year-in-the-URL lies, section-only files. This is
+   the pain. Show it; do not summarize it.
+4. What "extracted" means here: canonical field IDs (C.101, H.2A),
+   provenance back to the archived bytes, spreadsheet download. Link
+   VT and HMC year pages with descriptive anchors.
+5. What we are not: not the publisher, not IPEDS, not Scorecard.
+
+Figures live in-repo (`web/public/about/` or `docs/prd/assets/028/`),
+cropped to the relevant table, alt text that states school / year /
+section. Do not screenshot third-party commercial UIs.
+
+#### b) `/about/college-scorecard`
+
+Job: history and current shape of the federal consumer tool, then an
+honest join story — why Scorecard earnings/debt/net-price exist, why
+they lag the CDS year on the school page, why we never blend them into
+one unlabeled number.
+
+Must include:
+
+1. Origin: Obama-era College Scorecard as a consumer-information
+   product, not a guidebook survey. Link `collegescorecard.ed.gov`.
+2. What it actually is now: a join of IPEDS + NSLDS + Treasury/IRS
+   earnings + FSA, per
+   [docs/research/cds-vs-college-scorecard.md](../research/cds-vs-college-scorecard.md).
+   One table of "Scorecard is good at / CDS is good at / neither."
+3. Coverage vs CDS: Title IV mandate vs voluntary school PDF. This is
+   why a school with no public CDS still has a Scorecard row.
+4. Lag, with a worked example on a live school page (Harvey Mudd or
+   Virginia Tech): the CDS year on the admissions card vs the Scorecard
+   vintage note already rendered in the UI. Screenshot that pairing
+   and caption the vintages. Do not imply Scorecard is "the latest
+   CDS."
+5. Why it belongs next to CDS on this site: outcomes and net price
+   families ask for, labeled as federal, never silently mixed into
+   §C or §H.
+6. What the official Scorecard site does better (program-level CIP
+   earnings, the .gov tool) and what we do instead (source-linked
+   school page + API). Cite ed.gov; do not impersonate it.
+
+#### c) `/about/ipeds`
+
+Job: make IPEDS legible to a counselor who has heard the acronym, and
+to a journalist who is about to download the wrong Access file.
+
+Must include:
+
+1. NCES and IPEDS as the statistical system of record for U.S.
+   postsecondary institutions. Link `nces.ed.gov/ipeds`. UNITID as
+   the join key we actually use.
+2. How data gets in: survey components (HD, IC, ADM, EF, GR, SFA, F),
+   provisional vs final, the Access-database reality for recent
+   releases. This is the silo on the federal side — not a PDF, a
+   stack of tables with dictionaries.
+3. Worked examples from the live federal baseline table (PRD 021):
+   pick 3–4 facts on Virginia Tech or Harvey Mudd (admit rate Near
+   CDS, endowment Not CDS-equivalent, locale Direct). Screenshot the
+   school-page table with source column visible. Caption
+   `source_table` / `source_variable` / release type.
+4. What IPEDS cannot replace: current-year wait-list, ED vs other
+   rounds, H2A merit counts, the school-authored PDF as
+   accountability. Quote PRD 021's non-goals in public language.
+5. Why we load it: directory-scale coverage when no public CDS
+   exists; historical series; finance (PRD 027) that CDS never had.
+6. How to tell CDS from IPEDS on a school page. One annotated
+   screenshot of a page that shows both, with the source labels
+   circled.
+
+**Shared page chrome (all three):**
+
+- Serif H1, `max-w-2xl` or `max-w-3xl` reading column, same tokens as
+  About. Read `web/DESIGN_SYSTEM.md`. Figures may go slightly wider
+  than the text column. Captions in the meta/mono style.
+- Unique `<title>` and meta description. Canonical under `/about/…`.
+- `Article` JSON-LD (`headline`, `datePublished`, `author` as the
+  project / Bolewood, `about` pointing at the official source org).
+- Breadcrumb: About / {page}. Footer and About hub link all three.
+- In-body links to 3–5 school or year URLs. **Virginia Tech must
+  appear on the CDS page** (email-gate example). Harvey Mudd appears
+  as the fillable-PDF / extraction example. Scorecard and IPEDS pages
+  use the same two schools so a reader can cross the three stories
+  on one institution.
+- Last-reviewed date in the header (these pages will rot when NCES
+  ships a new Scorecard dictionary or CDS template year).
+
+**SEO expectation (honest):** the crawl is already compounding
+(17.5K visitors in three months, multi-engine). These pages will not
+move the Harvey Mudd head term and will not replace repeating VT.
+They are how we turn year-page landings into a library: unique
+indexable prose, internal links, something Bing/DDG/ChatGPT can cite
+besides a stats widget, and a reason not to bounce at 77%. Measure
+in GSC by landing page `/about/*` **and** in Vercel as `/about`
+entering the top-pages list plus pages/visitor moving off 1.75.
+Do not hope they steal VT clicks.
+
+Optional later, not M2: a Harvey Mudd year-over-year note only if
+PRD 019 public events already support it. Still no hand-authored
+"how to get into X" article.
+
+### M2.5 — VT-shaped school inventory (operator + light data)
+
+Not a new page type. A ranked worklist:
+
+1. From the GSC query export: school-name CDS queries with impressions
+   and average position 5–20 (page-two-ish, already in the index).
+2. For each, fetch the official IR URL we already store. Classify:
+   public PDF index / email-or-request gate / JS-only / 404 / unknown.
+3. Cross with demand proxies we already have (applicants, enrollment,
+   browser-row existence). Prefer large publics with gated pages.
+4. First 10 on that list get a manual SERP check and, if our coverage
+   is stale, a finder/archive pass **before** copy tweaks. Freshness
+   beat HMC; it must not lose VT. Stanford and Texas A&M year pages
+   are already in Vercel's top pages — include them in the first
+   SERP checks even if GSC is Google-only.
+
+GradGPT already ships visualized per-school CDS URLs (they appear on
+the VT SERP). Speed matters more than heading tags for this slice.
+
+### M3 — Off-page, the work PRD 009 already named
+
+Technical on-page work will not create domain authority. M3 is
+distribution, not HTML:
+
+1. Post the Show HN (draft already at `docs/blog/show-hn-draft.md`).
+2. Add the site to the obvious citation surfaces that accept primary
+   sources: Wikipedia *Common Data Set* page (if a reliable secondary
+   source exists first — do not cite ourselves as the RS), IR
+   community lists, relevant GitHub / academic README mentions.
+3. Ask journalists / researchers who already use the API to link the
+   school page they used, not only the homepage.
+4. Keep linking official IR pages; some of those offices will link
+   back if the archive is clearly complementary (historical +
+   extract) rather than competitive.
+
+M3 is operator work with a checklist, not an engineering milestone
+that "ships" in a PR. Record outcomes in CHANGELOG / this PRD's
+status line when something lands.
+
+### M4 — Later, only if M1–M3 hold VT and move two more schools
+
+Do not build these until VT stays #1–#3 for the head query **and** at
+least two more gated-official schools show GSC clicks, *or* a
+historical-year HMC query reaches the first 3 pages:
+
+- Comparison URLs (`/compare/harvey-mudd/caltech`) as indexable
+  pages, not only the API.
+- Peer-cluster pages (Claremont Colleges CDS).
+- Field-level year pages (`.../2025-26/waitlist`) only if year-page
+  headings plus Search Console query data show a real demand slice.
+- Programmatic FAQ / speakable schema. Easy to spam; skip until
+  unique copy exists.
+
+## What does NOT ship
+
+- Rank-tracking SaaS, Ahrefs/Semrush subscriptions as a product
+  dependency (operator may use them; the PRD does not require them).
+- Per-school LLM-generated "insights" paragraphs.
+- Changing `school_id` slugs or adding a parallel `/cds/` tree.
+- noindex on directory-only schools is already correct (PRD 015);
+  leave it.
+- Discover (`/discover`) stays noindex.
+- A blog, CMS, or `/methodology/common-data-set` alias of the About
+  tree. Three static pages. About remains the hub.
+
+## Implementation notes
+
+- Lead copy belongs in the school/year server components so it is in
+  the first HTML. Do not hide it behind a client island.
+- Prefer one shared `archiveLead(school)` helper over per-page string
+  soup, and snapshot-test **Virginia Tech** (gated official), Harvey
+  Mudd (excellent official), one thin school, and one directory-only
+  school (noindex, no lead claiming an archive).
+- Official IR link: use the curated discovery seed / IR URL already
+  in `schools.yaml` (`https://www.hmc.edu/institutional-research/common-data-set/`
+  for Harvey Mudd — note the live IR page is currently
+  `/institutional-research/institutional-statistics/common-data-set/`;
+  do not ship a 404). Resolve URL accuracy as part of M1, not as a
+  crawler. The seed 301s to the live path today; either URL is fine
+  as a link target.
+- Freshness: HMC is not behind. Latest linked year on both sides is
+  2025-26; the IR "2026-27" line has no href. When a real newer file
+  appears, the weekly archive probe should pick it up. School-page
+  copy should only disclose an actual archive lag, not a CMS stub.
+- Design: read `web/DESIGN_SYSTEM.md` before adding the lead or the
+  About-tree pages. School-page leads are typesetting. The three
+  source pages are long-form with figures — still paper, ink, and
+  one quiet green. No blue, no marketing cards.
+- Annotated screenshots: capture from files we archive or from our
+  own school-page UI. Store under `web/public/about/` (or
+  `docs/prd/assets/028/`) with a filename that includes school-id,
+  year, and section. Alt text is a sentence, not "screenshot".
+- After M2 ships, school-page leads may link "What is a Common Data
+  Set" to `/about/common-data-set`. Do not inline the essay on every
+  school page.
+
+## Verification
+
+Canaries:
+
+- **Protect:** Virginia Tech (`virginia-tech`) — head term already ranks.
+- **Hard case:** Harvey Mudd (`harvey-mudd`, IPEDS `115409`) — excellent
+  official page; do not use as the go/no-go for head-term ranking.
+- **Repeat:** first school from the M2.5 gated-official list.
+
+### M0
+
+- [ ] Search Console URL inspection: VT hub, VT 2025-26, HMC hub, HMC
+      2025-26 — "URL is on Google" or documented exclusion.
+- [ ] Query export (`common data set|cds`, 3 months) saved under
+      `scratch/` or `.context/` with position and landing page.
+- [ ] `curl -I https://collegedata.fyi/schools/virginia-tech` → **301**
+      to the www equivalent.
+- [ ] `/sitemap.xml` contains `/browse` and the missing recipes.
+- [ ] Automated test: year page metadata canonical is path-specific
+      for both `virginia-tech/2025-26` and `harvey-mudd/2025-26`.
+
+### M1
+
+- [ ] View-source on the school hub contains the phrase
+      "Common Data Set" in a heading or the first visible paragraph,
+      plus a document count and year span.
+- [ ] Official IR link present and non-404.
+- [ ] Year page heading structure contains both school name and
+      "Common Data Set {year}".
+- [ ] Still links to archived PDF and spreadsheet downloads.
+- [ ] No new invented adjectives in the lead (manual read of Harvey
+      Mudd, Harvard, and one small school).
+
+### M2
+
+- [ ] `/about` links to all three source pages; the gloss paragraphs
+      no longer pretend to be the full story.
+- [ ] Each page has a unique title, canonical, and at least three
+      annotated figures with captions that name school, year, and
+      archived source.
+- [ ] CDS page includes Harvey Mudd (fillable) and Virginia Tech
+      (email gate and/or XLSX).
+- [ ] Scorecard page shows a vintage lag example from a live school
+      page; does not claim Scorecard is current-year CDS.
+- [ ] IPEDS page shows `source_table` / `source_variable` on a live
+      federal baseline screenshot; states what IPEDS cannot replace.
+- [ ] Sitemap includes the three URLs.
+- [ ] No `/methodology/common-data-set` duplicate.
+
+### Success metrics (90 days after M1+M2, not a launch gate)
+
+Directional. Do not treat as engineering pass/fail.
+
+1. **No VT regression.** `virginia tech common data set` stays in the
+   top 3 with CTR in the 30%+ range. Year-page and hub titles still
+   contain "Common Data Set".
+2. **Repeat.** At least two more school head queries (gated-official
+   class) produce GSC clicks. Target: VT is no longer the only school
+   in the top-10 query report.
+3. Site-wide CTR moves up from 0.7% as more queries leave position
+   ~12. Average position moving from 12 toward 8 is the leading
+   indicator; click count is the lagging one.
+4. Harvey Mudd: `site:` still returns our page. A historical-year or
+   spreadsheet query in the first 3 pages is a bonus, not the bar.
+   Head-term page-10 absence is accepted.
+5. **Literacy pages.** GSC shows impressions for at least one of
+   `what is the common data set`, `IPEDS vs CDS`, or
+   `college scorecard vs common data set`, landing on `/about/…`.
+   Vercel: `/about` or an `/about/…` child enters the top-pages
+   list; pages/visitor moves up from ~1.75. Zero GSC impressions
+   after 90 days means inspect indexing before rewriting into
+   listicles.
+6. **Do not lose the non-Google crawl.** Bing/DDG/Yahoo/ChatGPT
+   referrers stay in the mix. A Google-only title tweak that
+   wrecks the year page for Bing is a regression.
+
+## Failure modes
+
+| Failure | Why it happens | Mitigation |
+|---------|----------------|------------|
+| VT ranking dies after a copy/heading change | We touched the only page that converts | Snapshot tests; SERP check before merge; protect VT in QA |
+| We "optimize" HMC H1, still invisible on page 10 | Excellent `.edu` competitor | Do not use HMC head-term rank as go/no-go |
+| Duplicate-content filter across 4,000 school pages | Leads are identical except for names | Generate from real per-school facts |
+| Google treats us as a scraper | We host their file and extract it | Always link the official page; JSON-LD `creator` is the school |
+| VT IR objects to ranking #2 | We made their gated file public | Principle 1 + 6; ADR 0008; the file was already on a DAM URL |
+| GradGPT (or similar) takes the VT slot | Visualized CDS pages on the same SERP | Freshness + spreadsheet download + source link; do not wait on a blog |
+| Literacy pages become listicles | SEO temptation on `what is IPEDS` | Keep PRD 021 rigor; if GSC is zero, inspect indexing before rewriting |
+| Unlinked IR heading looks like we are stale | HMC's 2026-27 block is a paragraph, not a PDF | Do not write "we're behind"; wait for an href. Optional later: detect heading-without-link as coverage signal |
+| CollegeData.com confusion | ADR 0004 known cost | Brand as collegedata.fyi in titles |
+
+## Open questions
+
+1. **Closed: Search Console is verified.** Remaining: the query ×
+   position export for `cds` / `common data set`.
+2. **Should year pages use H1 = `{name} Common Data Set {year}`** and
+   demote the visual school name, or keep the design-system school
+   name as H1 with a strong H2? Design consultation before merging.
+   A/B this on a non-VT school first.
+3. **Do we have a durable official-IR URL field** that is accurate
+   enough to render, or only a discovery seed that can drift (HMC's
+   seed vs. the live `/institutional-statistics/common-data-set/`
+   path; VT's public page vs. DAM PDFs)? If seeds 404, M1 must not
+   link them.
+4. **How many schools are VT-shaped?** Need the M2.5 classification
+   against our seed URLs. Do not guess a percentage in this PRD.
+5. **Closed: HMC 2026-27 is not a pipeline miss.** IR heading with no
+   `<a href>`; guessed upload URLs 404; archive last verified 2026-08-15
+   on the linked 2025-26 file. Next weekly probe should catch the PDF
+   when they attach one.
+6. **Wikipedia / Wikidata**: only with a reliable secondary source.
+
+## Recommendation
+
+Do not treat Harvey Mudd as the SEO canary. Treat **Virginia Tech as
+the ranking we already have** and **gated official pages as the
+repeatable pattern**.
+
+Ship M0 (GSC export + 301 + sitemap) and M1 copy on all school/year
+pages, with VT in the test fixtures so we cannot regress the only
+query that pays. Run M2.5 next — that list, not H1 tweaks, is where
+the next 277-click query comes from.
+
+Write the three `/about/…` source pages as M2, in parallel with that
+list, not instead of it. The visitor curve is already up. `/about` is
+already the essay and is not being read. These pages are the depth
+it currently skips, and the thing a 77% bounce session never sees.
+They are how a compounding crawl becomes a library — a trust bet
+that should also show up in Bing, DDG, and ChatGPT, not only GSC.
+
+Still do not promise page one for Harvey Mudd. That `.edu` is doing
+its job. The 236K impressions at position 12 are the queue of schools
+where the `.edu` is not. Stanford 2017-18 and Texas A&M 2023-24 are
+proof that queue already pays when we are the usable HTML.
+
+## References
+
+- GSC Performance, last 3 months (16 May–14 Aug 2026), screenshot in
+  `.context/attachments/` (2026-08-17)
+- Vercel Analytics, ~17 May–16 Aug 2026 (17.5K visitors, 77% bounce,
+  multi-engine referrers, VT/Stanford/Texas A&M year pages), screenshot
+  in `.context/attachments/` (2026-08-17)
+- Live **protect** canary: [Virginia Tech hub](https://www.collegedata.fyi/schools/virginia-tech),
+  [2025-26](https://www.collegedata.fyi/schools/virginia-tech/2025-26)
+- Official VT page (email gate): [aie.vt.edu common-data-set](https://aie.vt.edu/analytics-and-ai/common-data-set.html)
+- Live **hard** canary: [Harvey Mudd hub](https://www.collegedata.fyi/schools/harvey-mudd),
+  [2025-26](https://www.collegedata.fyi/schools/harvey-mudd/2025-26)
+- Official HMC publisher: [HMC Common Data Set](https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/)
+- SERP competitor already on VT: [GradGPT Virginia Tech CDS](https://www.gradgpt.com/common-data-set/virginia-tech)
+- [PRD 021 IPEDS coverage](021-ipeds-coverage-layer.md)
+- [CDS vs College Scorecard research](../research/cds-vs-college-scorecard.md)
+- Live About (the published Uncommon Data Set framing):
+  https://www.collegedata.fyi/about
+- Draft long essay (source for CDS-page examples, not a second URL):
+  `docs/blog/the-uncommon-data-set.md`
+- Show HN draft (still unposted): `docs/blog/show-hn-draft.md`

--- a/tools/seo/README.md
+++ b/tools/seo/README.md
@@ -1,0 +1,18 @@
+# SEO operator tools (PRD 028)
+
+- `generate_official_cds_pages.py` — rebuilds
+  `web/src/data/official-cds-pages.json` from `tools/finder/schools.yaml`.
+  Direct PDF/XLSX seeds are omitted. Curated overrides (Virginia Tech HTML
+  gate, Harvey Mudd live IR path) always win. Run after seed-URL edits.
+- `vt_shaped_inventory.py` — M2.5 worklist into `scratch/seo/`. Not a
+  product page. Does not replace a Search Console query export.
+
+## Remaining operator steps
+
+GSC URL inspect and the CDS query/page exports are done. Memo:
+[`docs/prd/028-gsc-cds-queries-2026-08.md`](../../docs/prd/028-gsc-cds-queries-2026-08.md).
+
+Still off-page (PRD 028 M3): Show HN, citations, ask-for-links.
+
+Confirm `curl -I https://collegedata.fyi/schools/virginia-tech` stays
+**301** to the www host (true as of 2026-08-17; Next.js now pins it).

--- a/tools/seo/generate_official_cds_pages.py
+++ b/tools/seo/generate_official_cds_pages.py
@@ -1,0 +1,101 @@
+"""Build the frontend lookup of official school CDS landing pages.
+
+PRD 028 M1: school/year leads should link the school's own CDS page when we
+have a usable HTML URL. Direct PDF/XLSX seeds are not landing pages and must
+not be labeled as "the school's own CDS page."
+
+Curated overrides win. Virginia Tech's yaml seed is a DAM PDF; the public
+HTML page is the email-request gate we actually want to cite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHOOLS_YAML = REPO_ROOT / "tools" / "finder" / "schools.yaml"
+OUT_PATH = REPO_ROOT / "web" / "src" / "data" / "official-cds-pages.json"
+
+DIRECT_DOC_SUFFIXES = (".pdf", ".xlsx", ".xls", ".docx", ".doc", ".csv", ".zip")
+
+# Only set access="request" when we have read the page. Do not guess.
+CURATED: dict[str, dict[str, str]] = {
+    "virginia-tech": {
+        "url": "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+        "access": "request",
+        "ipeds_id": "233921",
+        "also_school_ids": "virginia-polytechnic-institute-and-state-university",
+    },
+    "harvey-mudd": {
+        "url": "https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/",
+        "access": "public",
+        "ipeds_id": "115409",
+    },
+}
+
+
+def is_direct_document(url: str) -> bool:
+    if not url:
+        return True
+    path = url.split("?", 1)[0].split("#", 1)[0].lower()
+    return path.endswith(DIRECT_DOC_SUFFIXES)
+
+
+def landing_url(school: dict) -> str | None:
+    for key in ("browse_url", "discovery_seed_url"):
+        url = (school.get(key) or "").strip()
+        if url and not is_direct_document(url):
+            return url
+    return None
+
+
+def main() -> None:
+    payload = yaml.safe_load(SCHOOLS_YAML.read_text())
+    by_school_id: dict[str, dict[str, str]] = {}
+    by_ipeds_id: dict[str, dict[str, str]] = {}
+
+    for school in payload.get("schools") or []:
+        school_id = school.get("id")
+        ipeds_id = str(school.get("ipeds_id") or "").strip()
+        url = landing_url(school)
+        if not school_id or not url:
+            continue
+        entry = {"url": url, "access": "unknown"}
+        by_school_id[school_id] = entry
+        if ipeds_id:
+            by_ipeds_id[ipeds_id] = entry
+
+    for school_id, curated in CURATED.items():
+        entry = {"url": curated["url"], "access": curated["access"]}
+        by_school_id[school_id] = entry
+        for extra in (curated.get("also_school_ids") or "").split(","):
+            extra = extra.strip()
+            if extra:
+                by_school_id[extra] = entry
+        ipeds_id = curated.get("ipeds_id")
+        if ipeds_id:
+            by_ipeds_id[ipeds_id] = entry
+
+    OUT_PATH.write_text(
+        json.dumps(
+            {
+                "generated_from": "tools/finder/schools.yaml",
+                "bySchoolId": dict(sorted(by_school_id.items())),
+                "byIpedsId": dict(sorted(by_ipeds_id.items())),
+            },
+            indent=2,
+            sort_keys=False,
+        )
+        + "\n"
+    )
+    print(
+        f"Wrote {OUT_PATH.relative_to(REPO_ROOT)} "
+        f"({len(by_school_id)} school ids, {len(by_ipeds_id)} ipeds ids)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/seo/vt_shaped_inventory.py
+++ b/tools/seo/vt_shaped_inventory.py
@@ -1,0 +1,176 @@
+"""Classify official CDS landing pages for the PRD 028 M2.5 worklist.
+
+This is operator data, not a product page. It does not scrape IR pages on
+every web request. Output: scratch/seo/vt-shaped-inventory.md
+
+GSC query × position export is still an operator step (Search Console).
+This script uses the seed URLs we already store, plus a short manual
+fetch of the canaries named in the PRD.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHOOLS_YAML = REPO_ROOT / "tools" / "finder" / "schools.yaml"
+OFFICIAL_JSON = REPO_ROOT / "web" / "src" / "data" / "official-cds-pages.json"
+OUT_PATH = REPO_ROOT / "scratch" / "seo" / "vt-shaped-inventory.md"
+
+CANARIES = [
+    {
+        "label": "Virginia Tech",
+        "school_id": "virginia-tech",
+        "ipeds_id": "233921",
+        "demand": "GSC head term already #2; Vercel top year page",
+        "fetch_url": "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+    },
+    {
+        "label": "Harvey Mudd",
+        "school_id": "harvey-mudd",
+        "ipeds_id": "115409",
+        "demand": "Hard case: excellent official PDF index",
+        "fetch_url": "https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/",
+    },
+    {
+        "label": "Stanford",
+        "school_id": "stanford",
+        "ipeds_id": "243744",
+        "demand": "Vercel top pages: hub + 2017-18 year page",
+        "fetch_url": "https://irds.stanford.edu/data-findings/cds",
+    },
+    {
+        "label": "Texas A&M College Station",
+        "school_id": "texas-a-and-m-university-college-station",
+        "ipeds_id": "228723",
+        "demand": "Vercel top year page 2023-24",
+        "fetch_url": None,
+    },
+    {
+        "label": "Harvard",
+        "school_id": "harvard",
+        "ipeds_id": "166027",
+        "demand": "High-demand; excellent official listing expected",
+        "fetch_url": "https://oira.harvard.edu/common-data-set/",
+    },
+]
+
+
+def classify_html(text: str) -> str:
+    lower = text.lower()
+    has_pdf_link = ".pdf" in lower
+    requestish = (
+        "available via request" in lower
+        or "available by request" in lower
+        or "available on request" in lower
+        or "upon request" in lower
+    )
+    if requestish and not has_pdf_link:
+        return "email-or-request gate"
+    if requestish and has_pdf_link:
+        return "public PDF index (older years on request)"
+    if has_pdf_link or "common data set" in lower:
+        return "public PDF index (or listing)"
+    return "unknown"
+
+
+def fetch(url: str) -> tuple[int | str, str]:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "collegedata.fyi inventory (PRD 028 M2.5)"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as response:
+            body = response.read(200_000).decode("utf-8", errors="replace")
+            return response.status, classify_html(body)
+    except urllib.error.HTTPError as exc:
+        return exc.code, "http-error"
+    except Exception as exc:  # noqa: BLE001 — operator script
+        return "error", str(exc)
+
+
+def main() -> None:
+    payload = yaml.safe_load(SCHOOLS_YAML.read_text())
+    schools = payload.get("schools") or []
+    html = 0
+    pdf = 0
+    none = 0
+    for school in schools:
+        url = (school.get("browse_url") or school.get("discovery_seed_url") or "").strip()
+        if not url:
+            none += 1
+        elif url.lower().split("?", 1)[0].endswith((".pdf", ".xlsx", ".docx")):
+            pdf += 1
+        else:
+            html += 1
+
+    official = json.loads(OFFICIAL_JSON.read_text())
+    lines = [
+        "# VT-shaped school inventory (PRD 028 M2.5)",
+        "",
+        "Generated from `tools/finder/schools.yaml` landing-page classification",
+        "plus a short fetch of PRD canaries. **Not** a GSC export. Paste the",
+        "Search Console `common data set|cds` query × page × position table",
+        "into this folder when available.",
+        "",
+        "## Seed-URL shape (all yaml schools)",
+        "",
+        f"- HTML-like landing pages: **{html}**",
+        f"- Direct document seeds (PDF/XLSX/DOCX): **{pdf}**",
+        f"- No seed URL: **{none}**",
+        f"- Frontend lookup rows: **{len(official['bySchoolId'])}** school ids",
+        "",
+        "Direct-document seeds are the first place to look for VT-shaped",
+        "schools: Google may index a DAM PDF or nothing, while we have HTML.",
+        "",
+        "## Canary SERP / official-page checks",
+        "",
+        "| School | Our slug | Demand proxy | Official URL checked | Fetch | Class |",
+        "|---|---|---|---|---|---|",
+    ]
+
+    for row in CANARIES:
+        url = row["fetch_url"]
+        if not url:
+            ipeds = row["ipeds_id"]
+            generated = official["byIpedsId"].get(ipeds) or official["bySchoolId"].get(
+                row["school_id"]
+            )
+            url = (generated or {}).get("url")
+        if not url:
+            lines.append(
+                f"| {row['label']} | `{row['school_id']}` | {row['demand']} | — | skipped | no HTML seed |"
+            )
+            continue
+        status, klass = fetch(url)
+        lines.append(
+            f"| {row['label']} | `{row['school_id']}` | {row['demand']} | {url} | {status} | {klass} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## First-10 attention list (until GSC export lands)",
+            "",
+            "1. Virginia Tech — protect. Official page is an email gate.",
+            "2. Stanford — already converting on year pages; check whether the IR listing is complete for historical years.",
+            "3. Texas A&M College Station — Vercel 2023-24 year page; yaml seed is a direct attachment PDF (`texas-am` / IPEDS 228723).",
+            "4. Other large publics whose yaml seed is a DAM/PDF rather than an HTML index.",
+            "5. Harvey Mudd — cite, do not treat head-term rank as go/no-go.",
+            "",
+            "Freshness before copy tweaks on any of the above except HMC.",
+            "",
+        ]
+    )
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,10 +1,14 @@
 import type { NextConfig } from "next";
 import retiredSchoolAliases from "./src/data/school-redirects.json";
+import { APEX_TO_WWW_REDIRECTS } from "./src/lib/apex-redirect";
 import { buildRetiredSchoolRedirects } from "./src/lib/school-alias";
 
 const nextConfig: NextConfig = {
   async redirects() {
-    return buildRetiredSchoolRedirects(retiredSchoolAliases);
+    return [
+      ...APEX_TO_WWW_REDIRECTS,
+      ...buildRetiredSchoolRedirects(retiredSchoolAliases),
+    ];
   },
   // Rewrite the pretty URL `/design-system` and `/design-system/` to the
   // static file under `public/design-system/index.html`. Next's default

--- a/web/public/about/college-scorecard-source-join.svg
+++ b/web/public/about/college-scorecard-source-join.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+  <rect width="920" height="300" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCORECARD JOIN · NOT A GUIDEBOOK SURVEY</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Five administrative systems</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">
+    <rect x="44" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="56" y="154">IPEDS</text>
+    <rect x="210" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="222" y="154">NSLDS</text>
+    <rect x="376" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="388" y="154">Treasury/IRS</text>
+    <rect x="542" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="554" y="154">FSA</text>
+    <rect x="708" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="720" y="154">OPE / ACS</text>
+  </g>
+  <text x="44" y="214" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Earnings, debt, and net price come from this join. They are not Section C or Section H of a school PDF.</text>
+  <text x="44" y="246" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official tool: collegescorecard.ed.gov. We cite it; we do not impersonate it.</text>
+</svg>

--- a/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 400" role="img">
+  <rect width="920" height="400" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="352" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SAME FILE · DOCLING ON A FILLABLE PDF · NOT THE LIVE EXTRACT</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">C1 row-shift after flattening</text>
+  <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Ground truth from AcroForm: men 3,452 · women 1,761 · another/unknown 4.</text>
+  <rect x="44" y="140" width="832" height="120" fill="#fff" stroke="rgba(140,42,31,.45)"/>
+  <text x="56" y="168" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#8c2a1f">Docling cell collapse</text>
+  <text x="56" y="196" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year men who applied     | 3452 1761</text>
+  <text x="56" y="220" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year women who applied   | 4</text>
+  <text x="56" y="244" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year unknown who applied |</text>
+  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Kerned year numerals in the same extract: Common Data Set 202 5 -202 6, Fall 201 8 Cohort.</text>
+  <text x="44" y="320" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Running header emitted as an H2 five times: Common Data Set 2025-2026.</text>
+  <text x="44" y="352" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live Harvey Mudd 2025-26 extract is the AcroForm path, not this Docling output.</text>
+</svg>

--- a/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 420" role="img">
+  <rect width="920" height="420" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="372" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">HARVEY MUDD COLLEGE · CDS 2025-26 · FILLABLE ACROFORM · §C1</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="28" fill="#1c1e1b">C1. Applicants, admits, enrolled</text>
+  <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Named fields from the unflattened template. Values are the field contents, not OCR.</text>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="13">
+    <rect x="44" y="140" width="832" height="36" fill="#e9e3d4"/>
+    <text x="56" y="163" fill="#6b6a63">PDF TAG</text>
+    <text x="430" y="163" fill="#6b6a63">FIELD</text>
+    <text x="780" y="163" fill="#6b6a63">VALUE</text>
+    <text x="56" y="204" fill="#1c1e1b">AP_RECD_1ST_MEN_N</text>
+    <text x="430" y="204" fill="#3a3b37">First-year men who applied</text>
+    <text x="780" y="204" fill="#1c1e1b">3,452</text>
+    <text x="56" y="236" fill="#1c1e1b">AP_RECD_1ST_WMN_N</text>
+    <text x="430" y="236" fill="#3a3b37">First-year women who applied</text>
+    <text x="780" y="236" fill="#1c1e1b">1,761</text>
+    <text x="56" y="268" fill="#1c1e1b">AP_ADMT_1ST_MEN_N</text>
+    <text x="430" y="268" fill="#3a3b37">First-year men admitted</text>
+    <text x="780" y="268" fill="#1c1e1b">276</text>
+    <text x="56" y="300" fill="#1c1e1b">AP_RECD_WAIT_N</text>
+    <text x="430" y="300" fill="#3a3b37">Offered a place on the wait list</text>
+    <text x="780" y="300" fill="#1c1e1b">685</text>
+  </g>
+  <rect x="44" y="328" width="832" height="44" fill="#27321f"/>
+  <text x="56" y="355" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#f1ece1">pypdf.get_fields() reads these tags directly. Docling is the wrong tool for this file.</text>
+</svg>

--- a/web/public/about/harvey-mudd-2025-26-page-header.svg
+++ b/web/public/about/harvey-mudd-2025-26-page-header.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+  <rect width="920" height="300" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="52" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">PAGE HEADER REPEATED · NOT A DATABASE</text>
+  <text x="44" y="88" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
+  <text x="44" y="118" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
+  <text x="44" y="148" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
+  <text x="44" y="178" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
+  <text x="44" y="208" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
+  <text x="44" y="248" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Harvey Mudd 2025-26 fillable PDF. The running header is print chrome. Google can index the phrase; it is still a form, not a table.</text>
+</svg>

--- a/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
+++ b/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+  <rect width="920" height="340" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCHOOL PAGE PAIRING · HARVEY MUDD</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">CDS year is not Scorecard vintage</text>
+  <rect x="44" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+  <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#3f5b3a">ARCHIVED CDS</text>
+  <text x="60" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">2025-26</text>
+  <text x="60" y="216" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Admissions card from the school-authored file.</text>
+  <rect x="468" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">COLLEGE SCORECARD</text>
+  <text x="484" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Federal vintage</text>
+  <text x="484" y="216" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Outcomes reflect earlier cohorts than the CDS year shown on the same page.</text>
+  <text x="44" y="308" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live note: Outcomes reflect earlier cohorts than the CDS year shown elsewhere on this page.</text>
+</svg>

--- a/web/public/about/ipeds-survey-components.svg
+++ b/web/public/about/ipeds-survey-components.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
+  <rect width="920" height="280" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">IPEDS SURVEY COMPONENTS · NOT ONE FILE</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">HD · IC · ADM · EF · GR · SFA · F</text>
+  <text x="44" y="136" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">Recent releases arrive as a stack of tables inside a Microsoft Access database, with dictionaries. Provisional first, then final with institutional revisions.</text>
+  <text x="44" y="196" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">UNITID is the join key this site actually uses.</text>
+  <text x="44" y="228" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official system of record: nces.ed.gov/ipeds</text>
+</svg>

--- a/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
+++ b/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
+  <rect width="920" height="280" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">COVERAGE · TITLE IV MANDATE VS VOLUNTARY PDF</text>
+  <text x="44" y="96" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">A school with no public CDS still has a Scorecard row</text>
+  <text x="44" y="140" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">College Scorecard covers Title IV institutions because IPEDS reporting is mandatory. The Common Data Set is a voluntary guidebook template. That is why the directory stub exists: federal baseline facts without pretending a CDS was published.</text>
+  <text x="44" y="210" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Harvey Mudd and Virginia Tech both publish a CDS. The coverage gap is everyone else.</text>
+</svg>

--- a/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
+++ b/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
+  <rect width="920" height="360" fill="#faf6ec"/>
+  <rect x="24" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="40" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">VIRGINIA TECH · 2025-26 · XLSX</text>
+  <text x="40" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Answer Sheet tab</text>
+  <text x="40" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.116  Applied (total)</text>
+  <text x="300" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">57,755</text>
+  <text x="40" y="148" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.117  Admitted</text>
+  <text x="40" y="176" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.118  Enrolled</text>
+  <text x="40" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">Machine-readable by construction. The school still does not index this file on a public HTML landing page.</text>
+  <rect x="476" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="492" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">AIE.VT.EDU · SAME SCHOOL</text>
+  <text x="492" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Email to request</text>
+  <text x="492" y="130" font-family="Georgia, serif" font-size="15" font-style="italic" fill="#1c1e1b">Current and historical CDS files for Virginia Tech are available via request to aiesupport@vt.edu.</text>
+  <text x="492" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">The official result explains the form, then withholds the file. The archive page is the public HTML that hands over the extract.</text>
+</svg>

--- a/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
+++ b/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+  <rect width="920" height="300" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">ONE SCHOOL PAGE · TWO SOURCE LAYERS</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">How to tell CDS from IPEDS</text>
+  <rect x="44" y="120" width="400" height="120" fill="#fff" stroke="#3f5b3a" stroke-width="2"/>
+  <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#3f5b3a">CIRCLED · CDS</text>
+  <text x="60" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">School-authored PDF / XLSX</text>
+  <text x="60" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Year page extract, field IDs C.101 / H.2A</text>
+  <rect x="468" y="120" width="400" height="120" fill="#fff" stroke="rgba(28,30,27,.45)" stroke-width="2"/>
+  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#6b6a63">CIRCLED · IPEDS</text>
+  <text x="484" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">NCES survey table</text>
+  <text x="484" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">source_table.source_variable · provisional/final</text>
+</svg>

--- a/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
+++ b/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
+  <rect width="920" height="360" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">NCES/IPEDS BASELINE · SOURCE COLUMN VISIBLE</text>
+  <text x="44" y="88" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Federal facts stay labeled</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">
+    <rect x="44" y="112" width="832" height="32" fill="#e9e3d4"/>
+    <text x="56" y="133" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">FACT</text>
+    <text x="360" y="133" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">ALIGNMENT</text>
+    <text x="560" y="133" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">SOURCE</text>
+    <text x="56" y="172" fill="#1c1e1b">Admission rate</text>
+    <text x="360" y="172" fill="#3a3b37">Near CDS</text>
+    <text x="560" y="172" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">ADM.DRVADM_RATE</text>
+    <text x="56" y="208" fill="#1c1e1b">Endowment</text>
+    <text x="360" y="208" fill="#3a3b37">Not CDS-equivalent</text>
+    <text x="560" y="208" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">F.F1H_END</text>
+    <text x="56" y="244" fill="#1c1e1b">Locale</text>
+    <text x="360" y="244" fill="#3a3b37">Direct</text>
+    <text x="560" y="244" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">HD.LOCALE</text>
+  </g>
+  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Worked example shape from the live federal baseline table. Captions on the school page show source_table, source_variable, and release type.</text>
+  <text x="44" y="318" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Do not read these as a substitute for the current-year CDS wait-list or H2A rows.</text>
+</svg>

--- a/web/src/app/about/college-scorecard/page.tsx
+++ b/web/src/app/about/college-scorecard/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  SOURCE_STORY_REVIEWED,
+  SourceStoryLayout,
+  StoryFigure,
+  StoryTable,
+} from "@/components/about/SourceStoryLayout";
+
+const CANONICAL = "/about/college-scorecard";
+const TITLE = "College Scorecard, and why it is not a CDS";
+const DESCRIPTION =
+  "College Scorecard is a federal consumer tool joined from IPEDS, NSLDS, Treasury, and FSA. It is not a Common Data Set, and its vintage lags the school-authored CDS year.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: CANONICAL },
+  openGraph: { url: CANONICAL, title: TITLE, description: DESCRIPTION },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: TITLE,
+  description: DESCRIPTION,
+  datePublished: SOURCE_STORY_REVIEWED,
+  dateModified: SOURCE_STORY_REVIEWED,
+  author: { "@type": "Organization", name: "Bolewood Group", url: "https://bolewood.com" },
+  publisher: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
+  about: {
+    "@type": "Organization",
+    name: "U.S. Department of Education College Scorecard",
+    url: "https://collegescorecard.ed.gov/",
+  },
+  mainEntityOfPage: `https://www.collegedata.fyi${CANONICAL}`,
+};
+
+export default function CollegeScorecardPage() {
+  return (
+    <SourceStoryLayout
+      kicker="College Scorecard"
+      title={
+        <>
+          College Scorecard, and why it is not a CDS
+        </>
+      }
+      lede="The federal consumer tool answers cost, debt, and earnings questions the Common Data Set never did. It is not this year’s admit table, and we do not blend the two into one unlabeled number."
+      jsonLd={jsonLd}
+    >
+      <h2>Origin</h2>
+      <p>
+        The Obama-era{" "}
+        <a
+          href="https://collegescorecard.ed.gov/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          College Scorecard
+        </a>{" "}
+        is a Department of Education consumer-information product. It was not
+        designed as a guidebook survey. Schools do not fill it in the way they
+        fill a Common Data Set. Administrative systems already hold the
+        records; Scorecard publishes a join of those records for prospective
+        students.
+      </p>
+      <p>
+        The official site at collegescorecard.ed.gov is the navigational
+        result for “college scorecard.” This page is not trying to replace
+        that. It exists so a reader of a school page here can see why a
+        Scorecard earnings figure sits next to a CDS admit rate without
+        becoming the same number.
+      </p>
+
+      <h2>What it actually is now</h2>
+      <p>
+        Current Scorecard institution files are a join of IPEDS, NSLDS
+        (federal student aid), Treasury/IRS earnings, Federal Student Aid
+        operating flags, and a handful of OPE and ACS fields. That mapping is
+        in{" "}
+        <a
+          href="https://github.com/bolewood/collegedata-fyi/blob/main/docs/research/cds-vs-college-scorecard.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          CDS vs College Scorecard
+        </a>
+        .
+      </p>
+      <StoryFigure
+        src="/about/college-scorecard-source-join.svg"
+        alt="Diagram of College Scorecard as a join of IPEDS, NSLDS, Treasury/IRS earnings, FSA, and OPE/ACS, not a school-authored Common Data Set."
+        caption="College Scorecard source systems. Not a screenshot of ed.gov; a map of the join this site actually cites on school pages."
+        href="/schools/harvey-mudd"
+        hrefLabel="See the pairing on Harvey Mudd"
+      />
+
+      <StoryTable
+        caption="What Scorecard is good at, what CDS is good at, and what neither covers"
+        headers={["Scorecard is good at", "CDS is good at", "Neither"]}
+        rows={[
+          [
+            "Net price, debt, repayment, earnings by cohort",
+            "Current-year applicants / admits / enrolled (C1)",
+            "Student-level records",
+          ],
+          [
+            "Title IV universe (~6,000 institutions)",
+            "Wait list, ED/EA, C7 factor matrix, H2A merit",
+            "A single “latest” number that mixes vintages",
+          ],
+          [
+            "Program-level CIP earnings on the .gov tool",
+            "School-authored PDF/XLSX you can archive and cite",
+            "Predicting admission for one applicant",
+          ],
+        ]}
+      />
+
+      <h2>Coverage vs the Common Data Set</h2>
+      <p>
+        IPEDS reporting is mandatory for Title IV schools. The Common Data
+        Set is voluntary. That is why a school with no public CDS still has a
+        Scorecard row, and why this site’s directory stub can show federal
+        facts without pretending a CDS exists. Harvey Mudd and Virginia Tech
+        both publish a CDS; they are the worked examples because a reader can
+        cross{" "}
+        <Link href="/about/common-data-set">the CDS story</Link> and{" "}
+        <Link href="/about/ipeds">the IPEDS story</Link> on the same two
+        institutions.
+      </p>
+      <StoryFigure
+        src="/about/scorecard-title-iv-vs-cds-coverage.svg"
+        alt="Coverage contrast: Title IV mandate gives every participating school a Scorecard row, while Common Data Set publication remains voluntary."
+        caption="Coverage rule, not a school-year extract. Directory-only pages on this site exist because of this gap."
+        href="/schools"
+        hrefLabel="Browse schools"
+      />
+
+      <h2>Lag, on a live school page</h2>
+      <p>
+        On{" "}
+        <Link href="/schools/harvey-mudd">Harvey Mudd</Link> and{" "}
+        <Link href="/schools/virginia-tech">Virginia Tech</Link>, the
+        admissions card is the archived CDS year. Directly under the federal
+        outcomes band, the page already prints a vintage note: Scorecard
+        outcomes reflect earlier cohorts than the CDS year shown elsewhere on
+        the page. That pairing is the product. Scorecard is not “the latest
+        CDS.”
+      </p>
+      <StoryFigure
+        src="/about/harvey-mudd-scorecard-vintage-lag.svg"
+        alt="Harvey Mudd school page pairing: archived Common Data Set year 2025-26 beside College Scorecard federal vintage note that outcomes lag the CDS year."
+        caption="Harvey Mudd College school page. CDS year 2025-26 on the admissions side; College Scorecard vintage note on the federal outcomes side. Same pairing exists on Virginia Tech."
+        href="/schools/harvey-mudd"
+        hrefLabel="Open the Harvey Mudd hub"
+      />
+
+      <h2>Why it belongs next to a CDS here</h2>
+      <p>
+        Families ask for net price, debt, and earnings. Those questions are
+        Scorecard’s job. We show them on the school page, labeled as federal,
+        and we do not fold them into §C or §H. Virginia Tech’s{" "}
+        <Link href="/schools/virginia-tech/2025-26">2025-26 year page</Link>{" "}
+        is still the place for wait-list and testing extracts from the school
+        file.
+      </p>
+
+      <h2>What the official site does better</h2>
+      <p>
+        Program-level CIP earnings, the comparison tool, and the full
+        dictionary live on{" "}
+        <a
+          href="https://collegescorecard.ed.gov/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          collegescorecard.ed.gov
+        </a>
+        . We do not impersonate that site. What we do instead is keep
+        Scorecard on the same source-linked school page as the archived CDS
+        and the{" "}
+        <Link href="/about/ipeds">IPEDS baseline</Link>, with the vintage
+        mismatch visible.
+      </p>
+    </SourceStoryLayout>
+  );
+}

--- a/web/src/app/about/common-data-set/page.tsx
+++ b/web/src/app/about/common-data-set/page.tsx
@@ -1,0 +1,214 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  SOURCE_STORY_REVIEWED,
+  SourceStoryLayout,
+  StoryFigure,
+  StoryTable,
+} from "@/components/about/SourceStoryLayout";
+
+const CANONICAL = "/about/common-data-set";
+const TITLE = "What is the Common Data Set";
+const DESCRIPTION =
+  "The Common Data Set is a voluntary 47-page school-authored form, not a database. How the template works, why publishing is a mess, and what collegedata.fyi extracts.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: CANONICAL },
+  openGraph: { url: CANONICAL, title: TITLE, description: DESCRIPTION },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: TITLE,
+  description: DESCRIPTION,
+  datePublished: SOURCE_STORY_REVIEWED,
+  dateModified: SOURCE_STORY_REVIEWED,
+  author: { "@type": "Organization", name: "Bolewood Group", url: "https://bolewood.com" },
+  publisher: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
+  about: {
+    "@type": "Organization",
+    name: "Common Data Set Initiative",
+    url: "https://commondataset.org/",
+  },
+  mainEntityOfPage: `https://www.collegedata.fyi${CANONICAL}`,
+};
+
+export default function CommonDataSetPage() {
+  return (
+    <SourceStoryLayout
+      kicker="Common Data Set"
+      title={
+        <>
+          What is the Common Data Set
+        </>
+      }
+      lede="A 47-page PDF on a random institutional-research URL is not a data system. It is a print form that three guidebook publishers asked schools to fill in once."
+      jsonLd={jsonLd}
+    >
+      <h2>The CDS Initiative</h2>
+      <p>
+        In the late 1990s the College Board, Peterson&apos;s, and U.S. News sat
+        down with college institutional-research offices and agreed on one
+        template. The point was to stop asking every school for the same
+        enrollment, admissions, and aid numbers in fifteen slightly different
+        shapes. The{" "}
+        <a href="https://commondataset.org/" target="_blank" rel="noopener noreferrer">
+          Common Data Set Initiative
+        </a>{" "}
+        still publishes that template. It is currently a 47-page workbook with
+        1,105 fields and an Answer Sheet tab.
+      </p>
+      <p>
+        Participation is voluntary. There is no federal mandate, no central
+        filing cabinet, and no API. Each school posts a file on its own
+        website, or does not.
+      </p>
+
+      <h2>Sections A–J, in English</h2>
+      <StoryTable
+        caption="Common Data Set sections A through J"
+        headers={["Section", "What it covers"]}
+        rows={[
+          ["A · General Information", "Name, calendar, degrees, respondent contact."],
+          ["B · Enrollment and Persistence", "Headcount, race/ethnicity, retention, graduation rates."],
+          ["C · First-time, first-year admission", "Applicants, admits, enrolled, tests, wait list, ED/EA."],
+          ["D · Transfer admission", "Transfer funnel and requirements."],
+          ["E · Academic offerings", "Special programs and policies."],
+          ["F · Student life", "Housing, activities, percent in-state."],
+          ["G · Annual expenses", "Tuition, fees, food and housing."],
+          ["H · Financial aid", "Need and non-need packages, H2A merit counts."],
+          ["I · Faculty and class size", "Student-faculty ratio, class-size bands."],
+          ["J · Degrees conferred", "Disciplinary areas of degrees awarded."],
+        ]}
+      />
+
+      <h2>A fillable PDF is the easy case</h2>
+      <p>
+        Harvey Mudd College still publishes the{" "}
+        <Link href="/schools/harvey-mudd/2025-26">
+          2025-26 Common Data Set
+        </Link>{" "}
+        as an unflattened fillable PDF. Named AcroForm fields carry the
+        canonical tags from the template. <code>AP_RECD_1ST_MEN_N</code> is
+        3,452. That is a 200-millisecond <code>pypdf.get_fields()</code>{" "}
+        extract, not a model guess. See{" "}
+        <Link href="/schools/harvey-mudd">the Harvey Mudd archive</Link>.
+      </p>
+      <StoryFigure
+        src="/about/harvey-mudd-2025-26-c1-fillable.svg"
+        alt="Harvey Mudd College Common Data Set 2025-26 section C1, showing named AcroForm tags such as AP_RECD_1ST_MEN_N with value 3,452 from the fillable PDF."
+        caption="Harvey Mudd College, Common Data Set 2025-26, archived fillable PDF CDS-HMC-2025.2026_shared.pdf, section C1. Values are AcroForm field contents."
+        href="/schools/harvey-mudd/2025-26"
+        hrefLabel="Open the 2025-26 year page"
+      />
+
+      <h2>Point the wrong extractor at that file and C1 shifts</h2>
+      <p>
+        The same kind of table, after a layout parser has flattened it, is why
+        this archive exists as software and not as a folder of PDFs. Docling
+        on the Harvey Mudd fillable file collapsed C1 so men-applied became
+        “3452 1761” and women-applied became “4”. Kerned year numerals read
+        as “202 5 -202 6”. The running header printed “Common Data Set
+        2025-2026” as a heading five times. That is documented in
+        <code> docs/known-issues/harvey-mudd-2025-26.md</code>. The live
+        extract is the AcroForm path. The Docling notes are what happens if
+        you pick the wrong tool.
+      </p>
+      <StoryFigure
+        src="/about/harvey-mudd-2025-26-c1-docling-shift.svg"
+        alt="Docling misread of Harvey Mudd 2025-26 C1, with applicant counts shifted into the wrong rows, shown as a warning rather than the live extract."
+        caption="Harvey Mudd College, Common Data Set 2025-26, same archived PDF. This figure is the historical Docling misread of C1, not the live extract."
+        href="/schools/harvey-mudd/2025-26"
+        hrefLabel="Open the year page whose live extract is correct"
+      />
+      <StoryFigure
+        src="/about/harvey-mudd-2025-26-page-header.svg"
+        alt="The phrase Common Data Set 2025-2026 repeated five times as a running page header from the Harvey Mudd fillable PDF."
+        caption="Harvey Mudd College, Common Data Set 2025-26, archived fillable PDF. The repeating header is print chrome. The document is a form, not a database."
+        href="/schools/harvey-mudd/2025-26"
+      />
+
+      <h2>Virginia Tech publishes XLSX and hides the index</h2>
+      <p>
+        Virginia Tech&apos;s{" "}
+        <Link href="/schools/virginia-tech/2025-26">
+          2025-26 Common Data Set
+        </Link>{" "}
+        is an Excel workbook — the theoretically ideal format. The school&apos;s
+        own page at{" "}
+        <a
+          href="https://aie.vt.edu/analytics-and-ai/common-data-set.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          aie.vt.edu
+        </a>{" "}
+        explains what a CDS is, then says files are available via request to
+        aiesupport@vt.edu. The PDFs and workbooks exist on a DAM path. The
+        landing page is a dead end.{" "}
+        <Link href="/schools/virginia-tech">The Virginia Tech archive</Link>{" "}
+        is the public HTML that actually hands over the extract.
+      </p>
+      <StoryFigure
+        src="/about/virginia-tech-2025-26-xlsx-and-email-gate.svg"
+        alt="Virginia Tech 2025-26 Common Data Set Excel answer sheet beside the official IR page text that asks the public to email aiesupport@vt.edu for the file."
+        caption="Virginia Tech, Common Data Set 2025-26, archived XLSX, next to the school’s own CDS page (email request). Applied total in the 2025-26 extract: 57,755."
+        href="/schools/virginia-tech/2025-26"
+        hrefLabel="Open the Virginia Tech 2025-26 year page"
+      />
+
+      <h2>The publishing mess</h2>
+      <p>
+        Schools do not publish one way. In this archive we already have, as
+        real files:
+      </p>
+      <ul>
+        <li>Unflattened fillable PDFs (Harvey Mudd 2025-26).</li>
+        <li>Flattened PDFs where the form structure is gone.</li>
+        <li>Image-only scans with almost no extractable text.</li>
+        <li>XLSX workbooks (Virginia Tech 2025-26).</li>
+        <li>DOCX uploads of the Word template.</li>
+        <li>HTML pages, some of them JS-only.</li>
+        <li>Box, SharePoint, Google Drive, and Digital Commons item pages.</li>
+        <li>
+          URLs whose path year is a CMS upload month, not the academic year.
+        </li>
+        <li>Section-only files, blank templates, and “test” uploads that are the real file.</li>
+      </ul>
+      <p>
+        None of that is a data system. It is a distributed print workflow
+        that happens to use a shared template. Stanford&apos;s{" "}
+        <Link href="/schools/stanford/2017-18">2017-18 year page</Link> is
+        already a used URL: historical files convert when the school no
+        longer lists them.
+      </p>
+
+      <h2>What “extracted” means here</h2>
+      <p>
+        Extracted means: canonical field IDs such as C.101 and H.2A, values
+        with provenance back to the archived bytes, and a spreadsheet
+        download of those fields. It does not mean we are the publisher. The
+        numbers are the school&apos;s. The year page links the archived original
+        and, when we have a usable HTML URL, the school&apos;s own CDS page.
+      </p>
+      <p>
+        For a counselor: send the year page, not a 47-page PDF, and keep the
+        official link in the same paragraph so you are not vouching for a
+        scrape.
+      </p>
+
+      <h2>What we are not</h2>
+      <p>
+        Not the publisher. Not{" "}
+        <Link href="/about/ipeds">IPEDS</Link>. Not{" "}
+        <Link href="/about/college-scorecard">College Scorecard</Link>. Those
+        are different systems with different mandates, lags, and field
+        definitions. This page is the school-authored form, archived and
+        extracted.
+      </p>
+    </SourceStoryLayout>
+  );
+}

--- a/web/src/app/about/ipeds/page.tsx
+++ b/web/src/app/about/ipeds/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  SOURCE_STORY_REVIEWED,
+  SourceStoryLayout,
+  StoryFigure,
+  StoryTable,
+} from "@/components/about/SourceStoryLayout";
+
+const CANONICAL = "/about/ipeds";
+const TITLE = "What IPEDS is, and what it cannot replace";
+const DESCRIPTION =
+  "IPEDS is the NCES statistical system of record for U.S. colleges, keyed by UNITID. It cannot replace current-year Common Data Set wait-list, ED/EA, or H2A merit counts.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: CANONICAL },
+  openGraph: { url: CANONICAL, title: TITLE, description: DESCRIPTION },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: TITLE,
+  description: DESCRIPTION,
+  datePublished: SOURCE_STORY_REVIEWED,
+  dateModified: SOURCE_STORY_REVIEWED,
+  author: { "@type": "Organization", name: "Bolewood Group", url: "https://bolewood.com" },
+  publisher: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
+  about: {
+    "@type": "Organization",
+    name: "National Center for Education Statistics IPEDS",
+    url: "https://nces.ed.gov/ipeds",
+  },
+  mainEntityOfPage: `https://www.collegedata.fyi${CANONICAL}`,
+};
+
+export default function IpedsPage() {
+  return (
+    <SourceStoryLayout
+      kicker="IPEDS"
+      title={
+        <>
+          What IPEDS is, and what it cannot replace
+        </>
+      }
+      lede="NCES already has a statistical system of record. It is a stack of survey tables with dictionaries, not a PDF, and it is not this year’s school-authored Common Data Set."
+      jsonLd={jsonLd}
+    >
+      <h2>NCES and UNITID</h2>
+      <p>
+        The{" "}
+        <a href="https://nces.ed.gov/" target="_blank" rel="noopener noreferrer">
+          National Center for Education Statistics
+        </a>{" "}
+        runs{" "}
+        <a
+          href="https://nces.ed.gov/ipeds"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          IPEDS
+        </a>
+        , the Integrated Postsecondary Education Data System. About 6,400
+        Title IV institutions file interrelated annual surveys. The join key
+        this site actually uses is UNITID — Harvey Mudd is 115409, Virginia
+        Tech is 233921.
+      </p>
+      <p>
+        The navigational query “IPEDS” belongs to nces.ed.gov/ipeds. This
+        page is the counselor-facing explanation of what those tables are,
+        how they show up on a school page here, and what they cannot stand in
+        for.
+      </p>
+
+      <h2>How data gets in</h2>
+      <p>
+        Components include HD (directory), IC (characteristics), ADM
+        (admissions), EF (fall enrollment), GR (graduation rates), SFA
+        (student financial aid), and F (finance), among others. NCES releases
+        provisional files after quality control, including imputations for
+        nonrespondents, then final files with institutional revisions.
+        Recent years still arrive as Microsoft Access databases plus
+        dictionaries. That is the silo on the federal side: not a 47-page
+        PDF, a stack of tables.
+      </p>
+      <StoryFigure
+        src="/about/ipeds-survey-components.svg"
+        alt="IPEDS described as survey components HD, IC, ADM, EF, GR, SFA, and F, released first as provisional then final Access databases."
+        caption="IPEDS survey-component stack. Official documentation: nces.ed.gov/ipeds. UNITID is the join key on this site."
+        href="/schools/virginia-tech"
+        hrefLabel="See Virginia Tech’s federal baseline table"
+      />
+
+      <h2>Worked examples on a live school page</h2>
+      <p>
+        The school-page federal baseline table (the IPEDS coverage layer)
+        keeps source_table, source_variable, release type, and
+        definition-alignment visible. Typical alignments:
+      </p>
+      <StoryTable
+        caption="Example IPEDS facts and how they align to CDS"
+        headers={["Fact", "Alignment", "Why it matters"]}
+        rows={[
+          [
+            "Admission rate",
+            "Near CDS",
+            "ADM totals can match C1 in spirit and still differ in population, gender treatment, and vintage.",
+          ],
+          [
+            "Endowment",
+            "Not CDS-equivalent",
+            "Finance (F) is additive context. CDS never had a standard endowment table.",
+          ],
+          [
+            "Locale",
+            "Direct",
+            "HD locale is a federal classification, not a school-authored CDS cell.",
+          ],
+        ]}
+      />
+      <StoryFigure
+        src="/about/virginia-tech-ipeds-baseline-source-column.svg"
+        alt="Federal baseline table with source column showing ADM admission rate as near CDS, finance endowment as not CDS-equivalent, and HD locale as direct, with source_table.source_variable labels."
+        caption="Virginia Tech school page, NCES/IPEDS baseline table. Source column is source_table.source_variable plus release status. Not a substitute for the 2025-26 CDS extract."
+        href="/schools/virginia-tech"
+        hrefLabel="Open the Virginia Tech hub"
+      />
+
+      <h2>What IPEDS cannot replace</h2>
+      <p>
+        In public language, the coverage layer’s non-goals are: IPEDS is not
+        a drop-in Common Data Set. It does not give you current-year wait-list
+        behavior, Early Decision versus other rounds, H2A merit counts, or
+        the school-authored PDF as accountability. CDS files often publish
+        months before the matching IPEDS release. We do not silently blend
+        CDS and IPEDS into one unlabeled number.
+      </p>
+      <p>
+        For those CDS-native slices, use the year page:{" "}
+        <Link href="/schools/virginia-tech/2025-26">
+          Virginia Tech 2025-26
+        </Link>{" "}
+        and{" "}
+        <Link href="/schools/harvey-mudd/2025-26">
+          Harvey Mudd 2025-26
+        </Link>
+        .
+      </p>
+
+      <h2>Why we load it</h2>
+      <ul>
+        <li>
+          Directory-scale coverage when no public CDS exists — the search
+          result is still a school page, not a dead end.
+        </li>
+        <li>Historical series that outlast a school’s current IR listing.</li>
+        <li>
+          Finance (endowment draw, Part H) that the CDS template never had.
+          See the{" "}
+          <Link href="/recipes/endowment-draw-rate">
+            endowment draw-rate recipe
+          </Link>
+          .
+        </li>
+      </ul>
+
+      <h2>How to tell CDS from IPEDS on a school page</h2>
+      <p>
+        CDS lives on the year page and in the document ledger: a downloadable
+        file, field IDs, an academic year in the URL. IPEDS lives in the
+        “source-labeled federal facts” table: UNITID, source_table,
+        source_variable, provisional or final. Scorecard is a third layer,
+        with its own vintage note. If a row does not name its source, do not
+        cite it.
+      </p>
+      <StoryFigure
+        src="/about/virginia-tech-cds-and-ipeds-source-labels.svg"
+        alt="Annotated split of a school page: Common Data Set extract with field IDs on one side, IPEDS source_table.source_variable on the other, both circled as separate source layers."
+        caption="Virginia Tech school page, CDS extract versus IPEDS baseline. Source labels are the product. Harvey Mudd uses the same two-layer layout."
+        href="/schools/virginia-tech"
+        hrefLabel="Open Virginia Tech"
+      />
+      <p>
+        Related:{" "}
+        <Link href="/about/common-data-set">What is the Common Data Set</Link>
+        {" · "}
+        <Link href="/about/college-scorecard">
+          College Scorecard, and why it is not a CDS
+        </Link>
+        .
+      </p>
+    </SourceStoryLayout>
+  );
+}

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -81,29 +81,50 @@ export default function AboutPage() {
         </p>
 
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          The problem
+          Three sources
         </h2>
 
         <p>
-          Common Data Set files are excellent, but scattered. They show up on
-          school websites in many formats, on different timetables, under
-          different URLs, and only a minority of the 3,000+ in-scope
-          undergraduate institutions publish a current public CDS that is easy
-          to find.
+          The data already exists. It lives in three systems that do not
+          replace each other. These notes are the long versions; this page
+          stays the product story.
         </p>
 
-        <p>
-          College Scorecard is useful, especially for outcomes like net price,
-          debt, completion, and earnings, but it is not a substitute for the
-          richer admissions and aid details schools publish in the CDS.
-        </p>
-
-        <p>
-          IPEDS is powerful and broad, but federal releases lag the freshest
-          school-published files, and the official tools can be hard to navigate
-          unless you already know the survey components, table names, and Access
-          database workflow.
-        </p>
+        <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
+          <li>
+            <a
+              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
+              href="/about/common-data-set"
+            >
+              What is the Common Data Set
+            </a>
+            {" "}
+            — the voluntary school-authored form, why a 47-page PDF is not a
+            database, and what “extracted” means here.
+          </li>
+          <li>
+            <a
+              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
+              href="/about/college-scorecard"
+            >
+              College Scorecard, and why it is not a CDS
+            </a>
+            {" "}
+            — federal outcomes and net price, lagged on purpose, never mixed
+            into §C or §H.
+          </li>
+          <li>
+            <a
+              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
+              href="/about/ipeds"
+            >
+              What IPEDS is, and what it cannot replace
+            </a>
+            {" "}
+            — NCES survey tables keyed by UNITID, and the wait-list / H2A
+            facts they do not carry.
+          </li>
+        </ul>
 
         <p>
           And if you want enriched data, the default option has often been a

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -29,7 +29,7 @@ const jetbrains = JetBrains_Mono({
 
 // metadataBase lets every route segment below use relative paths for
 // canonical / openGraph URLs. The apex (https://collegedata.fyi)
-// 307-redirects to www, so www is the canonical host.
+// 301-redirects to www, so www is the canonical host.
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.collegedata.fyi"),
   title: {

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -22,6 +22,12 @@ change line. Caveats travel inside each fact's quality.note — keep them when c
 methodology and a worked example: https://www.collegedata.fyi/recipes/endowment-draw-rate
 
 When summarizing values, preserve the source metadata in each fact. Do not blend CDS, IPEDS, and Scorecard values without naming the source layer. Use source.url or source.archive_url for citations when available.
+
+Source literacy:
+
+- What is the Common Data Set: https://www.collegedata.fyi/about/common-data-set
+- College Scorecard vs CDS: https://www.collegedata.fyi/about/college-scorecard
+- What IPEDS is, and what it cannot replace: https://www.collegedata.fyi/about/ipeds
 `;
 
   return new Response(body, {

--- a/web/src/app/school-alias-pages.test.tsx
+++ b/web/src/app/school-alias-pages.test.tsx
@@ -138,6 +138,62 @@ describe("retired alias pages and Open Graph images", () => {
     });
   });
 
+  it("emits path-specific canonicals for Virginia Tech and Harvey Mudd year pages", async () => {
+    mocks.fetchCanonicalSchoolId.mockImplementation(async (schoolId: string) => schoolId);
+    mocks.fetchSchoolDocuments.mockImplementation(async (schoolId: string) => [
+      {
+        school_id: schoolId,
+        school_name:
+          schoolId === "virginia-tech" ? "Virginia Tech" : "Harvey Mudd College",
+        canonical_year: "2025-26",
+      },
+    ]);
+    mocks.fetchDocumentsBySchoolAndYear.mockImplementation(
+      async (schoolId: string) => [
+        {
+          school_id: schoolId,
+          school_name:
+            schoolId === "virginia-tech"
+              ? "Virginia Tech"
+              : "Harvey Mudd College",
+        },
+      ],
+    );
+    mocks.fetchInstitutionCoverage.mockResolvedValue(null);
+
+    const [vtHub, vtYear, hmcHub, hmcYear] = await Promise.all([
+      generateSchoolMetadata({
+        params: Promise.resolve({ school_id: "virginia-tech" }),
+      }),
+      generateSchoolYearMetadata({
+        params: Promise.resolve({
+          school_id: "virginia-tech",
+          year: "2025-26",
+        }),
+      }),
+      generateSchoolMetadata({
+        params: Promise.resolve({ school_id: "harvey-mudd" }),
+      }),
+      generateSchoolYearMetadata({
+        params: Promise.resolve({
+          school_id: "harvey-mudd",
+          year: "2025-26",
+        }),
+      }),
+    ]);
+
+    expect(vtHub.alternates).toEqual({ canonical: "/schools/virginia-tech" });
+    expect(vtYear.alternates).toEqual({
+      canonical: "/schools/virginia-tech/2025-26",
+    });
+    expect(hmcHub.alternates).toEqual({ canonical: "/schools/harvey-mudd" });
+    expect(hmcYear.alternates).toEqual({
+      canonical: "/schools/harvey-mudd/2025-26",
+    });
+    expect(vtHub.alternates).not.toEqual({ canonical: "/" });
+    expect(vtYear.alternates).not.toEqual({ canonical: "/" });
+  });
+
   it("loads the canonical school for the school-level Open Graph image", async () => {
     mocks.fetchSchoolDocuments.mockResolvedValue([
       {

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -18,6 +18,8 @@ import { OutcomesBand } from "@/components/OutcomesBand";
 import { ScorecardVintageNote } from "@/components/ScorecardVintageNote";
 import { AdmissionStrategyCard } from "@/components/AdmissionStrategyCard";
 import { SpreadsheetDownloadLinks } from "@/components/SpreadsheetDownloadLinks";
+import { ArchiveLead } from "@/components/ArchiveLead";
+import { yearArchiveLead } from "@/lib/archive-lead";
 
 export const revalidate = 3600;
 
@@ -67,7 +69,15 @@ export default async function SchoolYearPage({ params }: {
   const ipedsId = docs.find((d) => d.ipeds_id)?.ipeds_id ?? null;
   const scorecard = await fetchScorecardByIpedsId(ipedsId);
 
-  const schoolName = docs[0].school_name;
+  const schoolName = docs[0].school_name ?? "Unknown school";
+  const yearLead = yearArchiveLead({
+    schoolId: school_id,
+    schoolName,
+    year,
+    ipedsId,
+    hasExtract: docs.some((doc) => doc.extraction_status === "extracted"),
+    sourceDownloadHref: storageUrl(docs[0]?.source_storage_path ?? null),
+  });
 
   const canonicalUrl = `https://www.collegedata.fyi/schools/${school_id}/${year}`;
   const jsonLd = [
@@ -124,7 +134,8 @@ export default async function SchoolYearPage({ params }: {
 
       {/* Header */}
       <h1 className="text-3xl font-bold text-gray-900">{schoolName}</h1>
-      <p className="text-xl text-gray-600 mt-1">Common Data Set {year}</p>
+      <h2 className="text-xl text-gray-600 mt-1">{yearLead.heading}</h2>
+      <ArchiveLead lead={yearLead} showHeading={false} />
 
       {/* Render each document variant. The spreadsheet download covers all
           variants in one workbook, so only the first variant shows links. */}

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -25,6 +25,8 @@ import { CoverageBadge } from "@/components/CoverageBadge";
 import { SubmissionForm } from "@/components/SubmissionForm";
 import { FederalBaselineTable } from "@/components/FederalBaselineTable";
 import { storageUrl, yearRange } from "@/lib/format";
+import { archiveLead } from "@/lib/archive-lead";
+import { ArchiveLead } from "@/components/ArchiveLead";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
 
 export const revalidate = 3600;
@@ -261,6 +263,12 @@ export default async function SchoolDetailPage({ params }: {
   ];
 
   const history = archiveHistory(docs);
+  const schoolLead = archiveLead({
+    schoolId: school_id,
+    schoolName: name,
+    ipedsId,
+    documents: docs,
+  });
   const carnegieCode = scorecard?.carnegie_basic;
   const positioningSourceDoc = positioningSchool
     ? docs.find((doc) => doc.canonical_year === positioningSchool.cdsYear) ?? docs[0]
@@ -338,6 +346,7 @@ export default async function SchoolDetailPage({ params }: {
               name
             )}
           </h1>
+          {schoolLead ? <ArchiveLead lead={schoolLead} /> : null}
           <div
             style={{
               display: "flex",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from "next";
 import { fetchManifest, aggregateSchools } from "@/lib/queries";
-
-const SITE_URL = "https://www.collegedata.fyi";
+import { SITE_URL, staticSitemapEntries } from "@/lib/sitemap-static";
 
 function isAcademicYear(value: string | null | undefined): value is string {
   if (!value) return false;
@@ -14,74 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const manifest = await fetchManifest();
   const schools = aggregateSchools(manifest);
 
-  const staticPages: MetadataRoute.Sitemap = [
-    { url: SITE_URL, changeFrequency: "daily", priority: 1 },
-    {
-      url: `${SITE_URL}/schools`,
-      changeFrequency: "daily",
-      priority: 0.9,
-    },
-    {
-      url: `${SITE_URL}/match`,
-      changeFrequency: "daily",
-      priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/coverage`,
-      changeFrequency: "daily",
-      priority: 0.7,
-    },
-    {
-      url: `${SITE_URL}/about`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE_URL}/api`,
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${SITE_URL}/privacy`,
-      changeFrequency: "yearly",
-      priority: 0.4,
-    },
-    {
-      url: `${SITE_URL}/methodology`,
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${SITE_URL}/methodology/positioning`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE_URL}/methodology/admission-strategy`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE_URL}/methodology/merit-profile`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE_URL}/recipes`,
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
-    {
-      url: `${SITE_URL}/recipes/acceptance-vs-yield`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE_URL}/recipes/test-optional-tracker`,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-  ];
+  const staticPages = staticSitemapEntries();
 
   const schoolPages: MetadataRoute.Sitemap = schools.map((s) => ({
     url: `${SITE_URL}/schools/${s.school_id}`,

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -431,6 +431,123 @@
   margin-right: 8px;
   color: var(--ink-4);
 }
+
+/* PRD 028 — crawlable archive lead. Typesetting, not a marketing card. */
+.cd-archive-lead {
+  max-width: 42rem;
+  margin-top: 18px;
+}
+.cd-archive-lead__heading {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  margin: 0 0 10px;
+}
+.cd-archive-lead p {
+  margin: 0 0 10px;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-2);
+}
+.cd-archive-lead p:last-child {
+  margin-bottom: 0;
+}
+
+/* PRD 028 — long-form source literacy pages off /about */
+.cd-source-story {
+  margin-top: 40px;
+  font-size: 16px;
+  line-height: 1.65;
+}
+.cd-source-story h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 30px;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  margin: 40px 0 14px;
+}
+.cd-source-story h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 28px 0 10px;
+}
+.cd-source-story p,
+.cd-source-story ul,
+.cd-source-story ol {
+  margin: 0 0 16px;
+}
+.cd-source-story ul,
+.cd-source-story ol {
+  padding-left: 1.3rem;
+}
+.cd-source-story li {
+  margin-bottom: 8px;
+}
+.cd-source-story a {
+  text-decoration-color: var(--rule-strong);
+  text-underline-offset: 3px;
+}
+.cd-story-figure {
+  margin: 28px -8px 32px;
+}
+.cd-story-figure img {
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--rule-strong);
+  background: #faf6ec;
+  display: block;
+}
+.cd-story-figure figcaption {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+  margin-top: 10px;
+  max-width: 42rem;
+}
+.cd-story-table-wrap {
+  overflow-x: auto;
+  margin: 20px 0 28px;
+  border: 1px solid var(--rule);
+}
+.cd-story-table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-size: 14.5px;
+}
+.cd-story-table th,
+.cd-story-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+.cd-story-table th {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  font-weight: 500;
+}
+.cd-story-table tbody th {
+  font-family: var(--sans);
+  font-size: 14.5px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink);
+  font-weight: 600;
+}
 @media (max-width: 640px) {
   .cd-school-header { grid-template-columns: 1fr; gap: 18px; }
   .cd-school-header__aside {

--- a/web/src/components/ArchiveLead.tsx
+++ b/web/src/components/ArchiveLead.tsx
@@ -1,0 +1,43 @@
+import type { ArchiveLead as ArchiveLeadModel, LeadPart } from "@/lib/archive-lead";
+import { officialPageLabel } from "@/lib/archive-lead";
+
+function Part({ part }: { part: LeadPart }) {
+  if (part.type === "text") return <>{part.text}</>;
+  const title =
+    part.external && part.href.startsWith("http")
+      ? officialPageLabel(part.href)
+      : undefined;
+  return (
+    <a
+      href={part.href}
+      title={title}
+      target={part.external ? "_blank" : undefined}
+      rel={part.external ? "noopener noreferrer" : undefined}
+    >
+      {part.text}
+    </a>
+  );
+}
+
+export function ArchiveLead({
+  lead,
+  showHeading = true,
+}: {
+  lead: ArchiveLeadModel;
+  showHeading?: boolean;
+}) {
+  return (
+    <div className="cd-archive-lead">
+      {showHeading && (
+        <h2 className="cd-archive-lead__heading">{lead.heading}</h2>
+      )}
+      {lead.paragraphs.map((parts, i) => (
+        <p key={i}>
+          {parts.map((part, j) => (
+            <Part key={j} part={part} />
+          ))}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -79,6 +79,16 @@ export function FieldsView({
   );
 }
 
+const SECTION_FRAGMENTS: Record<string, string> = {
+  C: "admissions",
+  H: "aid",
+};
+
+const SUBSECTION_FRAGMENTS: Record<string, string> = {
+  "Wait List": "waitlist",
+  "Entrance Exams": "testing",
+};
+
 function SectionBlock({ sec }: { sec: ReturnType<typeof groupBySection>[number] }) {
   const sectionValues = Object.fromEntries(
     sec.subsections.flatMap((sub) => sub.fields.map(({ id, field }) => [id, field])),
@@ -124,6 +134,7 @@ function SectionBlock({ sec }: { sec: ReturnType<typeof groupBySection>[number] 
       >
         <h2
           className="serif"
+          id={SECTION_FRAGMENTS[sec.letter]}
           style={{
             fontWeight: 400,
             fontSize: 24,
@@ -171,16 +182,32 @@ function SubsectionBlock({
   sub: SubsectionGroup;
 }) {
   const fallbackFields = sub.fields.filter(({ id }) => !hiddenFieldIds.has(id));
+  const fragment = SUBSECTION_FRAGMENTS[sub.name];
+  const heading = (
+    <>
+      {sub.code ? `${sub.code} · ` : ""}
+      {sub.name}
+    </>
+  );
 
   return (
     <div
       id={`sub-${sub.slug}`}
       style={{ marginBottom: 24, scrollMarginTop: 24 }}
     >
-      <div className="meta" style={{ marginBottom: 6 }}>
-        {sub.code ? `${sub.code} · ` : ""}
-        {sub.name}
-      </div>
+      {fragment ? (
+        <h3
+          id={fragment}
+          className="meta"
+          style={{ marginBottom: 6, fontSize: 11, fontWeight: 400 }}
+        >
+          {heading}
+        </h3>
+      ) : (
+        <div className="meta" style={{ marginBottom: 6 }}>
+          {heading}
+        </div>
+      )}
       {reconstructedTables.map((table) => (
         <ReconstructedTableView key={table.key} table={table} />
       ))}

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -28,7 +28,7 @@ export function Footer() {
             MIT License.
           </div>
         </div>
-        <div className="cd-footer-links" style={{ display: "flex", gap: 24, alignSelf: "end" }}>
+        <div className="cd-footer-links" style={{ display: "flex", gap: 24, alignSelf: "end", flexWrap: "wrap" }}>
           <a href="https://github.com/bolewood/collegedata-fyi" target="_blank" rel="noopener noreferrer">
             GitHub
           </a>
@@ -36,6 +36,9 @@ export function Footer() {
           <a href="/api">API</a>
           <a href="/privacy">Privacy</a>
           <a href="/about">About</a>
+          <a href="/about/common-data-set">CDS</a>
+          <a href="/about/college-scorecard">Scorecard</a>
+          <a href="/about/ipeds">IPEDS</a>
         </div>
       </div>
     </footer>

--- a/web/src/components/about/SourceStoryLayout.tsx
+++ b/web/src/components/about/SourceStoryLayout.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+export const SOURCE_STORY_REVIEWED = "2026-08-17";
+
+export function SourceStoryLayout({
+  kicker,
+  title,
+  lede,
+  lastReviewed = SOURCE_STORY_REVIEWED,
+  jsonLd,
+  children,
+}: {
+  kicker: string;
+  title: ReactNode;
+  lede: ReactNode;
+  lastReviewed?: string;
+  jsonLd: Record<string, unknown> | Record<string, unknown>[];
+  children: ReactNode;
+}) {
+  const reviewed = new Date(`${lastReviewed}T00:00:00Z`).toLocaleDateString(
+    "en-US",
+    { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" },
+  );
+
+  return (
+    <article
+      className="mx-auto max-w-3xl px-4 py-12 sm:px-6"
+      style={{ color: "var(--ink-2)" }}
+    >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
+      <nav className="meta" style={{ marginBottom: 16 }}>
+        <Link href="/about" style={{ color: "var(--ink-3)", textDecoration: "none" }}>
+          About
+        </Link>
+        {" / "}
+        <span style={{ color: "var(--ink)" }}>{kicker}</span>
+      </nav>
+      <p
+        className="mono"
+        style={{
+          fontSize: 11,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--ink-3)",
+          margin: "0 0 12px",
+        }}
+      >
+        Last reviewed {reviewed}
+      </p>
+      <h1
+        className="serif"
+        style={{
+          fontWeight: 400,
+          fontSize: "clamp(40px, 6vw, 56px)",
+          lineHeight: 1.05,
+          letterSpacing: "-0.02em",
+          color: "var(--ink)",
+          margin: 0,
+        }}
+      >
+        {title}
+      </h1>
+      <p
+        className="serif"
+        style={{
+          fontStyle: "italic",
+          fontSize: 18,
+          lineHeight: 1.55,
+          color: "var(--ink-2)",
+          margin: "20px 0 0",
+          maxWidth: "40rem",
+        }}
+      >
+        {lede}
+      </p>
+      <div className="cd-source-story">{children}</div>
+    </article>
+  );
+}
+
+export function StoryFigure({
+  src,
+  alt,
+  caption,
+  href,
+  hrefLabel,
+}: {
+  src: string;
+  alt: string;
+  caption: ReactNode;
+  href?: string;
+  hrefLabel?: string;
+}) {
+  return (
+    <figure className="cd-story-figure">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={src} alt={alt} />
+      <figcaption>
+        {caption}
+        {href && (
+          <>
+            {" "}
+            <Link href={href}>{hrefLabel ?? "Open the live page"}</Link>.
+          </>
+        )}
+      </figcaption>
+    </figure>
+  );
+}
+
+export function StoryTable({
+  caption,
+  headers,
+  rows,
+}: {
+  caption: string;
+  headers: string[];
+  rows: ReactNode[][];
+}) {
+  return (
+    <div className="cd-story-table-wrap">
+      <table className="cd-story-table">
+        <caption className="sr-only">{caption}</caption>
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} scope="col">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i}>
+              {row.map((cell, j) => (
+                <td key={j}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/data/official-cds-pages.json
+++ b/web/src/data/official-cds-pages.json
@@ -1,0 +1,3019 @@
+{
+  "generated_from": "tools/finder/schools.yaml",
+  "bySchoolId": {
+    "adams-state-university": {
+      "url": "https://adams.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "adelphi-university": {
+      "url": "https://adelphi.edu/institutional-research/research/data/",
+      "access": "unknown"
+    },
+    "agnes-scott-college": {
+      "url": "https://agnesscott.edu/institutionalresearch/common-data-set.html",
+      "access": "unknown"
+    },
+    "aims-community-college": {
+      "url": "https://www.aims.edu/departments/institutional-research/institution-and-student-data-reports",
+      "access": "unknown"
+    },
+    "albany-state-university": {
+      "url": "https://asurams.edu/institutional-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "albertus-magnus-college": {
+      "url": "https://www.albertus.edu/policy-reports/institutional-research-and-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "allegheny-college": {
+      "url": "https://sites.allegheny.edu/institutional-effectiveness/the-common-data-set/",
+      "access": "unknown"
+    },
+    "american-international-college": {
+      "url": "https://aic.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "angelo-state-university": {
+      "url": "https://www.angelo.edu/live/files/27087-common-data-set-2019-2020",
+      "access": "unknown"
+    },
+    "appalachian-state-university": {
+      "url": "https://analytics.appstate.edu/info_inst_res",
+      "access": "unknown"
+    },
+    "arkansas-tech-university": {
+      "url": "https://www.atu.edu/ir/",
+      "access": "unknown"
+    },
+    "auburn-university": {
+      "url": "https://ir.auburn.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "augsburg-university": {
+      "url": "https://sites.augsburg.edu/ope/institutional-research-reports/",
+      "access": "unknown"
+    },
+    "augustana-university": {
+      "url": "https://augie.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "austin-college": {
+      "url": "https://www.austincollege.edu/institutional-research",
+      "access": "unknown"
+    },
+    "austin-peay-state-university": {
+      "url": "https://www.apsu.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "azusa-pacific-university": {
+      "url": "https://www.apu.edu/oir/commondata/",
+      "access": "unknown"
+    },
+    "bard-college": {
+      "url": "https://bard.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "barnard": {
+      "url": "https://barnard.edu/institutional-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "bates": {
+      "url": "https://bates.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "bellarmine-university": {
+      "url": "https://www.bellarmine.edu/academicaffairs/ir/data-reports/common-data-set/",
+      "access": "unknown"
+    },
+    "beloit-college": {
+      "url": "https://www.beloit.edu/offices/institutional-research-assessment-planning/key-metrics/",
+      "access": "unknown"
+    },
+    "bentley-university": {
+      "url": "https://www.bentley.edu/offices/institutional-research/external-surveys",
+      "access": "unknown"
+    },
+    "berklee-college-of-music": {
+      "url": "https://www.berklee.edu/institutional-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "bethel-university": {
+      "url": "https://www.bethel.edu/institutional-data-research/institutional-data/common-data-set/",
+      "access": "unknown"
+    },
+    "biola-university": {
+      "url": "https://www.biola.edu/institutional-research/about",
+      "access": "unknown"
+    },
+    "bluefield-state-university": {
+      "url": "https://bluefieldstate.edu/institutional-research/research-data/",
+      "access": "unknown"
+    },
+    "boston-university": {
+      "url": "https://www.bu.edu/asir/bu-facts/common-data-set/",
+      "access": "unknown"
+    },
+    "bowdoin": {
+      "url": "https://www.bowdoin.edu/ir/",
+      "access": "unknown"
+    },
+    "bowling-green-state-university-main-campus": {
+      "url": "https://www.bgsu.edu/institutional-research/CDS.html",
+      "access": "unknown"
+    },
+    "brandeis": {
+      "url": "https://brandeis.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "bridgewater-college": {
+      "url": "https://www.bridgewater.edu/about-us/bridgewater-facts/",
+      "access": "unknown"
+    },
+    "bridgewater-state-university": {
+      "url": "https://vc.bridgew.edu/datasets/",
+      "access": "unknown"
+    },
+    "brigham-young-university": {
+      "url": "https://data.byu.edu/common-data-set",
+      "access": "unknown"
+    },
+    "brown": {
+      "url": "https://oir.brown.edu/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "bucknell": {
+      "url": "https://www.bucknell.edu/commondataset/",
+      "access": "unknown"
+    },
+    "california-polytechnic-state-university-san-luis-obispo": {
+      "url": "https://ir.calpoly.edu/content/publications_reports/cds/index",
+      "access": "unknown"
+    },
+    "california-state-university-bakersfield": {
+      "url": "https://www.csub.edu/irpa/reports.shtml",
+      "access": "unknown"
+    },
+    "california-state-university-long-beach": {
+      "url": "https://csulb.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "california-state-university-maritime-academy": {
+      "url": "https://www.csum.edu/ir/common-data-set.html",
+      "access": "unknown"
+    },
+    "california-state-university-monterey-bay": {
+      "url": "https://csumb.edu/iar/common-data-set/",
+      "access": "unknown"
+    },
+    "california-state-university-northridge": {
+      "url": "https://www.csun.edu/node/65206",
+      "access": "unknown"
+    },
+    "california-state-university-san-marcos": {
+      "url": "https://www.csusm.edu/ipa/campus-data/common-data-set.html",
+      "access": "unknown"
+    },
+    "cambridge-college": {
+      "url": "https://cambridgecollege.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "cameron-university": {
+      "url": "https://www.cameron.edu/iraa/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "campbellsville-university": {
+      "url": "https://tigernet.campbellsville.edu/ICS/Academic_Affairs/Institutional_Research/Handouts.jnz",
+      "access": "unknown"
+    },
+    "capital-university": {
+      "url": "https://www.capital.edu/about/facts-and-figures/institutional-research/",
+      "access": "unknown"
+    },
+    "carnegie-mellon": {
+      "url": "https://www.cmu.edu/ira/CDS/",
+      "access": "unknown"
+    },
+    "carroll-college": {
+      "url": "https://www.carroll.edu/about/consumer-information/institutional-effectiveness/common-data-set",
+      "access": "unknown"
+    },
+    "carthage-college": {
+      "url": "https://www.carthage.edu/about/offices-services/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "case-western-reserve-university": {
+      "url": "https://case.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "catawba-college": {
+      "url": "https://www.catawba.edu/ir/",
+      "access": "unknown"
+    },
+    "cedarville-university": {
+      "url": "https://www.cedarville.edu/offices/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "central-college": {
+      "url": "https://departments.central.edu/registrar/other/common-data-set/",
+      "access": "unknown"
+    },
+    "centre-college": {
+      "url": "https://www.centre.edu/about/college-policies-initiatives/common-data-set",
+      "access": "unknown"
+    },
+    "champlain-college": {
+      "url": "https://www.champlain.edu/office/institutional-research-assessment/data-analytics/data-reporting/",
+      "access": "unknown"
+    },
+    "citadel-military-college-of-south-carolina": {
+      "url": "https://www.citadel.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "claremont-mckenna": {
+      "url": "https://www.cmc.edu/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "college-of-southern-idaho": {
+      "url": "https://www.csi.edu/institutional-effectiveness/institutional-research/common-data-set.aspx",
+      "access": "unknown"
+    },
+    "college-of-the-atlantic": {
+      "url": "https://www.coa.edu/institutional-research/",
+      "access": "unknown"
+    },
+    "colorado": {
+      "url": "https://data.colorado.edu/reports/common-data-set",
+      "access": "unknown"
+    },
+    "colorado-mountain-college": {
+      "url": "https://coloradomtn.edu/contact-departments/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "colorado-school-of-mines": {
+      "url": "https://ir.mines.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "columbia": {
+      "url": "https://opir.columbia.edu/common-data-set",
+      "access": "unknown"
+    },
+    "commonwealth-university-of-pennsylvania": {
+      "url": "https://www.commonwealthu.edu/documents/bu-cds-2022-2023",
+      "access": "unknown"
+    },
+    "concordia-university-texas": {
+      "url": "https://www.concordia.edu/resources/office-of-student-registration-and-records/statistical-information.html",
+      "access": "unknown"
+    },
+    "connecticut-college": {
+      "url": "https://www.conncoll.edu/institutional-research/conn-facts/",
+      "access": "unknown"
+    },
+    "cornell": {
+      "url": "https://irp.dpb.cornell.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "cuny-bernard-m-baruch-college": {
+      "url": "https://ir.baruch.cuny.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "cuny-york-college": {
+      "url": "https://york.cuny.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "dartmouth": {
+      "url": "https://dartmouth.edu/oir/cds/",
+      "access": "unknown"
+    },
+    "davidson-college": {
+      "url": "https://www.davidson.edu/offices-and-services/institutional-effectiveness/common-data-set",
+      "access": "unknown"
+    },
+    "delaware-state-university": {
+      "url": "https://www.desu.edu/academics/academic-affairs/institutional-effectiveness/institutional-research-planning-analytics",
+      "access": "unknown"
+    },
+    "delaware-valley-university": {
+      "url": "https://delval.edu/institutional-research-and-effectiveness",
+      "access": "unknown"
+    },
+    "dominican-university": {
+      "url": "https://www.dom.edu/offices/oie/institutional-data/profile-and-common-data-set",
+      "access": "unknown"
+    },
+    "duquesne-university": {
+      "url": "https://www.duq.edu/commondataset/",
+      "access": "unknown"
+    },
+    "eastern-illinois-university": {
+      "url": "https://www.eiu.edu/ir/common_data_sets.php",
+      "access": "unknown"
+    },
+    "eastern-new-mexico-university-main-campus": {
+      "url": "https://my.enmu.edu/c/document_library/get_file?uuid=26589e87-9a73-40a5-b937-af8586f7dd39&groupId=2878891&filename=CDS_2019-2020.pdf",
+      "access": "unknown"
+    },
+    "eastern-oregon-university": {
+      "url": "https://eou.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "eastern-virginia-medical-school": {
+      "url": "https://evms.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "eastern-washington-university": {
+      "url": "https://sites.ewu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "eckerd-college": {
+      "url": "https://www.eckerd.edu/about/factsheet/",
+      "access": "unknown"
+    },
+    "ferrum-college": {
+      "url": "https://www.ferrum.edu/purpose-of-the-ire/",
+      "access": "unknown"
+    },
+    "fitchburg-state-university": {
+      "url": "https://www.fitchburgstate.edu/about/institutional-research-and-planning/institutional-data",
+      "access": "unknown"
+    },
+    "fort-lewis-college": {
+      "url": "https://www-dev.fortlewis.edu/about-flc/leadership/institutional-effectiveness/institutional-research/common-data-sets",
+      "access": "unknown"
+    },
+    "front-range-community-college": {
+      "url": "https://www.frontrange.edu/about/facts-figures/common-data-set.html",
+      "access": "unknown"
+    },
+    "geisinger-commonwealth-school-of-medicine": {
+      "url": "https://www.geisinger.edu/gchs/education/departments/division-education-administration/office-institutional-compliance-accreditation/common-data-set",
+      "access": "unknown"
+    },
+    "george-fox-university": {
+      "url": "https://www.georgefox.edu/offices/academic_affairs/effectiveness/common-data-set/index.html",
+      "access": "unknown"
+    },
+    "georgetown": {
+      "url": "https://oads.georgetown.edu/commondataset/",
+      "access": "unknown"
+    },
+    "georgia-gwinnett-college": {
+      "url": "https://www.ggc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "georgia-state-university": {
+      "url": "https://oie.gsu.edu/data-reporting-systems/common-data-set/",
+      "access": "unknown"
+    },
+    "georgia-tech": {
+      "url": "https://irp.gatech.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "gonzaga-university": {
+      "url": "https://www.gonzaga.edu/-/media/Website/Documents/About/Offices-and-Services/Institutional-Research/Gonzaga-University-CDS_2021-2022.ashx",
+      "access": "unknown"
+    },
+    "gordon-college": {
+      "url": "https://www.gordon.edu/commondata",
+      "access": "unknown"
+    },
+    "goshen-college": {
+      "url": "https://www.goshen.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "graceland-university-lamoni": {
+      "url": "https://my.graceland.edu/ICS/Resources/Institutional_Research/GU_Fact_Book/Common_Data_Set.jnz",
+      "access": "unknown"
+    },
+    "grambling-state-university": {
+      "url": "https://www.gram.edu/offices/ie/ir/surveys.php",
+      "access": "unknown"
+    },
+    "grand-valley-state-university": {
+      "url": "https://www.gvsu.edu/registrar/reporting-analysis-182.htm",
+      "access": "unknown"
+    },
+    "gwu": {
+      "url": "https://irp.gwu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "hamline-university": {
+      "url": "https://www.hamline.edu/about/offices-services/institutional-effectiveness-office",
+      "access": "unknown"
+    },
+    "hampden-sydney-college": {
+      "url": "https://www.hsc.edu/institutional-effectiveness/factbook",
+      "access": "unknown"
+    },
+    "hampshire-college": {
+      "url": "https://hampshire.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "harvard": {
+      "url": "https://oira.harvard.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "harvey-mudd": {
+      "url": "https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/",
+      "access": "public"
+    },
+    "hendrix-college": {
+      "url": "https://www.hendrix.edu/WorkArea/DownloadAsset.aspx?id=63451",
+      "access": "unknown"
+    },
+    "hilbert-college": {
+      "url": "https://www.hilbert.edu/about/institutional-research-assessment/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "hofstra-university": {
+      "url": "https://www.hofstra.edu/institutional-research-strategic-analysis/",
+      "access": "unknown"
+    },
+    "hollins-university": {
+      "url": "https://registrar.press.hollins.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "holy-family-university": {
+      "url": "https://www.holyfamily.edu/about/administrative-services/institutional-effectiveness",
+      "access": "unknown"
+    },
+    "howard-university": {
+      "url": "https://ira.howard.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "huntington-university": {
+      "url": "https://www.huntington.edu/about/consumer-info",
+      "access": "unknown"
+    },
+    "illinois-wesleyan-university": {
+      "url": "https://digitalcommons.iwu.edu/instres_dataset/",
+      "access": "unknown"
+    },
+    "indiana-bloomington": {
+      "url": "https://iuapps.iu.edu/cds/index.html?i=home&p=index",
+      "access": "unknown"
+    },
+    "ithaca-college": {
+      "url": "https://ithaca.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "jackson-state-university": {
+      "url": "https://www.jsums.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "jacksonville-state-university": {
+      "url": "https://jsu.edu/ire/research/common-data-set.html",
+      "access": "unknown"
+    },
+    "james-madison-university": {
+      "url": "https://www.jmu.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "johns-hopkins": {
+      "url": "https://oira.jhu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "johnson-c-smith-university": {
+      "url": "https://www.jcsu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "kansas-state-university": {
+      "url": "https://www.k-state.edu/data/institutional-research/resources/",
+      "access": "unknown"
+    },
+    "kennesaw-state-university": {
+      "url": "https://www.kennesaw.edu/data-strategy/institutional-research/publications/common-data-set/",
+      "access": "unknown"
+    },
+    "kent-state-university-at-ashtabula": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-east-liverpool": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-geauga": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-kent": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-salem": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-stark": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-trumbull": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kent-state-university-at-tuscarawas": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "kentucky-wesleyan-college": {
+      "url": "https://kwc.edu/academics/institutional-effectiveness-and-research/",
+      "access": "unknown"
+    },
+    "kettering-university": {
+      "url": "https://libguides.kettering.edu/c.php?g=1123795&p=8197698",
+      "access": "unknown"
+    },
+    "lafayette-college": {
+      "url": "https://oir.lafayette.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "lake-forest-college": {
+      "url": "https://www.lakeforest.edu/about-us/institutional-research",
+      "access": "unknown"
+    },
+    "lake-superior-state-university": {
+      "url": "https://www.lssu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "lee-university": {
+      "url": "https://leeuniversity.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "lehigh": {
+      "url": "https://data.lehigh.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "lewis-and-clark-college": {
+      "url": "https://www.lclark.edu/offices/institutional_research/common_data_set/",
+      "access": "unknown"
+    },
+    "lewis-clark-state-college": {
+      "url": "https://www.lcsc.edu/ir/need-lc-state-data",
+      "access": "unknown"
+    },
+    "lindenwood-university": {
+      "url": "https://www.lindenwood.edu/provost/assessment/institutional-data/common-data-sets/",
+      "access": "unknown"
+    },
+    "longwood-university": {
+      "url": "https://www.longwood.edu/universityanalytics/common-data-set/",
+      "access": "unknown"
+    },
+    "louisiana-state-university-and-agricultural-and-mechanical": {
+      "url": "https://www.lsu.edu/data/common-data-set/",
+      "access": "unknown"
+    },
+    "louisiana-tech-university": {
+      "url": "https://oierp.latech.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "loyola-university-chicago": {
+      "url": "https://www.luc.edu/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "marietta-college": {
+      "url": "https://www.marietta.edu/ir-common-data-set",
+      "access": "unknown"
+    },
+    "marist-college": {
+      "url": "https://www.marist.edu/documents/d/guest/cds_2020-2021-final",
+      "access": "unknown"
+    },
+    "mercer-university": {
+      "url": "https://oie.mercer.edu/research/common-data-set.cfm",
+      "access": "unknown"
+    },
+    "merrimack-college": {
+      "url": "https://www.merrimack.edu/office-of-institutional-effectiveness/surveys-and-qualtrix/",
+      "access": "unknown"
+    },
+    "messiah-university": {
+      "url": "https://www.messiah.edu/institutional-research/research/common-data-set",
+      "access": "unknown"
+    },
+    "miami-dade-college": {
+      "url": "https://www.mdc.edu/ppa/policy-analysis/",
+      "access": "unknown"
+    },
+    "miami-university-hamilton": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "miami-university-middletown": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "miami-university-oxford": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "michigan-state-university": {
+      "url": "https://ir.msu.edu/cds",
+      "access": "unknown"
+    },
+    "milwaukee-school-of-engineering": {
+      "url": "https://www.msoe.edu/about-msoe/who-we-are/consumer-information-and-policies/",
+      "access": "unknown"
+    },
+    "minnesota-state-colleges-and-universities-system-office": {
+      "url": "https://servicedesk.minnstate.edu/TDClient/30/Portal/KB/ArticleDet?ID=301",
+      "access": "unknown"
+    },
+    "misericordia-university": {
+      "url": "https://www.misericordia.edu/campus-community/other-offices/office-of-institutional-research/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "missouri-state-university-springfield": {
+      "url": "https://www.missouristate.edu/OIR/Ratings-Rankings-and-Publications.htm",
+      "access": "unknown"
+    },
+    "missouri-university-of-science-and-technology": {
+      "url": "https://data.mst.edu/cds/",
+      "access": "unknown"
+    },
+    "missouri-western-state-university": {
+      "url": "https://missouriwestern.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "mit": {
+      "url": "https://ir.mit.edu/project-topic/common-data-set",
+      "access": "unknown"
+    },
+    "montana-state-university": {
+      "url": "https://www.montana.edu/data/common-data-set/",
+      "access": "unknown"
+    },
+    "montclair-state-university": {
+      "url": "https://montclair.edu/provost/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "moravian-university": {
+      "url": "https://www.moravian.edu/research/Moravian-University-Data",
+      "access": "unknown"
+    },
+    "morehead-state-university": {
+      "url": "https://www.moreheadstate.edu/about-msu/leadership/ppe/institutional-research/institutional-data/common-data-sets",
+      "access": "unknown"
+    },
+    "morningside-university": {
+      "url": "https://my.morningside.edu/campus_offices/institutional_research/fast_facts/",
+      "access": "unknown"
+    },
+    "mount-holyoke-college": {
+      "url": "https://mtholyoke.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "muhlenberg-college": {
+      "url": "https://www.muhlenberg.edu/offices/ir/commondataset/",
+      "access": "unknown"
+    },
+    "nazareth-university": {
+      "url": "https://www2.naz.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "new-jersey-institute-of-technology": {
+      "url": "https://www.njit.edu/oie/factbook/commondata/index.php",
+      "access": "unknown"
+    },
+    "new-mexico-highlands-university": {
+      "url": "https://www.nmhu.edu/institutional-research/comon-data-set/",
+      "access": "unknown"
+    },
+    "new-mexico-institute-of-mining-and-technology": {
+      "url": "https://www.nmt.edu/academicaffairs/research/common.php",
+      "access": "unknown"
+    },
+    "nicholls-state-university": {
+      "url": "https://www.nicholls.edu/irep/common-data-set/",
+      "access": "unknown"
+    },
+    "north-carolina-state-university-at-raleigh": {
+      "url": "https://report.isa.ncsu.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "north-central-college": {
+      "url": "https://www.northcentralcollege.edu/transparency/general-compliance-information",
+      "access": "unknown"
+    },
+    "northeastern": {
+      "url": "https://uds.northeastern.edu/facts/common-data-set/",
+      "access": "unknown"
+    },
+    "northeastern-university-professional-programs": {
+      "url": "https://uds.northeastern.edu/facts/common-data-set/",
+      "access": "unknown"
+    },
+    "northern-arizona-university": {
+      "url": "https://in.nau.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "northern-kentucky-university": {
+      "url": "https://inside.nku.edu/ir/Reports.html",
+      "access": "unknown"
+    },
+    "northern-michigan-university": {
+      "url": "https://nmu.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "northland-college": {
+      "url": "https://northland.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "northwest-missouri-state-university": {
+      "url": "https://www.nwmissouri.edu/services/ir/CDS.htm",
+      "access": "unknown"
+    },
+    "northwestern-state-university-of-louisiana": {
+      "url": "https://www.nsula.edu/oir/nsu-factbook-common-data-set/",
+      "access": "unknown"
+    },
+    "norwich-university": {
+      "url": "https://www.norwich.edu/offices/institutional-effectiveness/common-data-sets",
+      "access": "unknown"
+    },
+    "oberlin": {
+      "url": "https://www.oberlin.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "occidental-college": {
+      "url": "https://www.oxy.edu/offices-services/institutional-research/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "oglethorpe-university": {
+      "url": "https://ir.oglethorpe.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "ohio-northern-university": {
+      "url": "https://archives.onu.edu/repositories/2/digital_objects/198",
+      "access": "unknown"
+    },
+    "oklahoma-state-university-main-campus": {
+      "url": "https://ira.okstate.edu/cds/",
+      "access": "unknown"
+    },
+    "old-dominion-university": {
+      "url": "https://odu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "oregon-health-and-science-university": {
+      "url": "https://covid19forecast.ohsu.edu/mit-common-data-set",
+      "access": "unknown"
+    },
+    "oregon-institute-of-technology": {
+      "url": "https://oit.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "osu": {
+      "url": "https://irp.osu.edu/institutional-data-and-reports",
+      "access": "unknown"
+    },
+    "otis-college-of-art-and-design": {
+      "url": "https://otis.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "pacific-lutheran-university": {
+      "url": "https://plu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "pacific-northwest-college-of-art": {
+      "url": "https://legacy.willamette.edu/ir/cds/index.html",
+      "access": "unknown"
+    },
+    "pacific-university": {
+      "url": "https://www.pacificu.edu/directory/provost-academic-affairs/institutional-research-assessment/data-center",
+      "access": "unknown"
+    },
+    "palm-beach-atlantic-university": {
+      "url": "https://pba.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "penn-state": {
+      "url": "https://opair.psu.edu/cds/",
+      "access": "unknown"
+    },
+    "peru-state-college": {
+      "url": "https://www.peru.edu/assessment/institutionalresearch/commondataset.html",
+      "access": "unknown"
+    },
+    "pitzer-college": {
+      "url": "https://www.pitzer.edu/institutional-research/common-data-sets/",
+      "access": "unknown"
+    },
+    "point-loma-nazarene-university": {
+      "url": "https://www.pointloma.edu/offices/institutional-research",
+      "access": "unknown"
+    },
+    "prairie-view-a-and-m-university": {
+      "url": "https://pvamu.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "purdue-university-northwest": {
+      "url": "https://www.pnw.edu/finding-truth-in-the-numbers/",
+      "access": "unknown"
+    },
+    "quincy-university": {
+      "url": "https://www.quincy.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "radford-university": {
+      "url": "https://radford.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "red-rocks-community-college": {
+      "url": "https://www.rrcc.edu/institutional-research/common-data",
+      "access": "unknown"
+    },
+    "rhode-island-college": {
+      "url": "https://www.ric.edu/about/public-institutional-data",
+      "access": "unknown"
+    },
+    "rhodes-college": {
+      "url": "https://rhodes.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "rice": {
+      "url": "https://oie.rice.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "rochester-institute-of-technology": {
+      "url": "https://rit.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "rocky-mountain-college": {
+      "url": "https://rocky.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "rogers-state-university": {
+      "url": "https://rsu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "rollins-college": {
+      "url": "https://rpublic.rollins.edu/sites/IR/Common%20Data%20Set%20CDS/",
+      "access": "unknown"
+    },
+    "rosemont-college": {
+      "url": "https://www.rosemont.edu/academics/registrar/ir/cds.php",
+      "access": "unknown"
+    },
+    "rpi": {
+      "url": "https://rpi.box.com/s/fkqisnv4wxanikf1yfpw0yvajjtupg2z",
+      "access": "unknown"
+    },
+    "rutgers": {
+      "url": "https://oirap.rutgers.edu/ReportingCommonDataSet.html",
+      "access": "unknown"
+    },
+    "saginaw-valley-state-university": {
+      "url": "https://www.svsu.edu/oir/commondataset/",
+      "access": "unknown"
+    },
+    "saint-louis-university": {
+      "url": "https://www.slu.edu/provost/office-of-institutional-research/institutional-data/2122cds.php",
+      "access": "unknown"
+    },
+    "saint-martins-university": {
+      "url": "https://www.stmartin.edu/documents/cds-2017-2018",
+      "access": "unknown"
+    },
+    "saint-marys-college-of-california": {
+      "url": "https://stmarys-ca.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "saint-norbert-college": {
+      "url": "https://www.snc.edu/oie/cds.html",
+      "access": "unknown"
+    },
+    "san-diego-state-university": {
+      "url": "https://asir.sdsu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "san-francisco-state-university": {
+      "url": "https://ir.sfsu.edu/applications-and-enrollment",
+      "access": "unknown"
+    },
+    "shenandoah-university": {
+      "url": "https://www.su.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "shepherd-university": {
+      "url": "https://shepherd.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "shippensburg-university-of-pennsylvania": {
+      "url": "https://www.ship.edu/about/offices/irp/common_data_set/",
+      "access": "unknown"
+    },
+    "simmons-university": {
+      "url": "https://www.simmons.edu/why-simmons/common-data-set",
+      "access": "unknown"
+    },
+    "skidmore-college": {
+      "url": "https://www.skidmore.edu/ir/facts/common/",
+      "access": "unknown"
+    },
+    "soka-university-of-america": {
+      "url": "https://www.soka.edu/about/institutional-research-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "south-carolina-state-university": {
+      "url": "https://scsu.edu/ier/common-data-sets.php",
+      "access": "unknown"
+    },
+    "southeastern-louisiana-university": {
+      "url": "https://southeastern.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "southeastern-oklahoma-state-university": {
+      "url": "https://www.se.edu/academic-affairs/common-data-set/",
+      "access": "unknown"
+    },
+    "southern-connecticut-state-university": {
+      "url": "https://southernct.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "southern-oregon-university": {
+      "url": "https://institutionalresearch.sou.edu/common-data-sets-cds/",
+      "access": "unknown"
+    },
+    "southern-wesleyan-university": {
+      "url": "https://www.swu.edu/about/consumer-information/common-data-set/",
+      "access": "unknown"
+    },
+    "southwestern-oklahoma-state-university": {
+      "url": "https://dc.swosu.edu/com_dat/12/",
+      "access": "unknown"
+    },
+    "southwestern-university": {
+      "url": "https://www.southwestern.edu/institutional-research/the-common-data-set/",
+      "access": "unknown"
+    },
+    "spelman-college": {
+      "url": "https://spelman.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "spring-arbor-university": {
+      "url": "https://www.arbor.edu/about/assessment-and-institutional-research/",
+      "access": "unknown"
+    },
+    "st-lawrence-university": {
+      "url": "https://ir.stlawu.edu/surveys/HERIFaculty",
+      "access": "unknown"
+    },
+    "st-marys-college-of-maryland": {
+      "url": "https://www.smcm.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "st-petersburg-college": {
+      "url": "https://ir.spcollege.edu/institutional-research/cds",
+      "access": "unknown"
+    },
+    "st-thomas-aquinas-college": {
+      "url": "https://stac.edu/consumer-info/",
+      "access": "unknown"
+    },
+    "st-thomas-university": {
+      "url": "https://web.stu.edu/AboutSTU/PlanningEnrollment/OfficeofInstitutionalResearch/CommonDataSets/tabid/80/Default.aspx",
+      "access": "unknown"
+    },
+    "stanford": {
+      "url": "https://irds.stanford.edu/data-findings/cds",
+      "access": "unknown"
+    },
+    "state-university-of-new-york-at-oswego": {
+      "url": "https://www.oswego.edu/institutional-research/common-data-set-0",
+      "access": "unknown"
+    },
+    "stonehill-college": {
+      "url": "https://www.stonehill.edu/offices-and-services/institutional-research-assessment/common-data-set/",
+      "access": "unknown"
+    },
+    "stony-brook-university": {
+      "url": "https://www.stonybrook.edu/commcms/irpe/fact_book/common_data_set/",
+      "access": "unknown"
+    },
+    "suny-at-fredonia": {
+      "url": "https://www.fredonia.edu/about/offices/institutional-research-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "suny-at-purchase-college": {
+      "url": "https://www.purchase.edu/right-to-know/student-information/",
+      "access": "unknown"
+    },
+    "suny-college-at-plattsburgh": {
+      "url": "https://www.plattsburgh.edu/about/president-leadership/institutional-effectiveness/data-resources.html",
+      "access": "unknown"
+    },
+    "suny-oneonta": {
+      "url": "https://suny.oneonta.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "susquehanna-university": {
+      "url": "https://susqu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "swarthmore": {
+      "url": "https://www.swarthmore.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "sweet-briar-college": {
+      "url": "https://sbc.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "texas-a-and-m-university-commerce": {
+      "url": "https://new.tamuc.edu/department-of-institutional-effectiveness-and-research/research/",
+      "access": "unknown"
+    },
+    "texas-aandm-university-central-texas": {
+      "url": "https://www.tamuct.edu/Institutional%20Research%20and%20Assessment/common-data-set.html",
+      "access": "unknown"
+    },
+    "texas-aandm-university-san-antonio": {
+      "url": "https://www.tamusa.edu/office-institutional-research/index.html",
+      "access": "unknown"
+    },
+    "texas-christian-university": {
+      "url": "https://ir.tcu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "texas-wesleyan-university": {
+      "url": "https://txwes.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "the-catholic-university-of-america": {
+      "url": "https://ir.catholic.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "the-college-of-new-jersey": {
+      "url": "https://ira.tcnj.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "the-college-of-wooster": {
+      "url": "https://inside.wooster.edu/consumer-and-accreditation-information/common-data-sets/",
+      "access": "unknown"
+    },
+    "the-evergreen-state-college": {
+      "url": "https://www.evergreen.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "the-new-school": {
+      "url": "https://findingaids.archives.newschool.edu/repositories/3/digital_objects/3416",
+      "access": "unknown"
+    },
+    "the-university-of-tennessee-knoxville": {
+      "url": "https://irsa.utk.edu/reporting/common-data-set/",
+      "access": "unknown"
+    },
+    "the-university-of-texas-at-el-paso": {
+      "url": "https://www.utep.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "the-university-of-texas-at-san-antonio": {
+      "url": "https://www.utsa.edu/ir/content/resources/commonDataSet.html",
+      "access": "unknown"
+    },
+    "thomas-jefferson-university": {
+      "url": "https://www.jefferson.edu/east-falls/institutional-research-and-planning/common-data-set.html",
+      "access": "unknown"
+    },
+    "touro-university": {
+      "url": "https://www.touro.edu/departments/office-of-the-provost/institutional-research/",
+      "access": "unknown"
+    },
+    "trinity-christian-college": {
+      "url": "https://trollweb.trnty.edu/download-category/common-data-set/",
+      "access": "unknown"
+    },
+    "tufts": {
+      "url": "https://provost.tufts.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "tulane-university-of-louisiana": {
+      "url": "https://oair.tulane.edu/common-data-set",
+      "access": "unknown"
+    },
+    "uc-davis": {
+      "url": "https://aggiedata.ucdavis.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "uc-irvine": {
+      "url": "https://irap.uci.edu/institutional-research/data-hub/common-data-set/",
+      "access": "unknown"
+    },
+    "uc-santa-barbara": {
+      "url": "https://bap.ucsb.edu/institutional-research",
+      "access": "unknown"
+    },
+    "ucla": {
+      "url": "https://apb.ucla.edu/file/22f7b216-5bcd-4401-bf95-6b9fc3652a67",
+      "access": "unknown"
+    },
+    "umd": {
+      "url": "https://www.irpa.umd.edu/InstitutionalData/cds.html",
+      "access": "unknown"
+    },
+    "umich": {
+      "url": "https://obp.umich.edu/campus-statistics/common-data-set/",
+      "access": "unknown"
+    },
+    "unc": {
+      "url": "https://oira.unc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "united-states-military-academy": {
+      "url": "https://www.westpoint.edu/about/west-point-staff/g5/institutional-research/common-data-sets",
+      "access": "unknown"
+    },
+    "united-states-naval-academy": {
+      "url": "https://www.usna.edu/Users/oceano/pguth/md_help/html/support_dbs.htm",
+      "access": "unknown"
+    },
+    "university-at-albany": {
+      "url": "https://www.albany.edu/ir/common-data-set-2020-2021",
+      "access": "unknown"
+    },
+    "university-of-alaska-anchorage": {
+      "url": "https://www.uaa.alaska.edu/academics/office-of-academic-affairs/institutional-effectiveness/departments/institutional-research/index.cshtml",
+      "access": "unknown"
+    },
+    "university-of-alaska-fairbanks": {
+      "url": "https://www.uaf.edu/pair/pair_reports/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-alaska-southeast": {
+      "url": "https://uas.alaska.edu/ie/external%20reporting.html",
+      "access": "unknown"
+    },
+    "university-of-alaska-system-of-higher-education": {
+      "url": "https://www.uaa.alaska.edu/academics/office-of-academic-affairs/institutional-effectiveness/departments/institutional-research/common-data-set.cshtml",
+      "access": "unknown"
+    },
+    "university-of-arizona": {
+      "url": "https://uair.arizona.edu/content/common-data-set",
+      "access": "unknown"
+    },
+    "university-of-arkansas": {
+      "url": "https://osai.uark.edu/datasets/cds/",
+      "access": "unknown"
+    },
+    "university-of-arkansas-at-little-rock": {
+      "url": "https://ualr.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-california-riverside": {
+      "url": "https://ir.ucr.edu/cds/",
+      "access": "unknown"
+    },
+    "university-of-central-oklahoma": {
+      "url": "http://sites.uco.edu/academic-affairs/ir/index.asp",
+      "access": "unknown"
+    },
+    "university-of-connecticut": {
+      "url": "https://oir.uconn.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-houston": {
+      "url": "https://uh.edu/ir/reports/common-data-sets/",
+      "access": "unknown"
+    },
+    "university-of-houston-clear-lake": {
+      "url": "https://www.uhcl.edu/about/administrative-offices/institutional-research/ir-resources",
+      "access": "unknown"
+    },
+    "university-of-houston-system-administration": {
+      "url": "https://uh.edu/ir/reports/common-data-sets/",
+      "access": "unknown"
+    },
+    "university-of-idaho": {
+      "url": "https://www.uidaho.edu/provost/ir/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "university-of-illinois-chicago": {
+      "url": "https://oir.uic.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-illinois-system-offices": {
+      "url": "https://www.uillinois.edu/erc/foia/available_records",
+      "access": "unknown"
+    },
+    "university-of-indianapolis": {
+      "url": "https://uindy.edu/",
+      "access": "unknown"
+    },
+    "university-of-kansas": {
+      "url": "https://aire.ku.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-kentucky": {
+      "url": "https://irads.uky.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-la-verne": {
+      "url": "https://laverne.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-louisville": {
+      "url": "https://louisville.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-maine-at-presque-isle": {
+      "url": "https://umpi.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-maryland-baltimore-county": {
+      "url": "https://irads.umbc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-massachusetts-lowell": {
+      "url": "https://www.uml.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-miami": {
+      "url": "https://irsa.miami.edu/facts-and-information/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-michigan-flint": {
+      "url": "https://www.umflint.edu/ia/campus-statistics/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-minnesota-duluth": {
+      "url": "https://oir.d.umn.edu/common-data-set",
+      "access": "unknown"
+    },
+    "university-of-minnesota-morris": {
+      "url": "https://digitalcommons.morris.umn.edu/institutionaldata/42/",
+      "access": "unknown"
+    },
+    "university-of-missouri-columbia": {
+      "url": "https://ir.missouri.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-nebraska-at-omaha": {
+      "url": "https://digitalcommons.unomaha.edu/oiecds/24/",
+      "access": "unknown"
+    },
+    "university-of-nevada-reno": {
+      "url": "https://dataden.unr.edu/CommonDataSet",
+      "access": "unknown"
+    },
+    "university-of-north-carolina-asheville": {
+      "url": "https://irep.unca.edu/institutional-facts",
+      "access": "unknown"
+    },
+    "university-of-north-carolina-at-charlotte": {
+      "url": "https://ir.charlotte.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-north-carolina-at-greensboro": {
+      "url": "https://ire.uncg.edu/external-reports-2/",
+      "access": "unknown"
+    },
+    "university-of-north-florida": {
+      "url": "https://www.unf.edu/ir/common-data-set/2024.html",
+      "access": "unknown"
+    },
+    "university-of-north-georgia": {
+      "url": "https://ung.edu/institutional-effectiveness-research-administration/institutional-research/common-data-set.php",
+      "access": "unknown"
+    },
+    "university-of-north-texas": {
+      "url": "https://institutionalresearch.unt.edu/common-data-set",
+      "access": "unknown"
+    },
+    "university-of-northern-colorado": {
+      "url": "https://www.unco.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-northern-iowa": {
+      "url": "https://ie.uni.edu/data-trends/uni-facts",
+      "access": "unknown"
+    },
+    "university-of-oregon": {
+      "url": "https://ir.uoregon.edu/cds",
+      "access": "unknown"
+    },
+    "university-of-rhode-island": {
+      "url": "https://web.uri.edu/ir/reports-and-surveys/common/",
+      "access": "unknown"
+    },
+    "university-of-saint-katherine": {
+      "url": "https://www.usk.edu/resources/common-data-set-2022-2023/",
+      "access": "unknown"
+    },
+    "university-of-scranton": {
+      "url": "https://www.scranton.edu/pir/institutional-research/institutional-research-reports/institutional-research-reports-page.shtml",
+      "access": "unknown"
+    },
+    "university-of-south-carolina-aiken": {
+      "url": "https://ie.usca.edu/facts/cds/index.html",
+      "access": "unknown"
+    },
+    "university-of-south-carolina-columbia": {
+      "url": "http://oiraa.dw.sc.edu/cds/cds2024/",
+      "access": "unknown"
+    },
+    "university-of-south-carolina-upstate": {
+      "url": "https://www.uscupstate.edu/faculty-staff/institutional-planning-and-research/data-and-statistics/",
+      "access": "unknown"
+    },
+    "university-of-southern-maine": {
+      "url": "https://usm.maine.edu/department-of-analysis-applications-institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-st-thomas": {
+      "url": "https://www.stthom.edu/Public/getFile.asp?File_Content_ID=127511",
+      "access": "unknown"
+    },
+    "university-of-vermont": {
+      "url": "https://uvm.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-washington-tacoma-campus": {
+      "url": "https://www.tacoma.uw.edu/ir",
+      "access": "unknown"
+    },
+    "university-of-wisconsin-eau-claire": {
+      "url": "https://uwec.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-wisconsin-la-crosse": {
+      "url": "https://www.uwlax.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-wisconsin-oshkosh": {
+      "url": "https://uwosh.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "university-of-wisconsin-superior": {
+      "url": "https://uwsuper.edu/academics/research-and-innovation/institutional-research/",
+      "access": "unknown"
+    },
+    "university-system-of-new-hampshire-system-office": {
+      "url": "https://www.usnh.edu/it/departments/center-data-constituent-development-services/data-requests",
+      "access": "unknown"
+    },
+    "upenn": {
+      "url": "https://ira.upenn.edu/penn-numbers/common-data-set",
+      "access": "unknown"
+    },
+    "upitt": {
+      "url": "https://ir.pitt.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "ursuline-college": {
+      "url": "https://womenwellnesswork.ursuline.edu/duke-common-data-set",
+      "access": "unknown"
+    },
+    "ut-austin": {
+      "url": "https://reports.utexas.edu/common-data-set",
+      "access": "unknown"
+    },
+    "utah-tech-university": {
+      "url": "https://ir.utahtech.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "uw": {
+      "url": "https://www.washington.edu/opb/uw-data/external-reporting/common-data-set/",
+      "access": "unknown"
+    },
+    "uw-madison": {
+      "url": "https://data.wisc.edu/common-data-set-and-rankings/",
+      "access": "unknown"
+    },
+    "valdosta-state-university": {
+      "url": "https://www.valdosta.edu/administration/institutional-research/",
+      "access": "unknown"
+    },
+    "valparaiso-university": {
+      "url": "https://www.valpo.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "vanderbilt": {
+      "url": "https://www.vanderbilt.edu/data/public-data/common-data-sets/",
+      "access": "unknown"
+    },
+    "vassar-college": {
+      "url": "https://offices.vassar.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "virginia-polytechnic-institute-and-state-university": {
+      "url": "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+      "access": "request"
+    },
+    "virginia-tech": {
+      "url": "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+      "access": "request"
+    },
+    "viterbo-university": {
+      "url": "https://www.viterbo.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "walla-walla-university": {
+      "url": "https://www.wallawalla.edu/resources/institutional-research/institutional-reports/common-data-set",
+      "access": "unknown"
+    },
+    "washington-and-jefferson-college": {
+      "url": "https://www.washjeff.edu/files/common-data-set/2021-2022/",
+      "access": "unknown"
+    },
+    "washington-and-lee": {
+      "url": "https://my.wlu.edu/document/2024-common-data-set",
+      "access": "unknown"
+    },
+    "washington-university-in-st-louis": {
+      "url": "https://wustl.edu/about/compliance-policies/registrar/student-consumer-information/",
+      "access": "unknown"
+    },
+    "watts-college-of-nursing": {
+      "url": "https://wattscollegeofnursing.edu/financial-information/consumer-information/",
+      "access": "unknown"
+    },
+    "wayne-state-university": {
+      "url": "https://irda.wayne.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "wentworth-institute-of-technology": {
+      "url": "https://wit.edu/about/institutional-effectiveness",
+      "access": "unknown"
+    },
+    "wesleyan-university": {
+      "url": "https://www.wesleyan.edu/ir/",
+      "access": "unknown"
+    },
+    "west-liberty-university": {
+      "url": "https://westliberty.edu/university-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "western-connecticut-state-university": {
+      "url": "https://www.wcsu.edu/ira/common-data-set/",
+      "access": "unknown"
+    },
+    "western-illinois-university": {
+      "url": "https://www.wiu.edu/irp/peers.php",
+      "access": "unknown"
+    },
+    "western-new-england-university": {
+      "url": "https://wne.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "western-washington-university": {
+      "url": "https://oie.wwu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "westfield-state-university": {
+      "url": "https://www.westfield.ma.edu/documents/cds2023-24pdf",
+      "access": "unknown"
+    },
+    "westminster-college": {
+      "url": "https://www.wcmo.edu/academics/assessment/report/index.html",
+      "access": "unknown"
+    },
+    "westminster-university": {
+      "url": "https://westminstercollege.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "wheaton-college-massachusetts": {
+      "url": "https://wheatoncollege.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "whitman-college": {
+      "url": "https://whitman.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "wilkes-university": {
+      "url": "https://www.wilkes.edu/about-wilkes/offices-and-administration/institutional-research/common-data-set.aspx",
+      "access": "unknown"
+    },
+    "willamette-university": {
+      "url": "https://legacy.willamette.edu/ir/cds/index.html",
+      "access": "unknown"
+    },
+    "william-and-mary": {
+      "url": "https://www.wm.edu/offices/ir/university_data/cds/",
+      "access": "unknown"
+    },
+    "williams-college": {
+      "url": "https://www.williams.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "wittenberg-university": {
+      "url": "https://www.wittenberg.edu/administration/provost/common-data-set",
+      "access": "unknown"
+    },
+    "yale": {
+      "url": "https://oir.yale.edu/common-data-set",
+      "access": "unknown"
+    },
+    "yeshiva-university": {
+      "url": "https://www.yu.edu/oir/statistics",
+      "access": "unknown"
+    }
+  },
+  "byIpedsId": {
+    "100858": {
+      "url": "https://ir.auburn.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "101480": {
+      "url": "https://jsu.edu/ire/research/common-data-set.html",
+      "access": "unknown"
+    },
+    "102553": {
+      "url": "https://www.uaa.alaska.edu/academics/office-of-academic-affairs/institutional-effectiveness/departments/institutional-research/index.cshtml",
+      "access": "unknown"
+    },
+    "102614": {
+      "url": "https://www.uaf.edu/pair/pair_reports/common-data-set/",
+      "access": "unknown"
+    },
+    "102632": {
+      "url": "https://uas.alaska.edu/ie/external%20reporting.html",
+      "access": "unknown"
+    },
+    "103529": {
+      "url": "https://www.uaa.alaska.edu/academics/office-of-academic-affairs/institutional-effectiveness/departments/institutional-research/common-data-set.cshtml",
+      "access": "unknown"
+    },
+    "104179": {
+      "url": "https://uair.arizona.edu/content/common-data-set",
+      "access": "unknown"
+    },
+    "105330": {
+      "url": "https://in.nau.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "106245": {
+      "url": "https://ualr.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "106397": {
+      "url": "https://osai.uark.edu/datasets/cds/",
+      "access": "unknown"
+    },
+    "106467": {
+      "url": "https://www.atu.edu/ir/",
+      "access": "unknown"
+    },
+    "107080": {
+      "url": "https://www.hendrix.edu/WorkArea/DownloadAsset.aspx?id=63451",
+      "access": "unknown"
+    },
+    "109785": {
+      "url": "https://www.apu.edu/oir/commondata/",
+      "access": "unknown"
+    },
+    "110097": {
+      "url": "https://www.biola.edu/institutional-research/about",
+      "access": "unknown"
+    },
+    "110422": {
+      "url": "https://ir.calpoly.edu/content/publications_reports/cds/index",
+      "access": "unknown"
+    },
+    "110486": {
+      "url": "https://www.csub.edu/irpa/reports.shtml",
+      "access": "unknown"
+    },
+    "110583": {
+      "url": "https://csulb.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "110608": {
+      "url": "https://www.csun.edu/node/65206",
+      "access": "unknown"
+    },
+    "110644": {
+      "url": "https://aggiedata.ucdavis.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "110653": {
+      "url": "https://irap.uci.edu/institutional-research/data-hub/common-data-set/",
+      "access": "unknown"
+    },
+    "110662": {
+      "url": "https://apb.ucla.edu/file/22f7b216-5bcd-4401-bf95-6b9fc3652a67",
+      "access": "unknown"
+    },
+    "110671": {
+      "url": "https://ir.ucr.edu/cds/",
+      "access": "unknown"
+    },
+    "110705": {
+      "url": "https://bap.ucsb.edu/institutional-research",
+      "access": "unknown"
+    },
+    "111188": {
+      "url": "https://www.csum.edu/ir/common-data-set.html",
+      "access": "unknown"
+    },
+    "112260": {
+      "url": "https://www.cmc.edu/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "115409": {
+      "url": "https://www.hmc.edu/institutional-research/institutional-statistics/common-data-set/",
+      "access": "public"
+    },
+    "117140": {
+      "url": "https://laverne.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "120254": {
+      "url": "https://www.oxy.edu/offices-services/institutional-research/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "120403": {
+      "url": "https://otis.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "121257": {
+      "url": "https://www.pitzer.edu/institutional-research/common-data-sets/",
+      "access": "unknown"
+    },
+    "121309": {
+      "url": "https://www.pointloma.edu/offices/institutional-research",
+      "access": "unknown"
+    },
+    "122409": {
+      "url": "https://asir.sdsu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "122597": {
+      "url": "https://ir.sfsu.edu/applications-and-enrollment",
+      "access": "unknown"
+    },
+    "123554": {
+      "url": "https://stmarys-ca.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "126182": {
+      "url": "https://adams.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "126207": {
+      "url": "https://www.aims.edu/departments/institutional-research/institution-and-student-data-reports",
+      "access": "unknown"
+    },
+    "126614": {
+      "url": "https://data.colorado.edu/reports/common-data-set",
+      "access": "unknown"
+    },
+    "126711": {
+      "url": "https://coloradomtn.edu/contact-departments/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "126775": {
+      "url": "https://ir.mines.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "127185": {
+      "url": "https://www-dev.fortlewis.edu/about-flc/leadership/institutional-effectiveness/institutional-research/common-data-sets",
+      "access": "unknown"
+    },
+    "127200": {
+      "url": "https://www.frontrange.edu/about/facts-figures/common-data-set.html",
+      "access": "unknown"
+    },
+    "127741": {
+      "url": "https://www.unco.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "127909": {
+      "url": "https://www.rrcc.edu/institutional-research/common-data",
+      "access": "unknown"
+    },
+    "128498": {
+      "url": "https://www.albertus.edu/policy-reports/institutional-research-and-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "128902": {
+      "url": "https://www.conncoll.edu/institutional-research/conn-facts/",
+      "access": "unknown"
+    },
+    "129020": {
+      "url": "https://oir.uconn.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "130493": {
+      "url": "https://southernct.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "130697": {
+      "url": "https://www.wesleyan.edu/ir/",
+      "access": "unknown"
+    },
+    "130776": {
+      "url": "https://www.wcsu.edu/ira/common-data-set/",
+      "access": "unknown"
+    },
+    "130794": {
+      "url": "https://oir.yale.edu/common-data-set",
+      "access": "unknown"
+    },
+    "130934": {
+      "url": "https://www.desu.edu/academics/academic-affairs/institutional-effectiveness/institutional-research-planning-analytics",
+      "access": "unknown"
+    },
+    "131283": {
+      "url": "https://ir.catholic.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "131469": {
+      "url": "https://irp.gwu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "131496": {
+      "url": "https://oads.georgetown.edu/commondataset/",
+      "access": "unknown"
+    },
+    "131520": {
+      "url": "https://ira.howard.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "133492": {
+      "url": "https://www.eckerd.edu/about/factsheet/",
+      "access": "unknown"
+    },
+    "135717": {
+      "url": "https://www.mdc.edu/ppa/policy-analysis/",
+      "access": "unknown"
+    },
+    "135726": {
+      "url": "https://irsa.miami.edu/facts-and-information/common-data-set/",
+      "access": "unknown"
+    },
+    "136172": {
+      "url": "https://www.unf.edu/ir/common-data-set/2024.html",
+      "access": "unknown"
+    },
+    "136330": {
+      "url": "https://pba.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "136950": {
+      "url": "https://rpublic.rollins.edu/sites/IR/Common%20Data%20Set%20CDS/",
+      "access": "unknown"
+    },
+    "137078": {
+      "url": "https://ir.spcollege.edu/institutional-research/cds",
+      "access": "unknown"
+    },
+    "137476": {
+      "url": "https://web.stu.edu/AboutSTU/PlanningEnrollment/OfficeofInstitutionalResearch/CommonDataSets/tabid/80/Default.aspx",
+      "access": "unknown"
+    },
+    "138600": {
+      "url": "https://agnesscott.edu/institutionalresearch/common-data-set.html",
+      "access": "unknown"
+    },
+    "138716": {
+      "url": "https://asurams.edu/institutional-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "139755": {
+      "url": "https://irp.gatech.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "139940": {
+      "url": "https://oie.gsu.edu/data-reporting-systems/common-data-set/",
+      "access": "unknown"
+    },
+    "140447": {
+      "url": "https://oie.mercer.edu/research/common-data-set.cfm",
+      "access": "unknown"
+    },
+    "140696": {
+      "url": "https://ir.oglethorpe.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "141060": {
+      "url": "https://spelman.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "141264": {
+      "url": "https://www.valdosta.edu/administration/institutional-research/",
+      "access": "unknown"
+    },
+    "142285": {
+      "url": "https://www.uidaho.edu/provost/ir/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "142328": {
+      "url": "https://www.lcsc.edu/ir/need-lc-state-data",
+      "access": "unknown"
+    },
+    "142559": {
+      "url": "https://www.csi.edu/institutional-effectiveness/institutional-research/common-data-set.aspx",
+      "access": "unknown"
+    },
+    "144892": {
+      "url": "https://www.eiu.edu/ir/common_data_sets.php",
+      "access": "unknown"
+    },
+    "145600": {
+      "url": "https://oir.uic.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "145646": {
+      "url": "https://digitalcommons.iwu.edu/instres_dataset/",
+      "access": "unknown"
+    },
+    "146481": {
+      "url": "https://www.lakeforest.edu/about-us/institutional-research",
+      "access": "unknown"
+    },
+    "146719": {
+      "url": "https://www.luc.edu/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "147660": {
+      "url": "https://www.northcentralcollege.edu/transparency/general-compliance-information",
+      "access": "unknown"
+    },
+    "148131": {
+      "url": "https://www.quincy.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "148496": {
+      "url": "https://www.dom.edu/offices/oie/institutional-data/profile-and-common-data-set",
+      "access": "unknown"
+    },
+    "149505": {
+      "url": "https://trollweb.trnty.edu/download-category/common-data-set/",
+      "access": "unknown"
+    },
+    "149587": {
+      "url": "https://www.uillinois.edu/erc/foia/available_records",
+      "access": "unknown"
+    },
+    "149772": {
+      "url": "https://www.wiu.edu/irp/peers.php",
+      "access": "unknown"
+    },
+    "150668": {
+      "url": "https://www.goshen.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "150941": {
+      "url": "https://www.huntington.edu/about/consumer-info",
+      "access": "unknown"
+    },
+    "151263": {
+      "url": "https://uindy.edu/",
+      "access": "unknown"
+    },
+    "151351": {
+      "url": "https://iuapps.iu.edu/cds/index.html?i=home&p=index",
+      "access": "unknown"
+    },
+    "152600": {
+      "url": "https://www.valpo.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "153108": {
+      "url": "https://departments.central.edu/registrar/other/common-data-set/",
+      "access": "unknown"
+    },
+    "153366": {
+      "url": "https://my.graceland.edu/ICS/Resources/Institutional_Research/GU_Fact_Book/Common_Data_Set.jnz",
+      "access": "unknown"
+    },
+    "154004": {
+      "url": "https://my.morningside.edu/campus_offices/institutional_research/fast_facts/",
+      "access": "unknown"
+    },
+    "154095": {
+      "url": "https://ie.uni.edu/data-trends/uni-facts",
+      "access": "unknown"
+    },
+    "155317": {
+      "url": "https://aire.ku.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "155399": {
+      "url": "https://www.k-state.edu/data/institutional-research/resources/",
+      "access": "unknown"
+    },
+    "156286": {
+      "url": "https://www.bellarmine.edu/academicaffairs/ir/data-reports/common-data-set/",
+      "access": "unknown"
+    },
+    "156365": {
+      "url": "https://tigernet.campbellsville.edu/ICS/Academic_Affairs/Institutional_Research/Handouts.jnz",
+      "access": "unknown"
+    },
+    "156408": {
+      "url": "https://www.centre.edu/about/college-policies-initiatives/common-data-set",
+      "access": "unknown"
+    },
+    "157076": {
+      "url": "https://kwc.edu/academics/institutional-effectiveness-and-research/",
+      "access": "unknown"
+    },
+    "157085": {
+      "url": "https://irads.uky.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "157289": {
+      "url": "https://louisville.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "157386": {
+      "url": "https://www.moreheadstate.edu/about-msu/leadership/ppe/institutional-research/institutional-data/common-data-sets",
+      "access": "unknown"
+    },
+    "157447": {
+      "url": "https://inside.nku.edu/ir/Reports.html",
+      "access": "unknown"
+    },
+    "159009": {
+      "url": "https://www.gram.edu/offices/ie/ir/surveys.php",
+      "access": "unknown"
+    },
+    "159391": {
+      "url": "https://www.lsu.edu/data/common-data-set/",
+      "access": "unknown"
+    },
+    "159647": {
+      "url": "https://oierp.latech.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "159966": {
+      "url": "https://www.nicholls.edu/irep/common-data-set/",
+      "access": "unknown"
+    },
+    "160038": {
+      "url": "https://www.nsula.edu/oir/nsu-factbook-common-data-set/",
+      "access": "unknown"
+    },
+    "160612": {
+      "url": "https://southeastern.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "160755": {
+      "url": "https://oair.tulane.edu/common-data-set",
+      "access": "unknown"
+    },
+    "160959": {
+      "url": "https://www.coa.edu/institutional-research/",
+      "access": "unknown"
+    },
+    "160977": {
+      "url": "https://bates.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "161004": {
+      "url": "https://www.bowdoin.edu/ir/",
+      "access": "unknown"
+    },
+    "161341": {
+      "url": "https://umpi.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "161554": {
+      "url": "https://usm.maine.edu/department-of-analysis-applications-institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "162928": {
+      "url": "https://oira.jhu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "163268": {
+      "url": "https://irads.umbc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "163286": {
+      "url": "https://www.irpa.umd.edu/InstitutionalData/cds.html",
+      "access": "unknown"
+    },
+    "163912": {
+      "url": "https://www.smcm.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "164155": {
+      "url": "https://www.usna.edu/Users/oceano/pguth/md_help/html/support_dbs.htm",
+      "access": "unknown"
+    },
+    "164447": {
+      "url": "https://aic.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "164739": {
+      "url": "https://www.bentley.edu/offices/institutional-research/external-surveys",
+      "access": "unknown"
+    },
+    "164748": {
+      "url": "https://www.berklee.edu/institutional-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "164988": {
+      "url": "https://www.bu.edu/asir/bu-facts/common-data-set/",
+      "access": "unknown"
+    },
+    "165015": {
+      "url": "https://brandeis.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "165024": {
+      "url": "https://vc.bridgew.edu/datasets/",
+      "access": "unknown"
+    },
+    "165167": {
+      "url": "https://cambridgecollege.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "165820": {
+      "url": "https://www.fitchburgstate.edu/about/institutional-research-and-planning/institutional-data",
+      "access": "unknown"
+    },
+    "165936": {
+      "url": "https://www.gordon.edu/commondata",
+      "access": "unknown"
+    },
+    "166018": {
+      "url": "https://hampshire.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "166027": {
+      "url": "https://oira.harvard.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "166513": {
+      "url": "https://www.uml.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "166683": {
+      "url": "https://ir.mit.edu/project-topic/common-data-set",
+      "access": "unknown"
+    },
+    "166850": {
+      "url": "https://www.merrimack.edu/office-of-institutional-effectiveness/surveys-and-qualtrix/",
+      "access": "unknown"
+    },
+    "166939": {
+      "url": "https://mtholyoke.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "167358": {
+      "url": "https://uds.northeastern.edu/facts/common-data-set/",
+      "access": "unknown"
+    },
+    "167783": {
+      "url": "https://www.simmons.edu/why-simmons/common-data-set",
+      "access": "unknown"
+    },
+    "167996": {
+      "url": "https://www.stonehill.edu/offices-and-services/institutional-research-assessment/common-data-set/",
+      "access": "unknown"
+    },
+    "168148": {
+      "url": "https://provost.tufts.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "168227": {
+      "url": "https://wit.edu/about/institutional-effectiveness",
+      "access": "unknown"
+    },
+    "168254": {
+      "url": "https://wne.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "168263": {
+      "url": "https://www.westfield.ma.edu/documents/cds2023-24pdf",
+      "access": "unknown"
+    },
+    "168281": {
+      "url": "https://wheatoncollege.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "168342": {
+      "url": "https://www.williams.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "169983": {
+      "url": "https://libguides.kettering.edu/c.php?g=1123795&p=8197698",
+      "access": "unknown"
+    },
+    "170082": {
+      "url": "https://www.gvsu.edu/registrar/reporting-analysis-182.htm",
+      "access": "unknown"
+    },
+    "170639": {
+      "url": "https://www.lssu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "170976": {
+      "url": "https://obp.umich.edu/campus-statistics/common-data-set/",
+      "access": "unknown"
+    },
+    "171100": {
+      "url": "https://ir.msu.edu/cds",
+      "access": "unknown"
+    },
+    "171146": {
+      "url": "https://www.umflint.edu/ia/campus-statistics/common-data-set/",
+      "access": "unknown"
+    },
+    "171456": {
+      "url": "https://nmu.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "172051": {
+      "url": "https://www.svsu.edu/oir/commondataset/",
+      "access": "unknown"
+    },
+    "172334": {
+      "url": "https://www.arbor.edu/about/assessment-and-institutional-research/",
+      "access": "unknown"
+    },
+    "172644": {
+      "url": "https://irda.wayne.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "173045": {
+      "url": "https://sites.augsburg.edu/ope/institutional-research-reports/",
+      "access": "unknown"
+    },
+    "173160": {
+      "url": "https://www.bethel.edu/institutional-data-research/institutional-data/common-data-set/",
+      "access": "unknown"
+    },
+    "173665": {
+      "url": "https://www.hamline.edu/about/offices-services/institutional-effectiveness-office",
+      "access": "unknown"
+    },
+    "174233": {
+      "url": "https://oir.d.umn.edu/common-data-set",
+      "access": "unknown"
+    },
+    "174251": {
+      "url": "https://digitalcommons.morris.umn.edu/institutionaldata/42/",
+      "access": "unknown"
+    },
+    "175856": {
+      "url": "https://www.jsums.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "177968": {
+      "url": "https://www.lindenwood.edu/provost/assessment/institutional-data/common-data-sets/",
+      "access": "unknown"
+    },
+    "178387": {
+      "url": "https://missouriwestern.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "178396": {
+      "url": "https://ir.missouri.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "178411": {
+      "url": "https://data.mst.edu/cds/",
+      "access": "unknown"
+    },
+    "178624": {
+      "url": "https://www.nwmissouri.edu/services/ir/CDS.htm",
+      "access": "unknown"
+    },
+    "179159": {
+      "url": "https://www.slu.edu/provost/office-of-institutional-research/institutional-data/2122cds.php",
+      "access": "unknown"
+    },
+    "179566": {
+      "url": "https://www.missouristate.edu/OIR/Ratings-Rankings-and-Publications.htm",
+      "access": "unknown"
+    },
+    "179867": {
+      "url": "https://wustl.edu/about/compliance-policies/registrar/student-consumer-information/",
+      "access": "unknown"
+    },
+    "179946": {
+      "url": "https://www.wcmo.edu/academics/assessment/report/index.html",
+      "access": "unknown"
+    },
+    "180106": {
+      "url": "https://www.carroll.edu/about/consumer-information/institutional-effectiveness/common-data-set",
+      "access": "unknown"
+    },
+    "180461": {
+      "url": "https://www.montana.edu/data/common-data-set/",
+      "access": "unknown"
+    },
+    "180595": {
+      "url": "https://rocky.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "181394": {
+      "url": "https://digitalcommons.unomaha.edu/oiecds/24/",
+      "access": "unknown"
+    },
+    "181534": {
+      "url": "https://www.peru.edu/assessment/institutionalresearch/commondataset.html",
+      "access": "unknown"
+    },
+    "182290": {
+      "url": "https://dataden.unr.edu/CommonDataSet",
+      "access": "unknown"
+    },
+    "182670": {
+      "url": "https://dartmouth.edu/oir/cds/",
+      "access": "unknown"
+    },
+    "183327": {
+      "url": "https://www.usnh.edu/it/departments/center-data-constituent-development-services/data-requests",
+      "access": "unknown"
+    },
+    "185590": {
+      "url": "https://montclair.edu/provost/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "185828": {
+      "url": "https://www.njit.edu/oie/factbook/commondata/index.php",
+      "access": "unknown"
+    },
+    "186380": {
+      "url": "https://oirap.rutgers.edu/ReportingCommonDataSet.html",
+      "access": "unknown"
+    },
+    "187134": {
+      "url": "https://ira.tcnj.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "187648": {
+      "url": "https://my.enmu.edu/c/document_library/get_file?uuid=26589e87-9a73-40a5-b937-af8586f7dd39&groupId=2878891&filename=CDS_2019-2020.pdf",
+      "access": "unknown"
+    },
+    "187897": {
+      "url": "https://www.nmhu.edu/institutional-research/comon-data-set/",
+      "access": "unknown"
+    },
+    "187967": {
+      "url": "https://www.nmt.edu/academicaffairs/research/common.php",
+      "access": "unknown"
+    },
+    "188429": {
+      "url": "https://adelphi.edu/institutional-research/research/data/",
+      "access": "unknown"
+    },
+    "189088": {
+      "url": "https://bard.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "189097": {
+      "url": "https://barnard.edu/institutional-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "190150": {
+      "url": "https://opir.columbia.edu/common-data-set",
+      "access": "unknown"
+    },
+    "190415": {
+      "url": "https://irp.dpb.cornell.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "190512": {
+      "url": "https://ir.baruch.cuny.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "190691": {
+      "url": "https://york.cuny.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "191621": {
+      "url": "https://www.hilbert.edu/about/institutional-research-assessment/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "191649": {
+      "url": "https://www.hofstra.edu/institutional-research-strategic-analysis/",
+      "access": "unknown"
+    },
+    "191968": {
+      "url": "https://ithaca.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "192819": {
+      "url": "https://www.marist.edu/documents/d/guest/cds_2020-2021-final",
+      "access": "unknown"
+    },
+    "193584": {
+      "url": "https://www2.naz.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "193654": {
+      "url": "https://findingaids.archives.newschool.edu/repositories/3/digital_objects/3416",
+      "access": "unknown"
+    },
+    "194824": {
+      "url": "https://rpi.box.com/s/fkqisnv4wxanikf1yfpw0yvajjtupg2z",
+      "access": "unknown"
+    },
+    "195003": {
+      "url": "https://rit.edu/institutionalresearch/common-data-set/",
+      "access": "unknown"
+    },
+    "195216": {
+      "url": "https://ir.stlawu.edu/surveys/HERIFaculty",
+      "access": "unknown"
+    },
+    "195243": {
+      "url": "https://stac.edu/consumer-info/",
+      "access": "unknown"
+    },
+    "195526": {
+      "url": "https://www.skidmore.edu/ir/facts/common/",
+      "access": "unknown"
+    },
+    "196060": {
+      "url": "https://www.albany.edu/ir/common-data-set-2020-2021",
+      "access": "unknown"
+    },
+    "196097": {
+      "url": "https://www.stonybrook.edu/commcms/irpe/fact_book/common_data_set/",
+      "access": "unknown"
+    },
+    "196158": {
+      "url": "https://www.fredonia.edu/about/offices/institutional-research-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "196185": {
+      "url": "https://suny.oneonta.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "196194": {
+      "url": "https://www.oswego.edu/institutional-research/common-data-set-0",
+      "access": "unknown"
+    },
+    "196219": {
+      "url": "https://www.purchase.edu/right-to-know/student-information/",
+      "access": "unknown"
+    },
+    "196246": {
+      "url": "https://www.plattsburgh.edu/about/president-leadership/institutional-effectiveness/data-resources.html",
+      "access": "unknown"
+    },
+    "196592": {
+      "url": "https://www.touro.edu/departments/office-of-the-provost/institutional-research/",
+      "access": "unknown"
+    },
+    "197036": {
+      "url": "https://www.westpoint.edu/about/west-point-staff/g5/institutional-research/common-data-sets",
+      "access": "unknown"
+    },
+    "197133": {
+      "url": "https://offices.vassar.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "197708": {
+      "url": "https://www.yu.edu/oir/statistics",
+      "access": "unknown"
+    },
+    "197869": {
+      "url": "https://analytics.appstate.edu/info_inst_res",
+      "access": "unknown"
+    },
+    "198215": {
+      "url": "https://www.catawba.edu/ir/",
+      "access": "unknown"
+    },
+    "198385": {
+      "url": "https://www.davidson.edu/offices-and-services/institutional-effectiveness/common-data-set",
+      "access": "unknown"
+    },
+    "198756": {
+      "url": "https://www.jcsu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "199111": {
+      "url": "https://irep.unca.edu/institutional-facts",
+      "access": "unknown"
+    },
+    "199120": {
+      "url": "https://oira.unc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "199139": {
+      "url": "https://ir.charlotte.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "199148": {
+      "url": "https://ire.uncg.edu/external-reports-2/",
+      "access": "unknown"
+    },
+    "199193": {
+      "url": "https://report.isa.ncsu.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "199883": {
+      "url": "https://wattscollegeofnursing.edu/financial-information/consumer-information/",
+      "access": "unknown"
+    },
+    "201441": {
+      "url": "https://www.bgsu.edu/institutional-research/CDS.html",
+      "access": "unknown"
+    },
+    "201548": {
+      "url": "https://www.capital.edu/about/facts-and-figures/institutional-research/",
+      "access": "unknown"
+    },
+    "201645": {
+      "url": "https://case.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "201654": {
+      "url": "https://www.cedarville.edu/offices/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "203447": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203456": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203465": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203474": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203483": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203492": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203517": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203526": {
+      "url": "https://www.kent.edu/ir/common-dataset-cds",
+      "access": "unknown"
+    },
+    "203845": {
+      "url": "https://www.marietta.edu/ir-common-data-set",
+      "access": "unknown"
+    },
+    "204006": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "204015": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "204024": {
+      "url": "https://miamioh.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "204501": {
+      "url": "https://www.oberlin.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "204635": {
+      "url": "https://archives.onu.edu/repositories/2/digital_objects/198",
+      "access": "unknown"
+    },
+    "204796": {
+      "url": "https://irp.osu.edu/institutional-data-and-reports",
+      "access": "unknown"
+    },
+    "206349": {
+      "url": "https://womenwellnesswork.ursuline.edu/duke-common-data-set",
+      "access": "unknown"
+    },
+    "206525": {
+      "url": "https://www.wittenberg.edu/administration/provost/common-data-set",
+      "access": "unknown"
+    },
+    "206589": {
+      "url": "https://inside.wooster.edu/consumer-and-accreditation-information/common-data-sets/",
+      "access": "unknown"
+    },
+    "206914": {
+      "url": "https://www.cameron.edu/iraa/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "206941": {
+      "url": "http://sites.uco.edu/academic-affairs/ir/index.asp",
+      "access": "unknown"
+    },
+    "207388": {
+      "url": "https://ira.okstate.edu/cds/",
+      "access": "unknown"
+    },
+    "207661": {
+      "url": "https://rsu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "207847": {
+      "url": "https://www.se.edu/academic-affairs/common-data-set/",
+      "access": "unknown"
+    },
+    "207865": {
+      "url": "https://dc.swosu.edu/com_dat/12/",
+      "access": "unknown"
+    },
+    "208646": {
+      "url": "https://eou.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "208822": {
+      "url": "https://www.georgefox.edu/offices/academic_affairs/effectiveness/common-data-set/index.html",
+      "access": "unknown"
+    },
+    "209056": {
+      "url": "https://www.lclark.edu/offices/institutional_research/common_data_set/",
+      "access": "unknown"
+    },
+    "209490": {
+      "url": "https://covid19forecast.ohsu.edu/mit-common-data-set",
+      "access": "unknown"
+    },
+    "209506": {
+      "url": "https://oit.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "209551": {
+      "url": "https://ir.uoregon.edu/cds",
+      "access": "unknown"
+    },
+    "209603": {
+      "url": "https://legacy.willamette.edu/ir/cds/index.html",
+      "access": "unknown"
+    },
+    "209612": {
+      "url": "https://www.pacificu.edu/directory/provost-academic-affairs/institutional-research-assessment/data-center",
+      "access": "unknown"
+    },
+    "210146": {
+      "url": "https://institutionalresearch.sou.edu/common-data-sets-cds/",
+      "access": "unknown"
+    },
+    "210401": {
+      "url": "https://legacy.willamette.edu/ir/cds/index.html",
+      "access": "unknown"
+    },
+    "210669": {
+      "url": "https://sites.allegheny.edu/institutional-effectiveness/the-common-data-set/",
+      "access": "unknown"
+    },
+    "211291": {
+      "url": "https://www.bucknell.edu/commondataset/",
+      "access": "unknown"
+    },
+    "211440": {
+      "url": "https://www.cmu.edu/ira/CDS/",
+      "access": "unknown"
+    },
+    "211981": {
+      "url": "https://delval.edu/institutional-research-and-effectiveness",
+      "access": "unknown"
+    },
+    "212106": {
+      "url": "https://www.duq.edu/commondataset/",
+      "access": "unknown"
+    },
+    "212984": {
+      "url": "https://www.holyfamily.edu/about/administrative-services/institutional-effectiveness",
+      "access": "unknown"
+    },
+    "213385": {
+      "url": "https://oir.lafayette.edu/ir/cds/",
+      "access": "unknown"
+    },
+    "213543": {
+      "url": "https://data.lehigh.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "213996": {
+      "url": "https://www.messiah.edu/institutional-research/research/common-data-set",
+      "access": "unknown"
+    },
+    "214069": {
+      "url": "https://www.misericordia.edu/campus-community/other-offices/office-of-institutional-research/institutional-research/common-data-set",
+      "access": "unknown"
+    },
+    "214157": {
+      "url": "https://www.moravian.edu/research/Moravian-University-Data",
+      "access": "unknown"
+    },
+    "214175": {
+      "url": "https://www.muhlenberg.edu/offices/ir/commondataset/",
+      "access": "unknown"
+    },
+    "214777": {
+      "url": "https://opair.psu.edu/cds/",
+      "access": "unknown"
+    },
+    "215062": {
+      "url": "https://ira.upenn.edu/penn-numbers/common-data-set",
+      "access": "unknown"
+    },
+    "215293": {
+      "url": "https://ir.pitt.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "215691": {
+      "url": "https://www.rosemont.edu/academics/registrar/ir/cds.php",
+      "access": "unknown"
+    },
+    "215929": {
+      "url": "https://www.scranton.edu/pir/institutional-research/institutional-research-reports/institutional-research-reports-page.shtml",
+      "access": "unknown"
+    },
+    "216010": {
+      "url": "https://www.ship.edu/about/offices/irp/common_data_set/",
+      "access": "unknown"
+    },
+    "216278": {
+      "url": "https://susqu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "216287": {
+      "url": "https://www.swarthmore.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "216366": {
+      "url": "https://www.jefferson.edu/east-falls/institutional-research-and-planning/common-data-set.html",
+      "access": "unknown"
+    },
+    "216667": {
+      "url": "https://www.washjeff.edu/files/common-data-set/2021-2022/",
+      "access": "unknown"
+    },
+    "216931": {
+      "url": "https://www.wilkes.edu/about-wilkes/offices-and-administration/institutional-research/common-data-set.aspx",
+      "access": "unknown"
+    },
+    "217156": {
+      "url": "https://oir.brown.edu/institutional-data/common-data-set",
+      "access": "unknown"
+    },
+    "217420": {
+      "url": "https://www.ric.edu/about/public-institutional-data",
+      "access": "unknown"
+    },
+    "217484": {
+      "url": "https://web.uri.edu/ir/reports-and-surveys/common/",
+      "access": "unknown"
+    },
+    "217776": {
+      "url": "https://www.swu.edu/about/consumer-information/common-data-set/",
+      "access": "unknown"
+    },
+    "217864": {
+      "url": "https://www.citadel.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "218645": {
+      "url": "https://ie.usca.edu/facts/cds/index.html",
+      "access": "unknown"
+    },
+    "218663": {
+      "url": "http://oiraa.dw.sc.edu/cds/cds2024/",
+      "access": "unknown"
+    },
+    "218733": {
+      "url": "https://scsu.edu/ier/common-data-sets.php",
+      "access": "unknown"
+    },
+    "218742": {
+      "url": "https://www.uscupstate.edu/faculty-staff/institutional-planning-and-research/data-and-statistics/",
+      "access": "unknown"
+    },
+    "219000": {
+      "url": "https://augie.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "219602": {
+      "url": "https://www.apsu.edu/institutional-research/cds/",
+      "access": "unknown"
+    },
+    "220613": {
+      "url": "https://leeuniversity.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "221351": {
+      "url": "https://rhodes.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "221759": {
+      "url": "https://irsa.utk.edu/reporting/common-data-set/",
+      "access": "unknown"
+    },
+    "221999": {
+      "url": "https://www.vanderbilt.edu/data/public-data/common-data-sets/",
+      "access": "unknown"
+    },
+    "222831": {
+      "url": "https://www.angelo.edu/live/files/27087-common-data-set-2019-2020",
+      "access": "unknown"
+    },
+    "222983": {
+      "url": "https://www.austincollege.edu/institutional-research",
+      "access": "unknown"
+    },
+    "224004": {
+      "url": "https://www.concordia.edu/resources/office-of-student-registration-and-records/statistical-information.html",
+      "access": "unknown"
+    },
+    "224554": {
+      "url": "https://new.tamuc.edu/department-of-institutional-effectiveness-and-research/research/",
+      "access": "unknown"
+    },
+    "225414": {
+      "url": "https://www.uhcl.edu/about/administrative-offices/institutional-research/ir-resources",
+      "access": "unknown"
+    },
+    "225511": {
+      "url": "https://uh.edu/ir/reports/common-data-sets/",
+      "access": "unknown"
+    },
+    "227216": {
+      "url": "https://institutionalresearch.unt.edu/common-data-set",
+      "access": "unknown"
+    },
+    "227526": {
+      "url": "https://pvamu.edu/ir/common-data-set/",
+      "access": "unknown"
+    },
+    "227757": {
+      "url": "https://oie.rice.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "227863": {
+      "url": "https://www.stthom.edu/Public/getFile.asp?File_Content_ID=127511",
+      "access": "unknown"
+    },
+    "228343": {
+      "url": "https://www.southwestern.edu/institutional-research/the-common-data-set/",
+      "access": "unknown"
+    },
+    "228778": {
+      "url": "https://reports.utexas.edu/common-data-set",
+      "access": "unknown"
+    },
+    "228796": {
+      "url": "https://www.utep.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "228875": {
+      "url": "https://ir.tcu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "229027": {
+      "url": "https://www.utsa.edu/ir/content/resources/commonDataSet.html",
+      "access": "unknown"
+    },
+    "229160": {
+      "url": "https://txwes.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "229407": {
+      "url": "https://uh.edu/ir/reports/common-data-sets/",
+      "access": "unknown"
+    },
+    "230038": {
+      "url": "https://data.byu.edu/common-data-set",
+      "access": "unknown"
+    },
+    "230171": {
+      "url": "https://ir.utahtech.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "230807": {
+      "url": "https://westminstercollege.edu/about/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "230852": {
+      "url": "https://www.champlain.edu/office/institutional-research-assessment/data-analytics/data-reporting/",
+      "access": "unknown"
+    },
+    "230995": {
+      "url": "https://www.norwich.edu/offices/institutional-effectiveness/common-data-sets",
+      "access": "unknown"
+    },
+    "231174": {
+      "url": "https://uvm.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "231581": {
+      "url": "https://www.bridgewater.edu/about-us/bridgewater-facts/",
+      "access": "unknown"
+    },
+    "231624": {
+      "url": "https://www.wm.edu/offices/ir/university_data/cds/",
+      "access": "unknown"
+    },
+    "231970": {
+      "url": "https://evms.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "232089": {
+      "url": "https://www.ferrum.edu/purpose-of-the-ire/",
+      "access": "unknown"
+    },
+    "232256": {
+      "url": "https://www.hsc.edu/institutional-effectiveness/factbook",
+      "access": "unknown"
+    },
+    "232308": {
+      "url": "https://registrar.press.hollins.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "232423": {
+      "url": "https://www.jmu.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "232566": {
+      "url": "https://www.longwood.edu/universityanalytics/common-data-set/",
+      "access": "unknown"
+    },
+    "232982": {
+      "url": "https://odu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "233277": {
+      "url": "https://radford.edu/institutional-research/common-data-set.html",
+      "access": "unknown"
+    },
+    "233541": {
+      "url": "https://www.su.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "233718": {
+      "url": "https://sbc.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "233921": {
+      "url": "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+      "access": "request"
+    },
+    "234207": {
+      "url": "https://my.wlu.edu/document/2024-common-data-set",
+      "access": "unknown"
+    },
+    "235097": {
+      "url": "https://sites.ewu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "235167": {
+      "url": "https://www.evergreen.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "235316": {
+      "url": "https://www.gonzaga.edu/-/media/Website/Documents/About/Offices-and-Services/Institutional-Research/Gonzaga-University-CDS_2021-2022.ashx",
+      "access": "unknown"
+    },
+    "236230": {
+      "url": "https://plu.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "236452": {
+      "url": "https://www.stmartin.edu/documents/cds-2017-2018",
+      "access": "unknown"
+    },
+    "236896": {
+      "url": "https://www.wallawalla.edu/resources/institutional-research/institutional-reports/common-data-set",
+      "access": "unknown"
+    },
+    "236948": {
+      "url": "https://www.washington.edu/opb/uw-data/external-reporting/common-data-set/",
+      "access": "unknown"
+    },
+    "237011": {
+      "url": "https://oie.wwu.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "237057": {
+      "url": "https://whitman.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "237215": {
+      "url": "https://bluefieldstate.edu/institutional-research/research-data/",
+      "access": "unknown"
+    },
+    "237792": {
+      "url": "https://shepherd.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "237932": {
+      "url": "https://westliberty.edu/university-effectiveness/common-data-set/",
+      "access": "unknown"
+    },
+    "238333": {
+      "url": "https://www.beloit.edu/offices/institutional-research-assessment-planning/key-metrics/",
+      "access": "unknown"
+    },
+    "238476": {
+      "url": "https://www.carthage.edu/about/offices-services/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "239318": {
+      "url": "https://www.msoe.edu/about-msoe/who-we-are/consumer-information-and-policies/",
+      "access": "unknown"
+    },
+    "239512": {
+      "url": "https://northland.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "239716": {
+      "url": "https://www.snc.edu/oie/cds.html",
+      "access": "unknown"
+    },
+    "240107": {
+      "url": "https://www.viterbo.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "240268": {
+      "url": "https://uwec.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "240329": {
+      "url": "https://www.uwlax.edu/institutional-research/common-data-set/",
+      "access": "unknown"
+    },
+    "240365": {
+      "url": "https://uwosh.edu/oir/common-data-set/",
+      "access": "unknown"
+    },
+    "240426": {
+      "url": "https://uwsuper.edu/academics/research-and-innovation/institutional-research/",
+      "access": "unknown"
+    },
+    "240444": {
+      "url": "https://data.wisc.edu/common-data-set-and-rankings/",
+      "access": "unknown"
+    },
+    "243744": {
+      "url": "https://irds.stanford.edu/data-findings/cds",
+      "access": "unknown"
+    },
+    "366711": {
+      "url": "https://www.csusm.edu/ipa/campus-data/common-data-set.html",
+      "access": "unknown"
+    },
+    "377564": {
+      "url": "https://www.tacoma.uw.edu/ir",
+      "access": "unknown"
+    },
+    "399911": {
+      "url": "https://www.soka.edu/about/institutional-research-assessment/common-data-set",
+      "access": "unknown"
+    },
+    "409698": {
+      "url": "https://csumb.edu/iar/common-data-set/",
+      "access": "unknown"
+    },
+    "428453": {
+      "url": "https://servicedesk.minnstate.edu/TDClient/30/Portal/KB/ArticleDet?ID=301",
+      "access": "unknown"
+    },
+    "447689": {
+      "url": "https://www.ggc.edu/common-data-set/",
+      "access": "unknown"
+    },
+    "456542": {
+      "url": "https://www.geisinger.edu/gchs/education/departments/division-education-administration/office-institutional-compliance-accreditation/common-data-set",
+      "access": "unknown"
+    },
+    "459949": {
+      "url": "https://www.tamusa.edu/office-institutional-research/index.html",
+      "access": "unknown"
+    },
+    "482680": {
+      "url": "https://ung.edu/institutional-effectiveness-research-administration/institutional-research/common-data-set.php",
+      "access": "unknown"
+    },
+    "482705": {
+      "url": "https://uds.northeastern.edu/facts/common-data-set/",
+      "access": "unknown"
+    },
+    "483036": {
+      "url": "https://www.tamuct.edu/Institutional%20Research%20and%20Assessment/common-data-set.html",
+      "access": "unknown"
+    },
+    "486840": {
+      "url": "https://www.kennesaw.edu/data-strategy/institutional-research/publications/common-data-set/",
+      "access": "unknown"
+    },
+    "488785": {
+      "url": "https://www.usk.edu/resources/common-data-set-2022-2023/",
+      "access": "unknown"
+    },
+    "490805": {
+      "url": "https://www.pnw.edu/finding-truth-in-the-numbers/",
+      "access": "unknown"
+    },
+    "498562": {
+      "url": "https://www.commonwealthu.edu/documents/bu-cds-2022-2023",
+      "access": "unknown"
+    }
+  }
+}

--- a/web/src/lib/about-source-pages.test.ts
+++ b/web/src/lib/about-source-pages.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { metadata as aboutMetadata } from "../app/about/page";
+import { metadata as cdsMetadata } from "../app/about/common-data-set/page";
+import { metadata as scorecardMetadata } from "../app/about/college-scorecard/page";
+import { metadata as ipedsMetadata } from "../app/about/ipeds/page";
+
+describe("About source-story metadata", () => {
+  it("gives each source page a unique title and /about canonical", () => {
+    const pages = [cdsMetadata, scorecardMetadata, ipedsMetadata];
+    const titles = new Set(pages.map((page) => page.title));
+    const canonicals = pages.map((page) => page.alternates?.canonical);
+    expect(titles.size).toBe(3);
+    expect(canonicals).toEqual([
+      "/about/common-data-set",
+      "/about/college-scorecard",
+      "/about/ipeds",
+    ]);
+    expect(aboutMetadata.alternates?.canonical).toBe("/about");
+    expect(canonicals).not.toContain("/methodology/common-data-set");
+  });
+});

--- a/web/src/lib/apex-redirect.test.ts
+++ b/web/src/lib/apex-redirect.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { APEX_TO_WWW_REDIRECTS, CANONICAL_ORIGIN } from "./apex-redirect";
+
+describe("apex → www redirects", () => {
+  it("issues a permanent 301 to the www host", () => {
+    expect(APEX_TO_WWW_REDIRECTS.length).toBeGreaterThan(0);
+    for (const redirect of APEX_TO_WWW_REDIRECTS) {
+      expect(redirect.statusCode).toBe(301);
+      expect(redirect.destination.startsWith(CANONICAL_ORIGIN)).toBe(true);
+      expect(redirect.has).toEqual([
+        { type: "host", value: "collegedata.fyi" },
+      ]);
+    }
+  });
+});

--- a/web/src/lib/apex-redirect.ts
+++ b/web/src/lib/apex-redirect.ts
@@ -1,0 +1,18 @@
+export const APEX_HOST = "collegedata.fyi";
+export const CANONICAL_ORIGIN = "https://www.collegedata.fyi";
+
+/** Apex → www must be a 301. Next.js `permanent: true` would emit 308. */
+export const APEX_TO_WWW_REDIRECTS = [
+  {
+    source: "/",
+    has: [{ type: "host" as const, value: APEX_HOST }],
+    destination: `${CANONICAL_ORIGIN}/`,
+    statusCode: 301,
+  },
+  {
+    source: "/:path*",
+    has: [{ type: "host" as const, value: APEX_HOST }],
+    destination: `${CANONICAL_ORIGIN}/:path*`,
+    statusCode: 301,
+  },
+];

--- a/web/src/lib/archive-lead.test.ts
+++ b/web/src/lib/archive-lead.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  archiveLead,
+  leadContainsBannedCopy,
+  leadPlainText,
+  yearArchiveLead,
+} from "./archive-lead";
+
+const vtDocs = [
+  { canonical_year: "2011-12", source_format: "pdf_flat", extraction_status: "extracted" },
+  { canonical_year: "2024-25", source_format: "xlsx", extraction_status: "extracted" },
+  { canonical_year: "2025-26", source_format: "xlsx", extraction_status: "extracted" },
+];
+
+const hmcDocs = Array.from({ length: 16 }, (_, i) => {
+  const start = 2010 + i;
+  return {
+    canonical_year: `${start}-${String((start + 1) % 100).padStart(2, "0")}`,
+    source_format: i === 15 ? "pdf_fillable" : "pdf_flat",
+    extraction_status: "extracted",
+  };
+});
+
+describe("archiveLead", () => {
+  it("snapshots Virginia Tech gated-official copy", () => {
+    const lead = archiveLead({
+      schoolId: "virginia-tech",
+      schoolName: "Virginia Tech",
+      ipedsId: "233921",
+      documents: vtDocs,
+    });
+    expect(leadPlainText(lead)).toMatchInlineSnapshot(
+      `"Virginia Tech Common Data Set archive, 2011–2025 (3 documents). This page archives 3 documents from 2011–2025. Latest extracted year is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own CDS page currently asks the public to request the file. This page is the archived source plus extract. What is a Common Data Set?"`,
+    );
+    expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
+  });
+
+  it("snapshots Harvey Mudd excellent-official copy", () => {
+    const lead = archiveLead({
+      schoolId: "harvey-mudd",
+      schoolName: "Harvey Mudd College",
+      ipedsId: "115409",
+      documents: hmcDocs,
+    });
+    expect(leadPlainText(lead)).toMatchInlineSnapshot(
+      `"Harvey Mudd College Common Data Set archive, 2010–2025 (16 documents). This page archives 16 documents from 2010–2025. Latest extracted year is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own CDS page is the publisher; this page is the archive and extract. What is a Common Data Set?"`,
+    );
+    expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
+  });
+
+  it("snapshots a thin school without an official landing page", () => {
+    const lead = archiveLead({
+      schoolId: "thin-college",
+      schoolName: "Thin College",
+      documents: [
+        {
+          canonical_year: "2023-24",
+          source_format: "pdf_scanned",
+          extraction_status: "extracted",
+        },
+      ],
+    });
+    expect(leadPlainText(lead)).toMatchInlineSnapshot(
+      `"Thin College Common Data Set archive, 2023-24 (1 document). This page archives 1 document from 2023-24. Latest extracted year is 2023-24. Downloads include PDF, XLSX, and CSV. What is a Common Data Set?"`,
+    );
+  });
+
+  it("does not claim an archive for directory-only schools", () => {
+    expect(
+      archiveLead({
+        schoolId: "directory-only",
+        schoolName: "Directory College",
+        directoryOnly: true,
+        documents: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("year-page lead names the school, year, and source file", () => {
+    const lead = yearArchiveLead({
+      schoolId: "virginia-tech",
+      schoolName: "Virginia Tech",
+      year: "2025-26",
+      ipedsId: "233921",
+      hasExtract: true,
+      sourceDownloadHref: "https://example.invalid/vt.xlsx",
+    });
+    expect(lead.heading).toBe("Virginia Tech Common Data Set 2025-26");
+    expect(leadPlainText(lead)).toContain("archived source file");
+    expect(leadPlainText(lead)).toContain("extracted field tables");
+    expect(leadPlainText(lead)).toContain("school's own CDS page");
+    expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
+  });
+});

--- a/web/src/lib/archive-lead.ts
+++ b/web/src/lib/archive-lead.ts
@@ -1,0 +1,244 @@
+import { yearRange } from "./format";
+import {
+  getOfficialCdsPage,
+  type OfficialCdsPage,
+} from "./official-cds-page";
+
+export type ArchiveDocumentFacts = {
+  canonical_year: string | null;
+  source_format: string | null;
+  extraction_status: string | null;
+};
+
+export type ArchiveLeadFacts = {
+  schoolId: string;
+  schoolName: string;
+  ipedsId?: string | null;
+  documents: ArchiveDocumentFacts[];
+  directoryOnly?: boolean;
+};
+
+export type YearArchiveLeadFacts = {
+  schoolId: string;
+  schoolName: string;
+  year: string;
+  ipedsId?: string | null;
+  hasExtract?: boolean;
+  sourceDownloadHref?: string | null;
+};
+
+export type LeadPart =
+  | { type: "text"; text: string }
+  | { type: "link"; href: string; text: string; external?: boolean };
+
+export type ArchiveLead = {
+  heading: string;
+  paragraphs: LeadPart[][];
+};
+
+const FORMAT_LABELS: Record<string, string> = {
+  pdf: "PDF",
+  pdf_fillable: "PDF",
+  pdf_flat: "PDF",
+  pdf_scanned: "PDF",
+  xlsx: "XLSX",
+  xls: "XLSX",
+  docx: "DOCX",
+  doc: "DOCX",
+  html: "HTML",
+  htm: "HTML",
+  csv: "CSV",
+};
+
+const BANNED_LEAD_WORDS = [
+  "prestigious",
+  "elite",
+  "top stem",
+  "chance me",
+  "how to get in",
+];
+
+export function officialPageLabel(url: string): string {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "");
+    return `${host} CDS page`;
+  } catch {
+    return "school CDS page";
+  }
+}
+
+function uniqueYears(documents: ArchiveDocumentFacts[]): string[] {
+  return Array.from(
+    new Set(
+      documents
+        .map((doc) => doc.canonical_year)
+        .filter((year): year is string => Boolean(year)),
+    ),
+  ).sort();
+}
+
+function extractedYears(documents: ArchiveDocumentFacts[]): string[] {
+  return uniqueYears(
+    documents.filter((doc) => doc.extraction_status === "extracted"),
+  );
+}
+
+function formatLabels(documents: ArchiveDocumentFacts[]): string[] {
+  const labels = new Set<string>();
+  for (const doc of documents) {
+    const format = doc.source_format?.toLowerCase() ?? "";
+    const label = FORMAT_LABELS[format];
+    if (label) labels.add(label);
+  }
+  if (documents.some((doc) => doc.extraction_status === "extracted")) {
+    labels.add("XLSX");
+    labels.add("CSV");
+  }
+  const order = ["PDF", "XLSX", "CSV", "DOCX", "HTML"];
+  return order.filter((label) => labels.has(label));
+}
+
+function joinList(items: string[]): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function officialSource(
+  schoolId: string,
+  ipedsId?: string | null,
+): OfficialCdsPage | null {
+  return getOfficialCdsPage(schoolId, ipedsId);
+}
+
+export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
+  if (facts.directoryOnly) return null;
+  if (facts.documents.length === 0) return null;
+
+  const years = uniqueYears(facts.documents);
+  const extracted = extractedYears(facts.documents);
+  const range = years.length > 0 ? yearRange(years[0], years[years.length - 1]) : null;
+  const count = facts.documents.length;
+  const countLabel = `${count} document${count === 1 ? "" : "s"}`;
+  const heading = range
+    ? `${facts.schoolName} Common Data Set archive, ${range} (${countLabel}).`
+    : `${facts.schoolName} Common Data Set archive (${countLabel}).`;
+
+  const paragraphs: LeadPart[][] = [];
+
+  const first: LeadPart[] = [
+    {
+      type: "text",
+      text: range
+        ? `This page archives ${countLabel} from ${range}.`
+        : `This page archives ${countLabel}.`,
+    },
+  ];
+  if (extracted.length > 0) {
+    first.push({
+      type: "text",
+      text: ` Latest extracted year is ${extracted[extracted.length - 1]}.`,
+    });
+  }
+  const formats = formatLabels(facts.documents);
+  if (formats.length > 0) {
+    first.push({
+      type: "text",
+      text: ` Downloads include ${joinList(formats)}.`,
+    });
+  }
+  paragraphs.push(first);
+
+  const official = officialSource(facts.schoolId, facts.ipedsId);
+  if (official) {
+    const sourceLink: LeadPart = {
+      type: "link",
+      href: official.url,
+      text: "school's own CDS page",
+      external: true,
+    };
+    if (official.access === "request") {
+      paragraphs.push([
+        { type: "text", text: "The " },
+        sourceLink,
+        {
+          type: "text",
+          text: " currently asks the public to request the file. This page is the archived source plus extract.",
+        },
+      ]);
+    } else {
+      paragraphs.push([
+        { type: "text", text: "The " },
+        sourceLink,
+        { type: "text", text: " is the publisher; this page is the archive and extract." },
+      ]);
+    }
+  }
+
+  paragraphs.push([
+    { type: "text", text: "What is a " },
+    {
+      type: "link",
+      href: "/about/common-data-set",
+      text: "Common Data Set",
+    },
+    { type: "text", text: "?" },
+  ]);
+
+  return { heading, paragraphs };
+}
+
+export function yearArchiveLead(facts: YearArchiveLeadFacts): ArchiveLead {
+  const official = officialSource(facts.schoolId, facts.ipedsId);
+  const parts: LeadPart[] = [
+    {
+      type: "text",
+      text: `This is the archived source file for ${facts.schoolName} Common Data Set ${facts.year}`,
+    },
+  ];
+  if (facts.hasExtract) {
+    parts.push({ type: "text", text: " plus the extracted field tables" });
+  }
+  parts.push({ type: "text", text: "." });
+
+  if (facts.sourceDownloadHref) {
+    parts.push({ type: "text", text: " " });
+    parts.push({
+      type: "link",
+      href: facts.sourceDownloadHref,
+      text: "Download the source",
+      external: true,
+    });
+    parts.push({ type: "text", text: "." });
+  }
+
+  if (official) {
+    parts.push({ type: "text", text: " See the " });
+    parts.push({
+      type: "link",
+      href: official.url,
+      text: "school's own CDS page",
+      external: true,
+    });
+    parts.push({ type: "text", text: "." });
+  }
+
+  return {
+    heading: `${facts.schoolName} Common Data Set ${facts.year}`,
+    paragraphs: [parts],
+  };
+}
+
+export function leadPlainText(lead: ArchiveLead | null): string {
+  if (!lead) return "";
+  const paragraphs = lead.paragraphs
+    .map((parts) => parts.map((part) => part.text).join(""))
+    .join(" ");
+  return `${lead.heading} ${paragraphs}`.replace(/\s+/g, " ").trim();
+}
+
+export function leadContainsBannedCopy(text: string): boolean {
+  const lower = text.toLowerCase();
+  return BANNED_LEAD_WORDS.some((word) => lower.includes(word));
+}

--- a/web/src/lib/official-cds-page.test.ts
+++ b/web/src/lib/official-cds-page.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getOfficialCdsPage } from "./official-cds-page";
+
+describe("getOfficialCdsPage", () => {
+  it("uses the curated Virginia Tech HTML gate, not the DAM PDF seed", () => {
+    const page = getOfficialCdsPage("virginia-tech", "233921");
+    expect(page?.access).toBe("request");
+    expect(page?.url).toBe(
+      "https://aie.vt.edu/analytics-and-ai/common-data-set.html",
+    );
+    expect(page?.url.toLowerCase().endsWith(".pdf")).toBe(false);
+  });
+
+  it("points Harvey Mudd at the live IR listing", () => {
+    const page = getOfficialCdsPage("harvey-mudd", "115409");
+    expect(page?.access).toBe("public");
+    expect(page?.url).toContain("institutional-statistics/common-data-set");
+  });
+
+  it("returns null when no HTML landing page is known", () => {
+    expect(getOfficialCdsPage("no-such-school")).toBeNull();
+  });
+});

--- a/web/src/lib/official-cds-page.ts
+++ b/web/src/lib/official-cds-page.ts
@@ -1,0 +1,32 @@
+import officialPages from "@/data/official-cds-pages.json";
+
+export type OfficialCdsAccess = "request" | "public" | "unknown";
+
+export type OfficialCdsPage = {
+  url: string;
+  access: OfficialCdsAccess;
+};
+
+type OfficialCdsPagesFile = {
+  bySchoolId: Record<string, OfficialCdsPage>;
+  byIpedsId: Record<string, OfficialCdsPage>;
+};
+
+const pages = officialPages as OfficialCdsPagesFile;
+
+function isHttpUrl(url: string): boolean {
+  return url.startsWith("https://") || url.startsWith("http://");
+}
+
+export function getOfficialCdsPage(
+  schoolId: string,
+  ipedsId?: string | null,
+): OfficialCdsPage | null {
+  const bySchool = pages.bySchoolId[schoolId];
+  if (bySchool?.url && isHttpUrl(bySchool.url)) return bySchool;
+  if (ipedsId) {
+    const byIpeds = pages.byIpedsId[ipedsId];
+    if (byIpeds?.url && isHttpUrl(byIpeds.url)) return byIpeds;
+  }
+  return null;
+}

--- a/web/src/lib/sitemap-static.test.ts
+++ b/web/src/lib/sitemap-static.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { SITEMAP_STATIC_PATHS, SITE_URL, staticSitemapEntries } from "./sitemap-static";
+
+describe("static sitemap entries", () => {
+  it("includes browse, public recipes, and the About source pages", () => {
+    expect(SITEMAP_STATIC_PATHS).toContain("/browse");
+    expect(SITEMAP_STATIC_PATHS).toContain("/recipes/waitlist-odds");
+    expect(SITEMAP_STATIC_PATHS).toContain("/recipes/endowment-draw-rate");
+    expect(SITEMAP_STATIC_PATHS).toContain("/about/common-data-set");
+    expect(SITEMAP_STATIC_PATHS).toContain("/about/college-scorecard");
+    expect(SITEMAP_STATIC_PATHS).toContain("/about/ipeds");
+    expect(SITEMAP_STATIC_PATHS).not.toContain("/methodology/common-data-set");
+    expect(SITEMAP_STATIC_PATHS).not.toContain("/discover");
+  });
+
+  it("emits www canonical URLs", () => {
+    const urls = staticSitemapEntries().map((entry) => entry.url);
+    expect(urls[0]).toBe(SITE_URL);
+    expect(urls).toContain(`${SITE_URL}/browse`);
+    expect(urls).toContain(`${SITE_URL}/about/common-data-set`);
+  });
+});

--- a/web/src/lib/sitemap-static.ts
+++ b/web/src/lib/sitemap-static.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from "next";
+
+export const SITE_URL = "https://www.collegedata.fyi";
+
+type StaticEntry = {
+  path: string;
+  changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+  priority: number;
+};
+
+const STATIC_PAGES: StaticEntry[] = [
+  { path: "/", changeFrequency: "daily", priority: 1 },
+  { path: "/schools", changeFrequency: "daily", priority: 0.9 },
+  { path: "/browse", changeFrequency: "daily", priority: 0.7 },
+  { path: "/match", changeFrequency: "daily", priority: 0.8 },
+  { path: "/coverage", changeFrequency: "daily", priority: 0.7 },
+  { path: "/about", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/about/common-data-set", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/about/college-scorecard", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/about/ipeds", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/api", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/privacy", changeFrequency: "yearly", priority: 0.4 },
+  { path: "/methodology", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/methodology/positioning", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/methodology/admission-strategy", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/methodology/merit-profile", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/recipes", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/recipes/acceptance-vs-yield", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/recipes/test-optional-tracker", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/recipes/waitlist-odds", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/recipes/endowment-draw-rate", changeFrequency: "monthly", priority: 0.5 },
+];
+
+export const SITEMAP_STATIC_PATHS = STATIC_PAGES.map((page) => page.path);
+
+export function staticSitemapEntries(): MetadataRoute.Sitemap {
+  return STATIC_PAGES.map((page) => ({
+    url: page.path === "/" ? SITE_URL : `${SITE_URL}${page.path}`,
+    changeFrequency: page.changeFrequency,
+    priority: page.priority,
+  }));
+}


### PR DESCRIPTION
## Summary
- Ship PRD 028 M0–M2: path-specific canonicals, 301 apex→www, sitemap gaps, data-generated Common Data Set archive leads, and three `/about` source pages.
- Record the August 2026 Search Console CDS-query export next to the PRD. Virginia Tech is still ~77% of CDS clicks; Haverford is the second converting school. An indexed `.edu` PDF is not a usable session — cite the official file, still ship the HTML archive, prior years, and comparison.
- GSC URL inspect is green on the Virginia Tech and Harvey Mudd hub and 2025-26 canaries. M3 (Show HN / citations) stays off-page.

## Test plan
- [ ] Confirm `curl -I https://collegedata.fyi/schools/virginia-tech` is still 301 to www.
- [ ] Open `/schools/virginia-tech` and `/schools/virginia-tech/2025-26`: H1 stays the school name; lead/H2 mentions Common Data Set; official link is the gated IR page with request copy.
- [ ] Open a school whose yaml seed is a PDF (e.g. Haverford): lead does not call that PDF “the school’s own CDS page.”
- [ ] Open `/about`, `/about/common-data-set`, `/about/college-scorecard`, `/about/ipeds`; check footer and `/llms.txt` links.
- [ ] Confirm sitemap includes `/browse`, waitlist-odds, endowment-draw-rate, and the three About URLs.
- [ ] Frontend tests and typecheck stay green.


Made with [Cursor](https://cursor.com)