### PR TITLE
fix: rank Jump-to-school initials and nicknames ahead of substrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project uses four-part semantic versioning.
 - Replace the About page’s three-paragraph source gloss with a short hub that points at the longer CDS, Scorecard, and IPEDS notes.
 - Add R (`httr2`) copy-paste examples on `/api` and the acceptance-vs-yield recipe, and round recipe-page percents to whole numbers except below 10% and for endowment draw rates.
 
+### Fixed
+
+- Rank Jump-to-school exact slugs and nicknames (MIT, Penn) ahead of accidental name substrings, and prefer schools that already have a CDS year.
+
 ## [0.5.1.0] - 2026-08-10
 
 ### Added

--- a/data/search_nicknames.yaml
+++ b/data/search_nicknames.yaml
@@ -1,0 +1,20 @@
+# Public Jump-to-school nicknames. Not a ranking and not the PRD 019
+# operator watchlist. These tokens are loaded into
+# institution_slug_crosswalk as source=manual so typed initials like
+# "penn" resolve to the school people mean.
+version: 1
+nicknames:
+  - school_id: upenn
+    aliases: [penn]
+  - school_id: uc-berkeley
+    aliases: [cal]
+  - school_id: washington-university-in-st-louis
+    aliases: [washu]
+  - school_id: johns-hopkins
+    aliases: [jhu]
+  - school_id: georgia-tech
+    aliases: [gt]
+  - school_id: william-and-mary
+    aliases: [wm, w&m]
+  - school_id: california-institute-of-technology
+    aliases: [caltech]

