### PR TITLE
fix: wrap About figure copy so SVG text stays inside the panels

### DIFF
--- a/web/public/about/college-scorecard-source-join.svg
+++ b/web/public/about/college-scorecard-source-join.svg
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
-  <rect width="920" height="300" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+  <rect width="920" height="340" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCORECARD JOIN · NOT A GUIDEBOOK SURVEY</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Five administrative systems</text>
-  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">
-    <rect x="44" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-    <text x="56" y="154">IPEDS</text>
-    <rect x="210" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-    <text x="222" y="154">NSLDS</text>
-    <rect x="376" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-    <text x="388" y="154">Treasury/IRS</text>
-    <rect x="542" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-    <text x="554" y="154">FSA</text>
-    <rect x="708" y="120" width="150" height="56" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-    <text x="720" y="154">OPE / ACS</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b" text-anchor="middle">
+    <rect x="44" y="120" width="156" height="64" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="122" y="158">IPEDS</text>
+    <rect x="216" y="120" width="156" height="64" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="294" y="158">NSLDS</text>
+    <rect x="388" y="120" width="156" height="64" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="466" y="158">Treasury / IRS</text>
+    <rect x="560" y="120" width="156" height="64" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="638" y="158">FSA</text>
+    <rect x="732" y="120" width="144" height="64" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+    <text x="804" y="158">OPE / ACS</text>
   </g>
-  <text x="44" y="214" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Earnings, debt, and net price come from this join. They are not Section C or Section H of a school PDF.</text>
-  <text x="44" y="246" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official tool: collegescorecard.ed.gov. We cite it; we do not impersonate it.</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="44" y="220">Earnings, debt, and net price come from this join. They are not</tspan>
+    <tspan x="44" y="242">Section C or Section H of a school PDF.</tspan>
+  </text>
+  <text x="44" y="278" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official tool: collegescorecard.ed.gov. We cite it; we do not impersonate it.</text>
 </svg>

--- a/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-docling-shift.svg
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 400" role="img">
-  <rect width="920" height="400" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="352" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="460" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 460" role="img">
+  <rect width="920" height="460" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="412" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SAME FILE · DOCLING ON A FILLABLE PDF · NOT THE LIVE EXTRACT</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">C1 row-shift after flattening</text>
   <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Ground truth from AcroForm: men 3,452 · women 1,761 · another/unknown 4.</text>
   <rect x="44" y="140" width="832" height="120" fill="#fff" stroke="rgba(140,42,31,.45)"/>
   <text x="56" y="168" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#8c2a1f">Docling cell collapse</text>
-  <text x="56" y="196" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year men who applied     | 3452 1761</text>
-  <text x="56" y="220" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year women who applied   | 4</text>
-  <text x="56" y="244" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">Total first-time, first-year unknown who applied |</text>
-  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Kerned year numerals in the same extract: “Common Data Set 202 5 -202 6”, “Fall 201 8 Cohort”.</text>
-  <text x="44" y="320" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Running header emitted as an H2 five times: “Common Data Set 2025-2026”.</text>
-  <text x="44" y="352" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live Harvey Mudd 2025-26 extract is the AcroForm path, not this Docling output.</text>
+  <text font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">
+    <tspan x="56" y="196">Total first-time, first-year men who applied     | 3452 1761</tspan>
+    <tspan x="56" y="220">Total first-time, first-year women who applied   | 4</tspan>
+    <tspan x="56" y="244">Total first-time, first-year unknown who applied |</tspan>
+  </text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="44" y="292">Kerned year numerals in the same extract: Common Data Set 202 5 -202 6,</tspan>
+    <tspan x="44" y="314">Fall 201 8 Cohort.</tspan>
+    <tspan x="44" y="342">Running header emitted as an H2 five times: Common Data Set 2025-2026.</tspan>
+    <tspan x="44" y="370">The live Harvey Mudd 2025-26 extract is the AcroForm path, not this</tspan>
+    <tspan x="44" y="392">Docling output.</tspan>
+  </text>
 </svg>

--- a/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
+++ b/web/public/about/harvey-mudd-2025-26-c1-fillable.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="420" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 420" role="img">
-  <rect width="920" height="420" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="372" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="440" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 440" role="img">
+  <rect width="920" height="440" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="392" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">HARVEY MUDD COLLEGE · CDS 2025-26 · FILLABLE ACROFORM · §C1</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="28" fill="#1c1e1b">C1. Applicants, admits, enrolled</text>
   <text x="44" y="118" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Named fields from the unflattened template. Values are the field contents, not OCR.</text>
@@ -23,6 +23,9 @@
     <text x="430" y="300" fill="#3a3b37">Offered a place on the wait list</text>
     <text x="780" y="300" fill="#1c1e1b">685</text>
   </g>
