### PR TITLE
docs: note the Show HN draft was posted with little traction

### DIFF
--- a/docs/blog/show-hn-draft.md
+++ b/docs/blog/show-hn-draft.md
@@ -1,8 +1,11 @@
 # Show HN draft
 
-> **Status:** Draft, not posted. Edit and post when ready. See ADR 0008 for
-> takedown protocol — having this live before the launch means the
-> response process exists if the post goes viral.
+> **Status:** Posted a few months back; minimal traction. Kept here as
+> reference for a possible repost with a genuinely updated pitch (real
+> traffic/ranking data, an outside contributor, a live MCP server — none
+> of which existed at the first posting). See ADR 0008 for takedown
+> protocol — having this live means the response process exists if a
+> future post goes viral.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the Show HN draft status from "not posted" to posted-with-minimal-traction, and keep the file as a reference for a possible later repost.

## Test plan
- [ ] Confirm `docs/blog/show-hn-draft.md` status note reads as already posted, not still waiting to launch.


Made with [Cursor](https://cursor.com)