--- a/supabase/migrations/20260819160000_search_institutions_identity_rank.sql
+++ b/supabase/migrations/20260819160000_search_institutions_identity_rank.sql
@@ -1,0 +1,178 @@
+-- Rank Jump-to-school by identity (school_id / alias) before name
+-- substring, and prefer rows that actually have a CDS year. Fixes
+-- "MIT" matching Smith and "Penn" losing to larger Pennsylvania names.
+-- Does not consult the PRD 019 operator watchlist.
+
+begin;
+
+insert into public.institution_slug_crosswalk
+  (ipeds_id, school_id, alias, source, is_primary)
+values
+  ('215062', 'upenn', 'penn', 'manual', false),
+  ('110635', 'uc-berkeley', 'cal', 'manual', false),
+  ('179867', 'washington-university-in-st-louis', 'washu', 'manual', false),
+  ('162928', 'johns-hopkins', 'jhu', 'manual', false),
+  ('139755', 'georgia-tech', 'gt', 'manual', false),
+  ('231624', 'william-and-mary', 'wm', 'manual', false),
+  ('231624', 'william-and-mary', 'w&m', 'manual', false),
+  ('110404', 'california-institute-of-technology', 'caltech', 'manual', false)
+on conflict (ipeds_id, alias) do nothing;
+
+do $$
+begin
+  perform public.refresh_institution_cds_coverage();
+end$$;
+
+create or replace function public.search_institutions(
+  p_query text,
+  p_limit int default 10
+)
+returns table (
+  school_id                  text,
+  school_name                text,
+  city                       text,
+  state                      text,
+  coverage_status            public.coverage_status_t,
+  coverage_label             text,
+  latest_available_cds_year  text
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with q as (
+    select
+      lower(trim(coalesce(p_query, ''))) as qstr,
+      regexp_replace(
+        lower(trim(coalesce(p_query, ''))),
+        '[^a-z0-9]',
+        '',
+        'g'
+      ) as qcompact,
+      regexp_replace(
+        lower(trim(coalesce(p_query, ''))),
+        '([\\.^$|?*+(){}\[\]-])',
+        '\\\1',
+        'g'
+      ) as qescaped
+  )
+  select
+    c.school_id,
+    c.school_name,
+    c.city,
+    c.state,
+    c.coverage_status,
+    c.coverage_label,
+    c.latest_available_cds_year
+  from public.institution_cds_coverage c, q
+  where c.coverage_status <> 'out_of_scope'
+    and length(q.qstr) > 0
+    and length(q.qcompact) > 0
+    and (
+      regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+      or exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g')
+          like q.qcompact || '%'
+      )
+      or (
+        length(q.qescaped) > 0
+        and lower(c.school_name) ~ ('\y' || q.qescaped)
+      )
+      or (
+        length(q.qstr) > 4
+        and c.search_text like '%' || q.qstr || '%'
+      )
+    )
+  order by
+    case
+      when regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') = q.qcompact
+        then 0
+      when exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g') = q.qcompact
+      ) then 0
+      when regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+        then 1
+      when exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+      ) then 1
+      when length(q.qescaped) > 0
+        and lower(c.school_name) ~ ('\y' || q.qescaped)
+        then 2
+      when lower(c.school_name) like '%' || q.qstr || '%'
+        then 3
+      else 4
+    end,
+    case when c.latest_available_cds_year is not null then 0 else 1 end,
+    c.undergraduate_enrollment desc nulls last,
+    c.school_name
+  limit greatest(p_limit, 1);
+$$;
+
+comment on function public.search_institutions(text, int) is
+  'Public autocomplete over institution_cds_coverage. Rank: exact school_id/alias, id/alias prefix, name token-prefix, name substring, other search_text. CDS year then enrollment as tie-breaks. Short queries do not match mid-word. SECURITY INVOKER so RLS hides out_of_scope rows.';
+
+grant execute on function public.search_institutions(text, int) to anon, authenticated;
+
+do $$
+declare
+  first_school text;
+  found_count int;
+begin
+  insert into public.institution_directory (
+    ipeds_id, school_id, school_name, scorecard_data_year, in_scope,
+    exclusion_reason, undergraduate_enrollment
+  ) values
+    ('9999201', 'z9qk', 'Z9qk Institute of Technology', '2024', true, null, 1000),
+    ('9999202', '__test_z9qk_mid__', 'Foz9qkton College', '2024', true, null, 90000),
+    ('9999203', 'z9qk-state', 'Z9qk State University', '2024', true, null, 80000),
+    ('9999204', '__test_z9qn_u__', 'University of Z9qnsylvania', '2024', true, null, 12000),
+    ('9999205', 'z9qn-state', 'Z9qn State University', '2024', true, null, 85000);
+
+  insert into public.institution_slug_crosswalk
+    (ipeds_id, school_id, alias, source, is_primary)
+  values
+    ('9999201', 'z9qk', 'z9qk', 'manual', true),
+    ('9999202', '__test_z9qk_mid__', '__test_z9qk_mid__', 'manual', true),
+    ('9999203', 'z9qk-state', 'z9qk-state', 'manual', true),
+    ('9999204', '__test_z9qn_u__', '__test_z9qn_u__', 'manual', true),
+    ('9999204', '__test_z9qn_u__', 'z9qn', 'manual', false),
+    ('9999205', 'z9qn-state', 'z9qn-state', 'manual', true);
+
+  perform public.refresh_institution_cds_coverage();
+
+  select school_id into first_school
+    from public.search_institutions('z9qk', 7)
+   limit 1;
+  if first_school is distinct from 'z9qk' then
+    raise exception 'search identity rank FAIL: z9qk first was %, expected z9qk', first_school;
+  end if;
+
+  select count(*) into found_count
+    from public.search_institutions('z9qk', 20)
+   where school_id = '__test_z9qk_mid__';
+  if found_count <> 0 then
+    raise exception 'search identity rank FAIL: mid-word Foz9qkton should not match z9qk';
+  end if;
+
+  select school_id into first_school
+    from public.search_institutions('z9qn', 7)
+   limit 1;
+  if first_school is distinct from '__test_z9qn_u__' then
+    raise exception 'search identity rank FAIL: z9qn first was %, expected __test_z9qn_u__', first_school;
+  end if;
+
+  delete from public.institution_slug_crosswalk
+   where ipeds_id in ('9999201', '9999202', '9999203', '9999204', '9999205');
+  delete from public.institution_directory
+   where ipeds_id in ('9999201', '9999202', '9999203', '9999204', '9999205');
+  perform public.refresh_institution_cds_coverage();
+end$$;
+
+commit;

--- a/tools/scorecard/load_directory.py
+++ b/tools/scorecard/load_directory.py
@@ -47,8 +47,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHOOLS_YAML = REPO_ROOT / "tools" / "finder" / "schools.yaml"
+DEFAULT_SEARCH_NICKNAMES = REPO_ROOT / "data" / "search_nicknames.yaml"
 MISSING_FROM_CURRENT_SCORECARD = "missing_from_current_scorecard"
 
 if str(REPO_ROOT) not in sys.path:
@@ -354,6 +357,25 @@ def load_schools_yaml(path: Path) -> dict[str, str]:
     return school_claim_slug_map(load_school_claims(path))
 
 
