### PR TITLE
fix: stale coverage floor and Ohio IEA listing seed

### DIFF
--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -120,7 +120,8 @@ jobs:
         if: env.INPUT_APPLY_LANDING_HINTS == 'true'
         run: |
           python tools/finder/promote_landing_hints.py \
-            --min-confidence high \
+            --min-confidence medium \
+            --ids-file finder-probe/stuck-ids.txt \
             --apply \
             --report finder-probe/landing-hints.md \
             2>&1 | tee finder-probe/landing-hints.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project uses four-part semantic versioning.
 - Rank Jump-to-school exact slugs and nicknames (MIT, Penn) ahead of accidental name substrings, and prefer schools that already have a CDS year.
 - Point Oklahoma's archive seed at the IRR listing (`/irr/other-reports`) instead of a single 2023-24 DAM PDF, and prefer Brave HTML listings over year-specific PDFs so sibling years are not frozen out.
 - Stop copying Ohio University's main-campus CDS URL onto the five regional UNITIDs that share ohio.edu.
+- Mark coverage `cds_available_stale` when the latest extracted year is older than the finder freshness floor, even if weekly archive re-verified the same file.
+- Point Ohio University's main-campus seed at the IEA university-data listing instead of a 404 `/instres` PDF.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/supabase/functions/_shared/resolve.test.ts
+++ b/supabase/functions/_shared/resolve.test.ts
@@ -68,6 +68,19 @@ Deno.test("extractCdsAnchors: commondataset.org documents are excluded even when
   assertEquals(anchors[0].url, "https://example.edu/files/cds2024-25.pdf");
 });
 
