### PR TITLE
fix: seed Oklahoma CDS from the IRR listing, not a one-year PDF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Audit retired school redirects
         run: python tools/finder/school_redirect_guard.py
       - name: Run finder identity tests
-        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard
+        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
       - name: Run IPEDS loader tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project uses four-part semantic versioning.
 ### Fixed
 
 - Rank Jump-to-school exact slugs and nicknames (MIT, Penn) ahead of accidental name substrings, and prefer schools that already have a CDS year.
+- Point Oklahoma's archive seed at the IRR listing (`/irr/other-reports`) instead of a single 2023-24 DAM PDF, and prefer Brave HTML listings over year-specific PDFs so sibling years are not frozen out.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/supabase/functions/_shared/resolve.test.ts
+++ b/supabase/functions/_shared/resolve.test.ts
@@ -685,6 +685,25 @@ Deno.test("parentLandingCandidates: Boston-College-style direct PDF returns CDS 
   assertEquals(candidates[1], "https://www.bc.edu/content/dam/bc1/offices/irp/ir/");
 });
 
+Deno.test("parentLandingCandidates: OU DAM path keeps irr / common-data-sets ancestors", () => {
+  const hint =
+    "https://www.ou.edu/content/dam/irr/docs/common-data-sets/norman-campus-only/2023-24-nc/CDS%202023-2024%20Combined.pdf";
+  const candidates = parentLandingCandidates(hint);
+  const urls = new Set(candidates);
+  assertEquals(
+    urls.has(
+      "https://www.ou.edu/content/dam/irr/docs/common-data-sets/norman-campus-only/2023-24-nc/",
+    ),
+    true,
+  );
+  assertEquals(
+    urls.has(
+      "https://www.ou.edu/content/dam/irr/docs/common-data-sets/norman-campus-only/",
+    ),
+    true,
+  );
+});
+
 Deno.test("parentLandingCandidates: Drupal upload-dir path has no CDS-like segments, returns []", () => {
   const hint = "https://oir.brown.edu/sites/default/files/2020-04/CDS2009_2010.pdf";
   const candidates = parentLandingCandidates(hint);
@@ -733,6 +752,7 @@ Deno.test("wellKnownPathUrls: expands to host-rooted CDS landing paths", () => {
   assertEquals(set.has("https://irp.dpb.cornell.edu/institutional-data/common-data-set"), true);
   assertEquals(set.has("https://irp.dpb.cornell.edu/institutional-research/common-data-set/"), true);
   assertEquals(set.has("https://irp.dpb.cornell.edu/ir/common-data-set/"), true);
+  assertEquals(set.has("https://irp.dpb.cornell.edu/irr/other-reports"), true);
   // Origin is preserved without the hint's path.
   for (const u of urls) {
     assertEquals(u.startsWith("https://irp.dpb.cornell.edu"), true);

--- a/supabase/functions/_shared/resolve.ts
+++ b/supabase/functions/_shared/resolve.ts
@@ -834,7 +834,7 @@ function extensionFromContentType(contentType: string): "pdf" | "xlsx" | "docx" 
 // just the direct doc (pre-upgrade behavior).
 const MAX_PARENT_LEVELS = 3;
 const CDS_LIKE_PATH_SEGMENT_RE =
-  /^(cds|common-data-set|common_data_set|institutional-research|institutional_research|ir|oir|oira|iro|irp)$/i;
+  /^(cds|common-data-set|common-data-sets|common_data_set|institutional-research|institutional_research|ir|irr|oir|oira|iro|irp|other-reports)$/i;
 
 function pathHasCdsLikeSegment(segments: string[]): boolean {
   return segments.some((s) => CDS_LIKE_PATH_SEGMENT_RE.test(s));
@@ -940,6 +940,12 @@ const WELL_KNOWN_CDS_LANDING_PATHS: readonly string[] = [
   "/institutional-data/common-data-set",
   "/reports/common-data-set",
   "/reports/cds-reports/",
+  // Mixed IR report hubs (OU posts CDS on /irr/other-reports, not /ir/cds/)
+  "/irr/other-reports",
+  "/irr/other-reports/",
+  "/irr/common-data-set/",
+  "/institutional-research/reports/",
+  "/ir/reports/",
 ];
 
 export function wellKnownPathUrls(hint: string): string[] {

--- a/supabase/functions/_shared/schools.ts
+++ b/supabase/functions/_shared/schools.ts
@@ -44,9 +44,9 @@ interface SubInstitution {
 // `discovery_seed_url` is what the resolver fetches as the seed for its
 // upgrade path (parent walk, well-known paths, multi-candidate fan-out).
 // `browse_url` is the human-friendly URL surfaced by the kids worklist
-// and any contributor-facing tool. They differ when a school's seed is
-// a direct PDF (good for the resolver, useless for a kid trying to
-// browse for new years).
+// and any contributor-facing tool. Prefer an HTML listing as the seed.
+// A direct PDF archives that one file but often misses sibling years
+// (OU's 2023-24 DAM PDF vs /irr/other-reports).
 //
 // `cds_url_hint` is preserved for back-compat with un-renamed YAML rows
 // during the PR 5 migration window.

--- a/tools/finder/debug_brave.py
+++ b/tools/finder/debug_brave.py
@@ -133,17 +133,9 @@ def brave_query(q, api_key):
 
 
 def extract_with_current_parser(data, domain):
-    """Replicate probe_urls.py's brave_search extraction logic."""
-    results = data.get("web", {}).get("results", [])
-    for r in results:
-        link = r.get("url", "")
-        if link.lower().endswith(".pdf"):
-            return link
-        desc = r.get("description", "").lower()
-        title = r.get("title", "").lower()
-        if "common data set" in desc or "common data set" in title:
-            return link
-    return None
+    """Use probe_urls.py's Brave picker so this diagnostic cannot drift."""
+    from probe_urls import select_brave_cds_url
+    return select_brave_cds_url(data.get("web", {}).get("results", []))
 
 
 def summarize_results(data, domain):

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -101,6 +101,15 @@ PATTERNS = [
     # ── Generic "data" page (for schools like Adelphi whose CDS is
     #    linked from a data hub with no CDS keyword in the path) ──
     "/institutional-research/research/data/",
+
+    # ── IR "other reports" hubs ──
+    # Oklahoma (ou.edu/irr/other-reports) posts CDS on a mixed-reports
+    # page, not under /ir/cds/. The CDS heading is below the fold.
+    "/irr/other-reports",
+    "/irr/other-reports/",
+    "/irr/common-data-set/",
+    "/institutional-research/reports/",
+    "/ir/reports/",
 ]
 
 # Subdomains to try. `sites` catches Wordpress-multisite institutions
@@ -188,7 +197,10 @@ def is_cds_page(content: bytes, content_type: str) -> bool:
     if "pdf" in ct:
         return True
     if "html" in ct:
-        text = content[:5000].decode("utf-8", errors="ignore").lower()
+        # OU's /irr/other-reports puts the CDS heading ~8KB into the page,
+        # below Facts-at-a-Glance. 5KB was enough for dedicated CDS pages
+        # and missed mixed IR hubs.
+        text = content[:32_000].decode("utf-8", errors="ignore").lower()
         return "common data set" in text
     return False
 
@@ -307,7 +319,7 @@ def probe_school(domain: str, rps: float, max_seconds: float = DEFAULT_SCHOOL_BU
                 return None, tried
             url = base.rstrip("/") + pattern
             tried += 1
-            status, headers, body = _get(url, timeout=10, read_bytes=5000)
+            status, headers, body = _get(url, timeout=10, read_bytes=32_000)
             if status == 200:
                 ct = headers.get("content-type", "")
                 if is_cds_page(body, ct):
@@ -445,15 +457,23 @@ def brave_search(domain: str, api_key: str) -> str | None:
         return None
 
     results = data.get("web", {}).get("results", [])
-    # Prefer PDFs when present, but accept CDS landing pages as fallback.
-    #
-    # Reject URL paths that look like they point at the CDS Initiative's
-    # template/definitions/instructions documents rather than a school's
-    # filled-out data. Without this filter, Brave's landing-page fallback
-    # returns e.g. `.../Common+Data+Set+Definitions.pdf` or `.../cds-template.pdf`
-    # because those titles legitimately contain "Common Data Set". They are
-    # not extractable school data. Filter was added 2026-04-14 after
-    # Amherst's Brave-discovered hint turned out to be the definitions PDF.
+    return select_brave_cds_url(results)
+
+
+def select_brave_cds_url(results: list[dict]) -> str | None:
+    """Pick a discovery seed from Brave web results.
+
+    Prefer an HTML listing over a year-specific PDF. A PDF seed locks the
+    archive resolver onto one file — OU's 2023-24 Combined.pdf instead of
+    ou.edu/irr/other-reports, which lists every year plus section PDFs.
+    Landing pages still have to mention "Common Data Set" in title or
+    description so random IR homepages do not win.
+
+    Reject URL paths that look like the CDS Initiative's template /
+    definitions / instructions documents rather than a school's filled-out
+    data. Filter added 2026-04-14 after Amherst's hint turned out to be
+    the definitions PDF.
+    """
     bad_keywords = ("definition", "definitions", "template", "instructions",
                     "blank", "glossary")
 
@@ -461,20 +481,22 @@ def brave_search(domain: str, api_key: str) -> str | None:
         p = url_str.lower()
         return any(kw in p for kw in bad_keywords)
 
-    landing_fallback = None
+    landing = None
+    pdf = None
     for r in results:
         link = r.get("url", "")
         if not link or looks_like_template(link):
             continue
         if link.lower().endswith(".pdf"):
-            return link
+            if pdf is None:
+                pdf = link
+            continue
         desc = r.get("description", "").lower()
         title = r.get("title", "").lower()
         if "common data set" in desc or "common data set" in title:
-            if landing_fallback is None:
-                landing_fallback = link
-
-    return landing_fallback
+            if landing is None:
+                landing = link
+    return landing or pdf
 
 
 def google_dork(domain: str, api_key: str, cx: str) -> str | None:

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -24047,7 +24047,10 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ou.edu/content/dam/irr/docs/Common%20Data%20Sets/Norman%20Campus%20Only/2023-24-nc/CDS%202023-2024%20Combined.pdf
+  discovery_seed_url: https://www.ou.edu/irr/other-reports
+  browse_url: https://www.ou.edu/irr/other-reports
+  notes: Brave locked onto a 2023-24 DAM PDF; the IR listing at /irr/other-reports
+    has combined prior years plus 2025-26 section PDFs. Seed is the listing, not a file.
 - id: university-of-oregon
   name: University of Oregon
   domain: uoregon.edu

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -1,0 +1,71 @@
+"""Tests for CDS URL discovery helpers in probe_urls.py."""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.finder.probe_urls import is_cds_page, select_brave_cds_url
+
+
+class SelectBraveCdsUrlTests(unittest.TestCase):
+    def test_prefers_html_listing_over_year_specific_pdf(self) -> None:
+        results = [
+            {
+                "url": "https://www.ou.edu/content/dam/irr/docs/CDS%202023-2024%20Combined.pdf",
+                "title": "CDS 2023-2024 Combined.pdf",
+                "description": "Common Data Set 2023-2024",
+            },
+            {
+                "url": "https://www.ou.edu/irr/other-reports",
+                "title": "Other Reports | Institutional Research & Reporting",
+                "description": "Facts at a Glance, the Factbook, and the Common Data Set (CDS).",
+            },
+        ]
+        self.assertEqual(
+            select_brave_cds_url(results),
+            "https://www.ou.edu/irr/other-reports",
+        )
+
+    def test_falls_back_to_pdf_when_no_listing_mentions_cds(self) -> None:
+        results = [
+            {
+                "url": "https://example.edu/ir/cds-2023-2024.pdf",
+                "title": "CDS 2023-2024",
+                "description": "Common Data Set",
+            },
+            {
+                "url": "https://example.edu/ir/",
+                "title": "Institutional Research",
+                "description": "Enrollment dashboards and fact books.",
+            },
+        ]
+        self.assertEqual(
+            select_brave_cds_url(results),
+            "https://example.edu/ir/cds-2023-2024.pdf",
+        )
+
+    def test_rejects_definitions_pdf_and_listing(self) -> None:
+        results = [
+            {
+                "url": "https://example.edu/cds-definitions.pdf",
+                "title": "Common Data Set Definitions",
+                "description": "Common Data Set definitions",
+            },
+            {
+                "url": "https://example.edu/cds-template.pdf",
+                "title": "CDS template",
+                "description": "Common Data Set",
+            },
+        ]
+        self.assertIsNone(select_brave_cds_url(results))
+
+
+class IsCdsPageTests(unittest.TestCase):
+    def test_mixed_ir_hub_cds_heading_below_5kb_still_matches(self) -> None:
+        prefix = ("x" * 6000).encode()
+        body = prefix + b"<h2>Common Data Set (CDS)</h2>"
+        self.assertTrue(is_cds_page(body, "text/html; charset=utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Point `university-of-oklahoma-norman-campus` at `https://www.ou.edu/irr/other-reports` instead of the 2023-24 DAM PDF Brave locked onto in April.
- Prefer HTML CDS listings over year-specific PDFs in Brave results, so a one-file seed does not freeze sibling years out of weekly refresh.
- Treat `irr` / `common-data-sets` / `/irr/other-reports` as crawlable IR paths, and sniff mixed report hubs past the first 5KB (OU's CDS heading sits at ~8KB).

## Test plan
- [ ] CI green (finder unit tests + Deno resolve tests)
- [ ] After merge: deploy `archive-process` (and `discover` if bundled) so well-known-path changes are live
- [ ] `curl -X POST '.../archive-process?force_school=university-of-oklahoma-norman-campus'`
- [ ] Production has 2024-25 combined plus 2025-26 section package (and older combined years), not only 2023-24


Made with [Cursor](https://cursor.com)