### PR TITLE
fix: make About story figures valid UTF-8 SVG

### DIFF
--- a/web/public/about/college-scorecard-source-join.svg
+++ b/web/public/about/college-scorecard-source-join.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
   <rect width="920" height="300" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCORECARD JOIN · NOT A GUIDEBOOK SURVEY</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCORECARD JOIN Â· NOT A GUIDEBOOK SURVEY</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Five administrative systems</text>
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">
     <rect x="44" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>

--- a/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
@@ -1,15 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 400" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 400" role="img">
   <rect width="920" height="400" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="352" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SAME FILE � DOCLING ON A FILLABLE PDF � NOT THE LIVE EXTRACT</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SAME FILE · DOCLING ON A FILLABLE PDF · NOT THE LIVE EXTRACT</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">C1 row-shift after flattening</text>
-  <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Ground truth from AcroForm: men 3,452 � women 1,761 � another/unknown 4.</text>
+  <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Ground truth from AcroForm: men 3,452 · women 1,761 · another/unknown 4.</text>
   <rect x="44" y="140" width="832" height="120" fill="#fff" stroke="rgba(140,42,31,.45)"/>
   <text x="56" y="168" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#8c2a1f">Docling cell collapse</text>
   <text x="56" y="196" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year men who applied     | 3452 1761</text>
   <text x="56" y="220" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year women who applied   | 4</text>
   <text x="56" y="244" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year unknown who applied |</text>
-  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Kerned year numerals in the same extract: Common Data Set 202 5 -202 6, Fall 201 8 Cohort.</text>
-  <text x="44" y="320" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Running header emitted as an H2 five times: Common Data Set 2025-2026.</text>
+  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Kerned year numerals in the same extract: “Common Data Set 202 5 -202 6”, “Fall 201 8 Cohort”.</text>
+  <text x="44" y="320" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Running header emitted as an H2 five times: “Common Data Set 2025-2026”.</text>
   <text x="44" y="352" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live Harvey Mudd 2025-26 extract is the AcroForm path, not this Docling output.</text>
 </svg>

--- a/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 420" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="420" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 420" role="img">
   <rect width="920" height="420" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="372" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">HARVEY MUDD COLLEGE · CDS 2025-26 · FILLABLE ACROFORM · §C1</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">HARVEY MUDD COLLEGE Â· CDS 2025-26 Â· FILLABLE ACROFORM Â· Â§C1</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="28" fill="#1c1e1b">C1. Applicants, admits, enrolled</text>
   <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Named fields from the unflattened template. Values are the field contents, not OCR.</text>
   <g font-family="ui-monospace, Menlo, monospace" font-size="13">

--- a/web/public/about/harvey-mudd-2025-26-page-header.svg
+++ b/web/public/about/harvey-mudd-2025-26-page-header.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
   <rect width="920" height="300" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="52" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">PAGE HEADER REPEATED · NOT A DATABASE</text>
+  <text x="44" y="52" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">PAGE HEADER REPEATED Â· NOT A DATABASE</text>
   <text x="44" y="88" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
   <text x="44" y="118" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
   <text x="44" y="148" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>

--- a/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
+++ b/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
   <rect width="920" height="340" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCHOOL PAGE PAIRING � HARVEY MUDD</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCHOOL PAGE PAIRING · HARVEY MUDD</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">CDS year is not Scorecard vintage</text>
   <rect x="44" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.28)"/>
   <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#3f5b3a">ARCHIVED CDS</text>
@@ -11,5 +12,5 @@
   <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">COLLEGE SCORECARD</text>
   <text x="484" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Federal vintage</text>
   <text x="484" y="216" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Outcomes reflect earlier cohorts than the CDS year shown on the same page.</text>
-  <text x="44" y="308" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live note: Outcomes reflect earlier cohorts than the CDS year shown elsewhere on this page.</text>
+  <text x="44" y="308" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live note: “Outcomes reflect earlier cohorts than the CDS year shown elsewhere on this page.”</text>
 </svg>

--- a/web/public/about/ipeds-survey-components.svg
+++ b/web/public/about/ipeds-survey-components.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="280" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
   <rect width="920" height="280" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">IPEDS SURVEY COMPONENTS · NOT ONE FILE</text>
-  <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">HD · IC · ADM · EF · GR · SFA · F</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">IPEDS SURVEY COMPONENTS Â· NOT ONE FILE</text>
+  <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">HD Â· IC Â· ADM Â· EF Â· GR Â· SFA Â· F</text>
   <text x="44" y="136" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">Recent releases arrive as a stack of tables inside a Microsoft Access database, with dictionaries. Provisional first, then final with institutional revisions.</text>
   <text x="44" y="196" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">UNITID is the join key this site actually uses.</text>
   <text x="44" y="228" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official system of record: nces.ed.gov/ipeds</text>

--- a/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
+++ b/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="280" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
   <rect width="920" height="280" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">COVERAGE · TITLE IV MANDATE VS VOLUNTARY PDF</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">COVERAGE Â· TITLE IV MANDATE VS VOLUNTARY PDF</text>
   <text x="44" y="96" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">A school with no public CDS still has a Scorecard row</text>
   <text x="44" y="140" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">College Scorecard covers Title IV institutions because IPEDS reporting is mandatory. The Common Data Set is a voluntary guidebook template. That is why the directory stub exists: federal baseline facts without pretending a CDS was published.</text>
   <text x="44" y="210" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Harvey Mudd and Virginia Tech both publish a CDS. The coverage gap is everyone else.</text>