+Deno.test("extractCdsAnchors: SharePoint :x: link with CDS title is a document", () => {
+  const html = `
+    <a href="https://catmailohio.sharepoint.com/:x:/s/PRO-IeaWebdocs2/IQC__vQsqLFdQ732wvQ8Z4M2Af3jwIEccxlwEDYLMr8U6r8">2025 Common Data Set</a>
+  `;
+  const anchors = extractCdsAnchors(html, "https://www.ohio.edu/iea/university-data");
+  assertEquals(anchors.length, 1);
+  assertEquals(anchors[0].kind, "document");
+  assertEquals(
+    anchors[0].url,
+    "https://catmailohio.sharepoint.com/:x:/s/PRO-IeaWebdocs2/IQC__vQsqLFdQ732wvQ8Z4M2Af3jwIEccxlwEDYLMr8U6r8",
+  );
+});
+
 Deno.test("extractCdsAnchors: section marker detected", () => {
   const html = `
     <a href="/files/cds-section-d-2024-25.pdf">Common Data Set Section D 2024-25</a>
@@ -753,6 +766,7 @@ Deno.test("wellKnownPathUrls: expands to host-rooted CDS landing paths", () => {
   assertEquals(set.has("https://irp.dpb.cornell.edu/institutional-research/common-data-set/"), true);
   assertEquals(set.has("https://irp.dpb.cornell.edu/ir/common-data-set/"), true);
   assertEquals(set.has("https://irp.dpb.cornell.edu/irr/other-reports"), true);
+  assertEquals(set.has("https://irp.dpb.cornell.edu/iea/university-data"), true);
   // Origin is preserved without the hint's path.
   for (const u of urls) {
     assertEquals(u.startsWith("https://irp.dpb.cornell.edu"), true);

--- a/supabase/functions/_shared/resolve.ts
+++ b/supabase/functions/_shared/resolve.ts
@@ -35,6 +35,10 @@ const MAX_SUBPAGES_PER_SCHOOL = 25;
 // false positives where cds is a prefix of a different word.
 const CDS_KEYWORDS_RE = /common\s*data\s*set|\bcds(?![a-z])/i;
 const DOCUMENT_EXT_RE = /\.(pdf|xlsx|docx)(\?|#|$)/i;
+// SharePoint sharing links encode the Office type in the path (/:b:/ PDF,
+// /:x:/ Excel, /:w:/ Word) instead of a filename extension. Ohio's 2025
+// CDS is a :x: link titled "2025 Common Data Set" with no .xlsx suffix.
+const SHAREPOINT_FILE_PATH_RE = /^\/:[xbw]:\//i;
 
 // Section-file detection deliberately scoped to filenames only.
 // The earlier broader regex produced false positives when legit full-CDS
@@ -517,9 +521,12 @@ export function extractCdsAnchors(html: string, baseUrl: string): CdsAnchor[] {
       if (year) yearSource = "link_text";
     }
 
-    const kind: AnchorKind = DOCUMENT_EXT_RE.test(filename)
-      ? "document"
-      : "subpage";
+    const kind: AnchorKind =
+      DOCUMENT_EXT_RE.test(filename) ||
+        (parsed.hostname.endsWith("sharepoint.com") &&
+          SHAREPOINT_FILE_PATH_RE.test(parsed.pathname))
+        ? "document"
+        : "subpage";
 
     all.push({
       url: absoluteUrl,
@@ -834,7 +841,7 @@ function extensionFromContentType(contentType: string): "pdf" | "xlsx" | "docx" 
 // just the direct doc (pre-upgrade behavior).
 const MAX_PARENT_LEVELS = 3;
 const CDS_LIKE_PATH_SEGMENT_RE =
-  /^(cds|common-data-set|common-data-sets|common_data_set|institutional-research|institutional_research|ir|irr|oir|oira|iro|irp|other-reports)$/i;
+  /^(cds|common-data-set|common-data-sets|common_data_set|institutional-research|institutional_research|ir|irr|iea|oir|oira|iro|irp|other-reports|university-data)$/i;
 
 function pathHasCdsLikeSegment(segments: string[]): boolean {
   return segments.some((s) => CDS_LIKE_PATH_SEGMENT_RE.test(s));
@@ -946,6 +953,9 @@ const WELL_KNOWN_CDS_LANDING_PATHS: readonly string[] = [
   "/irr/common-data-set/",
   "/institutional-research/reports/",
   "/ir/reports/",
+  // Ohio University IEA mixed hub (2025 CDS is a SharePoint card on this page)
+  "/iea/university-data",
+  "/iea/university-data/",
 ];
 
 export function wellKnownPathUrls(hint: string): string[] {

--- a/supabase/migrations/20260821160000_coverage_year_freshness_floor.sql
+++ b/supabase/migrations/20260821160000_coverage_year_freshness_floor.sql
@@ -1,0 +1,249 @@
+-- Treat a successfully re-verified old CDS year as stale, not current.
+--
+-- archive-enqueue weekly-confirms the same one-file PDF seed
+-- (unchanged_verified). derive_coverage_status then called that
+-- cds_available_current even when the latest extracted year was
+-- 2022-23. Public coverage should not look healthy when the file we
+-- hold is older than the freshness floor used by the finder stuck-PDF
+-- job (tools/finder/stuck_pdf_seeds.py default_min_fresh_year).
+
+begin;
+
+create or replace function public.cds_freshness_floor(p_as_of date default current_date)
+returns text
+language sql
+immutable
+set search_path = public
+as $$
+  -- Before September: prior complete cycle (Aug 2026 → 2024-25).
+  -- From September: previous academic year (Sep 2026 → 2025-26).
+  select case
+    when extract(month from p_as_of) >= 9 then
+      (extract(year from p_as_of)::int - 1)::text
+      || '-'
+      || right((extract(year from p_as_of)::int)::text, 2)
+    else
+      (extract(year from p_as_of)::int - 2)::text
+      || '-'
+      || right((extract(year from p_as_of)::int - 1)::text, 2)
+  end;
+$$;
+
+comment on function public.cds_freshness_floor(date) is
+  'Canonical CDS year that should already be on file. Matches tools/finder/stuck_pdf_seeds.default_min_fresh_year. Used by refresh_institution_cds_coverage to demote cds_available_current → cds_available_stale.';
+
+revoke all on function public.cds_freshness_floor(date) from public;
+grant execute on function public.cds_freshness_floor(date) to anon, authenticated, service_role;
+
+create or replace function public.refresh_institution_cds_coverage()
+returns table (rows_written int, duration_ms int)
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  started timestamptz := clock_timestamp();
+  written int;
+begin
+  truncate table public.institution_cds_coverage;
+
+  with
+    cds_extracted as (
+      select distinct on (school_id)
+        school_id,
+        cds_year             as latest_extracted_year,
+        id                   as latest_document_id,
+        source_url           as latest_extracted_source_url
+      from public.cds_documents
+      where extraction_status = 'extracted'
+      order by school_id, cds_year desc
+    ),
+    cds_found as (
+      select distinct on (school_id)
+        school_id,
+        cds_year             as latest_found_year,
+        extraction_status    as latest_found_extraction_status
+      from public.cds_documents
+      where source_url is not null
+      order by school_id, cds_year desc
+    ),
+    queue_latest as (
+      select distinct on (school_id)
+        school_id,
+        last_outcome,
+        processed_at
+      from public.archive_queue
+      where status in ('done', 'failed_permanent')
+        and last_outcome is not null
+        and processed_at is not null
+      order by school_id, processed_at desc
+    ),
+    crosswalk_aliases as (
+      select
+        ipeds_id,
+        array_agg(distinct alias) filter (where source <> 'redirect') as aliases
+      from public.institution_slug_crosswalk
+      group by ipeds_id
+    ),
+    resolved_raw as (
+      select
+        d.ipeds_id,
+        d.school_id,
+        d.school_name,
+        d.city,
+        d.state,
+        d.website_url,
+        d.undergraduate_enrollment,
+        d.scorecard_data_year,
+        coalesce(ca.aliases, '{}'::text[])              as aliases,
+        ce.latest_extracted_year,
+        ce.latest_document_id,
+        ce.latest_extracted_source_url,
+        cf.latest_found_year,
+        cf.latest_found_extraction_status,
+        q.last_outcome,
+        q.processed_at                                    as last_checked_at,
+        o.public_note                                     as override_note,
+        coalesce(
+          o.status,
+          public.derive_coverage_status(
+            d.in_scope,
+            ce.latest_extracted_year,
+            cf.latest_found_year,
+            cf.latest_found_extraction_status,
+            q.last_outcome
+          )
+        )                                                 as derived_status
+      from public.institution_directory d
+      left join cds_extracted ce on ce.school_id = d.school_id
+      left join cds_found cf on cf.school_id = d.school_id
+      left join queue_latest q on q.school_id = d.school_id
+      left join crosswalk_aliases ca on ca.ipeds_id = d.ipeds_id
+      left join public.institution_cds_coverage_overrides o on o.ipeds_id = d.ipeds_id
+    ),
+    resolved as (
+      select
+        ipeds_id,
+        school_id,
+        school_name,
+        city,
+        state,
+        website_url,
+        undergraduate_enrollment,
+        scorecard_data_year,
+        aliases,
+        latest_extracted_year,
+        latest_document_id,
+        latest_extracted_source_url,
+        latest_found_year,
+        latest_found_extraction_status,
+        last_outcome,
+        last_checked_at,
+        override_note,
+        case
+          when derived_status = 'cds_available_current'
+               and latest_extracted_year is not null
+               and latest_extracted_year < public.cds_freshness_floor()
+            then 'cds_available_stale'::public.coverage_status_t
+          else derived_status
+        end as coverage_status
+      from resolved_raw
+    )
+  insert into public.institution_cds_coverage (
+    ipeds_id,
+    school_id,
+    school_name,
+    aliases,
+    city,
+    state,
+    website_url,
+    undergraduate_enrollment,
+    scorecard_data_year,
+    coverage_status,
+    coverage_label,
+    coverage_summary,
+    latest_available_cds_year,
+    latest_found_cds_year,
+    latest_attempted_year,
+    latest_document_id,
+    latest_public_source_url,
+    latest_field_count,
+    last_checked_at,
+    can_submit_source,
+    search_text,
+    updated_at
+  )
+  select
+    ipeds_id,
+    school_id,
+    school_name,
+    aliases,
+    city,
+    state,
+    website_url,
+    undergraduate_enrollment,
+    scorecard_data_year,
+    coverage_status,
+    public.coverage_status_label(coverage_status),
+    public.coverage_status_summary(
+      school_name,
+      coverage_status,
+      latest_extracted_year,
+      latest_found_year,
+      last_outcome,
+      override_note
+    ),
+    latest_extracted_year                                          as latest_available_cds_year,
+    latest_found_year                                              as latest_found_cds_year,
+    latest_found_year                                              as latest_attempted_year,
+    latest_document_id,
+    case
+      when coverage_status = 'cds_available_current'
+        then latest_extracted_source_url
+      else null
+    end                                                            as latest_public_source_url,
+    null::integer                                                  as latest_field_count,
+    last_checked_at,
+    coverage_status in (
+      'no_public_cds_found',
+      'source_not_automatically_accessible',
+      'not_checked'
+    )                                                              as can_submit_source,
+    lower(
+      school_name
+      || ' ' || coalesce(array_to_string(aliases, ' '), '')
+      || ' ' || coalesce(city, '')
+      || ' ' || coalesce(state, '')
+    )                                                              as search_text,
+    now()                                                          as updated_at
+  from resolved;
+
+  get diagnostics written = row_count;
+
+  return query select
+    written,
+    extract(milliseconds from clock_timestamp() - started)::int;
+end;
+$$;
+
+revoke all on function public.refresh_institution_cds_coverage() from public;
+revoke all on function public.refresh_institution_cds_coverage() from anon, authenticated;
+grant execute on function public.refresh_institution_cds_coverage() to service_role;
+
+do $$
+declare
+  floor_aug text;
+  floor_sep text;
+begin
+  select public.cds_freshness_floor(date '2026-08-21') into floor_aug;
+  if floor_aug is distinct from '2024-25' then
+    raise exception 'cds_freshness_floor Aug 2026 returned %, expected 2024-25', floor_aug;
+  end if;
+  select public.cds_freshness_floor(date '2026-09-01') into floor_sep;
+  if floor_sep is distinct from '2025-26' then
+    raise exception 'cds_freshness_floor Sep 2026 returned %, expected 2025-26', floor_sep;
+  end if;
+end;
+$$;
+
+commit;

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -119,6 +119,8 @@ PATTERNS = [
     "/irr/common-data-set/",
     "/institutional-research/reports/",
     "/ir/reports/",
+    "/iea/university-data",
+    "/iea/university-data/",
 ]
 
 # Subdomains to try. `sites` catches Wordpress-multisite institutions

--- a/tools/finder/promote_landing_hints.py
+++ b/tools/finder/promote_landing_hints.py
@@ -76,7 +76,7 @@ SKIP_HOST_RE = re.compile(
 CDS_LIKE_SEGMENT_RE = re.compile(
     r"^(cds|common-data-set|common_data_set|common-data-sets|commondataset|"
     r"institutional-research|institutional_research|institutionalresearch|"
-    r"institutional-data|ir|irr|oir|oira|iro|irp|other-reports)$",
+    r"institutional-data|ir|irr|iea|oir|oira|iro|irp|other-reports|university-data)$",
     re.I,
 )
 

--- a/tools/finder/school_overrides.yaml
+++ b/tools/finder/school_overrides.yaml
@@ -691,6 +691,20 @@ overrides:
         the WAF/headless downloader to capture the SharePoint download.aspx
         bytes before extraction.
 
+  - school_id: ohio-university-main-campus
+    browse_url: https://www.ohio.edu/iea/university-data
+    direct_archive_urls:
+      - { url: "https://catmailohio.sharepoint.com/:x:/s/PRO-IeaWebdocs2/IQC__vQsqLFdQ732wvQ8Z4M2Af3jwIEccxlwEDYLMr8U6r8", year: "2025-26" }
+    hosting_override:
+      file_storage: sharepoint
+      cms: drupal
+      auth_required: none
+      notes: >-
+        IEA moved CDS off /instres/commondataset.pdf (404). The 2025 file is
+        a public SharePoint xlsx card on /iea/university-data. Historical CDS
+        files were pulled in 2026 pending an H1 review. Regional UNITIDs on
+        ohio.edu must not inherit this seed.
+
   - school_id: colorado
     browse_url: https://data.colorado.edu/reports/common-data-set
     hosting_override:

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -15347,7 +15347,8 @@ schools:
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ohio.edu/instres/commondataset.pdf
+  discovery_seed_url: https://www.ohio.edu/iea/university-data
+  browse_url: https://www.ohio.edu/iea/university-data
 - id: ohio-university-southern-campus
   name: Ohio University-Southern Campus
   domain: ohio.edu


### PR DESCRIPTION
## Summary
- Public coverage now marks \`cds_available_stale\` when the latest extracted year is older than the finder freshness floor (Aug → \`2024-25\`), even if weekly archive re-verified the same file.
- Ohio University main campus seed is \`https://www.ohio.edu/iea/university-data\` (the 2025 CDS is a SharePoint xlsx card). Regional UNITIDs stay unseeded. Resolver treats SharePoint \`/:x:/\` / \`/:b:/\` / \`/:w:/\` links as documents.
- Monthly finder job applies medium-confidence landing-hint rewrites on the stuck-PDF cohort (high-confidence proposals are currently empty).

## Test plan
- [ ] CI Deno + finder tests pass
- [ ] After merge, \`supabase db push --linked\` from the main checkout (migration \`20260821160000\`)
- [ ] Redeploy \`archive-process\` and \`discover\`
- [ ] \`force_school=ohio-university-main-campus\` and drain extraction for 2025-26 (SharePoint fetch may need the Oregon-style headless path)
- [ ] Spot-check \`/coverage\`: a 2023-24-only school should show stale, not current


Made with [Cursor](https://cursor.com)