+def load_search_nicknames(path: Path) -> dict[str, list[str]]:
+    """Canonical school_id → extra typed aliases for Jump-to-school."""
+    if not path.exists():
+        return {}
+    payload = yaml.safe_load(path.read_text()) or {}
+    out: dict[str, list[str]] = {}
+    for row in payload.get("nicknames") or []:
+        school_id = str(row["school_id"]).strip()
+        aliases = [
+            str(alias).strip().lower()
+            for alias in (row.get("aliases") or [])
+            if str(alias).strip()
+        ]
+        if not school_id or not aliases:
+            continue
+        out[school_id] = aliases
+    return out
+
+
 def audit_directory_identities(
     claims: Iterable[dict[str, str]],
     directory_rows: Iterable[dict[str, Any]],
@@ -414,6 +436,7 @@ def build_crosswalk_rows(
     directory_rows: list[dict[str, Any]],
     schools_yaml_map: dict[str, str],
     retired_aliases_by_ipeds: Optional[dict[str, list[str]]] = None,
+    search_nicknames: Optional[dict[str, list[str]]] = None,
 ) -> list[dict[str, Any]]:
     """One row per known alias. Each ipeds_id always has at least one
     primary row (its school_id). When a schools.yaml ID and the
@@ -424,6 +447,7 @@ def build_crosswalk_rows(
     as a non-primary alias so legacy URLs keep resolving."""
     out: list[dict[str, Any]] = []
     retired_aliases_by_ipeds = retired_aliases_by_ipeds or {}
+    search_nicknames = search_nicknames or {}
     retired_alias_owners: dict[str, str] = {}
     for owner_ipeds, aliases in retired_aliases_by_ipeds.items():
         for alias in aliases:
@@ -441,6 +465,19 @@ def build_crosswalk_rows(
         raise ValueError(
             "retired alias collides with a schools.yaml canonical claim: "
             + ", ".join(yaml_alias_conflicts)
+        )
+
+    canonical_ids = {row["school_id"] for row in directory_rows}
+    nickname_collisions = sorted(
+        alias
+        for aliases in search_nicknames.values()
+        for alias in aliases
+        if alias in canonical_ids
+    )
+    if nickname_collisions:
+        raise ValueError(
+            "search nickname collides with a canonical school_id: "
+            + ", ".join(nickname_collisions)
         )
 
     for row in directory_rows:
@@ -505,6 +542,22 @@ def build_crosswalk_rows(
                     "is_primary": False,
                 }
             )
+        emitted = {primary, *retired_aliases}
+        if yaml_slug:
+            emitted.add(yaml_slug)
+        for alias in search_nicknames.get(primary, []):
+            if alias in emitted or alias in retired_alias_owners:
+                continue
+            out.append(
+                {
+                    "ipeds_id": ipeds,
+                    "school_id": primary,
+                    "alias": alias,
+                    "source": "manual",
+                    "is_primary": False,
+                }
+            )
+            emitted.add(alias)
     return out
 
 
@@ -730,6 +783,11 @@ def main() -> int:
     parser.add_argument("--schools-yaml", default=str(DEFAULT_SCHOOLS_YAML),
                         help="Path to schools.yaml for slug preservation (default: tools/finder/schools.yaml)")
     parser.add_argument(
+        "--search-nicknames",
+        default=str(DEFAULT_SEARCH_NICKNAMES),
+        help="Path to Jump-to-school nicknames YAML (default: data/search_nicknames.yaml)",
+    )
+    parser.add_argument(
         "--identity-exceptions",
         default=str(DEFAULT_IDENTITY_EXCEPTIONS),
         help=(
@@ -793,7 +851,9 @@ def main() -> int:
         return 4
     schools_yaml_map = school_claim_slug_map(school_claims)
     retired_aliases_by_ipeds = school_claim_retired_alias_map(school_claims)
+    search_nicknames = load_search_nicknames(Path(args.search_nicknames).expanduser())
     print(f"Loaded {len(schools_yaml_map)} schools.yaml slug claims", file=sys.stderr)
+    print(f"Loaded {sum(len(v) for v in search_nicknames.values())} search nicknames", file=sys.stderr)
 
     print(f"Reading {csv_path} ...", file=sys.stderr)
     df = pd.read_csv(csv_path, dtype=str, low_memory=False)
@@ -930,7 +990,7 @@ def main() -> int:
         row.pop("_previous_predominant_degree", None)
 
     crosswalk_rows = build_crosswalk_rows(
-        rows, schools_yaml_map, retired_aliases_by_ipeds
+        rows, schools_yaml_map, retired_aliases_by_ipeds, search_nicknames
     )
 
     in_scope_rows = [r for r in rows if r["in_scope"]]

--- a/tools/scorecard/test_load_directory.py
+++ b/tools/scorecard/test_load_directory.py
@@ -31,6 +31,7 @@ from tools.scorecard.load_directory import (  # noqa: E402
     preserve_existing_redirect_aliases,
     fetch_existing_directory_rows,
     load_schools_yaml,
+    load_search_nicknames,
     main as load_directory_main,
     normalize_ipeds,
     previous_predominant_degrees,
@@ -395,7 +396,70 @@ class BuildCrosswalkRowsTests(unittest.TestCase):
         self.assertTrue(cw[0]["is_primary"])
         self.assertEqual(cw[0]["source"], "scorecard")
 
-    def test_retired_alias_stays_a_redirect_across_scorecard_refreshes(self):
+    def test_search_nicknames_emit_manual_aliases(self):
+        rows = [
+            {
+                "ipeds_id": "215062",
+                "school_id": "upenn",
+                "school_name": "University of Pennsylvania",
+            },
+            {
+                "ipeds_id": "243780",
+                "school_id": "penn-state",
+                "school_name": "Pennsylvania State University",
+            },
+        ]
+        cw = build_crosswalk_rows(
+            rows,
+            {"215062": "upenn", "243780": "penn-state"},
+            search_nicknames={"upenn": ["penn"]},
+        )
+        penn = [row for row in cw if row["alias"] == "penn"]
+        self.assertEqual(
+            penn,
+            [
+                {
+                    "ipeds_id": "215062",
+                    "school_id": "upenn",
+                    "alias": "penn",
+                    "source": "manual",
+                    "is_primary": False,
+                }
+            ],
+        )
+
+    def test_search_nickname_cannot_collide_with_canonical_id(self):
+        rows = [
+            {"ipeds_id": "000001", "school_id": "harvard", "school_name": "Harvard University"},
+            {"ipeds_id": "000002", "school_id": "yale", "school_name": "Yale University"},
+        ]
+        with self.assertRaisesRegex(ValueError, "search nickname collides"):
+            build_crosswalk_rows(
+                rows,
+                {"000001": "harvard"},
+                search_nicknames={"harvard": ["yale"]},
+            )
+
+    def test_load_search_nicknames_reads_penn(self):
+        nicknames = load_search_nicknames(
+            Path(__file__).resolve().parents[2] / "data" / "search_nicknames.yaml"
+        )
+        self.assertIn("penn", nicknames["upenn"])
+        self.assertNotIn("mit", {alias for aliases in nicknames.values() for alias in aliases})
+
+    def test_search_nicknames_are_not_the_operator_watchlist(self):
+        root = Path(__file__).resolve().parents[2]
+        nickname_text = (root / "data" / "search_nicknames.yaml").read_text()
+        sql_text = (
+            root
+            / "supabase"
+            / "migrations"
+            / "20260819160000_search_institutions_identity_rank.sql"
+        ).read_text()
+        body = sql_text.split("as $$", 1)[1].split("$$;", 1)[0]
+        self.assertNotIn("top_200", nickname_text)
+        self.assertNotIn("watchlist", body.lower())
+        self.assertNotIn("top_200", body)
         rows = [
             {
                 "ipeds_id": "168148",

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -10,8 +10,8 @@ import { CoverageBadge } from "./CoverageBadge";
 // PRD 015 M4 — server-backed autocomplete over institution_cds_coverage.
 // Calls the search_institutions RPC with a debounced query so missing-
 // CDS and not-yet-checked schools surface as first-class results. The
-// RPC ranks name-exact > prefix > substring; we just render the order
-// it returns.
+// RPC ranks exact school_id/alias, then prefix, then name token, with
+// CDS year and enrollment as tie-breaks.
 //
 // Replaces the prior in-memory ILIKE that only knew about CDS-backed
 // schools (see git blame for the swap).


### PR DESCRIPTION
## Summary
- Rank Jump-to-school / homepage search by exact compact `school_id` or alias first, then prefix, then name word-start, then substring — so `MIT` beats Smith and `Penn` beats Penn State.
- Add curated public nicknames (`penn`, `cal`, `washu`, `jhu`, `gt`, `wm`/`w&m`, `caltech`) in `data/search_nicknames.yaml`, seed them in the migration, and emit them from `load_directory.py`.
- Tie-break a ranking tier by CDS coverage, then enrollment. Short queries skip mid-word `search_text` matches. Does not use the PRD 019 operator watchlist.

## Test plan
- [ ] CI green (Python loader tests + web tests)
- [ ] After merge: `supabase db push --linked` from the main checkout
- [ ] Header search `MIT` → Massachusetts Institute of Technology first
- [ ] Header search `Penn` → University of Pennsylvania first
- [ ] Header search `Cal` → UC Berkeley first
- [ ] Header search `w&m` → William & Mary first


Made with [Cursor](https://cursor.com)