### PR TITLE
fix: pin school-page smoke locators to the H1

### DIFF
--- a/web/tests/school-alias-redirect.spec.ts
+++ b/web/tests/school-alias-redirect.spec.ts
@@ -14,7 +14,7 @@ test.describe("retired school aliases", () => {
     expect(url.searchParams.get("tab")).toBe("sources");
     expect(url.searchParams.getAll("compare")).toEqual(["cost", "aid"]);
     await expect(
-      page.getByRole("heading", { name: /Tufts University/i }),
+      page.getByRole("heading", { name: "Tufts University", exact: true, level: 1 }),
     ).toBeVisible();
   });
 
@@ -28,7 +28,7 @@ test.describe("retired school aliases", () => {
     expect(url.pathname).toBe("/schools/tufts/2024-25");
     expect(url.searchParams.get("download")).toBe("1");
     await expect(
-      page.getByRole("heading", { name: /Tufts University/i }),
+      page.getByRole("heading", { name: "Tufts University", exact: true, level: 1 }),
     ).toBeVisible();
   });
 

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -24,7 +24,7 @@ test("homepage search opens an institution page", async ({ page }) => {
 
   await expect(page).toHaveURL(/\/schools\/rice/);
   await expect(
-    page.getByRole("heading", { name: /Rice University/i }),
+    page.getByRole("heading", { name: "Rice University", exact: true, level: 1 }),
   ).toBeVisible();
 });
 
@@ -76,7 +76,7 @@ test("facts endpoint returns flat JSON", async ({ request }) => {
 test("school-year page renders reconstructed CDS tables", async ({ page }) => {
   await page.goto("/schools/bowdoin/2024-25");
   await expect(
-    page.getByRole("heading", { name: /Bowdoin College/i }),
+    page.getByRole("heading", { name: "Bowdoin College", exact: true, level: 1 }),
   ).toBeVisible();
 
   const b1 = page.getByRole("table", { name: /B1 undergraduate enrollment/i });


### PR DESCRIPTION
## Summary
- PR #125 made school hubs and year pages render an H2 archive lead that also contains the school name.
- Playwright smoke tests were matching both the H1 and that H2, so Next.js CI on main is red.
- Pin Rice, Bowdoin, and Tufts heading assertions to the exact level-1 heading.

## Test plan
- [ ] GitHub Actions `Next.js build` (Playwright smoke) is green on this PR.
- [ ] Confirm the remaining CI jobs (Python unit tests, migrations, Supabase functions) stay green.


Made with [Cursor](https://cursor.com)