### PR TITLE
fix: schedule Brave finder probes and unstick PDF seeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Audit retired school redirects
         run: python tools/finder/school_redirect_guard.py
       - name: Run finder identity tests
-        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls
+        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls tools.finder.test_stuck_pdf_seeds
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
       - name: Run IPEDS loader tests

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -1,0 +1,232 @@
+name: Ops finder probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "unknown = cooldown-aged unknowns; stuck-pdf = stale PDF seeds; both = stuck first, remaining Brave budget on unknowns."
+        type: choice
+        options:
+          - both
+          - stuck-pdf
+          - unknown
+        default: both
+      cooldown_days:
+        description: "Skip unknowns probed within N days (0 = ignore)."
+        required: false
+        default: "30"
+      brave_budget:
+        description: "Max Brave Search API calls this run (0 = unlimited)."
+        required: false
+        default: "1800"
+      apply_landing_hints:
+        description: "Apply high-confidence landing-page seed rewrites."
+        type: boolean
+        required: false
+        default: true
+      create_pr:
+        description: "Open a PR if schools.yaml changed."
+        type: boolean
+        required: false
+        default: true
+  schedule:
+    # Monthly. The README called this a cron for months; nothing actually
+    # called the Brave API after 2026-04-14. Day 2 avoids colliding with
+    # the IPEDS release probe on the 5th.
+    - cron: "18 14 2 * *"
+
+concurrency:
+  group: ops-finder-probe
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  probe:
+    name: Probe CDS listing URLs
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: https://api.collegedata.fyi
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzZHV3bXlndm1kb3pocHZ6YWl4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxMDk3NTksImV4cCI6MjA5MTY4NTc1OX0.fYZOIHyrOWzidgc-CVxWCY5Fe9pQk12-6YjDIS6y9qs
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      INPUT_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'both' }}
+      INPUT_COOLDOWN_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.cooldown_days || '30' }}
+      INPUT_BRAVE_BUDGET: ${{ github.event_name == 'workflow_dispatch' && inputs.brave_budget || '1800' }}
+      INPUT_APPLY_LANDING_HINTS: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_landing_hints }}
+      INPUT_CREATE_PR: ${{ github.event_name != 'workflow_dispatch' || inputs.create_pr }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/ci-requirements.txt
+
+      - name: Install Python dependencies
+        run: python -m pip install -r tools/ci-requirements.txt
+
+      - name: Require Brave API key
+        run: |
+          if [[ -z "${BRAVE_API_KEY}" ]]; then
+            echo "::error::Add the BRAVE_API_KEY repository secret. The finder talks to api.search.brave.com, not public brave.com, and has not been called since 2026-04-14."
+            exit 2
+          fi
+
+      - name: Classify stuck PDF seeds
+        run: |
+          mkdir -p finder-probe
+          python tools/finder/stuck_pdf_seeds.py \
+            --out-json finder-probe/stuck.json \
+            --out-md finder-probe/stuck.md \
+            --out-ids finder-probe/stuck-ids.txt
+
+      - name: Re-probe stuck PDF seeds
+        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf'
+        run: |
+          if [[ ! -s finder-probe/stuck-ids.txt ]]; then
+            echo "No stuck PDF seeds to re-probe."
+            exit 0
+          fi
+          PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
+            --brave-fallback \
+            --ids-file finder-probe/stuck-ids.txt \
+            --brave-budget "${INPUT_BRAVE_BUDGET}" \
+            --school-budget-sec 20 \
+            --save-every 25 \
+            2>&1 | tee finder-probe/stuck-probe.log
+
+      - name: Probe unknown schools
+        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown'
+        run: |
+          PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
+            --brave-fallback \
+            --include-active-no-hint \
+            --cooldown-days "${INPUT_COOLDOWN_DAYS}" \
+            --brave-budget "${INPUT_BRAVE_BUDGET}" \
+            --school-budget-sec 20 \
+            --save-every 50 \
+            2>&1 | tee finder-probe/unknown-probe.log
+
+      - name: Promote high-confidence landing hints
+        if: env.INPUT_APPLY_LANDING_HINTS == 'true'
+        run: |
+          python tools/finder/promote_landing_hints.py \
+            --min-confidence high \
+            --apply \
+            --report finder-probe/landing-hints.md \
+            2>&1 | tee finder-probe/landing-hints.log
+
+      - name: Refresh stuck report after seed rewrites
+        run: |
+          python tools/finder/stuck_pdf_seeds.py \
+            --out-json finder-probe/stuck-after.json \
+            --out-md finder-probe/stuck-after.md \
+            --out-ids finder-probe/stuck-ids-after.txt
+
+      - name: Add run summary
+        if: always()
+        run: |
+          {
+            echo "## Finder probe"
+            echo
+            echo "Mode: \`${INPUT_MODE}\`"
+            echo
+            if [[ -f finder-probe/stuck.md ]]; then
+              echo "### Stuck PDF seeds (before)"
+              echo
+              wc -l finder-probe/stuck-ids.txt | awk '{print $1 " school ids"}'
+              echo
+            fi
+            if [[ -f finder-probe/stuck-after.md ]]; then
+              echo "### Stuck PDF seeds (after)"
+              echo
+              wc -l finder-probe/stuck-ids-after.txt | awk '{print $1 " school ids"}'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert coverage issue
+        if: success()
+        run: |
+          python - <<'PY'
+          import json, os, subprocess, sys
+          from pathlib import Path
+          repo = os.environ["REPO"]
+          path = Path("finder-probe/stuck-after.md")
+          if not path.exists():
+              path = Path("finder-probe/stuck.md")
+          if not path.exists():
+              print("No stuck report; skipping issue.")
+              sys.exit(0)
+          title = "Finder: stuck PDF discovery seeds"
+          body = path.read_text()[:60000]
+          existing = subprocess.run(
+              ["gh", "issue", "list", "--repo", repo, "--state", "open",
+               "--search", f'in:title "{title}"', "--json", "number,title"],
+              check=True, text=True, stdout=subprocess.PIPE,
+          )
+          rows = json.loads(existing.stdout or "[]")
+          match = next((r for r in rows if r.get("title") == title), None)
+          if match:
+              subprocess.run(
+                  ["gh", "issue", "comment", str(match["number"]),
+                   "--repo", repo, "--body", body],
+                  check=True,
+              )
+              print(f"Commented on existing issue #{match['number']}")
+          else:
+              subprocess.run(
+                  ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
+                  check=True,
+              )
+              print("Created coverage issue")
+          PY
+
+      - name: Open PR for seed updates
+        if: success() && (env.INPUT_CREATE_PR == 'true')
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tools/finder/schools.yaml
+          if git diff --cached --quiet; then
+            echo "No schools.yaml changes."
+            exit 0
+          fi
+          branch="chore/finder-probe-${GITHUB_RUN_ID}"
+          git checkout -b "$branch"
+          git commit -m "$(cat <<'EOF'
+          chore: refresh CDS discovery seeds from monthly finder probe
+
+          Re-probe stale PDF seeds and unknowns via the Brave Search API, and
+          promote high-confidence HTML listings so weekly archive is not stuck
+          on a single year file.
+
+          EOF
+          )"
+          git push -u origin HEAD
+          gh pr create --title "chore: refresh CDS discovery seeds from monthly finder probe" --body "$(cat <<EOF
+          ## Summary
+          - Monthly finder probe (\`${INPUT_MODE}\`) updated \`tools/finder/schools.yaml\`.
+          - Stuck PDF-seed report is in the workflow artifacts / coverage issue.
+
+          ## Test plan
+          - [ ] Skim the PR diff for accidental satellite-campus seed copies
+          - [ ] After merge, weekly \`archive-enqueue\` picks up new listing seeds
+          EOF
+          )"
+
+      - name: Upload probe artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: finder-probe
+          path: finder-probe/
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses four-part semantic versioning.
 - Publish three source-literacy pages under `/about` (Common Data Set, College Scorecard, IPEDS) and link them from About, the footer, and `/llms.txt`.
 - Record the August 2026 Search Console CDS-query export next to PRD 028, including URL inspection of the Virginia Tech and Harvey Mudd canaries.
 - Record school-direct Common Data Set insert and refresh events in an append-only log, expose a per-school RSS feed of those events, show which freshness signal a school or year page is using, and daily-probe the top 50 schools by public C1 applicant volume once they are nine months past that file date.
+- Run the CDS URL finder monthly via GitHub Actions against the Brave Search API, re-probe stale one-file PDF seeds, flag that coverage class on a GitHub issue, and open a seed-update PR.
 
 ### Changed
 
@@ -22,6 +23,7 @@ This project uses four-part semantic versioning.
 
 - Rank Jump-to-school exact slugs and nicknames (MIT, Penn) ahead of accidental name substrings, and prefer schools that already have a CDS year.
 - Point Oklahoma's archive seed at the IRR listing (`/irr/other-reports`) instead of a single 2023-24 DAM PDF, and prefer Brave HTML listings over year-specific PDFs so sibling years are not frozen out.
+- Stop copying Ohio University's main-campus CDS URL onto the five regional UNITIDs that share ohio.edu.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/tools/finder/README.md
+++ b/tools/finder/README.md
@@ -266,17 +266,29 @@ The guard catches all three at build time before they ship.
 
 **SIGINT saves partial progress.** `Ctrl-C` triggers a finally-block save in `probe_urls.py`, so the fraction of schools probed before interrupt get committed to `schools.yaml`. Tested via an 11-minute wedge + SIGINT during the elite-seed pattern run.
 
-## Recommended monthly cron command
+## Recommended monthly cron
+
+GitHub Actions runs this on the 2nd of each month (`ops-finder-probe.yml`). It needs the `BRAVE_API_KEY` repository secret — the finder talks to `api.search.brave.com`, not public brave.com. Manual dispatch:
 
 ```bash
-cd /path/to/collegedata-fyi/tools/finder && \
-  PYTHONUNBUFFERED=1 python probe_urls.py \
-    --brave-fallback \
-    --include-active-no-hint \
-    2>&1 | tee logs/probe-$(date +%Y%m%d).log
+gh workflow run ops-finder-probe.yml
 ```
 
-`PYTHONUNBUFFERED=1` so `tee` sees output as it happens; `--brave-fallback` for URL discovery; `--include-active-no-hint` to keep rescuing any future seed-list entries that are marked active but lack a hint. Expected runtime: 5-15 minutes depending on how many schools have aged out of cooldown. Expected Brave spend: under $1 for a typical cron.
+Operator equivalent, from a laptop that has `BRAVE_API_KEY` in the environment:
+
+```bash
+cd /path/to/collegedata-fyi && \
+  PYTHONUNBUFFERED=1 python tools/finder/stuck_pdf_seeds.py --out-ids /tmp/stuck-ids.txt && \
+  PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
+    --brave-fallback \
+    --ids-file /tmp/stuck-ids.txt \
+    --brave-budget 1800 \
+    2>&1 | tee logs/probe-stuck-$(date +%Y%m%d).log && \
+  PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
+    --brave-fallback \
+    --include-active-no-hint \
+    2>&1 | tee logs/probe-unknown-$(date +%Y%m%d).log
+```
 
 ## See also
 

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -45,8 +45,17 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
+from collections import defaultdict
 
 import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from tools.finder.stuck_pdf_seeds import (  # noqa: E402
+    choose_canonical_school,
+    is_direct_doc_seed,
+)
 
 ROOT = Path(__file__).parent
 SCHOOLS_YAML = ROOT / "schools.yaml"
@@ -247,15 +256,73 @@ def _days_since(iso_str: str) -> float:
         return 999  # treat unparseable as "very old"
 
 
-def should_skip(school: dict, cooldown_days: float) -> bool:
-    """Return True if this school was probed recently and came back not_found."""
+def should_skip(school: dict, cooldown_days: float, *, reprobe_found: bool = False) -> bool:
+    """Return True if this school should not be probed this run.
+
+    `last_result: found` used to skip forever — that froze PDF seeds in
+    place (OU). Re-probe runs pass reprobe_found=True. Satellite campuses
+    that inherited a sibling's URL stay skipped until an operator
+    explicitly includes them.
+    """
     ps = school.get("probe_state")
     if not ps:
         return False
-    if ps.get("last_result") == "found":
-        return True  # already found, nothing to do
-    last = ps.get("last_probed_at", "")
-    return _days_since(last) < cooldown_days
+    last = ps.get("last_result")
+    if last == "shared_parent_seed" and not reprobe_found:
+        return True
+    if last == "found" and not reprobe_found:
+        return True
+    probed_at = ps.get("last_probed_at", "")
+    return _days_since(probed_at) < cooldown_days
+
+
+def should_replace_seed(existing: str | None, new: str | None) -> bool:
+    """Listing pages replace year-specific PDFs; PDFs do not replace listings."""
+    if not new:
+        return False
+    if not existing:
+        return True
+    existing_doc = is_direct_doc_seed(existing)
+    new_doc = is_direct_doc_seed(new)
+    if existing_doc and not new_doc:
+        return True
+    if not existing_doc:
+        return False
+    return False
+
+
+def clear_shared_parent_seed(school: dict, keeper_id: str) -> None:
+    school.pop("discovery_seed_url", None)
+    school.pop("cds_url_hint", None)
+    school["scrape_policy"] = "unknown"
+    record_probe(school, "shared_parent_seed", "shared_parent", 0, False)
+    note = (
+        f"Cleared identical seed also assigned to {keeper_id}; "
+        "Brave site:domain search is not campus-specific."
+    )
+    existing = school.get("notes") or ""
+    if note not in existing:
+        school["notes"] = f"{existing} {note}".strip() if existing else note
+
+
+def dedupe_identical_seeds(schools: list[dict]) -> list[tuple[str, str]]:
+    """Keep one owner per identical discovery_seed_url; clear the rest."""
+    by_url: dict[str, list[dict]] = defaultdict(list)
+    for school in schools:
+        seed = school.get("discovery_seed_url") or ""
+        if seed:
+            by_url[seed].append(school)
+    cleared: list[tuple[str, str]] = []
+    for _url, group in by_url.items():
+        if len(group) < 2:
+            continue
+        keeper = choose_canonical_school(group)
+        for school in group:
+            if school.get("id") == keeper.get("id"):
+                continue
+            clear_shared_parent_seed(school, keeper.get("id") or "")
+            cleared.append((school.get("id") or "", keeper.get("id") or ""))
+    return cleared
 
 
 def record_probe(school: dict, result: str, method: str,
@@ -419,12 +486,19 @@ def bing_html_search(domain: str) -> str | None:
     return None
 
 
-def brave_search(domain: str, api_key: str) -> str | None:
+def brave_search(domain: str, api_key: str, tracker: dict | None = None) -> str | None:
     """Use Brave Search API to find CDS PDFs for a school.
 
     Free tier: 2,000 queries/month. Paid: $0.003/query.
     Independent index, no domain pre-registration.
     """
+    if tracker is not None:
+        with tracker["lock"]:
+            budget = tracker.get("budget")
+            if budget is not None and tracker["calls"] >= budget:
+                print("  [brave] budget exhausted — skipping remaining queries", flush=True)
+                return None
+            tracker["calls"] += 1
     # NOTE: do not add `filetype:pdf` here. Many schools publish CDS as an
     # HTML landing page (oair.tulane.edu/common-data-set) or a .cfm page
     # (american.edu/provost/oira/common-data-set.cfm), not a raw PDF.
@@ -558,7 +632,7 @@ def process_school(school: dict, args: argparse.Namespace,
     if not url and args.brave_fallback and env.get("brave_api_key"):
         search_tried = True
         last_attempted_method = "brave"
-        url = brave_search(domain, env["brave_api_key"])
+        url = brave_search(domain, env["brave_api_key"], env.get("brave_tracker"))
         if url:
             method = "brave"
         time.sleep(0.5)
@@ -582,8 +656,10 @@ def process_school(school: dict, args: argparse.Namespace,
 
     if url:
         if not args.dry_run:
-            school["discovery_seed_url"] = url
-            school["scrape_policy"] = "active"
+            existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
+            if should_replace_seed(existing, url):
+                school["discovery_seed_url"] = url
+                school["scrape_policy"] = "active"
             record_probe(school, "found", method, patterns_tried, search_tried)
     else:
         if not args.dry_run:
@@ -621,7 +697,9 @@ def main():
 
     ap = argparse.ArgumentParser(
         description="Discover CDS URLs for schools in schools.yaml")
-    ap.add_argument("--only", help="Only probe this school id")
+    ap.add_argument("--only", help="Only probe this school id, or comma-separated ids")
+    ap.add_argument("--ids-file", type=Path,
+                    help="Probe only the school ids listed in this file (one per line)")
     ap.add_argument("--dry-run", action="store_true",
                     help="Print results but don't update schools.yaml")
     ap.add_argument("--rps", type=float, default=1.0,
@@ -656,6 +734,13 @@ def main():
                          "have no discovery_seed_url. Used to resolve seed-list "
                          "entries that were marked active on faith but never "
                          "got a URL — populates their seeds without demoting.")
+    ap.add_argument("--reprobe-pdf-seeds", action="store_true",
+                    help="Also re-probe active schools whose seed is a PDF/XLSX/"
+                         "DOCX. Needed because last_result=found otherwise skips "
+                         "them forever and weekly archive never finds listings.")
+    ap.add_argument("--brave-budget", type=int, default=1800,
+                    help="Max Brave Search API calls this run (default 1800, "
+                         "under the 2000/month free tier). 0 means unlimited.")
     ap.add_argument("--school-budget-sec", type=float, default=DEFAULT_SCHOOL_BUDGET_SEC,
                     help=f"Per-school wall-clock budget for the pattern "
                          f"ladder in seconds (default: {DEFAULT_SCHOOL_BUDGET_SEC}). "
@@ -672,7 +757,28 @@ def main():
         "google_api_key": os.environ.get("GOOGLE_API_KEY"),
         "google_cx": os.environ.get("GOOGLE_CX"),
         "brave_api_key": os.environ.get("BRAVE_API_KEY"),
+        "brave_tracker": {
+            "calls": 0,
+            "budget": None if args.brave_budget == 0 else args.brave_budget,
+            "lock": Lock(),
+        },
     }
+    if args.brave_fallback and not env["brave_api_key"]:
+        print("BRAVE_API_KEY is not set; --brave-fallback will find nothing.",
+              file=sys.stderr)
+
+    only_ids: set[str] | None = None
+    if args.only:
+        only_ids = {s.strip() for s in args.only.split(",") if s.strip()}
+    if args.ids_file:
+        file_ids = {
+            line.strip()
+            for line in args.ids_file.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+        only_ids = file_ids if only_ids is None else only_ids | file_ids
+    targeted = only_ids is not None
+    reprobe_found = targeted or args.reprobe_pdf_seeds
 
     # ── Build candidate list (apply all filters up front) ──
     name_filter = args.name_contains.lower() if args.name_contains else None
@@ -683,23 +789,34 @@ def main():
         sid = school.get("id", "")
         policy = school.get("scrape_policy", "unknown")
         name = school.get("name", sid)
+        seed = school.get("discovery_seed_url") or school.get("cds_url_hint") or ""
 
-        if args.only and sid != args.only:
+        if only_ids is not None and sid not in only_ids:
             continue
-        if not args.only and policy != "unknown":
+        if not targeted and policy != "unknown":
             # Allow through active-but-no-hint entries when the caller asks
             # for them. These are hand-curated seed-list rows that were
             # marked active on faith but never got a URL resolved, so
             # downstream has nothing to fetch. Running them through the
             # probe populates discovery_seed_url without touching scrape_policy.
             # Both names checked so legacy YAML rows (pre-PR-5) still match.
-            if not (args.include_active_no_hint
-                    and policy == "active"
-                    and not (school.get("discovery_seed_url") or school.get("cds_url_hint"))):
+            allow_active_no_hint = (
+                args.include_active_no_hint
+                and policy == "active"
+                and not seed
+            )
+            allow_pdf_reprobe = (
+                args.reprobe_pdf_seeds
+                and policy == "active"
+                and is_direct_doc_seed(seed)
+            )
+            if not allow_active_no_hint and not allow_pdf_reprobe:
                 continue
         if name_filter and name_filter not in name.lower():
             continue
-        if not args.only and args.cooldown_days > 0 and should_skip(school, args.cooldown_days):
+        if not targeted and args.cooldown_days > 0 and should_skip(
+            school, args.cooldown_days, reprobe_found=reprobe_found
+        ):
             skipped += 1
             continue
 
@@ -746,12 +863,14 @@ def main():
 
                 # Periodic save so Ctrl-C doesn't lose hours of probes
                 if not args.dry_run and args.save_every > 0 and completed % args.save_every == 0:
+                    dedupe_identical_seeds(schools)
                     _save_yaml(data)
                     print(f"  [checkpoint saved at {completed}/{total}]")
         except KeyboardInterrupt:
             print(f"\n[interrupted at {completed}/{total}] — cancelling pending workers")
             executor.shutdown(wait=False, cancel_futures=True)
             if not args.dry_run:
+                dedupe_identical_seeds(schools)
                 _save_yaml(data)
                 print(f"  [partial progress saved to {SCHOOLS_YAML}]")
             print(f"\nProbed: {completed}, Found: {found}, Not found: {failed}")
@@ -761,8 +880,14 @@ def main():
     if skipped:
         print(f", Skipped (cooldown): {skipped}", end="")
     print()
+    tracker = env.get("brave_tracker") or {}
+    if tracker.get("calls"):
+        print(f"Brave API calls this run: {tracker['calls']}")
 
     if not args.dry_run and completed > 0:
+        cleared = dedupe_identical_seeds(schools)
+        if cleared:
+            print(f"Cleared {len(cleared)} duplicate seed(s) shared across UNITIDs")
         _save_yaml(data)
         print(f"Updated {SCHOOLS_YAML}")
 

--- a/tools/finder/promote_landing_hints.py
+++ b/tools/finder/promote_landing_hints.py
@@ -76,7 +76,7 @@ SKIP_HOST_RE = re.compile(
 CDS_LIKE_SEGMENT_RE = re.compile(
     r"^(cds|common-data-set|common_data_set|common-data-sets|commondataset|"
     r"institutional-research|institutional_research|institutionalresearch|"
-    r"institutional-data|ir|oir|oira|iro|irp)$",
+    r"institutional-data|ir|irr|oir|oira|iro|irp|other-reports)$",
     re.I,
 )
 
@@ -427,6 +427,18 @@ def main() -> int:
                          "positives where the 'parent' is a 404 or 403. "
                          "option-(a) proposals are already probe-verified "
                          "via the manual_urls.yaml pipeline.")
+    ap.add_argument(
+        "--min-confidence",
+        choices=("high", "medium", "low"),
+        default="low",
+        help="Only keep proposals at this confidence or better "
+             "(high > medium > low). Default low keeps every proposal.",
+    )
+    ap.add_argument(
+        "--ids-file",
+        type=Path,
+        help="Limit proposals to school ids listed in this file.",
+    )
     args = ap.parse_args()
 
     schools_data = yaml.safe_load(args.schools_yaml.read_text())
@@ -502,6 +514,21 @@ def main() -> int:
                   f"{', '.join(dropped) if dropped else '(none)'}",
                   file=sys.stderr)
             print(f"Proposals (post-verify): {len(proposals)}", file=sys.stderr)
+
+    rank = {"high": 3, "medium": 2, "low": 1}
+    min_rank = rank[args.min_confidence]
+    proposals = [
+        p for p in proposals
+        if rank.get(p.get("confidence") or "low", 0) >= min_rank
+    ]
+    if args.ids_file:
+        allow = {
+            line.strip()
+            for line in args.ids_file.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+        proposals = [p for p in proposals if p["school_id"] in allow]
+    print(f"Proposals (after confidence/id filters): {len(proposals)}", file=sys.stderr)
 
     if args.apply:
         if not proposals:

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -1816,14 +1816,15 @@ schools:
   name: Arizona State University Digital Immersion
   domain: asu.edu
   ipeds_id: '483124'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:16:46Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://provost.asu.edu/sites/g/files/litvpz671/files/page/2556/uoia-commondataset-2017.pdf
+  notes: Cleared identical seed also assigned to arizona-state-university-campus-immersion; search is not campus-specific.
+
 - id: arkansas-baptist-college
   name: Arkansas Baptist College
   domain: arkansasbaptist.edu
@@ -6862,14 +6863,15 @@ schools:
   name: Drury University-College of Continuing Professional Studies
   domain: drury.edu
   ipeds_id: '492801'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:18:19Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.drury.edu/wp-content/uploads/files/academic-affairs/pdf/institutional_research/CDS_2023-2024_DruryU.pdf
+  notes: Cleared identical seed also assigned to drury-university; search is not campus-specific.
+
 - id: dunwoody-college-of-technology
   name: Dunwoody College of Technology
   domain: dunwoody.edu
@@ -7548,14 +7550,15 @@ schools:
   name: Fairleigh Dickinson University-Florham Campus
   domain: fdu.edu
   ipeds_id: '184694'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:18:31Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.fdu.edu/wp-content/uploads/2025/04/2024-25-Common-Data-Set-University.pdf
+  notes: Cleared identical seed also assigned to fairleigh-dickinson-university-metropolitan-campus; search is not campus-specific.
+
 - id: fairleigh-dickinson-university-metropolitan-campus
   name: Fairleigh Dickinson University-Metropolitan Campus
   domain: fdu.edu
@@ -7857,14 +7860,15 @@ schools:
   name: Florida Institute of Technology-Online
   domain: fit.edu
   ipeds_id: '480569'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:18:37Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.fit.edu/media/site-specific/wwwfitedu/oir/documents/CDS_2022-2023.pdf
+  notes: Cleared identical seed also assigned to florida-institute-of-technology; search is not campus-specific.
+
 - id: florida-international-university
   name: Florida International University
   domain: fiu.edu
@@ -10682,38 +10686,41 @@ schools:
   name: Kent State University at Ashtabula
   domain: kent.edu
   ipeds_id: '203447'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:28Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-east-liverpool
   name: Kent State University at East Liverpool
   domain: kent.edu
   ipeds_id: '203456'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:28Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-geauga
   name: Kent State University at Geauga
   domain: kent.edu
   ipeds_id: '203526'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:28Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-kent
   name: Kent State University at Kent
   domain: kent.edu
@@ -10730,50 +10737,54 @@ schools:
   name: Kent State University at Salem
   domain: kent.edu
   ipeds_id: '203492'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:29Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-stark
   name: Kent State University at Stark
   domain: kent.edu
   ipeds_id: '203465'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:29Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-trumbull
   name: Kent State University at Trumbull
   domain: kent.edu
   ipeds_id: '203474'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:29Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kent-state-university-at-tuscarawas
   name: Kent State University at Tuscarawas
   domain: kent.edu
   ipeds_id: '203483'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:19:29Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kent.edu/ir/common-dataset-cds
+  notes: Cleared identical seed also assigned to kent-state-university-at-kent; search is not campus-specific.
+
 - id: kentucky-christian-university
   name: Kentucky Christian University
   domain: kcu.edu
@@ -12872,26 +12883,28 @@ schools:
   name: Miami University-Hamilton
   domain: miamioh.edu
   ipeds_id: '204006'
-  scrape_policy: active
-  discovery_seed_url: https://miamioh.edu/institutional-research/common-data-set.html
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T06:36:07Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: pattern
     patterns_tried: 3
     search_fallback_tried: false
+  notes: Cleared identical seed also assigned to miami-university-oxford; search is not campus-specific.
+
 - id: miami-university-middletown
   name: Miami University-Middletown
   domain: miamioh.edu
   ipeds_id: '204015'
-  scrape_policy: active
-  discovery_seed_url: https://miamioh.edu/institutional-research/common-data-set.html
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T06:36:11Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: pattern
     patterns_tried: 3
     search_fallback_tried: false
+  notes: Cleared identical seed also assigned to miami-university-oxford; search is not campus-specific.
+
 - id: miami-university-oxford
   name: Miami University-Oxford
   domain: miamioh.edu
@@ -13044,14 +13057,15 @@ schools:
   name: Middlebury Institute of International Studies at Monterey
   domain: middlebury.edu
   ipeds_id: '119058'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:11Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.middlebury.edu/sites/default/files/2023-03/CDS_2022-2023_3.pdf
+  notes: Cleared identical seed also assigned to middlebury-college; search is not campus-specific.
+
 - id: midland-college
   name: Midland College
   domain: midland.edu
@@ -14743,14 +14757,15 @@ schools:
   name: Northeastern University Professional Programs
   domain: northeastern.edu
   ipeds_id: '482705'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:42Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://uds.northeastern.edu/facts/common-data-set/
+  notes: Cleared identical seed also assigned to northeastern; search is not campus-specific.
+
 - id: northern-arizona-university
   name: Northern Arizona University
   domain: nau.edu
@@ -14937,14 +14952,15 @@ schools:
   name: Northwest University-Center for Online and Extended Education
   domain: northwestu.edu
   ipeds_id: '487603'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:45Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.northwestu.edu/assets/documents/about/Common_Data_Set_Northwest_University_2022-2023.pdf
+  notes: Cleared identical seed also assigned to northwest-university; search is not campus-specific.
+
 - id: northwestern-college
   name: Northwestern College
   domain: nwciowa.edu
@@ -15285,38 +15301,41 @@ schools:
   name: Ohio University-Chillicothe Campus
   domain: ohio.edu
   ipeds_id: '204820'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:51Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  notes: Brave site:ohio.edu assigned the main-campus CDS PDF to every Ohio University UNITID. Regional campuses do not get that file.
+
 - id: ohio-university-eastern-campus
   name: Ohio University-Eastern Campus
   domain: ohio.edu
   ipeds_id: '204802'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:51Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  notes: Brave site:ohio.edu assigned the main-campus CDS PDF to every Ohio University UNITID. Regional campuses do not get that file.
+
 - id: ohio-university-lancaster-campus
   name: Ohio University-Lancaster Campus
   domain: ohio.edu
   ipeds_id: '204848'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:51Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  notes: Brave site:ohio.edu assigned the main-campus CDS PDF to every Ohio University UNITID. Regional campuses do not get that file.
+
 - id: ohio-university-main-campus
   name: Ohio University-Main Campus
   domain: ohio.edu
@@ -15333,26 +15352,28 @@ schools:
   name: Ohio University-Southern Campus
   domain: ohio.edu
   ipeds_id: '204839'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:52Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  notes: Brave site:ohio.edu assigned the main-campus CDS PDF to every Ohio University UNITID. Regional campuses do not get that file.
+
 - id: ohio-university-zanesville-campus
   name: Ohio University-Zanesville Campus
   domain: ohio.edu
   ipeds_id: '204866'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:52Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  notes: Brave site:ohio.edu assigned the main-campus CDS PDF to every Ohio University UNITID. Regional campuses do not get that file.
+
 - id: ohio-wesleyan-university
   name: Ohio Wesleyan University
   domain: owu.edu
@@ -15755,14 +15776,15 @@ schools:
   name: Pacific Northwest College of Art
   domain: willamette.edu
   ipeds_id: '209603'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:20:58Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://legacy.willamette.edu/ir/cds/index.html
+  notes: Cleared identical seed also assigned to willamette-university; search is not campus-specific.
+
 - id: pacific-northwest-university-of-health-sciences
   name: Pacific Northwest University of Health Sciences
   domain: pnwu.edu
@@ -19665,14 +19687,15 @@ schools:
   name: Springfield College-Regional, Online, and Continuing Education
   domain: springfield.edu
   ipeds_id: '475273'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:22:10Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://springfield.edu/sites/default/files/springfield-college-2024-25-common-data-set-usnews-v4.pdf
+  notes: Cleared identical seed also assigned to springfield-college; search is not campus-specific.
+
 - id: st-bernards-school-of-theology-and-ministry
   name: St Bernard's School of Theology and Ministry
   domain: stbernards.edu
@@ -22898,14 +22921,15 @@ schools:
   name: University of Hawaii System Office
   domain: hawaii.edu
   ipeds_id: '141963'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:23:10Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://manoa.hawaii.edu/miro/wp-content/uploads/2023/11/AnalysisBrief_CommonDataSet_2023-2024_updated.pdf
+  notes: Cleared identical seed also assigned to university-of-hawaii-at-manoa; search is not campus-specific.
+
 - id: university-of-hawaii-west-oahu
   name: University of Hawaii-West Oahu
   domain: westoahu.hawaii.edu
@@ -22980,14 +23004,15 @@ schools:
   name: University of Houston-System Administration
   domain: uh.edu
   ipeds_id: '229407'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-04-14T13:23:12Z'
-    last_result: found
+    last_result: shared_parent_seed
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://uh.edu/ir/reports/common-data-sets/
+  notes: Cleared identical seed also assigned to university-of-houston; search is not campus-specific.
+
 - id: university-of-houston-victoria
   name: University of Houston-Victoria
   domain: uhv.edu

--- a/tools/finder/stuck_pdf_seeds.py
+++ b/tools/finder/stuck_pdf_seeds.py
@@ -1,0 +1,291 @@
+"""Flag schools whose discovery seed is a one-file PDF (or xlsx/docx).
+
+A direct-document seed plus fewer than a few archived years, with the latest
+year older than the current CDS cycle, is the OU failure class: weekly
+archive refresh re-verifies that one file and never looks for a listing.
+
+This is the coverage job for that class. It reads schools.yaml and public
+cds_documents year counts, then emits JSON / markdown / id lists the monthly
+finder workflow and probe_urls.py consume.
+
+Usage:
+    python tools/finder/stuck_pdf_seeds.py
+    python tools/finder/stuck_pdf_seeds.py --ids-only
+    python tools/finder/stuck_pdf_seeds.py --out-json stuck.json --out-md stuck.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+import yaml
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parents[1]
+DOCUMENT_EXT_RE = re.compile(r"\.(pdf|xlsx|docx)(\?|#|$)", re.I)
+DEFAULT_API = "https://api.collegedata.fyi"
+
+
+def default_min_fresh_year(today: date | None = None) -> str:
+    """Freshness floor: the CDS year that should already be on a listing.
+
+    Before September, last complete cycle is year-2/year-1 (Aug 2026 →
+    2024-25). From September, expect the previous academic year (Sep 2026
+    → 2025-26).
+    """
+    today = today or date.today()
+    start = today.year if today.month >= 9 else today.year - 1
+    return f"{start - 1}-{str(start)[2:]}"
+
+
+def is_direct_doc_seed(url: str | None) -> bool:
+    if not url:
+        return False
+    return bool(DOCUMENT_EXT_RE.search(url))
+
+
+SATELLITE_MARKERS = (
+    "online",
+    "professional-programs",
+    "continuing",
+    "digital-immersion",
+    "regional",
+    "system-office",
+    "system-administration",
+    "center-for-online",
+    "institute-of-international",
+    "hamilton",
+    "middletown",
+    "florham",
+)
+MAIN_MARKERS = (
+    "main-campus",
+    "main campus",
+    "-at-kent",
+    "campus-immersion",
+)
+
+
+def choose_canonical_school(schools: list[dict]) -> dict:
+    """Prefer a main-campus row when several UNITIDs share one seed URL."""
+
+    def score(school: dict) -> tuple[int, int, str]:
+        sid = school.get("id") or ""
+        name = (school.get("name") or "").lower()
+        blob = f"{sid} {name}"
+        points = 0
+        if any(m in sid or m in name for m in MAIN_MARKERS):
+            points += 100
+        if any(m in blob for m in SATELLITE_MARKERS):
+            points -= 80
+        return (points, -len(sid), sid)
+
+    return max(schools, key=score)
+
+
+def classify_school(
+    school: dict,
+    years: list[str],
+    *,
+    min_fresh_year: str,
+    max_years: int,
+) -> dict[str, Any] | None:
+    seed = school.get("discovery_seed_url") or school.get("cds_url_hint") or ""
+    if not is_direct_doc_seed(seed):
+        return None
+    unique_years = sorted({y for y in years if y})
+    latest = unique_years[-1] if unique_years else None
+    n_years = len(unique_years)
+    if n_years > max_years:
+        return None
+    if latest and latest >= min_fresh_year:
+        return None
+    return {
+        "id": school.get("id"),
+        "name": school.get("name"),
+        "domain": school.get("domain"),
+        "seed": seed,
+        "years": unique_years,
+        "n_years": n_years,
+        "latest": latest,
+        "min_fresh_year": min_fresh_year,
+    }
+
+
+def fetch_years_by_school(
+    api_url: str,
+    anon_key: str | None,
+) -> dict[str, list[str]]:
+    headers = {"Accept": "application/json"}
+    if anon_key:
+        headers["apikey"] = anon_key
+        headers["Authorization"] = f"Bearer {anon_key}"
+    by_school: dict[str, list[str]] = defaultdict(list)
+    start = 0
+    page = 1000
+    while True:
+        path = (
+            "/rest/v1/cds_documents"
+            "?select=school_id,cds_year"
+            "&removed_at=is.null"
+        )
+        req = urllib.request.Request(
+            api_url.rstrip("/") + path,
+            headers={**headers, "Range": f"{start}-{start + page - 1}"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                chunk = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            raise SystemExit(f"cds_documents fetch failed: HTTP {exc.code}") from exc
+        for row in chunk:
+            sid = row.get("school_id")
+            year = row.get("cds_year")
+            if sid and year:
+                by_school[sid].append(year)
+        if len(chunk) < page:
+            break
+        start += page
+        if start > 50_000:
+            break
+    return by_school
+
+
+def load_schools(path: Path) -> list[dict]:
+    data = yaml.safe_load(path.read_text()) or {}
+    return data.get("schools") or []
+
+
+def shared_seed_groups(schools: list[dict]) -> list[dict[str, Any]]:
+    by_url: dict[str, list[dict]] = defaultdict(list)
+    for school in schools:
+        seed = school.get("discovery_seed_url") or ""
+        if seed:
+            by_url[seed].append(school)
+    groups = []
+    for seed, group in sorted(by_url.items()):
+        if len(group) < 2:
+            continue
+        keeper = choose_canonical_school(group)
+        groups.append({
+            "seed": seed,
+            "keeper_id": keeper.get("id"),
+            "school_ids": [s.get("id") for s in group],
+        })
+    return groups
+
+
+def render_markdown(stuck: list[dict], shared: list[dict], min_fresh_year: str) -> str:
+    lines = [
+        f"# Stuck PDF discovery seeds",
+        "",
+        f"Freshness floor: `{min_fresh_year}`. Direct-document seed, "
+        f"≤2 archived years, latest older than the floor (or none).",
+        "",
+        f"Stuck schools: **{len(stuck)}**",
+        "",
+        "| school_id | latest | years | seed |",
+        "|---|---|---|---|",
+    ]
+    for row in stuck:
+        seed = (row.get("seed") or "").replace("|", "\\|")
+        lines.append(
+            f"| `{row['id']}` | {row.get('latest') or 'none'} | "
+            f"{row.get('n_years', 0)} | `{seed}` |"
+        )
+    if shared:
+        lines += [
+            "",
+            "## Identical seeds shared across UNITIDs",
+            "",
+            "| keeper | also assigned to | seed |",
+            "|---|---|---|",
+        ]
+        for group in shared:
+            others = [s for s in group["school_ids"] if s != group["keeper_id"]]
+            seed = group["seed"].replace("|", "\\|")
+            lines.append(
+                f"| `{group['keeper_id']}` | "
+                f"{', '.join(f'`{s}`' for s in others)} | `{seed}` |"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
+    ap.add_argument("--schools-yaml", type=Path, default=ROOT / "schools.yaml")
+    ap.add_argument("--api-url", default=os.environ.get("NEXT_PUBLIC_SUPABASE_URL") or DEFAULT_API)
+    ap.add_argument(
+        "--anon-key",
+        default=os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY") or "",
+    )
+    ap.add_argument("--min-fresh-year", default=default_min_fresh_year())
+    ap.add_argument("--max-years", type=int, default=2)
+    ap.add_argument("--ids-only", action="store_true")
+    ap.add_argument("--out-json", type=Path)
+    ap.add_argument("--out-md", type=Path)
+    ap.add_argument("--out-ids", type=Path)
+    args = ap.parse_args()
+
+    schools = load_schools(args.schools_yaml)
+    years_by_school: dict[str, list[str]] = {}
+    if args.anon_key:
+        years_by_school = fetch_years_by_school(args.api_url, args.anon_key)
+    else:
+        print("warn: no anon key; year counts will be empty", file=sys.stderr)
+
+    stuck = []
+    for school in schools:
+        row = classify_school(
+            school,
+            years_by_school.get(school.get("id") or "", []),
+            min_fresh_year=args.min_fresh_year,
+            max_years=args.max_years,
+        )
+        if row:
+            stuck.append(row)
+    stuck.sort(key=lambda r: ((r.get("latest") or ""), r["id"] or ""))
+    shared = shared_seed_groups(schools)
+
+    if args.ids_only:
+        sys.stdout.write("\n".join(r["id"] for r in stuck if r.get("id")) + "\n")
+    else:
+        print(
+            f"stuck_pdf_seeds {len(stuck)}  "
+            f"shared_url_groups {len(shared)}  "
+            f"min_fresh_year {args.min_fresh_year}",
+            file=sys.stderr,
+        )
+
+    payload = {
+        "min_fresh_year": args.min_fresh_year,
+        "max_years": args.max_years,
+        "stuck": stuck,
+        "shared_seed_groups": shared,
+    }
+    if args.out_json:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(json.dumps(payload, indent=2) + "\n")
+    if args.out_md:
+        args.out_md.parent.mkdir(parents=True, exist_ok=True)
+        args.out_md.write_text(render_markdown(stuck, shared, args.min_fresh_year))
+    if args.out_ids:
+        args.out_ids.parent.mkdir(parents=True, exist_ok=True)
+        args.out_ids.write_text(
+            "\n".join(r["id"] for r in stuck if r.get("id")) + "\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import unittest
 
-from tools.finder.probe_urls import is_cds_page, select_brave_cds_url
+from tools.finder.probe_urls import (
+    is_cds_page,
+    select_brave_cds_url,
+    should_replace_seed,
+    should_skip,
+    dedupe_identical_seeds,
+)
 
 
 class SelectBraveCdsUrlTests(unittest.TestCase):
@@ -65,6 +71,55 @@ class IsCdsPageTests(unittest.TestCase):
         prefix = ("x" * 6000).encode()
         body = prefix + b"<h2>Common Data Set (CDS)</h2>"
         self.assertTrue(is_cds_page(body, "text/html; charset=utf-8"))
+
+
+class SeedReplaceTests(unittest.TestCase):
+    def test_listing_replaces_pdf(self) -> None:
+        self.assertTrue(
+            should_replace_seed(
+                "https://example.edu/cds-2023.pdf",
+                "https://example.edu/ir/cds/",
+            )
+        )
+
+    def test_pdf_does_not_replace_listing(self) -> None:
+        self.assertFalse(
+            should_replace_seed(
+                "https://example.edu/ir/cds/",
+                "https://example.edu/cds-2024.pdf",
+            )
+        )
+
+    def test_pdf_does_not_replace_other_pdf(self) -> None:
+        self.assertFalse(
+            should_replace_seed(
+                "https://example.edu/cds-2023.pdf",
+                "https://example.edu/cds-2024.pdf",
+            )
+        )
+
+
+class SkipAndDedupeTests(unittest.TestCase):
+    def test_found_skips_until_reprobe(self) -> None:
+        school = {"probe_state": {"last_result": "found", "last_probed_at": "2026-04-14T00:00:00Z"}}
+        self.assertTrue(should_skip(school, 30))
+        self.assertFalse(should_skip(school, 30, reprobe_found=True))
+
+    def test_shared_parent_stays_skipped(self) -> None:
+        school = {"probe_state": {"last_result": "shared_parent_seed"}}
+        self.assertTrue(should_skip(school, 30))
+
+    def test_dedupe_keeps_main_campus(self) -> None:
+        url = "https://www.ohio.edu/instres/commondataset.pdf"
+        schools = [
+            {"id": "ohio-university-chillicothe-campus", "discovery_seed_url": url, "scrape_policy": "active"},
+            {"id": "ohio-university-main-campus", "discovery_seed_url": url, "scrape_policy": "active"},
+        ]
+        cleared = dedupe_identical_seeds(schools)
+        self.assertEqual(cleared, [("ohio-university-chillicothe-campus", "ohio-university-main-campus")])
+        self.assertNotIn("discovery_seed_url", schools[0])
+        self.assertEqual(schools[0]["probe_state"]["last_result"], "shared_parent_seed")
+        self.assertEqual(schools[1]["discovery_seed_url"], url)
 
 
 if __name__ == "__main__":

--- a/tools/finder/test_stuck_pdf_seeds.py
+++ b/tools/finder/test_stuck_pdf_seeds.py
@@ -1,0 +1,112 @@
+"""Tests for stuck PDF-seed classification and shared-domain ownership."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from tools.finder.stuck_pdf_seeds import (
+    choose_canonical_school,
+    classify_school,
+    default_min_fresh_year,
+    is_direct_doc_seed,
+    shared_seed_groups,
+)
+
+
+class FreshYearTests(unittest.TestCase):
+    def test_august_uses_prior_complete_cycle(self) -> None:
+        self.assertEqual(default_min_fresh_year(date(2026, 8, 21)), "2024-25")
+
+    def test_september_expects_previous_academic_year(self) -> None:
+        self.assertEqual(default_min_fresh_year(date(2026, 9, 1)), "2025-26")
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_listing_seed_is_not_stuck(self) -> None:
+        school = {"id": "ou", "discovery_seed_url": "https://www.ou.edu/irr/other-reports"}
+        self.assertIsNone(
+            classify_school(school, ["2023-24"], min_fresh_year="2024-25", max_years=2)
+        )
+
+    def test_stale_single_pdf_is_stuck(self) -> None:
+        school = {
+            "id": "portland-state-university",
+            "discovery_seed_url": "https://example.edu/cds-2023-2024.pdf",
+        }
+        row = classify_school(
+            school, ["2023-24"], min_fresh_year="2024-25", max_years=2
+        )
+        self.assertIsNotNone(row)
+        self.assertEqual(row["latest"], "2023-24")
+
+    def test_recent_single_pdf_is_not_coverage_stuck(self) -> None:
+        school = {
+            "id": "example",
+            "discovery_seed_url": "https://example.edu/cds-2024-2025.pdf",
+        }
+        self.assertIsNone(
+            classify_school(school, ["2024-25"], min_fresh_year="2024-25", max_years=2)
+        )
+
+    def test_zero_years_pdf_is_stuck(self) -> None:
+        school = {
+            "id": "ohio-university-main-campus",
+            "discovery_seed_url": "https://www.ohio.edu/instres/commondataset.pdf",
+        }
+        row = classify_school(school, [], min_fresh_year="2024-25", max_years=2)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["n_years"], 0)
+
+    def test_many_years_not_stuck_even_if_pdf(self) -> None:
+        school = {"id": "x", "discovery_seed_url": "https://example.edu/a.pdf"}
+        self.assertIsNone(
+            classify_school(
+                school,
+                ["2020-21", "2021-22", "2022-23"],
+                min_fresh_year="2024-25",
+                max_years=2,
+            )
+        )
+
+
+class SharedSeedTests(unittest.TestCase):
+    def test_direct_doc_detection(self) -> None:
+        self.assertTrue(is_direct_doc_seed("https://x.edu/a.pdf"))
+        self.assertFalse(is_direct_doc_seed("https://x.edu/ir/cds/"))
+
+    def test_kent_main_beats_regional_campuses(self) -> None:
+        schools = [
+            {"id": "kent-state-university-at-tuscarawas"},
+            {"id": "kent-state-university-at-kent"},
+            {"id": "kent-state-university-at-salem"},
+        ]
+        self.assertEqual(
+            choose_canonical_school(schools)["id"],
+            "kent-state-university-at-kent",
+        )
+
+    def test_manoa_beats_system_office(self) -> None:
+        schools = [
+            {"id": "university-of-hawaii-system-office"},
+            {"id": "university-of-hawaii-at-manoa"},
+        ]
+        self.assertEqual(
+            choose_canonical_school(schools)["id"],
+            "university-of-hawaii-at-manoa",
+        )
+
+    def test_shared_seed_groups(self) -> None:
+        url = "https://www.ohio.edu/instres/commondataset.pdf"
+        schools = [
+            {"id": "ohio-university-chillicothe-campus", "discovery_seed_url": url},
+            {"id": "ohio-university-main-campus", "discovery_seed_url": url},
+            {"id": "yale", "discovery_seed_url": "https://oir.yale.edu/common-data-set"},
+        ]
+        groups = shared_seed_groups(schools)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["keeper_id"], "ohio-university-main-campus")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wire the documented monthly Brave Search probe to GitHub Actions (`ops-finder-probe.yml`), re-probe stale one-file PDF seeds instead of skipping `last_result: found` forever, and open a seed-update PR plus a stuck-seed coverage issue.
- Promote high-confidence HTML listings from `promote_landing_hints.py` as a recurring job, not a one-shot.
- Stop sharing one CDS URL across sibling UNITIDs (Ohio University regionals, Kent State campuses, Miami Hamilton/Middletown, and the other identical-seed groups).

## Test plan
- [ ] CI finder unittests pass (`test_probe_urls`, `test_stuck_pdf_seeds`)
- [ ] Add the `BRAVE_API_KEY` repository secret (`gh secret set BRAVE_API_KEY`)
- [ ] After merge, `gh workflow run ops-finder-probe.yml` (mode `both`) and confirm it calls `api.search.brave.com`
- [ ] Skim the satellite-campus `schools.yaml` notes: Ohio regionals, Kent State non-Kent campuses, and other shared-URL rows should have no `discovery_seed_url`
- [ ] After the first probe PR merges, `force_school` any newly found listings and drain extraction for current years


Made with [Cursor](https://cursor.com)