### PR TITLE
feat: add R API examples and round recipe percents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses four-part semantic versioning.
 ### Changed
 
 - Replace the About page’s three-paragraph source gloss with a short hub that points at the longer CDS, Scorecard, and IPEDS notes.
+- Add R (`httr2`) copy-paste examples on `/api` and the acceptance-vs-yield recipe, and round recipe-page percents to whole numbers except below 10% and for endowment draw rates.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/docs/recipes/acceptance-vs-yield.md
+++ b/docs/recipes/acceptance-vs-yield.md
@@ -18,10 +18,10 @@ Eighteen points is enough to see the four quadrants resolve — but still only 2
 
 The plot divides roughly into four quadrants:
 
-- **Top-left — selective and desired.** Low acceptance, high yield. Harvard sits here: 3.65% accept rate and 83.60% yield. Schools in this quadrant are both hard to get into and hard to turn down, usually because their market position is strong enough that most admits don't have meaningfully better options.
+- **Top-left — selective and desired.** Low acceptance, high yield. Harvard sits here: 3.6% accept rate and 84% yield. Schools in this quadrant are both hard to get into and hard to turn down, usually because their market position is strong enough that most admits don't have meaningfully better options.
 - **Top-right — loved despite openness.** Higher acceptance but strong yield. Often state flagships, religious-fit schools, or institutions with strong regional pull. Admits know what they're getting and most of them come.
-- **Bottom-left — selective but second-choice.** Hard to get into, but most admits choose somewhere else. Often cross-admit peers of top-left schools — they admit strong students who would also get into the Harvards of the world, and lose the cross-admit battle. Dartmouth at 5.40% / 69.12% is edge-of-this-quadrant; it wins a solid majority of its admits but loses some to HYPS peers.
-- **Bottom-right — accessible and optional.** Admits freely, captures a smaller share. Common safety-school territory. Harvey Mudd at 12.30% / 36.51% is here — a top-tier STEM liberal arts college with a specific fit, so its admits often accept offers from MIT, Caltech, Stanford instead.
+- **Bottom-left — selective but second-choice.** Hard to get into, but most admits choose somewhere else. Often cross-admit peers of top-left schools — they admit strong students who would also get into the Harvards of the world, and lose the cross-admit battle. Dartmouth at 5.4% / 69% is edge-of-this-quadrant; it wins a solid majority of its admits but loses some to HYPS peers.
+- **Bottom-right — accessible and optional.** Admits freely, captures a smaller share. Common safety-school territory. Harvey Mudd at 12% / 37% is here — a top-tier STEM liberal arts college with a specific fit, so its admits often accept offers from MIT, Caltech, Stanford instead.
 
 ## How to populate this with all 700+ schools
 
@@ -35,6 +35,33 @@ curl 'https://api.collegedata.fyi/rest/v1/cds_manifest?canonical_year=eq.2024-25
 # 2) Pull the C1 and B1 fields we need, for all those schools
 curl 'https://api.collegedata.fyi/rest/v1/cds_fields?canonical_year=eq.2024-25&field_id=in.(c1_total_applied,c1_total_admitted,c1_total_enrolled,b1_ft_total_ug_men,b1_ft_total_ug_women,b22_retention_pct)&select=document_id,ipeds_id,school_id,canonical_year,field_id,value_numeric' \
   > fields-2024-25.json
+```
+
+From R, the projected `school_browser_rows` table is usually enough: it already has acceptance rate and yield. Ask PostgREST for CSV so the result is a data frame. The public anon key is on [`/api`](https://www.collegedata.fyi/api).
+
+```r
+library(httr2)
+library(readr)
+
+anon <- "<anon key>"
+
+rows <- request("https://api.collegedata.fyi/rest/v1/school_browser_rows") |>
+  req_url_query(
+    select = "school_id,school_name,canonical_year,applied,admitted,enrolled_first_year,acceptance_rate,yield_rate",
+    canonical_year = "eq.2024-25",
+    sub_institutional = "is.null",
+    acceptance_rate = "not.is.null",
+    yield_rate = "not.is.null"
+  ) |>
+  req_headers(
+    apikey = anon,
+    Authorization = paste("Bearer", anon),
+    Accept = "text/csv",
+    `X-CollegeData-Client` = "r-httr2"
+  ) |>
+  req_perform() |>
+  resp_body_string() |>
+  read_csv()
 ```
 
 The Field Reference tab in the XLSX documents exactly which field IDs to pull. Join CDS fields to

--- a/docs/recipes/waitlist-odds.md
+++ b/docs/recipes/waitlist-odds.md
@@ -32,9 +32,9 @@ High-volume rows that report near-total wait-list admission are treated as data-
 
 The current generated dataset contains 191 complete school-year rows across 148 schools, plus 61 partial rows where the CDS projection reports only some wait-list values. After collapsing duplicate school-year rows, six high-volume near-total rows are flagged as reported anomalies, leaving 180 school-year rows across 144 schools in the rate analysis. Across those analysis rows:
 
-- median success rate among accepted wait-list spots: 13.16%
-- weighted success rate: 21.51%
-- median "admitted / offered a spot" rate: 5.51%
+- median success rate among accepted wait-list spots: 13%
+- weighted success rate: 22%
+- median "admitted / offered a spot" rate: 5.5%
 - rows under 2% success: 23
 
 The median is not the lesson by itself. The split matters:

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -90,6 +90,34 @@ curl 'https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chi
 curl 'https://www.collegedata.fyi/api/fields'
 
 curl 'https://www.collegedata.fyi/openapi.json'`}</CodeBlock>