-  <rect x="44" y="328" width="832" height="44" fill="#27321f"/>
-  <text x="56" y="355" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#f1ece1">pypdf.get_fields() reads these tags directly. Docling is the wrong tool for this file.</text>
+  <rect x="44" y="328" width="832" height="64" fill="#27321f"/>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#f1ece1">
+    <tspan x="56" y="354">pypdf.get_fields() reads these tags directly.</tspan>
+    <tspan x="56" y="376">Docling is the wrong tool for this file.</tspan>
+  </text>
 </svg>

--- a/web/public/about/harvey-mudd-2025-26-page-header.svg
+++ b/web/public/about/harvey-mudd-2025-26-page-header.svg
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
-  <rect width="920" height="300" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="380" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 380" role="img">
+  <rect width="920" height="380" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="332" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="52" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">PAGE HEADER REPEATED · NOT A DATABASE</text>
-  <text x="44" y="88" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
-  <text x="44" y="118" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
-  <text x="44" y="148" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
-  <text x="44" y="178" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
-  <text x="44" y="208" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Common Data Set 2025-2026</text>
-  <text x="44" y="248" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Harvey Mudd 2025-26 fillable PDF. The running header is print chrome. Google can index the phrase; it is still a form, not a table.</text>
+  <text font-family="Georgia, serif" font-size="22" fill="#1c1e1b">
+    <tspan x="44" y="92">Common Data Set 2025-2026</tspan>
+    <tspan x="44" y="128">Common Data Set 2025-2026</tspan>
+    <tspan x="44" y="164">Common Data Set 2025-2026</tspan>
+    <tspan x="44" y="200">Common Data Set 2025-2026</tspan>
+    <tspan x="44" y="236">Common Data Set 2025-2026</tspan>
+  </text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="44" y="284">Harvey Mudd 2025-26 fillable PDF. The running header is print chrome.</tspan>
+    <tspan x="44" y="306">Google can index the phrase; it is still a form, not a table.</tspan>
+  </text>
 </svg>

--- a/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
+++ b/web/public/about/harvey-mudd-scorecard-vintage-lag.svg
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
-  <rect width="920" height="340" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="440" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 440" role="img">
+  <rect width="920" height="440" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="392" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">SCHOOL PAGE PAIRING · HARVEY MUDD</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="26" fill="#1c1e1b">CDS year is not Scorecard vintage</text>
-  <rect x="44" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+  <rect x="44" y="120" width="400" height="180" fill="#fff" stroke="rgba(28,30,27,.28)"/>
   <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#3f5b3a">ARCHIVED CDS</text>
   <text x="60" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">2025-26</text>
-  <text x="60" y="216" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Admissions card from the school-authored file.</text>
-  <rect x="468" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.28)"/>
-  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">COLLEGE SCORECARD</text>
-  <text x="484" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Federal vintage</text>
-  <text x="484" y="216" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Outcomes reflect earlier cohorts than the CDS year shown on the same page.</text>
-  <text x="44" y="308" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">The live note: “Outcomes reflect earlier cohorts than the CDS year shown elsewhere on this page.”</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="60" y="220">Admissions card from the</tspan>
+    <tspan x="60" y="242">school-authored file.</tspan>
+  </text>
+  <rect x="476" y="120" width="400" height="180" fill="#fff" stroke="rgba(28,30,27,.28)"/>
+  <text x="492" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1" fill="#6b6a63">COLLEGE SCORECARD</text>
+  <text x="492" y="184" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Federal vintage</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="492" y="220">Outcomes reflect earlier cohorts</tspan>
+    <tspan x="492" y="242">than the CDS year shown on the</tspan>
+    <tspan x="492" y="264">same page.</tspan>
+  </text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">
+    <tspan x="44" y="334">The live note: Outcomes reflect earlier cohorts than the CDS year</tspan>
+    <tspan x="44" y="356">shown elsewhere on this page.</tspan>
+  </text>
 </svg>

--- a/web/public/about/ipeds-survey-components.svg
+++ b/web/public/about/ipeds-survey-components.svg
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="280" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
-  <rect width="920" height="280" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+  <rect width="920" height="340" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">IPEDS SURVEY COMPONENTS · NOT ONE FILE</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">HD · IC · ADM · EF · GR · SFA · F</text>
-  <text x="44" y="136" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">Recent releases arrive as a stack of tables inside a Microsoft Access database, with dictionaries. Provisional first, then final with institutional revisions.</text>
-  <text x="44" y="196" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">UNITID is the join key this site actually uses.</text>
-  <text x="44" y="228" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official system of record: nces.ed.gov/ipeds</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">
+    <tspan x="44" y="136">Recent releases arrive as a stack of tables inside a Microsoft</tspan>
+    <tspan x="44" y="158">Access database, with dictionaries. Provisional first, then final</tspan>
+    <tspan x="44" y="180">with institutional revisions.</tspan>
+  </text>
+  <text x="44" y="224" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#1c1e1b">UNITID is the join key this site actually uses.</text>
+  <text x="44" y="256" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Official system of record: nces.ed.gov/ipeds</text>
 </svg>