--- a/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
+++ b/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="360" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
   <rect width="920" height="360" fill="#faf6ec"/>
   <rect x="24" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="40" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">VIRGINIA TECH ∑ 2025-26 ∑ XLSX</text>
+  <text x="40" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">VIRGINIA TECH ¬∑ 2025-26 ¬∑ XLSX</text>
   <text x="40" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Answer Sheet tab</text>
   <text x="40" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.116  Applied (total)</text>
   <text x="300" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">57,755</text>
@@ -9,8 +10,8 @@
   <text x="40" y="176" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.118  Enrolled</text>
   <text x="40" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">Machine-readable by construction. The school still does not index this file on a public HTML landing page.</text>
   <rect x="476" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="492" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">AIE.VT.EDU ∑ SAME SCHOOL</text>
+  <text x="492" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">AIE.VT.EDU ¬∑ SAME SCHOOL</text>
   <text x="492" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Email to request</text>
-  <text x="492" y="130" font-family="Georgia, serif" font-size="15" font-style="italic" fill="#1c1e1b">Current and historical CDS files for Virginia Tech are available via request to aiesupport@vt.edu.</text>
+  <text x="492" y="130" font-family="Georgia, serif" font-size="15" font-style="italic" fill="#1c1e1b">‚ÄúCurrent and historical CDS files for Virginia Tech are available via request to aiesupport@vt.edu.‚Äù</text>
   <text x="492" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">The official result explains the form, then withholds the file. The archive page is the public HTML that hands over the extract.</text>
 </svg>

--- a/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
+++ b/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
@@ -1,14 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
   <rect width="920" height="300" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">ONE SCHOOL PAGE · TWO SOURCE LAYERS</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">ONE SCHOOL PAGE Â· TWO SOURCE LAYERS</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">How to tell CDS from IPEDS</text>
   <rect x="44" y="120" width="400" height="120" fill="#fff" stroke="#3f5b3a" stroke-width="2"/>
-  <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#3f5b3a">CIRCLED · CDS</text>
+  <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#3f5b3a">CIRCLED Â· CDS</text>
   <text x="60" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">School-authored PDF / XLSX</text>
   <text x="60" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Year page extract, field IDs C.101 / H.2A</text>
   <rect x="468" y="120" width="400" height="120" fill="#fff" stroke="rgba(28,30,27,.45)" stroke-width="2"/>
-  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#6b6a63">CIRCLED · IPEDS</text>
+  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#6b6a63">CIRCLED Â· IPEDS</text>
   <text x="484" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">NCES survey table</text>
-  <text x="484" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">source_table.source_variable · provisional/final</text>
+  <text x="484" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">source_table.source_variable Â· provisional/final</text>
 </svg>

--- a/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
+++ b/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="920" height="360" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
   <rect width="920" height="360" fill="#faf6ec"/>
   <rect x="24" y="24" width="872" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">NCES/IPEDS BASELINE · SOURCE COLUMN VISIBLE</text>
+  <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">NCES/IPEDS BASELINE Â· SOURCE COLUMN VISIBLE</text>
   <text x="44" y="88" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Federal facts stay labeled</text>
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">
     <rect x="44" y="112" width="832" height="32" fill="#e9e3d4"/>

--- a/web/src/lib/about-source-pages.test.ts
+++ b/web/src/lib/about-source-pages.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { metadata as aboutMetadata } from "../app/about/page";
 import { metadata as cdsMetadata } from "../app/about/common-data-set/page";
@@ -17,5 +19,20 @@ describe("About source-story metadata", () => {
     ]);
     expect(aboutMetadata.alternates?.canonical).toBe("/about");
     expect(canonicals).not.toContain("/methodology/common-data-set");
+  });
+});
+
+describe("About story figures", () => {
+  it("checks in UTF-8 SVG that XML parsers can decode", () => {
+    const dir = join(process.cwd(), "public/about");
+    const files = readdirSync(dir).filter((name) => name.endsWith(".svg"));
+    expect(files.length).toBeGreaterThanOrEqual(10);
+    for (const name of files) {
+      const bytes = readFileSync(join(dir, name));
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      expect(text.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+      expect(text).toMatch(/<svg[^>]+xmlns="http:\/\/www.w3.org\/2000\/svg"/);
+      expect(text).not.toMatch(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- The About source pages already had figures in `web/public/about/`. They returned HTTP 200, but they were Latin-1 SVG with illegal XML control-character quotes, so the browser could not decode them and showed the alt-text boxes.
- Rewrite them as UTF-8 XML with an encoding declaration and width/height, and add a test so they stay parseable.

## Test plan
- [ ] Hard-refresh `/about/common-data-set` and confirm the Harvey Mudd C1, Docling-shift, and page-header figures paint instead of broken-image placeholders.
- [ ] Check `/about/college-scorecard` and `/about/ipeds` figures the same way.
- [ ] Frontend unit tests covering the SVG files stay green.


Made with [Cursor](https://cursor.com)