+      <p className="mt-4 text-sm leading-relaxed text-gray-700">
+        The same simple endpoints from R, with no API key.{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">httr2</code>{" "}
+        and{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">jsonlite</code>{" "}
+        are enough. Send{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+          X-CollegeData-Client
+        </code>{" "}
+        so we can tell research scripts apart from other traffic.
+      </p>
+      <CodeBlock>{`library(httr2)
+library(jsonlite)
+
+facts <- request("https://www.collegedata.fyi/api/schools/mit/facts") |>
+  req_url_query(categories = "admissions,cost,outcomes") |>
+  req_headers(\`X-CollegeData-Client\` = "r-httr2") |>
+  req_perform() |>
+  resp_body_json()
+
+compare <- request("https://www.collegedata.fyi/api/compare") |>
+  req_url_query(
+    schools = "mit,yale,university-of-chicago",
+    fields = "acceptance_rate,avg_net_price"
+  ) |>
+  req_headers(\`X-CollegeData-Client\` = "r-httr2") |>
+  req_perform() |>
+  resp_body_json()`}</CodeBlock>
       <p className="mt-3 text-sm leading-relaxed text-gray-700">
         The per-school facts endpoint accepts the <code>finance</code> category
         for endowment facts. The fixed-schema compare endpoint does not: a

--- a/web/src/app/recipes/acceptance-vs-yield/page.tsx
+++ b/web/src/app/recipes/acceptance-vs-yield/page.tsx
@@ -245,15 +245,57 @@ export default function AcceptanceVsYieldPage() {
             overflowX: "auto",
           }}
         >
-{`curl https://collegedata.fyi/api/facts \\
-  ?fields=C.116,C.117,C.118        `}
-          <span style={{ color: "#c9c2ae" }}>{`# accept · admit · enroll`}</span>
-{`
-  &year=latest                     `}
-          <span style={{ color: "#c9c2ae" }}>{`# most-recent CDS per school`}</span>
-{`
-  &verified=true                   `}
-          <span style={{ color: "#c9c2ae" }}>{`# skip PDFs awaiting review`}</span>
+{`curl 'https://api.collegedata.fyi/rest/v1/school_browser_rows?select=school_id,school_name,canonical_year,applied,admitted,enrolled_first_year,acceptance_rate,yield_rate&canonical_year=eq.2024-25&sub_institutional=is.null&acceptance_rate=not.is.null&yield_rate=not.is.null' \\
+  -H 'apikey: <anon key>' \\
+  -H 'Authorization: Bearer <anon key>' \\
+  -H 'Accept: text/csv'`}
+        </pre>
+        <p
+          style={{
+            color: "var(--ink-2)",
+            fontSize: 14,
+            lineHeight: 1.55,
+            margin: "16px 0 10px",
+          }}
+        >
+          From R, the same query lands in a data frame. The anon key is on the{" "}
+          <Link href="/api">API page</Link>.
+        </p>
+        <pre
+          style={{
+            background: "var(--ink)",
+            color: "var(--paper)",
+            padding: "20px 24px",
+            fontFamily: "var(--mono)",
+            fontSize: 13,
+            lineHeight: 1.55,
+            margin: 0,
+            borderRadius: 2,
+            overflowX: "auto",
+          }}
+        >
+{`library(httr2)
+library(readr)
+
+anon <- "<anon key>"
+
+rows <- request("https://api.collegedata.fyi/rest/v1/school_browser_rows") |>
+  req_url_query(
+    select = "school_id,school_name,canonical_year,applied,admitted,enrolled_first_year,acceptance_rate,yield_rate",
+    canonical_year = "eq.2024-25",
+    sub_institutional = "is.null",
+    acceptance_rate = "not.is.null",
+    yield_rate = "not.is.null"
+  ) |>
+  req_headers(
+    apikey = anon,
+    Authorization = paste("Bearer", anon),
+    Accept = "text/csv",
+    \`X-CollegeData-Client\` = "r-httr2"
+  ) |>
+  req_perform() |>
+  resp_body_string() |>
+  read_csv()`}
         </pre>
         <div
           style={{

--- a/web/src/components/AcceptanceYieldChart.tsx
+++ b/web/src/components/AcceptanceYieldChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { formatRecipeShare } from "@/lib/format";
 
 type SchoolPoint = {
   school: string;
@@ -310,9 +311,9 @@ export function AcceptanceYieldChart() {
           </div>
           <div style={{ color: "var(--ink-4)", marginTop: 2 }}>CDS {tooltip.cdsYear}</div>
           <div style={{ marginTop: 6 }}>
-            Acceptance rate: {tooltip.accept.toFixed(2)}%
+            Acceptance rate: {formatRecipeShare(tooltip.accept / 100)}
           </div>
-          <div>Yield: {tooltip.yieldPct.toFixed(1)}%</div>
+          <div>Yield: {formatRecipeShare(tooltip.yieldPct / 100)}</div>
           <div style={{ marginTop: 6, color: "var(--ink-4)" }}>
             Applied {tooltip.applied.toLocaleString("en-US")} · Admitted{" "}
             {tooltip.admitted.toLocaleString("en-US")} · Enrolled{" "}

--- a/web/src/components/EndowmentDrawRateExplorer.tsx
+++ b/web/src/components/EndowmentDrawRateExplorer.tsx
@@ -499,7 +499,7 @@ function SchoolHistoryChart({ school }: { school: EndowmentDrawRateSchool }) {
                   stroke="var(--paper)"
                   strokeWidth="2"
                 >
-                  <title>{`FY${point.year} draw rate: ${formatPct(point.drawRate, 2)}`}</title>
+                  <title>{`FY${point.year} draw rate: ${formatPct(point.drawRate, 1)}`}</title>
                 </circle>
               ) : (
                 <text
@@ -599,7 +599,7 @@ function SchoolDetail({ school }: { school: EndowmentDrawRateSchool }) {
                 <td>
                   {point.drawRate == null
                     ? <span title={exclusionLabel(point)}>n/a*</span>
-                    : formatPct(point.drawRate, 2)}
+                    : formatPct(point.drawRate, 1)}
                 </td>
                 <td><span className="mono">{point.sourceTable}</span> · {point.releaseType}</td>
               </tr>

--- a/web/src/components/TestOptionalChart.tsx
+++ b/web/src/components/TestOptionalChart.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { trackEvent } from "@/lib/analytics";
+import { formatRecipeShare } from "@/lib/format";
 
 type Point = { year: string; sat: number; act: number | null };
 type Series = {
@@ -468,10 +469,10 @@ export function TestOptionalChart() {
             CDS {hoverPoint.year}
           </div>
           <div style={{ marginTop: 6 }}>
-            SAT submitted: {hoverPoint.sat.toFixed(1)}%
+            SAT submitted: {formatRecipeShare(hoverPoint.sat / 100)}
           </div>
           {hoverPoint.act != null && (
-            <div>ACT submitted: {hoverPoint.act.toFixed(1)}%</div>
+            <div>ACT submitted: {formatRecipeShare(hoverPoint.act / 100)}</div>
           )}
         </div>
       )}

--- a/web/src/components/WaitlistOddsExplorer.tsx
+++ b/web/src/components/WaitlistOddsExplorer.tsx
@@ -17,6 +17,7 @@ import {
   type WaitlistBucketKey,
   summarizeWaitlistBuckets,
 } from "@/lib/waitlist-recipe-analysis";
+import { formatRecipeShare } from "@/lib/format";
 
 const BUCKET_LABELS: Record<WaitlistBucketKey, string> = {
   selectivity: "Admit-rate band",
@@ -30,19 +31,9 @@ const H = 540;
 const M = { l: 210, r: 36, t: 34, b: 58 };
 const IW = W - M.l - M.r;
 
-function formatPct(value: number | null, digits = 1): string {
-  if (value == null || !Number.isFinite(value)) return "n/a";
-  return `${(value * 100).toFixed(digits)}%`;
-}
-
 function formatNumber(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return "n/a";
   return value.toLocaleString("en-US");
-}
-
-function formatSuccessPct(value: number | null): string {
-  if (value == null) return "n/a";
-  return formatPct(value, value > 0 && value < 0.01 ? 2 : 1);
 }
 
 function compactNumber(value: number | null): string {
@@ -158,7 +149,7 @@ function Chart({
               fontSize="11"
               fill="var(--chart-axis)"
             >
-              {tick === 0 ? "0" : formatPct(tick, tick < 0.1 ? 0 : 0)}
+              {tick === 0 ? "0" : formatRecipeShare(tick, 0)}
             </text>
           </g>
         ))}
@@ -186,7 +177,7 @@ function Chart({
                 fontSize="10"
                 fill="var(--ink-3)"
               >
-                {summary.schools} schools · median {formatPct(summary.medianSuccessRate)}
+                {summary.schools} schools · median {formatRecipeShare(summary.medianSuccessRate)}
               </text>
               <line
                 x1={xScale(rowMedian(summary))}
@@ -289,10 +280,10 @@ function Chart({
             {formatNumber(hover.waitListAdmitted)} admitted from{" "}
             {formatNumber(hover.waitListAccepted)} accepted spots
           </div>
-          <div>Wait-list success: {formatPct(hover.waitListSuccessRate)}</div>
+          <div>Wait-list success: {formatRecipeShare(hover.waitListSuccessRate)}</div>
           <div style={{ color: "var(--ink-4)", marginTop: 6 }}>
             Offered {formatNumber(hover.waitListOffered)} · Admit rate{" "}
-            {formatPct(hover.acceptanceRate)}
+            {formatRecipeShare(hover.acceptanceRate)}
           </div>
         </div>
       )}
@@ -340,13 +331,13 @@ function BucketTable({
                 {bucket.schools}
               </td>
               <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                {formatPct(bucket.medianSuccessRate)}
+                {formatRecipeShare(bucket.medianSuccessRate)}
               </td>
               <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                {formatPct(bucket.weightedSuccessRate)}
+                {formatRecipeShare(bucket.weightedSuccessRate)}
               </td>
               <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                {formatPct(bucket.zeroishShare, 0)}
+                {formatRecipeShare(bucket.zeroishShare, 0)}
               </td>
               <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
                 {formatNumber(bucket.medianAccepted)}
@@ -394,8 +385,8 @@ function CaseStudy({ row }: { row: WaitlistRecipeRow }) {
       <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, marginTop: 12 }}>
         {complete ? (
           <>
-            {formatSuccessPct(row.waitListSuccessRate)} of students who accepted a spot were admitted from
-            the wait list. The same CDS row reports a normal admit rate of {formatPct(row.acceptanceRate)}.
+            {formatRecipeShare(row.waitListSuccessRate)} of students who accepted a spot were admitted from
+            the wait list. The same CDS row reports a normal admit rate of {formatRecipeShare(row.acceptanceRate)}.
           </>
         ) : (
           <>
@@ -494,7 +485,7 @@ function BerkeleyHistoryChart() {
                   fontSize="11"
                   fill="var(--chart-axis)"
                 >
-                  {formatPct(tick, 0)}
+                  {formatRecipeShare(tick, 0)}
                 </text>
               </g>
             ))}
@@ -588,7 +579,7 @@ function BerkeleyHistoryChart() {
                     {formatNumber(row.waitListAdmitted)}
                   </td>
                   <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                    {formatSuccessPct(row.waitListSuccessRate)}
+                    {formatRecipeShare(row.waitListSuccessRate)}
                   </td>
                 </tr>
               ))}
@@ -664,8 +655,8 @@ export function WaitlistOddsExplorer() {
       >
         {[
           ["Analysis rows", WAITLIST_ANALYSIS_SUMMARY.analysisRows.toLocaleString("en-US")],
-          ["Median success", formatPct(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)],
-          ["Weighted success", formatPct(WAITLIST_ANALYSIS_SUMMARY.weightedSuccessRate)],
+          ["Median success", formatRecipeShare(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)],
+          ["Weighted success", formatRecipeShare(WAITLIST_ANALYSIS_SUMMARY.weightedSuccessRate)],
           ["Flagged rows", WAITLIST_ANALYSIS_SUMMARY.reportedAnomalyRows.toLocaleString("en-US")],
         ].map(([label, value]) => (
           <div key={label} className="cd-card" style={{ padding: 16 }}>
@@ -737,7 +728,7 @@ export function WaitlistOddsExplorer() {
                       {formatNumber(row.waitListAdmitted)}
                     </td>
                     <td className="nums" style={{ textAlign: "right", padding: "10px 0", borderBottom: "1px dashed var(--rule)" }}>
-                      {formatPct(row.waitListSuccessRate)}
+                      {formatRecipeShare(row.waitListSuccessRate)}
                     </td>
                   </tr>
                 ))}
@@ -768,7 +759,7 @@ export function WaitlistOddsExplorer() {
         </div>
         <p style={{ color: "var(--ink-2)", fontSize: 16, lineHeight: 1.65, margin: 0 }}>
           Across complete CDS wait-list rows in the current corpus, the median school admits{" "}
-          {formatPct(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)} of students who accept a spot.
+          {formatRecipeShare(WAITLIST_ANALYSIS_SUMMARY.medianSuccessRate)} of students who accept a spot.
           That sounds meaningful until you split the schools: the most selective buckets cluster
           around low single digits, and {WAITLIST_ANALYSIS_SUMMARY.zeroishRows} complete rows are
           effectively closed doors under 2%. Higher rates exist, but they are concentrated at less
@@ -868,10 +859,10 @@ export function WaitlistOddsExplorer() {
                     {compactNumber(row.waitListAdmitted)}
                   </td>
                   <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                    {formatPct(row.waitListSuccessRate, row.waitListSuccessRate && row.waitListSuccessRate < 0.01 ? 2 : 1)}
+                    {formatRecipeShare(row.waitListSuccessRate)}
                   </td>
                   <td className="nums" style={{ textAlign: "right", padding: "12px 14px", borderBottom: "1px dashed var(--rule)" }}>
-                    {formatPct(row.acceptanceRate)}
+                    {formatRecipeShare(row.acceptanceRate)}
                   </td>
                 </tr>
               ))}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { sourceDownloadLabel } from "./format";
+import { formatRecipeShare, sourceDownloadLabel } from "./format";
+
+describe("formatRecipeShare", () => {
+  it("uses whole percents at 10% and above", () => {
+    expect(formatRecipeShare(0.762)).toBe("76%");
+    expect(formatRecipeShare(0.836)).toBe("84%");
+    expect(formatRecipeShare(0.1)).toBe("10%");
+  });
+
+  it("keeps one tenth below 10%", () => {
+    expect(formatRecipeShare(0.0365)).toBe("3.6%");
+    expect(formatRecipeShare(0.054)).toBe("5.4%");
+    expect(formatRecipeShare(0.004)).toBe("0.4%");
+  });
+
+  it("lets draw-rate figures keep a tenth even above 10%", () => {
+    expect(formatRecipeShare(0.048, 1)).toBe("4.8%");
+    expect(formatRecipeShare(0.151, 1)).toBe("15.1%");
+  });
+});
 
 describe("sourceDownloadLabel", () => {
   it("uses the storage extension when the stored source format is stale", () => {

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -122,6 +122,19 @@ export function formatPercent(
   return `${(n * 100).toFixed(decimals)}%`;
 }
 
+// Recipe charts and tables. Whole percents by default; one tenth below 10%
+// so elite admit rates and rare wait-list outcomes do not collapse to 0% or
+// 3%. Pass digits: 1 for endowment draw rates — 4.8% vs 5% vs 7% is the claim.
+export function formatRecipeShare(
+  rate01: number | null | undefined,
+  digits?: number,
+): string {
+  if (rate01 == null || !Number.isFinite(rate01)) return "n/a";
+  const pct = rate01 * 100;
+  const places = digits ?? (pct > 0 && pct < 10 ? 1 : 0);
+  return `${pct.toFixed(places)}%`;
+}
+
 export function yearRange(
   earliest: string | null,
   latest: string | null


### PR DESCRIPTION
## Summary
- Add copy-paste `httr2` examples on `/api` (no-key facts/compare) and the acceptance-vs-yield recipe (`school_browser_rows` as CSV).
- Round recipe-page percents to whole numbers, keeping one tenth below 10% and on endowment draw rates.

## Test plan
- [ ] `/api` shows a working R snippet next to the curl examples.
- [ ] `/recipes/acceptance-vs-yield` hover shows `3.6%` / `84%` style percents, not hundredths, and the R CSV block is copy-pasteable.
- [ ] Wait-list recipe summaries use whole percents except rates under 10%.
- [ ] Endowment draw-rate table still shows one decimal (`4.8%`), and Playwright bucket assertions still match `\d+\.\d%`.


Made with [Cursor](https://cursor.com)