--- a/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
+++ b/web/public/about/scorecard-title-iv-vs-cds-coverage.svg
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="280" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 280" role="img">
-  <rect width="920" height="280" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="232" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+  <rect width="920" height="340" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">COVERAGE · TITLE IV MANDATE VS VOLUNTARY PDF</text>
   <text x="44" y="96" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">A school with no public CDS still has a Scorecard row</text>
-  <text x="44" y="140" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">College Scorecard covers Title IV institutions because IPEDS reporting is mandatory. The Common Data Set is a voluntary guidebook template. That is why the directory stub exists: federal baseline facts without pretending a CDS was published.</text>
-  <text x="44" y="210" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Harvey Mudd and Virginia Tech both publish a CDS. The coverage gap is everyone else.</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#3a3b37">
+    <tspan x="44" y="140">College Scorecard covers Title IV institutions because IPEDS</tspan>
+    <tspan x="44" y="162">reporting is mandatory. The Common Data Set is a voluntary</tspan>
+    <tspan x="44" y="184">guidebook template. That is why the directory stub exists:</tspan>
+    <tspan x="44" y="206">federal baseline facts without pretending a CDS was published.</tspan>
+  </text>
+  <text x="44" y="250" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Harvey Mudd and Virginia Tech both publish a CDS. The coverage gap is everyone else.</text>
 </svg>

--- a/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
+++ b/web/public/about/virginia-tech-2025-26-xlsx-and-email-gate.svg
@@ -1,17 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="360" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
-  <rect width="920" height="360" fill="#faf6ec"/>
-  <rect x="24" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="40" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">VIRGINIA TECH · 2025-26 · XLSX</text>
-  <text x="40" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Answer Sheet tab</text>
-  <text x="40" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.116  Applied (total)</text>
-  <text x="300" y="120" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">57,755</text>
-  <text x="40" y="148" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.117  Admitted</text>
-  <text x="40" y="176" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">C.118  Enrolled</text>
-  <text x="40" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">Machine-readable by construction. The school still does not index this file on a public HTML landing page.</text>
-  <rect x="476" y="24" width="420" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
-  <text x="492" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">AIE.VT.EDU · SAME SCHOOL</text>
-  <text x="492" y="84" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Email to request</text>
-  <text x="492" y="130" font-family="Georgia, serif" font-size="15" font-style="italic" fill="#1c1e1b">“Current and historical CDS files for Virginia Tech are available via request to aiesupport@vt.edu.”</text>
-  <text x="492" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">The official result explains the form, then withholds the file. The archive page is the public HTML that hands over the extract.</text>
+<svg width="920" height="500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 500" role="img">
+  <rect width="920" height="500" fill="#faf6ec"/>
+  <rect x="24" y="24" width="420" height="452" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="44" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">VIRGINIA TECH · 2025-26 · XLSX</text>
+  <text x="44" y="88" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Answer Sheet tab</text>
+  <text font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">
+    <tspan x="44" y="128">C.116  Applied (total)</tspan>
+    <tspan x="300" y="128">57,755</tspan>
+    <tspan x="44" y="156">C.117  Admitted</tspan>
+    <tspan x="44" y="184">C.118  Enrolled</tspan>
+  </text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">
+    <tspan x="44" y="240">Machine-readable by construction.</tspan>
+    <tspan x="44" y="262">The school still does not index this</tspan>
+    <tspan x="44" y="284">file on a public HTML landing page.</tspan>
+  </text>
+  <rect x="476" y="24" width="420" height="452" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+  <text x="496" y="52" font-family="ui-monospace, Menlo, monospace" font-size="11" letter-spacing="1.2" fill="#6b6a63">AIE.VT.EDU · SAME SCHOOL</text>
+  <text x="496" y="88" font-family="Georgia, serif" font-size="22" fill="#1c1e1b">Email to request</text>
+  <text font-family="Georgia, serif" font-size="15" font-style="italic" fill="#1c1e1b">
+    <tspan x="496" y="132">Current and historical CDS files</tspan>
+    <tspan x="496" y="154">for Virginia Tech are available</tspan>
+    <tspan x="496" y="176">via request to aiesupport@vt.edu.</tspan>
+  </text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#3a3b37">
+    <tspan x="496" y="240">The official result explains the form,</tspan>
+    <tspan x="496" y="262">then withholds the file. The archive</tspan>
+    <tspan x="496" y="284">page is the public HTML that hands</tspan>
+    <tspan x="496" y="306">over the extract.</tspan>
+  </text>
 </svg>

--- a/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
+++ b/web/public/about/virginia-tech-cds-and-ipeds-source-labels.svg
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img">
-  <rect width="920" height="300" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="252" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="340" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 340" role="img">
+  <rect width="920" height="340" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="292" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">ONE SCHOOL PAGE · TWO SOURCE LAYERS</text>
   <text x="44" y="92" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">How to tell CDS from IPEDS</text>
-  <rect x="44" y="120" width="400" height="120" fill="#fff" stroke="#3f5b3a" stroke-width="2"/>
+  <rect x="44" y="120" width="400" height="160" fill="#fff" stroke="#3f5b3a" stroke-width="2"/>
   <text x="60" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#3f5b3a">CIRCLED · CDS</text>
   <text x="60" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">School-authored PDF / XLSX</text>
-  <text x="60" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Year page extract, field IDs C.101 / H.2A</text>
-  <rect x="468" y="120" width="400" height="120" fill="#fff" stroke="rgba(28,30,27,.45)" stroke-width="2"/>
-  <text x="484" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#6b6a63">CIRCLED · IPEDS</text>
-  <text x="484" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">NCES survey table</text>
-  <text x="484" y="206" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">source_table.source_variable · provisional/final</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="60" y="210">Year page extract, field IDs</tspan>
+    <tspan x="60" y="232">C.101 / H.2A</tspan>
+  </text>
+  <rect x="476" y="120" width="400" height="160" fill="#fff" stroke="rgba(28,30,27,.45)" stroke-width="2"/>
+  <text x="492" y="148" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#6b6a63">CIRCLED · IPEDS</text>
+  <text x="492" y="180" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#1c1e1b">NCES survey table</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="492" y="210">source_table.source_variable</tspan>
+    <tspan x="492" y="232">provisional / final</tspan>
+  </text>
 </svg>

--- a/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
+++ b/web/public/about/virginia-tech-ipeds-baseline-source-column.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="920" height="360" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 360" role="img">
-  <rect width="920" height="360" fill="#faf6ec"/>
-  <rect x="24" y="24" width="872" height="312" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
+<svg width="920" height="420" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 420" role="img">
+  <rect width="920" height="420" fill="#faf6ec"/>
+  <rect x="24" y="24" width="872" height="372" fill="#f1ece1" stroke="rgba(28,30,27,.28)"/>
   <text x="44" y="56" font-family="ui-monospace, Menlo, monospace" font-size="12" letter-spacing="1.2" fill="#6b6a63">NCES/IPEDS BASELINE · SOURCE COLUMN VISIBLE</text>
   <text x="44" y="88" font-family="Georgia, serif" font-size="24" fill="#1c1e1b">Federal facts stay labeled</text>
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="14">
@@ -19,6 +19,9 @@
     <text x="360" y="244" fill="#3a3b37">Direct</text>
     <text x="560" y="244" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#1c1e1b">HD.LOCALE</text>
   </g>
-  <text x="44" y="292" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">Worked example shape from the live federal baseline table. Captions on the school page show source_table, source_variable, and release type.</text>
-  <text x="44" y="318" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Do not read these as a substitute for the current-year CDS wait-list or H2A rows.</text>
+  <text font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#3a3b37">
+    <tspan x="44" y="292">Worked example shape from the live federal baseline table. Captions</tspan>
+    <tspan x="44" y="314">on the school page show source_table, source_variable, and release type.</tspan>
+  </text>
+  <text x="44" y="350" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#27321f">Do not read these as a substitute for the current-year CDS wait-list or H2A rows.</text>
 </svg>


### PR DESCRIPTION
## Summary
- Reviewed `/about/common-data-set`, `/about/college-scorecard`, and `/about/ipeds` in Chromium. SVG `<text>` does not wrap, so body copy ran through the panel borders (Virginia Tech XLSX/email-gate was the attached example; Scorecard coverage, vintage lag, IPEDS components, and the baseline footer did the same).
- Break those sentences onto explicit `tspan` lines and give the two-column cards enough height.

## Test plan
- [ ] Hard-refresh `/about/common-data-set` and confirm the Virginia Tech two-panel figure no longer clips “landing page” / the aiesupport quote.
- [ ] Check `/about/college-scorecard` coverage and vintage-lag figures.
- [ ] Check `/about/ipeds` survey-components and baseline-table figures.


Made with [Cursor](https://cursor.com)