### PR TITLE
feat: ship PRD 030 M0 public pipeline observation board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: python -m unittest discover -s tools/change_intelligence -p "test_*.py"
       - name: Run discovery policy and engine tests
         run: python -m pytest tools/discovery -q
+      - name: Run ops tests
+        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit
       - name: Run data-integrity audit support tests
         run: python -m unittest tools.data_quality.test_audit_support
 

--- a/.github/workflows/ipeds-release-probe.yml
+++ b/.github/workflows/ipeds-release-probe.yml
@@ -38,6 +38,8 @@ jobs:
       INPUT_AS_OF: ${{ github.event_name == 'workflow_dispatch' && inputs.as_of || '' }}
       INPUT_FORCE_PROBE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_probe || false }}
       INPUT_PROBE_DELAY_MONTHS: ${{ github.event_name == 'workflow_dispatch' && inputs.probe_delay_months || '10' }}
+      PIPELINE_TRIGGER: ${{ github.event_name == 'schedule' && 'schedule' || 'dispatch' }}
+      PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +56,16 @@ jobs:
       - name: Install probe dependencies
         run: python -m pip install -r tools/ci-requirements.txt
 
-      - name: Run release probe
+      - name: Heartbeat ipeds_release_probe start
+        run: |
+          python tools/ops/record_heartbeat.py \
+            --station ipeds_release_probe \
+            --status running \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - id: run_probe
+        name: Run release probe
         shell: bash
         run: |
           set -euo pipefail
@@ -188,7 +199,44 @@ jobs:
               )
               minted += 1
           print(f"Created {minted} IPEDS release issue(s).")
+          summary["issue_opened"] = minted > 0
+          with open(path, "w", encoding="utf-8") as f:
+              json.dump(summary, f, indent=2, sort_keys=True)
+              f.write("\n")
           PY
+
+      - name: Heartbeat ipeds_release_probe finish
+        if: always()
+        env:
+          STEP_OUTCOME: ${{ steps.run_probe.outcome }}
+        run: |
+          mkdir -p ipeds-release-probe
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path("ipeds-release-probe/summary.json")
+          summary = {}
+          if path.exists():
+              summary = json.loads(path.read_text(encoding="utf-8"))
+          heartbeat = {
+              "new_release": bool((summary.get("available_count") or 0) > 0),
+              "issue_opened": bool(summary.get("issue_opened", False)),
+          }
+          Path("ipeds-release-probe/heartbeat.json").write_text(json.dumps(heartbeat) + "\n")
+          PY
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station ipeds_release_probe \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json ipeds-release-probe/heartbeat.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
 
       - name: Upload probe artifact
         if: always()

--- a/.github/workflows/ops-extraction-worker.yml
+++ b/.github/workflows/ops-extraction-worker.yml
@@ -80,6 +80,8 @@ jobs:
       INPUT_LOW_FIELD_THRESHOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.low_field_threshold || '25' }}
       INPUT_MIN_YEAR_START: ${{ github.event_name == 'workflow_dispatch' && inputs.min_year_start || '' }}
       INPUT_DEADLINE_MINUTES: ${{ github.event_name == 'workflow_dispatch' && inputs.deadline_minutes || '25' }}
+      PIPELINE_TRIGGER: ${{ github.event_name == 'schedule' && 'schedule' || 'dispatch' }}
+      PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
@@ -102,7 +104,16 @@ jobs:
           pdftoppm -h >/dev/null 2>&1
           tesseract --version
 
-      - name: Run bounded pending-row drain
+      - name: Heartbeat extraction_worker start
+        run: |
+          python tools/ops/record_heartbeat.py \
+            --station extraction_worker \
+            --status running \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - id: drain_pending
+        name: Run bounded pending-row drain
         shell: bash
         run: |
           set -euo pipefail
@@ -193,6 +204,41 @@ jobs:
           fi
 
           python tools/extraction_worker/worker.py "${args[@]}" | tee ops-summary/worker.log
+
+      - name: Heartbeat extraction_worker finish
+        if: always()
+        env:
+          STEP_OUTCOME: ${{ steps.drain_pending.outcome }}
+        run: |
+          mkdir -p ops-summary
+          if [[ ! -f ops-summary/summary.json ]]; then
+            printf '{"extracted":0,"failed":0,"pending_remaining":0,"stopped_reason":"error"}\n' > ops-summary/heartbeat.json
+          else
+            python - <<'PY'
+          import json
+          from pathlib import Path
+          summary = json.loads(Path("ops-summary/summary.json").read_text())
+          Path("ops-summary/heartbeat.json").write_text(json.dumps({
+              "extracted": summary.get("extracted", 0),
+              "failed": summary.get("failed", 0),
+              "pending_remaining": summary.get("pending_remaining", 0),
+              "stopped_reason": summary.get("stopped_reason", "error"),
+          }) + "\n")
+          PY
+          fi
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station extraction_worker \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json ops-summary/heartbeat.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
 
       - name: Add run summary
         if: always()

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -62,6 +62,8 @@ jobs:
       INPUT_BRAVE_BUDGET: ${{ github.event_name == 'workflow_dispatch' && inputs.brave_budget || '1800' }}
       INPUT_APPLY_LANDING_HINTS: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_landing_hints }}
       INPUT_CREATE_PR: ${{ github.event_name != 'workflow_dispatch' || inputs.create_pr }}
+      PIPELINE_TRIGGER: ${{ github.event_name == 'schedule' && 'schedule' || 'dispatch' }}
+      PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v5
 
@@ -89,11 +91,28 @@ jobs:
             --out-md finder-probe/stuck.md \
             --out-ids finder-probe/stuck-ids.txt
 
-      - name: Re-probe stuck PDF seeds
+      - name: Heartbeat finder_stuck_pdf start
+        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf'
+        run: |
+          python tools/ops/record_heartbeat.py \
+            --station finder_stuck_pdf \
+            --status running \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - id: re_probe_stuck
+        name: Re-probe stuck PDF seeds
         if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf'
         run: |
           if [[ ! -s finder-probe/stuck-ids.txt ]]; then
             echo "No stuck PDF seeds to re-probe."
+            python - <<'PY'
+            import json
+            from pathlib import Path
+            Path("finder-probe/stuck-probe-summary.json").write_text(json.dumps({
+                "probed": 0, "found": 0, "replaced": 0, "budget_remaining": 0, "still_stuck": 0,
+            }) + "\n")
+            PY
             exit 0
           fi
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
@@ -102,9 +121,59 @@ jobs:
             --brave-budget "${INPUT_BRAVE_BUDGET}" \
             --school-budget-sec 20 \
             --save-every 25 \
+            --summary-json finder-probe/stuck-probe-summary.json \
             2>&1 | tee finder-probe/stuck-probe.log
 
-      - name: Probe unknown schools
+      - name: Heartbeat finder_stuck_pdf finish
+        if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf')
+        env:
+          STEP_OUTCOME: ${{ steps.re_probe_stuck.outcome }}
+        run: |
+          stuck=0
+          if [[ -f finder-probe/stuck-ids.txt ]]; then
+            stuck=$(grep -cve '^[[:space:]]*$' finder-probe/stuck-ids.txt || true)
+          fi
+          python - "$stuck" "$STEP_OUTCOME" <<'PY'
+          import json, sys
+          from pathlib import Path
+          stuck = int(sys.argv[1])
+          outcome = sys.argv[2]
+          path = Path("finder-probe/stuck-probe-summary.json")
+          summary = {"probed": 0, "found": 0, "replaced": 0, "still_stuck": 0}
+          if path.exists():
+              summary.update(json.loads(path.read_text()))
+          Path("finder-probe/stuck-heartbeat.json").write_text(json.dumps({
+              "stuck": stuck,
+              "reprobed": summary.get("probed", 0),
+              "still_stuck": summary.get("still_stuck", max(0, summary.get("probed", 0) - summary.get("found", 0))),
+          }) + "\n")
+          print(outcome)
+          PY
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station finder_stuck_pdf \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json finder-probe/stuck-heartbeat.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - name: Heartbeat finder_brave start
+        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown'
+        run: |
+          python tools/ops/record_heartbeat.py \
+            --station finder_brave \
+            --status running \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - id: probe_unknown
+        name: Probe unknown schools
         if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown'
         run: |
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
@@ -114,9 +183,42 @@ jobs:
             --brave-budget "${INPUT_BRAVE_BUDGET}" \
             --school-budget-sec 20 \
             --save-every 50 \
+            --summary-json finder-probe/unknown-summary.json \
             2>&1 | tee finder-probe/unknown-probe.log
 
-      - name: Promote high-confidence landing hints
+      - name: Heartbeat finder_brave finish
+        if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown')
+        env:
+          STEP_OUTCOME: ${{ steps.probe_unknown.outcome }}
+        run: |
+          if [[ ! -f finder-probe/unknown-summary.json ]]; then
+            printf '{"probed":0,"found":0,"replaced":0,"budget_remaining":0}\n' > finder-probe/unknown-summary.json
+          fi
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station finder_brave \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json finder-probe/unknown-summary.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - name: Heartbeat finder_landing_hints start
+        if: env.INPUT_APPLY_LANDING_HINTS == 'true'
+        run: |
+          python tools/ops/record_heartbeat.py \
+            --station finder_landing_hints \
+            --status running \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --run-url "${PIPELINE_RUN_URL}"
+
+      - id: promote_landing_hints
+        name: Promote high-confidence landing hints
         if: env.INPUT_APPLY_LANDING_HINTS == 'true'
         run: |
           python tools/finder/promote_landing_hints.py \
@@ -124,7 +226,30 @@ jobs:
             --ids-file finder-probe/stuck-ids.txt \
             --apply \
             --report finder-probe/landing-hints.md \
+            --summary-json finder-probe/landing-hints-summary.json \
             2>&1 | tee finder-probe/landing-hints.log
+
+      - name: Heartbeat finder_landing_hints finish
+        if: always() && env.INPUT_APPLY_LANDING_HINTS == 'true'
+        env:
+          STEP_OUTCOME: ${{ steps.promote_landing_hints.outcome }}
+        run: |
+          if [[ ! -f finder-probe/landing-hints-summary.json ]]; then
+            printf '{"proposals":0,"promoted":0}\n' > finder-probe/landing-hints-summary.json
+          fi
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station finder_landing_hints \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json finder-probe/landing-hints-summary.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
 
       - name: Refresh stuck report after seed rewrites
         run: |

--- a/docs/design/pipeline-observation-preview.html
+++ b/docs/design/pipeline-observation-preview.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pipeline observation — collegedata.fyi (preview)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:ital,wght@0,400;0,500;1,400&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --paper: #f1ece1;
+      --paper-2: #e9e3d4;
+      --ink: #1c1e1b;
+      --ink-2: #3a3b37;
+      --ink-3: #6b6a63;
+      --rule: rgba(28,30,27,0.12);
+      --serif: "Newsreader", "Times New Roman", serif;
+      --sans: "IBM Plex Sans", system-ui, sans-serif;
+      --mono: "IBM Plex Mono", ui-monospace, monospace;
+      --lamp-ok: #1f7a4d;
+      --lamp-late: #e0a106;
+      --lamp-down: #d7263d;
+      --lamp-lock: #6b3fa0;
+      --lamp-sso: #7a2f6a;
+      --lamp-waf: #c45c14;
+      --lamp-slate: #5c5a54;
+      --late-ink: #1c1400;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: var(--sans);
+      line-height: 1.5;
+    }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 32px 20px 80px; }
+    .meta {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+    }
+    h1 {
+      font-family: var(--serif);
+      font-weight: 400;
+      font-size: clamp(40px, 6vw, 64px);
+      line-height: 1.05;
+      letter-spacing: -0.02em;
+      margin: 16px 0 0;
+    }
+    h1 em { font-style: italic; }
+    .lede { max-width: 720px; margin: 18px 0 0; color: var(--ink-2); font-size: 16px; }
+    .banner {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      margin: 16px 0 0;
+      padding: 14px 18px;
+      background: var(--lamp-down);
+      color: #fff;
+      font-family: var(--mono);
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    h2 {
+      font-family: var(--serif);
+      font-weight: 400;
+      font-size: 22px;
+      margin: 48px 0 16px;
+    }
+    .board {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+      gap: 8px;
+    }
+    .tile {
+      min-height: 168px;
+      padding: 14px 14px 12px;
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+    .tile.ok { background: var(--lamp-ok); }
+    .tile.down { background: var(--lamp-down); }
+    .tile.late { background: var(--lamp-late); color: var(--late-ink); }
+    .tile.slate { background: var(--lamp-slate); }
+    .tile .id {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.85;
+    }
+    .tile h3 {
+      font-family: var(--serif);
+      font-weight: 400;
+      font-size: 20px;
+      line-height: 1.1;
+      margin: 8px 0 0;
+    }
+    .tile .ago {
+      font-family: var(--mono);
+      font-size: 18px;
+      font-variant-numeric: tabular-nums;
+      margin-top: 8px;
+    }
+    .tile .result { font-size: 12px; opacity: 0.92; margin-top: 4px; }
+    .tile .lamp {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-top: 10px;
+    }
+    .manual {
+      margin-top: 20px;
+      font-size: 13px;
+      color: var(--ink-3);
+      font-family: var(--mono);
+    }
+    .groups {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 10px;
+    }
+    .door {
+      border: 1px solid var(--rule);
+      background: var(--paper);
+      padding: 14px 16px 8px;
+    }
+    .door header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 10px;
+    }
+    .chip {
+      display: inline-block;
+      color: #fff;
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 3px 8px;
+    }
+    .chip.lock { background: var(--lamp-lock); }
+    .chip.sso { background: var(--lamp-sso); }
+    .count { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+    .school {
+      padding: 8px 0;
+      border-top: 1px solid var(--rule);
+      font-size: 14px;
+    }
+    .school small { display: block; color: var(--ink-3); font-size: 12px; }
+    .method { max-width: 720px; color: var(--ink-2); font-size: 14px; }
+    .preview-flag {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+      margin-bottom: 24px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="preview-flag">
+      Static preview · not live data · PRD 030 · production fonts are Newsreader / Geist / JetBrains Mono; Plex is preview-only
+    </div>
+    <div class="meta">§ Pipeline observation</div>
+    <div class="banner">3 stations overdue · finder scheduled 41 days ago · extract late (84 pending, cap)</div>
+    <h1>The clocks, <em>and the locked doors.</em></h1>
+    <p class="lede">
+      Every dispatch station on collegedata.fyi, when it last ran on schedule,
+      and what it found. If a step goes quiet, the lamp turns red — including
+      the monthly search that sat idle from April to August 2026. Schools that
+      put the Common Data Set behind Tableau, SharePoint, or SSO are listed by name.
+    </p>
+
+    <h2>Dispatch board</h2>
+    <div class="board">
+      <article class="tile down" aria-label="Finder: DOWN, 41 days overdue"><div class="id">monthly · scheduled SLA 40d</div><div><h3>Finder</h3><div class="lamp">Down</div><div class="ago">41 days</div><div class="result">Last scheduled Brave: Apr 14. Dispatch does not reset this clock.</div></div></article>
+      <article class="tile down" aria-label="Stuck PDFs: DOWN, 41 days overdue"><div class="id">monthly · scheduled SLA 40d</div><div><h3>Stuck PDFs</h3><div class="lamp">Down</div><div class="ago">41 days</div><div class="result">227 seeds frozen on last_result=found</div></div></article>
+      <article class="tile down" aria-label="Landing hints: DOWN, 41 days overdue"><div class="id">monthly · scheduled SLA 40d</div><div><h3>Landing hints</h3><div class="lamp">Down</div><div class="ago">41 days</div><div class="result">No scheduled promotion since Apr</div></div></article>
+      <article class="tile ok" aria-label="Enqueue: OK, 11 hours ago"><div class="id">daily · SLA 36h</div><div><h3>Enqueue</h3><div class="lamp">Ok</div><div class="ago">11 hours</div><div class="result">412 queued · 1,988 skipped</div></div></article>
+      <article class="tile ok" aria-label="Process: OK, 22 seconds ago"><div class="id">every 30s</div><div><h3>Process</h3><div class="lamp">Ok</div><div class="ago">22 sec</div><div class="result">queue depth 3 · 2 verified</div></div></article>
+      <article class="tile late" aria-label="Extract: LATE, 84 pending, hosted cap"><div class="id">daily · pending &gt; 0</div><div><h3>Extract</h3><div class="lamp">Late</div><div class="ago">20 hours</div><div class="result">84 pending · stopped at hosted cap</div></div></article>
+      <article class="tile ok" aria-label="Coverage: OK, 48 minutes ago"><div class="id">hourly · SLA 3h</div><div><h3>Coverage</h3><div class="lamp">Ok</div><div class="ago">48 min</div><div class="result">348 current · 322 stale</div></div></article>
+      <article class="tile ok" aria-label="Serving caches: OK, 37 minutes ago"><div class="id">hourly · SLA 3h</div><div><h3>Serving caches</h3><div class="lamp">Ok</div><div class="ago">37 min</div><div class="result">refresh_public_serving_caches</div></div></article>
+      <article class="tile ok" aria-label="IPEDS probe: OK, 12 days ago"><div class="id">monthly · scheduled SLA 40d</div><div><h3>IPEDS probe</h3><div class="lamp">Ok</div><div class="ago">12 days</div><div class="result">no new release</div></div></article>
+      <article class="tile slate" aria-label="Schema: SLATE, no heartbeat yet"><div class="id">yearly · slate until a heartbeat</div><div><h3>Schema</h3><div class="lamp">Slate</div><div class="ago">no heartbeat</div><div class="result">Do not infer vintage from git.</div></div></article>
+      <article class="tile slate" aria-label="Scorecard: SLATE, no heartbeat yet"><div class="id">yearly · slate until a heartbeat</div><div><h3>Scorecard</h3><div class="lamp">Slate</div><div class="ago">no heartbeat</div><div class="result">Do not infer vintage from git.</div></div></article>
+    </div>
+    <p class="manual">Manual sources (not on the strip): Directory enqueue — never · Mirror ingest — never</p>
+
+    <h2>Locked doors</h2>
+    <p class="lede" style="margin-top:0;margin-bottom:16px">
+      These IR offices publish a Common Data Set we can see but cannot archive
+      as a file. That is a school choice, not a collegedata.fyi outage.
+      Tableau and SharePoint IRM are listed from a public override file.
+    </p>
+    <div class="groups">
+      <section class="door">
+        <header><span class="chip lock">Tableau</span><span class="count">override</span></header>
+        <div class="school">Pomona College <small>CDS 2025-26 is a Tableau view, not a downloadable file.</small></div>
+      </section>
+      <section class="door">
+        <header><span class="chip lock">SharePoint IRM</span><span class="count">override</span></header>
+        <div class="school">Ohio University <small>2025-26 CDS is listed in Excel Online with download blocked.</small></div>
+      </section>
+      <section class="door">
+        <header><span class="chip sso">Microsoft SSO</span><span class="count">from last_outcome</span></header>
+        <div class="school">Adelphi University <small>Redirects to login.microsoftonline.com.</small></div>
+      </section>
+    </div>
+
+    <h2 id="methodology">Methodology</h2>
+    <div class="method">
+      <p>Each station writes a public heartbeat when it starts and when it finishes. Lamps are computed at read time. If the scheduled heartbeat is older than the SLA, the lamp is red — including when a manual run succeeded yesterday. Missing data is red, not gray.</p>
+      <p>Locked doors use probe outcomes plus a short public override list for Tableau and SharePoint IRM. We do not publish stack traces, seed URLs with tokens, or operator notes.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/prd/030-pipeline-observation.md
+++ b/docs/prd/030-pipeline-observation.md
@@ -1,0 +1,727 @@
+# PRD 030: Public pipeline observation
+
+**Status:** Implementing M0 — board, heartbeats, writers, JSON. Locked-door wall is M1.
+**Created:** 2026-08-21
+**Updated:** 2026-08-21 (eng review T1: match the codebase; split M0/M1)
+**Author:** Anthony Showalter (with Cursor Grok, via CEO-design)
+**URL:** `https://www.collegedata.fyi/pipeline-observation`
+**Related:** [ARCHITECTURE](../ARCHITECTURE.md), [PRD 015 coverage](015-institution-directory-and-cds-coverage.md), [PRD 029 freshness](029-discovery-freshness-and-publish-alerts.md), [probe outcomes](../../supabase/functions/_shared/probe_outcome.ts), [design system](../../web/DESIGN_SYSTEM.md), [eng review](../../.context/prd-030-eng-review.md)
+
+---
+
+## One-line job
+
+A public page that makes it impossible to miss a pipeline breakdown, and
+that names every school whose CDS sits behind a lock we cannot open.
+
+If this page had existed in April 2026, the monthly Brave finder sitting
+unscheduled until August would have been a red lamp on day 40, not a
+surprise four months later.
+
+---
+
+## Why this is not `/coverage`
+
+| Page | Question it answers |
+|---|---|
+| `/coverage` | Do we have a public CDS for this school? |
+| `/pipeline-observation` | Is our machine running, and what is blocking it? |
+
+Coverage is a school ledger. This page is a **dispatch board**. Mixing
+them would hide a dead cron behind 2,900 school rows. Keep both.
+
+---
+
+## Premise (CEO inversion)
+
+The failure mode that actually happened: a job that "succeeds" when it
+runs, while the job that finds new listings **never ran**. Archive-enqueue
+re-verified existing PDF seeds on schedule. Coverage looked fine. The
+finder was silent. Silence looked like health.
+
+**Proxy to kill:** "last job succeeded" — including a manual
+`workflow_dispatch` that resets a clock while the monthly schedule is
+still missing.
+
+**Metric that matters:** every SLA station has a **scheduled** heartbeat
+inside its predicate, or the lamp is red. Missing data is red, not gray.
+
+---
+
+## Sequencing (D1)
+
+Two PRs. Do not land M0+M1 together: the migration must come from
+`main`, and the locked-door wall must not block the clocks.
+
+| Slice | Ships | Does not ship |
+|---|---|---|
+| **M0** | Registry + heartbeats + RPC + facts function + writers + board + JSON + nav/footer/sitemap | Locked-door wall |
+| **M1** | `pipeline_locked_doors`, override YAML, wall UI, JSON `locked_doors` populated | RSS |
+| **M3** | Incident feed, reusing `cds_publish_events` as the event-log precedent | New event tables unless that pattern does not fit |
+
+Writers ship with the M0 UI. A board without writers is a pretty lie.
+
+---
+
+## Calls already made
+
+1. **Canonical route** `/pipeline-observation` (Next default: no
+   trailing slash). Add `/pipeline` → `/pipeline-observation` **308** in
+   `web/next.config.ts` next to `APEX_TO_WWW_REDIRECTS` (those are 301).
+   `/pipeline-observation/` already 308s for free. Tests for both.
+2. **No login.**
+3. **Name schools** on the M1 wall. Civic, not dunking.
+4. **Do not leak** stacks, service-role errors, Vault, GitHub secrets,
+   `archive_queue.last_error`, `hosting.notes`,
+   `tools/finder/school_overrides.yaml` (never parsed by this feature),
+   signed SharePoint URLs, seed URLs with tokens.
+5. **Heartbeat table is the source of truth.** Jobs write; the page
+   reads a facts function. Do not scrape GitHub Actions from Vercel.
+   `tools/ops/automation_health.py` stays operator-only (D9).
+6. **Color is a scoped exception.** Site chrome stays paper/ink. Lamps
+   are page-local CSS. **No teal, no blue.** `run` is ok-green with a
+   hatched treatment plus the word `RUN` (D7).
+7. **Nav:** `{ href: "/pipeline-observation", label: "Pipeline" }`
+   immediately after Coverage in the module-local `SECONDARY_NAV_LINKS`
+   (`web/src/components/Nav.tsx`). Footer: Pipeline **and** Coverage.
+   Sitemap `web/src/lib/sitemap-static.ts` `daily` / `0.7` (update the
+   guard test). `web/src/app/llms.txt/route.ts` bullet.
+8. **Tableau / SharePoint IRM / Box / Drive / Dropbox / intranet are
+   override-only (M1).** Auto-list is a **positive allowlist** of latest
+   `archive_queue.last_outcome` in
+   `{auth_walled_microsoft, auth_walled_okta, auth_walled_google, bot_challenge}`
+   **and** `processed_at` within **120 days** (D5). Overrides are exempt
+   from the 120-day rule. `wrong_content_type` is not auto-listed.
+   `marked_removed` is not a lock.
+9. **Machine faults vs school gates are visually split.**
+10. **Lamps computed at read time** from `last_scheduled_status`. Dispatch
+    cannot green a failed/missing schedule.
+11. **Ad-hoc stations are not on the dispatch board.** Directory and
+    mirror are a "Manual sources" footnote.
+12. **JSON is M0.** `locked_doors` is `[]` until M1.
+
+---
+
+## Audiences, in order
+
+1. Anthony at 11pm, scanning for quiet jobs.
+2. A journalist / HN reader inspecting infrastructure.
+3. An IR office that finds their school on the wall.
+4. A contributor who must add a heartbeat or the board goes red.
+
+Not an operator console. No enqueue / force_school buttons.
+
+---
+
+## Information architecture
+
+```
+1. § kicker + STATUS STRIP (sticky, above the 64px headline)
+   Brick if any board station is `down`.
+   Amber if any is `late` and none are `down`.
+   Ok sentence only when every SLA station is `ok` or `run`.
+   Every tile shows text (`DOWN` / `LATE` / `OK` / `RUN` / `SLATE`)
+   plus `aria-label`. Color is not the only channel.
+
+2. Headline + lede
+
+3. DISPATCH BOARD
+
+4. LOCKED DOORS (M1 only; M0 omits the section)
+
+5. METHODOLOGY
+```
+
+Mobile: sticky strip; vertical tiles; M1 door groups accordion with
+Tableau / SharePoint IRM / SSO open by default.
+
+Headline: **The clocks, and the locked doors.**
+
+---
+
+## Stations
+
+Eleven stations on the **dispatch board**. Finder's three **work** steps
+get three tiles because they get three writes.
+
+| `station_id` | Plain name | Actual job | Class | Overdue predicate |
+|---|---|---|---|---|
+| `finder_brave` | Finder (Brave search) | `ops-finder-probe.yml` step **Probe unknown schools** (`probe_urls.py` without `--ids-file`) | monthly SLA | `last_scheduled_status` not `ok` inside **40 days** |
+| `finder_stuck_pdf` | Stuck PDF re-probe | same Action, step **Re-probe stuck PDF seeds** (`probe_urls.py --ids-file`). Not the unguarded `stuck_pdf_seeds.py` classifier, which runs twice and has no mode guard. | monthly SLA | same 40-day scheduled clock |
+| `finder_landing_hints` | Landing-hint promotion | same Action, **Promote high-confidence landing hints**. Guarded by `INPUT_APPLY_LANDING_HINTS` only (not by mode). On `schedule`, that env is forced `true` (`ops-finder-probe.yml:63`). Do not spec a scheduled skip path. | monthly SLA | same 40-day scheduled clock |
+| `archive_enqueue` | Archive enqueue | pg_cron `archive-enqueue-daily` (`0 2 * * *`) → `archive-enqueue` | daily SLA | `last_scheduled_status` not `ok` inside **36 hours** |
+| `archive_process` | Archive process | pg_cron `archive-process-every-30s` → `archive-process` | continuous SLA | see below |
+| `extraction_worker` | Extraction | `ops-extraction-worker.yml` (schedule `--limit 5`, `--deadline-minutes 25`) | daily SLA | see below |
+| `coverage_refresh` | Coverage refresh | pg_cron `refresh-coverage-hourly` (`17 * * * *`) → `refresh-coverage` | hourly SLA | `last_scheduled_status` not `ok` inside **3 hours** |
+| `serving_cache_refresh` | Public serving caches | pg_cron `refresh-public-serving-caches-hourly` (`23 * * * *`, plain SQL `refresh_public_serving_caches()`) (D4) | hourly SLA | `last_scheduled_status` not `ok` inside **3 hours** |
+| `ipeds_release_probe` | IPEDS release probe | `ipeds-release-probe.yml` | monthly SLA | `last_scheduled_status` not `ok` inside **40 days**. A monthly no-op still writes `ok` with `new_release=false`. |
+| `schema_build` | Schema (CDS year) | operator | yearly | `never` → slate. Down only if `last_finished_at` is non-null and older than **18 months**. Do not infer vintage from git. |
+| `scorecard_load` | Scorecard load | operator | yearly | same 18-month rule |
+
+`pg_cron` ticks use `last_trigger=cron` (**counts as scheduled**).
+GHA `schedule` counts as scheduled. `dispatch` / `operator` never
+update `last_scheduled_*`.
+
+The three edge-function crons are **secret-gated and do not exist in
+local/fresh DBs**. Seed migration and tests must **not** assert cron
+rows. Heartbeat silence is the public signal.
+
+**Manual sources** (below the board, not on the strip):
+`directory_enqueue`, `mirror_ingest`.
+
+**Not on the page:** IPEDS CSV load, `build_school_list.py`, PRD 019,
+Playwright, gated `/changes`, PRD 026 `/discover`. No
+`publish_alerts` station.
+
+### Archive-process predicate
+
+Finish-only heartbeat on **every tick**, including empty dequeues and
+the existing `queue_drained` early return
+(`supabase/functions/archive-process/index.ts`). Never writes `running`.
+Keep the 30s upsert (~2,880/day); empty-queue liveness has no other
+public signal. **Never key a cache on `updated_at`.**
+
+Live unfinished count from the facts function:
+`archive_queue.status IN ('ready','processing')`.
+(`processing` exists only on `archive_queue.status`, not on
+`cds_documents`.)
+
+- Live unfinished > 0 AND no successful cron process in **15 minutes** → `down`
+- Live unfinished = 0 AND no cron heartbeat in **2 hours** → `down`
+- Else `last_scheduled_status=ok` → `ok`; `error` → `down`
+
+This route uses **`revalidate = 60`**. `/coverage` stays **900**
+(`web/src/app/coverage/page.tsx`). Do not copy `fetchCoverageRows`:
+it **throws** on error and has an `isStaticBuild()` branch
+(`web/src/lib/queries.ts`). The pipeline loader needs its **own**
+try/catch and static-build path. Seed rows render `down`/`slate` on
+failure; the page still paints.
+
+`--lamp-run` is finder + extraction only.
+
+### Extraction predicate (D2)
+
+Today the worker summary (`tools/extraction_worker/worker.py` ~2174)
+emits `processed_count`, `failure_count`, `stopped_early`,
+`extraction_counts` — **not** `stopped_reason` / `extracted` /
+`pending`. Cap is enforced in `ops-extraction-worker.yml` (hosted
+`--limit` 100 max; schedule `--limit 5`). The worker slices
+`docs[:args.limit]`. `--deadline-minutes` on schedule is **25**.
+
+**M0 worker change (required, not a wrapper):** emit in `summary.json`:
+
+- `stopped_reason`: `cap | deadline | complete | error`
+- `extracted` (int)
+- `failed` (int)
+- `pending_remaining` (int; live count of
+  `cds_documents.extraction_status = 'extraction_pending'` at finish)
+
+Heartbeat step reads that file. `llm_fallback` is **not** required
+(optional, from `extraction_counts` if cheap).
+
+Collapsed lamp (scheduled clock only):
+
+- No scheduled finish inside **36 hours** (including `never`) → `down`
+- Live `extraction_pending` > 0 AND (`stopped_reason` in `{cap, deadline}`
+  OR `extracted = 0`) → `late`
+- Else → `ok`
+
+Missing required keys on a finish write → `down` with
+`error_code=heartbeat_summary_malformed`.
+
+Empty drain still writes a scheduled heartbeat. Dispatch is a footnote.
+
+Confirm an index on `cds_documents(extraction_status)` or add one in
+the M0 migration so the pending count is not a seq scan every minute.
+
+### Schedule vs dispatch
+
+SLA lamps use **only** `last_scheduled_*`. Dispatch writes
+`last_status` / `last_finished_at` / `last_summary` as a footnote.
+
+Test: scheduled `error` yesterday + dispatch `ok` today = `down`.
+
+**`on.schedule` CI is a lint**, not a detector. It would have caught
+the April failure (schedule removed from the workflow file). It will
+not catch disabled schedules, GitHub suppression, broken secrets, or
+default-branch drift. Keep it labeled as lint: finder, extraction, and
+IPEDS workflows contain `on.schedule`; station IDs in the registry
+equal writer calls.
+
+### Bootstrap
+
+Migration seeds registry + heartbeat rows with
+`last_scheduled_status = 'never'`. SLA `never` → `down` on first paint.
+Yearly `never` → `slate`. Manual sources omitted from the strip. Board
+stations are never dropped from the grid.
+
+---
+
+## Data model
+
+### `pipeline_stations` (static registry, D8)
+
+One row per `station_id`. Name, cadence_label, class, required/allowed
+summary keys, `source_kind`. RPC validates writes against this table.
+CI asserts every writer `--station` is a subset of the registry.
+Seeded in the migration; not updated by jobs.
+
+### `pipeline_heartbeats` (state)
+
+One row per station, FK to the registry. Cron ticks write **finish
+only**. GHA finder / extract / IPEDS write start (`running`) then
+finish. Any `(class, last_status)` combo not in the lamp table → `down`.
+
+`running` older than **8 hours** → `down`.
+
+Anon **cannot** `SELECT` this table.
+
+```
+station_id                     text PK  FK pipeline_stations
+last_started_at                timestamptz
+last_finished_at               timestamptz   -- any trigger; footnote
+last_status                    text          -- never | running | ok | error
+last_trigger                   text          -- schedule | dispatch | operator | cron
+last_summary                   jsonb         -- top-level keys only
+last_scheduled_finished_at     timestamptz
+last_scheduled_status          text
+last_scheduled_summary         jsonb
+last_scheduled_error_code      text
+last_error_code                text
+source_url                     text          -- sanitized GitHub URL or null
+updated_at                     timestamptz   -- do not key caches on this
+```
+
+`error_code` closed set: `search_provider_rejected`,
+`missing_required_secret`, `heartbeat_summary_malformed`,
+`worker_timeout`, `job_failed`, `none`. Page maps code → copy. Raw
+exception text is never stored.
+
+### RPC `record_pipeline_heartbeat(station_id, status, trigger, summary, error_code)`
+
+- Validates `station_id` against `pipeline_stations`.
+- Unknown JSON keys dropped. Nested `counts.{…}` stripped.
+  Keys are **top-level**.
+- Missing required keys on **finish** → persist `error` +
+  `heartbeat_summary_malformed`, not `ok`.
+- `trigger` in `{schedule, cron}` copies into `last_scheduled_*`.
+  `dispatch` / `operator` leave scheduled columns alone.
+- `source_url` / `run_url`: only
+  `https://github.com/bolewood/collegedata-fyi/actions/runs/<digits>`
+  or `.../pull/<digits>`. Everything else dropped. Test the sanitizer.
+
+**Grants (load-bearing — Supabase grants EXECUTE on new public
+functions to anon by default):**
+
+```
+revoke all on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) from public;
+revoke all on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) from anon, authenticated;
+grant execute on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) to service_role;
+```
+
+Precedent: `claim_archive_queue_row`, `refresh_institution_cds_coverage`.
+Test: anon EXECUTE denied.
+
+Reuse `SUPABASE_SERVICE_ROLE_KEY`. No new secret.
+
+### `pipeline_station_facts()` (D3)
+
+**SECURITY DEFINER function**, not a view. Owner-rights views reintroduce
+the advisor warning cleared in `20260614141000`.
+
+```
+revoke all on function public.pipeline_station_facts() from public;
+grant execute on function public.pipeline_station_facts() to anon, authenticated;
+```
+
+Returns, per registry station:
+
+- heartbeat scheduled columns (no raw errors)
+- `queue_unfinished` (archive_process only)
+- `extraction_pending` (count of
+  `cds_documents.extraction_status = 'extraction_pending'`)
+
+The Next loader and JSON **only** call this function (and, in M1, select
+`pipeline_locked_doors`). They never read `archive_queue` from the browser.
+
+Lamps: `web/src/lib/pipeline-lamps.ts` + `pipeline-lamps.test.ts` with
+an exhaustive fixture next to it (D6). **No Python lamp tests.**
+`tools/ops/record_heartbeat.py` tests cover RPC payload validation only.
+
+### `last_summary` required keys on finish
+
+| station | required keys |
+|---|---|
+| `finder_brave` | `probed`, `found`, `replaced`, `budget_remaining` |
+| `finder_stuck_pdf` | `stuck`, `reprobed`, `still_stuck` |
+| `finder_landing_hints` | `proposals`, `promoted` |
+| `archive_enqueue` | `queued`, `skipped`, `errors` |
+| `archive_process` | `dequeued`, `queue_depth`, `inserted`, `refreshed`, `walled`, `events_written` |
+| `extraction_worker` | `extracted`, `failed`, `pending_remaining`, `stopped_reason` |
+| `coverage_refresh` | `current`, `stale`, `inaccessible`, `never_found` |
+| `serving_cache_refresh` | `ok` (bool) |
+| `ipeds_release_probe` | `new_release`, `issue_opened` |
+| `schema_build` | `years` |
+| `scorecard_load` | `vintage`, `rows` |
+| `directory_enqueue` | `seeded` |
+| `mirror_ingest` | `source`, `rows_added` |
+
+`events_written` is on **`archive_process`**, not enqueue.
+`recordPublishEvent` is reached from `_shared/archive.ts` via
+archive-process and archive-upload only.
+
+Optional shared: `pr_url`, `run_url` (sanitized). No free-form `notes`.
+`coverage_refresh` may set `overrides_stale: true` in M1 if the override
+YAML fetch failed (last-good rows kept).
+
+### Writers (M0)
+
+Helper: `tools/ops/record_heartbeat.py` with
+`tools/ops/test_record_heartbeat.py` (co-located, like other Python
+packages). There is no `tools/pipeline/` or `tests/fixtures/` tree today;
+do not create them.
+
+Finder writes are **separate steps** with `id:`. `if: always()` on the
+same step as a mode guard is wrong. Pattern:
+
+```yaml
+- id: re_probe_stuck
+  name: Re-probe stuck PDF seeds
+  if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf'
+  run: python tools/finder/probe_urls.py --ids-file …   # not stuck_pdf_seeds.py
+- name: Heartbeat finder_stuck_pdf
+  if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf')
+  run: python tools/ops/record_heartbeat.py --station finder_stuck_pdf …
+```
+
+Same pair for `probe_unknown` → `finder_brave` and
+`promote_landing_hints` → `finder_landing_hints`.
+A `stuck-pdf`-only run does not write `finder_brave`.
+
+Heartbeat POST failure: **exit 0** and print
+`::warning::pipeline heartbeat failed for <station>` so it shows in the
+Actions summary, not only logs. Same for Deno `finally` writers: catch,
+log, do not throw.
+
+`serving_cache_refresh`: write from `refresh_public_serving_caches()`
+(SQL) or a one-line wrapper in that function. Finish only, `trigger=cron`.
+
+`archive_enqueue` / `archive_process` / `coverage_refresh`: Deno
+`finally`, finish only, `trigger=cron`.
+
+### `pipeline_locked_doors` (M1 only)
+
+Table refreshed by `refresh_pipeline_locked_doors()`, called from
+`refresh-coverage`. Service role. **Own** `DISTINCT ON (school_id)
+ORDER BY processed_at DESC, id DESC` using
+`archive_queue_terminal_latest_idx`. **Do not** call
+`latest_archive_terminal_rows(p_since, …)` — it is time-bounded and
+will silently miss old locks.
+
+Overrides file: `tools/finder/locked_door_overrides.yaml` (same
+directory as `school_overrides.yaml` and `schools.yaml`). Fetched from
+GitHub `main` raw, same pattern as
+`supabase/functions/_shared/schools.ts`. Fetch fail → keep last good
+rows + `overrides_stale: true` on the coverage heartbeat. **Never
+parse or import `tools/finder/school_overrides.yaml`.** Test that.
+
+Join names from `institution_cds_coverage` (**table**, not a view):
+`school_name`, `undergraduate_enrollment`, `state`, `coverage_status`,
+`school_id`, `ipeds_id`. Alias to `name` / `enrollment` only in the
+TypeScript loader, not in SQL.
+
+**Drop `final_host`.** `archive_queue` has no host column;
+`latest_school_hosting.final_url_host` is forbidden (anon revoked;
+unsafe). Do not add a hostname column in M1.
+
+#### Override YAML
+
+Keyed by `school_id`. Closed `reason_key` only. CI rejects URLs, query
+strings, emails, token-shaped strings, unknown keys.
+
+Sample IDs from `tools/finder/schools.yaml` (do not invent UNITIDs):
+
+```yaml
+- school_id: ohio-university-main-campus
+  ipeds_id: "204857"
+  kind: sharepoint_irm
+  reason_key: excel_online_download_blocked
+- school_id: pomona-college
+  ipeds_id: "121345"
+  kind: tableau
+  reason_key: tableau_view_not_file
+- school_id: colorado
+  ipeds_id: "126614"
+  kind: sharepoint
+  reason_key: sharepoint_folder
+```
+
+M1 does not merge without Ohio + Pomona. Colorado is the third
+SharePoint fixture. Negative tests: HTML must **not** contain
+`sharepoint.com/:x:`, the Ohio sharing token, `H1 review`, or
+Pomona `force_urls` — those strings live in `school_overrides.yaml`
+and must never leak.
+
+#### Auto-list (positive allowlist + D5 recency)
+
+Include if **latest** terminal `last_outcome` is in
+`{auth_walled_microsoft, auth_walled_okta, auth_walled_google, bot_challenge}`
+**and** `processed_at >= now() - interval '120 days'`.
+Else drop, unless an override applies (overrides skip the 120-day rule).
+
+`inserted` / `refreshed` / `unchanged_verified` / `unchanged_repaired`
+/ `marked_removed` / `wrong_content_type` / anything else → not auto-listed.
+
+#### Closed copy
+
+| reason_key / kind | Copy |
+|---|---|
+| `microsoft_sso` | Redirects to login.microsoftonline.com. |
+| `okta_sso` | Redirects to an Okta login. |
+| `google_sso` | Redirects to accounts.google.com. |
+| `bot_challenge` | School CDN served a bot challenge instead of the file. |
+| `excel_online_download_blocked` | Listed in Excel Online with download blocked. |
+| `tableau_view_not_file` | CDS is a Tableau view, not a downloadable file. |
+| `sharepoint_folder` | CDS files sit in a SharePoint folder we cannot archive as a file. |
+| `box` / `google_drive` / `dropbox` / `intranet` | Closed one-liners; override-only. |
+
+Public columns: `school_id`, `ipeds_id`, `name` (from `school_name`),
+`state`, `enrollment` (from `undergraduate_enrollment`), `kind`,
+`vendor_label`, `reason_key`, `public_reason` (generated),
+`last_observed_at`, `coverage_status`. No host, no path, no query string.
+
+Anon `SELECT` on those columns only.
+
+---
+
+## Lamps
+
+Computed in `web/src/lib/pipeline-lamps.ts` from facts + the fixture.
+Jobs never write a lamp. SLA stations use `last_scheduled_status`.
+
+| Lamp | CSS | Ink | Predicate |
+|---|---|---|---|
+| `down` | `--lamp-down` `#d7263d` | white | scheduled predicate failed, OR scheduled `error`, OR `running` > 8h |
+| `late` | `--lamp-late` `#e0a106` | `#1c1400` | extraction backlog only |
+| `ok` | `--lamp-ok` `#1f7a4d` | white | scheduled `ok` AND not `late` |
+| `run` | same `--lamp-ok` + CSS hatch (no new hue) | white | GHA `running` within 8h; finder + extraction only |
+| `slate` | `--lamp-slate` `#5c5a54` | white | yearly `never` or yearly inside 18 months |
+| `lock` | `--lamp-lock` `#6b3fa0` | white | M1 chips |
+| `sso` | `--lamp-sso` `#7a2f6a` | white | M1 SSO chips |
+| `waf` | `--lamp-waf` `#c45c14` | white | M1 bot_challenge chips |
+
+Error is never `late`. Test 13 = page-CSS **hex allowlist** (these
+hexes plus paper/ink tokens). No `#2a9d8f`, no blue.
+
+Door cards: `--paper` / `.cd-card` (`tokens.css`). Page-local CSS:
+`web/src/app/pipeline-observation/pipeline-observation.css`.
+`web/DESIGN_SYSTEM.md` gets a "Pipeline observation exception"
+subsection.
+
+---
+
+## Public JSON (M0)
+
+`GET /pipeline-observation.json` (`revalidate = 60`):
+
+```
+{
+  "as_of": "ISO-8601",
+  "strip": { "lamp": "down|late|ok", "text": "…" },
+  "stations": [{ "station_id", "lamp", "label",
+                 "last_scheduled_finished_at", "last_scheduled_status",
+                 "last_finished_at", "last_trigger", "summary",
+                 "error_code" }],
+  "locked_doors": [],
+  "manual_sources": [{ "station_id", "last_finished_at" }],
+  "methodology_url": "https://www.collegedata.fyi/pipeline-observation#methodology"
+}
+```
+
+M1 fills `locked_doors`. Snapshot test: shape, precomputed lamps, no
+secret-shaped strings.
+
+---
+
+## Public-safe / threat model
+
+**Allowed:** station names, cadences, timestamps, allowlisted counts,
+sanitized Actions/PR URLs, school names, UNITIDs, lock kinds,
+coverage_status, enrollment.
+
+**Forbidden:** stacks; Deno logs; `last_error`; Storage paths; cron SQL;
+Vault; `BRAVE_API_KEY` presence (`search_provider_rejected` only);
+redirect chains; cookies; signed query strings; operator notes;
+`school_overrides.yaml`; hostnames we cannot legally source.
+
+**Anon surface (final-grants test):**
+
+- CAN: `EXECUTE pipeline_station_facts()`; `SELECT` on
+  `pipeline_locked_doors` public columns (M1).
+- CANNOT: `EXECUTE record_pipeline_heartbeat`; `SELECT`
+  `pipeline_heartbeats`, `archive_queue`, `latest_school_hosting`,
+  `bot_challenged_documents`. (`bot_challenged_documents` was granted
+  to anon in `20260505160000` and revoked in `20260614141000` — pin
+  that with this test.)
+
+---
+
+## Error & empty states
+
+| State | User sees |
+|---|---|
+| Facts fetch fails | Brick: "Could not load station clocks." Seed rows `down`/`slate`. Page paints. |
+| Locked-doors fetch fails (M1) | Board still shows. "Could not load the lock list." |
+| Zero locked doors | "No vendor locks in the current snapshot. Tableau and SharePoint IRM only appear when listed in the public override file." |
+| `isStaticBuild()` | Fixture/seed lamps, no live RPC. |
+
+---
+
+## Implementation slices
+
+**M0 PR:** `pipeline_stations` + `pipeline_heartbeats` + RPC grants +
+`pipeline_station_facts()` + `record_heartbeat.py` + worker summary
+fields + workflow `id:` / heartbeats + edge-function writers +
+`serving_cache_refresh` + page/JSON/lamps/CSS/nav/footer/sitemap/llms.txt
++ `/pipeline` 308 + loader try/catch + `isStaticBuild` +
+`on.schedule` lint + hex allowlist test + stale cron name fix in
+`automation_health.py` + TODO to read heartbeats.
+
+**M1 PR:** locked-doors table + refresh + YAML + wall + JSON fill +
+never-parse-`school_overrides` test + Ohio/Pomona/Colorado fixtures +
+120-day recency.
+
+**M3:** RSS of overdue transitions; reuse `cds_publish_events` as the
+append-only precedent (`web/src/lib/school-rss.ts`), do not invent a
+second event-log style unless that table cannot represent station
+transitions.
+
+Lane A (migration/RPC/facts) and Lane B (Python/workflows) and Lane C
+(web against fixtures) can parallelize after M0 migration exists.
+M1 waits on M0 because both touch `supabase/migrations/`.
+
+---
+
+## What already exists (reuse)
+
+- `/coverage` public RLS + ISR **pattern** (900s, not 60s)
+- `probe_outcome.ts` (all 16 values)
+- `archive_queue.last_outcome` + `archive_queue_terminal_latest_idx`
+- `institution_cds_coverage` table (`school_name`,
+  `undergraduate_enrollment`)
+- Actions `SUPABASE_SERVICE_ROLE_KEY`
+- Edge functions on service role
+- `schools.yaml` GitHub-raw fetch
+  (`supabase/functions/_shared/schools.ts`)
+- `.cd-card`, `SECONDARY_NAV_LINKS`, sitemap guard test
+- `tools/ops/automation_health.py` (operator; stale job name
+  `refresh-coverage-every-15min` at line 21 — fix to
+  `refresh-coverage-hourly` and add `refresh-public-serving-caches-hourly`;
+  TODO to read `pipeline_heartbeats` and drop GHA scraping)
+- `cds_publish_events` + school RSS renderer (M3 precedent)
+- `archive_queue_attempts` is per-item, service-role only — not a
+  heartbeat log
+
+`HOSTING_OBSERVATIONS_ENABLED` defaults **off**.
+`latest_school_hosting` / `bot_challenged_documents` already revoked
+from anon.
+
+---
+
+## NOT in scope
+
+- Operator controls; crawl tail; replacing `/coverage`; global recolor
+- Email / PagerDuty
+- Automatic Tableau / IRM detection
+- Seed URLs / SAS tokens
+- IPEDS CSV load, `build_school_list`, PRD 019, Playwright, `/changes`
+- Recent-results history UI
+- Incident RSS (M3)
+- `publish_alerts` station
+- Rewriting `automation_health.py` beyond the stale name + TODO (D9)
+- Owner-rights views for facts
+- Reusing `latest_archive_terminal_rows` for the wall
+- Python lamp tests / `tests/fixtures/` / `tools/pipeline/`
+- Teal `--lamp-run #2a9d8f`
+
+---
+
+## Tests (Friday-night + eng-review gaps)
+
+1. Scheduled `error` yesterday + dispatch `ok` today → `down`.
+2. Seed `never` → SLA `down`; yearly `slate`; manual sources off strip.
+3. `archive_process`: unfinished=0, cron 30s ago → `ok`; 3h ago → `down`; unfinished>0, 20 min → `down`.
+4. RPC `{queue_depth:3, stack:"…"}` keeps `queue_depth`, drops `stack`; nested `counts.*` dropped.
+5. Anon EXECUTE denied on `record_pipeline_heartbeat`.
+6. Final-grants: anon cannot select heartbeats / archive_queue / latest_school_hosting / bot_challenged_documents; can execute facts.
+7. Malformed finish → `error` + `heartbeat_summary_malformed`.
+8. `running` > 8h → `down`.
+9. Exhaustive (class, status, age) lamp matrix in `pipeline-lamps.test.ts`.
+10. Heartbeat POST failure exits 0 and prints `::warning::`.
+11. Worker summary contains `stopped_reason` / `extracted` / `failed` / `pending_remaining`; cap → `late`.
+12. `isStaticBuild()` path renders seed lamps.
+13. `/pipeline` 308 and `/pipeline-observation/` 308 tests; sitemap-static guard updated.
+14. JSON snapshot: `as_of`, precomputed lamps, no secret-shaped strings; hex allowlist (no teal, no blue).
+15. Finder: `stuck-pdf` mode does not bump `finder_brave`; heartbeats keyed off re-probe / unknown / promote steps (`id:` present).
+16. IPEDS scheduled no-op writes `ok` / `new_release=false`.
+17. Seed migration does **not** require pg_cron rows.
+18. **M1:** Ohio `204857` + Pomona `121345` + Colorado; HTML lacks `sharepoint.com/:x:`, tokens, `H1 review`, `force_urls`.
+19. **M1:** YAML fetch fail → last-good + `overrides_stale`.
+20. **M1:** refresh never parses `school_overrides.yaml`.
+21. **M1:** latest lock older than 120 days dropped unless override; `marked_removed` not listed; `wrong_content_type` not listed.
+22. [E2E, later] scheduled finder run → three tiles `ok` within 60s ISR.
+
+---
+
+## Dream state (12 months)
+
+```
+  NOW                         M0 THEN M1                 12 MONTHS
+  Jobs are folklore.    →   Public overdue lamps.  →  New job without
+  Brave silent 4 months.    Named vendor locks.       a registry row
+  Tableau in operator       Scheduled ≠ dispatch.     cannot merge.
+  notes.                    World can inspect.        Incident RSS.
+```
+
+---
+
+## Decisions locked (eng review D1–D9)
+
+| # | Decision | Letter |
+|---|---|---|
+| D1 | Two PRs: M0 board, then M1 wall | A |
+| D2 | Worker emits `stopped_reason` / `extracted` / `failed` / `pending_remaining`; collapsed lamp | A |
+| D3 | `pipeline_station_facts()` SECURITY DEFINER function; grant EXECUTE to anon | A |
+| D4 | Add `serving_cache_refresh` | A |
+| D5 | Auto-list latest lock outcome within 120 days; overrides exempt | A |
+| D6 | Lamps: `web/src/lib/pipeline-lamps.ts` + `.test.ts` only | A |
+| D7 | Drop teal; `run` = ok-green hatch + RUN text; hex allowlist | A |
+| D8 | Split `pipeline_stations` registry from `pipeline_heartbeats` | A |
+| D9 | Fix stale cron name in `automation_health.py`; TODO to read heartbeats | A |
+
+---
+
+## Review changelog
+
+**Round 1 (6/10) / Round 2 (8/10 inherit + 7/10 Codex):** silence is
+red; three finder writes; scheduled ≠ dispatch; public-safe copy;
+JSON in M0.
+
+**Eng review 2026-08-21** (`/plan-eng-review`, Codex outside voice):
+architecture kept; implementation blocked until this T1 pass. Corrected
+`extraction_pending`, worker summary, `events_written` station, coverage
+column names, Ohio UNITID `204857`, finder step mapping, pg_cron names,
+fourth cron, ISR/loader, paths, grants, recency allowlist, two-PR split.
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO / design | CEO-design + adversarial | Scope | 2 | patched | 6/10 then 8/10 |
+| Eng Review | `/plan-eng-review` | Architecture & tests | 1 | T1 applied; D1–D9 locked | 8 arch, 6 quality, 12 test gaps originally |
+| Codex | outside voice | Independent | 1 | 13 points folded | 3 tensions resolved as D9/lint/keep-30s |
+
+**VERDICT:** Spec is the build contract. Implement M0, then M1. Do not
+start until this file is what the PR is measured against.

--- a/supabase/functions/_shared/pipeline_heartbeat.test.ts
+++ b/supabase/functions/_shared/pipeline_heartbeat.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "jsr:@std/assert";
+import {
+  isWalledOutcome,
+  recordPipelineHeartbeat,
+} from "./pipeline_heartbeat.ts";
+
+Deno.test("isWalledOutcome allowlists SSO and bot challenge only", () => {
+  assertEquals(isWalledOutcome("auth_walled_microsoft"), true);
+  assertEquals(isWalledOutcome("bot_challenge"), true);
+  assertEquals(isWalledOutcome("wrong_content_type"), false);
+  assertEquals(isWalledOutcome("marked_removed"), false);
+  assertEquals(isWalledOutcome(null), false);
+});
+
+Deno.test("recordPipelineHeartbeat swallows RPC errors", async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(String(args[0] ?? ""));
+  };
+  try {
+    await recordPipelineHeartbeat(
+      {
+        rpc: async () => ({ error: { message: "boom" } }),
+      },
+      {
+        stationId: "archive_process",
+        status: "ok",
+        trigger: "cron",
+        summary: { dequeued: 0 },
+      },
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+  assertEquals(warnings.length, 1);
+  assertEquals(
+    warnings[0].startsWith("::warning::pipeline heartbeat failed for archive_process"),
+    true,
+  );
+});

--- a/supabase/functions/_shared/pipeline_heartbeat.ts
+++ b/supabase/functions/_shared/pipeline_heartbeat.ts
@@ -1,0 +1,64 @@
+// Shared heartbeat writer for edge functions. Catch, log, never throw.
+// A missing RPC (local/fresh DB before the migration) must not fail archive.
+
+export type HeartbeatStatus = "running" | "ok" | "error";
+export type HeartbeatTrigger = "schedule" | "dispatch" | "operator" | "cron";
+
+export async function recordPipelineHeartbeat(
+  // deno-lint-ignore no-explicit-any
+  supabase: { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ error: { message: string } | null }> | any },
+  args: {
+    stationId: string;
+    status: HeartbeatStatus;
+    trigger: HeartbeatTrigger;
+    summary?: Record<string, unknown>;
+    errorCode?: string;
+  },
+): Promise<void> {
+  try {
+    const { error } = await supabase.rpc("record_pipeline_heartbeat", {
+      p_station_id: args.stationId,
+      p_status: args.status,
+      p_trigger: args.trigger,
+      p_summary: args.summary ?? {},
+      p_error_code: args.errorCode ?? "none",
+    });
+    if (error) {
+      console.warn(
+        `::warning::pipeline heartbeat failed for ${args.stationId}: ${error.message}`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `::warning::pipeline heartbeat failed for ${args.stationId}: ${message}`,
+    );
+  }
+}
+
+export async function countArchiveUnfinished(
+  // deno-lint-ignore no-explicit-any
+  supabase: any,
+): Promise<number> {
+  try {
+    const { count, error } = await supabase
+      .from("archive_queue")
+      .select("id", { count: "exact", head: true })
+      .in("status", ["ready", "processing"]);
+    if (error) return 0;
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+const WALLED = new Set([
+  "auth_walled_microsoft",
+  "auth_walled_okta",
+  "auth_walled_google",
+  "bot_challenge",
+]);
+
+export function isWalledOutcome(outcome: string | null | undefined): boolean {
+  return Boolean(outcome && WALLED.has(outcome));
+}

--- a/supabase/functions/archive-enqueue/index.ts
+++ b/supabase/functions/archive-enqueue/index.ts
@@ -43,6 +43,7 @@ import {
   archiveEnqueueRunId,
   parseCooldownDaysOverride,
 } from "./schedule.ts";
+import { recordPipelineHeartbeat } from "../_shared/pipeline_heartbeat.ts";
 
 Deno.serve(async (req: Request) => {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -57,6 +58,32 @@ Deno.serve(async (req: Request) => {
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey);
+  const heartbeat = {
+    queued: 0,
+    skipped: 0,
+    errors: 0,
+    status: "ok" as "ok" | "error",
+    errorCode: "none",
+  };
+  const send = async (body: unknown, status = 200): Promise<Response> => {
+    if (status >= 400) {
+      heartbeat.status = "error";
+      heartbeat.errorCode = "job_failed";
+      heartbeat.errors = Math.max(heartbeat.errors, 1);
+    }
+    await recordPipelineHeartbeat(supabase, {
+      stationId: "archive_enqueue",
+      status: heartbeat.status,
+      trigger: "cron",
+      summary: {
+        queued: heartbeat.queued,
+        skipped: heartbeat.skipped,
+        errors: heartbeat.errors,
+      },
+      errorCode: heartbeat.errorCode,
+    });
+    return json(body, status);
+  };
 
   // run_id is deterministic for the UTC calendar day. Duplicate cron calls on
   // the same day collide on the unique (run_id, school_id) index and no-op. The
@@ -84,7 +111,7 @@ Deno.serve(async (req: Request) => {
       run_id: runId,
       error: err.message,
     });
-    return json({
+    return await send({
       error: `schools.yaml fetch failed: ${err.message}`,
     }, 502);
   }
@@ -101,7 +128,8 @@ Deno.serve(async (req: Request) => {
 
   if (allSchools.length === 0) {
     logEvent({ event: "no_schools_to_enqueue", run_id: runId });
-    return json({
+    heartbeat.skipped = skippedInvalid;
+    return await send({
       mode: "enqueue",
       run_id: runId,
       enqueued: 0,
@@ -133,7 +161,7 @@ Deno.serve(async (req: Request) => {
       url.searchParams.get("cooldown_days"),
     );
   } catch (error) {
-    return json({ error: (error as Error).message }, 400);
+    return await send({ error: (error as Error).message }, 400);
   }
 
   const inCooldown = new Set<string>();
@@ -280,6 +308,7 @@ Deno.serve(async (req: Request) => {
   // After cooldown filtering, rows may be empty. Short-circuit so we
   // don't issue an empty upsert (which Supabase rejects).
   if (rows.length === 0) {
+    heartbeat.skipped = inCooldown.size + skippedInvalid;
     logEvent({
       event: "enqueue_completed",
       run_id: runId,
@@ -288,7 +317,7 @@ Deno.serve(async (req: Request) => {
       skipped_cooldown: inCooldown.size,
       duration_ms: Date.now() - started,
     });
-    return json({
+    return await send({
       mode: "enqueue",
       run_id: runId,
       enqueued: 0,
@@ -316,7 +345,7 @@ Deno.serve(async (req: Request) => {
       intended_count: rows.length,
       error: error.message,
     });
-    return json({
+    return await send({
       error: `enqueue failed: ${error.message}`,
       run_id: runId,
       intended_count: rows.length,
@@ -325,6 +354,8 @@ Deno.serve(async (req: Request) => {
 
   const enqueued = Number(enqueuedCount ?? 0);
   const skippedExisting = rows.length - enqueued;
+  heartbeat.queued = enqueued;
+  heartbeat.skipped = skippedExisting + inCooldown.size + skippedInvalid;
   logEvent({
     event: "enqueue_completed",
     run_id: runId,
@@ -334,7 +365,7 @@ Deno.serve(async (req: Request) => {
     duration_ms: Date.now() - started,
   });
 
-  return json({
+  return await send({
     mode: "enqueue",
     run_id: runId,
     enqueued,

--- a/supabase/functions/archive-process/index.ts
+++ b/supabase/functions/archive-process/index.ts
@@ -46,6 +46,11 @@ import {
   MAX_ATTEMPTS,
   type ArchiveQueueRow,
 } from "./queue.ts";
+import {
+  countArchiveUnfinished,
+  isWalledOutcome,
+  recordPipelineHeartbeat,
+} from "../_shared/pipeline_heartbeat.ts";
 
 // Relaxed client typing. supabase-js v2's strict generics collapse to never
 // when no Database type parameter is supplied, which breaks .update() with
@@ -217,10 +222,51 @@ async function runForceUrls(
 async function runQueueClaim(
   supabase: Client,
 ): Promise<Response> {
+  const summary = {
+    dequeued: 0,
+    queue_depth: 0,
+    inserted: 0,
+    refreshed: 0,
+    walled: 0,
+    events_written: 0,
+  };
+  const hb = { status: "ok" as "ok" | "error", errorCode: "none" };
+  try {
+    return await runQueueClaimInner(supabase, summary, hb);
+  } catch (_error) {
+    hb.status = "error";
+    hb.errorCode = "job_failed";
+    return json({ error: "archive-process failed" }, 500);
+  } finally {
+    summary.queue_depth = await countArchiveUnfinished(supabase);
+    await recordPipelineHeartbeat(supabase, {
+      stationId: "archive_process",
+      status: hb.status,
+      trigger: "cron",
+      summary,
+      errorCode: hb.errorCode,
+    });
+  }
+}
+
+async function runQueueClaimInner(
+  supabase: Client,
+  summary: {
+    dequeued: number;
+    queue_depth: number;
+    inserted: number;
+    refreshed: number;
+    walled: number;
+    events_written: number;
+  },
+  hb: { status: "ok" | "error"; errorCode: string },
+): Promise<Response> {
   const { data: claimed, error: claimErr } = await supabase
     .rpc("claim_archive_queue_row");
 
   if (claimErr) {
+    hb.status = "error";
+    hb.errorCode = "job_failed";
     logEvent({ event: "claim_error", error: claimErr.message });
     return json({ error: `claim failed: ${claimErr.message}` }, 500);
   }
@@ -231,6 +277,7 @@ async function runQueueClaim(
   }
 
   const row = claimed as ArchiveQueueRow;
+  summary.dequeued = 1;
   const started = Date.now();
   // attempts is already incremented by claim_archive_queue_row() so that a
   // worker which crashes before its finally block still consumes an attempt.
@@ -240,6 +287,8 @@ async function runQueueClaim(
   // returns, so a null here would indicate RPC-contract corruption; bail
   // loud rather than silently writing a bad guard.
   if (!row.claimed_at) {
+    hb.status = "error";
+    hb.errorCode = "job_failed";
     logEvent({
       event: "unexpected_null_claimed_at",
       id: row.id,
@@ -401,6 +450,8 @@ async function runQueueClaim(
   }
 
   if (terminalFailure) {
+    hb.status = "error";
+    hb.errorCode = "job_failed";
     return json({
       error: terminalFailure.error,
       school_id: row.school_id,
@@ -410,6 +461,15 @@ async function runQueueClaim(
   }
 
   const duration_ms = Date.now() - started;
+  if (outcome) {
+    const candidates = outcome.candidates ?? [];
+    summary.inserted = candidates.filter((c) => c.action === "inserted").length;
+    summary.refreshed = candidates.filter((c) => c.action === "refreshed").length;
+    summary.events_written = summary.inserted + summary.refreshed;
+    if (isWalledOutcome(outcome.outcome)) summary.walled = 1;
+  } else if (isWalledOutcome(failureCategory)) {
+    summary.walled = 1;
+  }
   logEvent({
     event: "completed",
     id: row.id,

--- a/supabase/functions/refresh-coverage/index.ts
+++ b/supabase/functions/refresh-coverage/index.ts
@@ -15,6 +15,7 @@
 
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
+import { recordPipelineHeartbeat } from "../_shared/pipeline_heartbeat.ts";
 
 Deno.serve(async (req: Request) => {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -35,12 +36,37 @@ Deno.serve(async (req: Request) => {
 
   logEvent({ event: "refresh_start", include_histogram: includeHistogram });
 
+  const heartbeat = {
+    current: 0,
+    stale: 0,
+    inaccessible: 0,
+    never_found: 0,
+  };
+  const send = async (
+    body: unknown,
+    status = 200,
+    histogram: Record<string, number> = {},
+  ): Promise<Response> => {
+    heartbeat.current = histogram.cds_available_current ?? 0;
+    heartbeat.stale = histogram.cds_available_stale ?? 0;
+    heartbeat.inaccessible = histogram.source_not_automatically_accessible ?? 0;
+    heartbeat.never_found = histogram.no_public_cds_found ?? 0;
+    await recordPipelineHeartbeat(supabase, {
+      stationId: "coverage_refresh",
+      status: status < 400 ? "ok" : "error",
+      trigger: "cron",
+      summary: heartbeat,
+      errorCode: status < 400 ? "none" : "job_failed",
+    });
+    return json(body, status);
+  };
+
   const { data: refreshData, error: refreshErr } = await supabase
     .rpc("refresh_institution_cds_coverage");
 
   if (refreshErr) {
     logEvent({ event: "refresh_failed", error: refreshErr.message });
-    return json({ error: `refresh failed: ${refreshErr.message}` }, 500);
+    return await send({ error: `refresh failed: ${refreshErr.message}` }, 500);
   }
 
   // The RPC returns SETOF (rows_written int, duration_ms int) — supabase-js
@@ -49,7 +75,7 @@ Deno.serve(async (req: Request) => {
   const rowsWritten = (rpcResult as { rows_written?: number })?.rows_written ?? 0;
   const durationMs = (rpcResult as { duration_ms?: number })?.duration_ms ?? 0;
 
-  const histogram = includeHistogram ? await loadStatusHistogram(supabase) : null;
+  const histogram = await loadStatusHistogram(supabase);
 
   const totalMs = Date.now() - started;
   logEvent({
@@ -58,15 +84,19 @@ Deno.serve(async (req: Request) => {
     refresh_duration_ms: durationMs,
     total_duration_ms: totalMs,
     histogram_included: includeHistogram,
-    ...(histogram ? { histogram } : {}),
+    ...(includeHistogram ? { histogram } : {}),
   });
 
-  return json({
-    rows_written: rowsWritten,
-    refresh_duration_ms: durationMs,
-    total_duration_ms: totalMs,
-    ...(histogram ? { coverage_status_histogram: histogram } : {}),
-  });
+  return await send(
+    {
+      rows_written: rowsWritten,
+      refresh_duration_ms: durationMs,
+      total_duration_ms: totalMs,
+      ...(includeHistogram ? { coverage_status_histogram: histogram } : {}),
+    },
+    200,
+    histogram,
+  );
 });
 
 async function parseBody(req: Request): Promise<{ include_histogram?: boolean }> {

--- a/supabase/migrations/20260821220000_pipeline_observation.sql
+++ b/supabase/migrations/20260821220000_pipeline_observation.sql
@@ -1,0 +1,610 @@
+-- PRD 030 M0: public pipeline observation.
+-- Registry + heartbeat state + writer RPC (service_role) + anon facts function.
+-- pg_cron jobs are secret-gated and absent locally; this migration does not
+-- assert cron.job rows. Heartbeat silence is the public signal.
+
+create table public.pipeline_stations (
+  station_id text primary key,
+  display_name text not null,
+  cadence_label text not null,
+  class text not null,
+  source_kind text not null,
+  on_board boolean not null,
+  sort_order integer not null,
+  required_keys text[] not null default '{}',
+  allowed_keys text[] not null default '{}',
+  constraint pipeline_stations_class_valid
+    check (class in (
+      'monthly_sla',
+      'daily_sla',
+      'hourly_sla',
+      'continuous_sla',
+      'yearly',
+      'adhoc'
+    )),
+  constraint pipeline_stations_source_kind_valid
+    check (source_kind in ('gha', 'pg_cron', 'sql', 'operator'))
+);
+
+comment on table public.pipeline_stations is
+  'Static registry for PRD 030 pipeline observation. Jobs do not update this table. record_pipeline_heartbeat validates writes against required/allowed keys here.';
+
+create table public.pipeline_heartbeats (
+  station_id text primary key references public.pipeline_stations (station_id),
+  last_started_at timestamptz,
+  last_finished_at timestamptz,
+  last_status text not null default 'never',
+  last_trigger text,
+  last_summary jsonb not null default '{}'::jsonb,
+  last_scheduled_finished_at timestamptz,
+  last_scheduled_status text not null default 'never',
+  last_scheduled_summary jsonb not null default '{}'::jsonb,
+  last_scheduled_error_code text not null default 'none',
+  last_error_code text not null default 'none',
+  source_url text,
+  updated_at timestamptz not null default now(),
+  constraint pipeline_heartbeats_status_valid
+    check (last_status in ('never', 'running', 'ok', 'error')),
+  constraint pipeline_heartbeats_scheduled_status_valid
+    check (last_scheduled_status in ('never', 'running', 'ok', 'error')),
+  constraint pipeline_heartbeats_trigger_valid
+    check (last_trigger is null or last_trigger in ('schedule', 'dispatch', 'operator', 'cron')),
+  constraint pipeline_heartbeats_error_code_valid
+    check (last_error_code in (
+      'search_provider_rejected',
+      'missing_required_secret',
+      'heartbeat_summary_malformed',
+      'worker_timeout',
+      'job_failed',
+      'none'
+    )),
+  constraint pipeline_heartbeats_scheduled_error_code_valid
+    check (last_scheduled_error_code in (
+      'search_provider_rejected',
+      'missing_required_secret',
+      'heartbeat_summary_malformed',
+      'worker_timeout',
+      'job_failed',
+      'none'
+    ))
+);
+
+comment on table public.pipeline_heartbeats is
+  'Per-station pipeline clocks. Anon cannot SELECT. Public page reads pipeline_station_facts(). Do not key caches on updated_at.';
+
+comment on column public.pipeline_heartbeats.last_scheduled_finished_at is
+  'Last finish whose trigger was schedule or cron. Dispatch and operator never copy here.';
+
+comment on column public.pipeline_heartbeats.updated_at is
+  'Row maintenance timestamp. Never use as an SLA clock.';
+
+create index if not exists cds_documents_extraction_pending_idx
+  on public.cds_documents (id)
+  where extraction_status = 'extraction_pending';
+
+insert into public.pipeline_stations (
+  station_id, display_name, cadence_label, class, source_kind, on_board, sort_order,
+  required_keys, allowed_keys
+) values
+  (
+    'finder_brave', 'Finder', 'monthly · scheduled SLA 40d', 'monthly_sla', 'gha', true, 10,
+    array['probed', 'found', 'replaced', 'budget_remaining'],
+    array['probed', 'found', 'replaced', 'budget_remaining', 'pr_url', 'run_url']
+  ),
+  (
+    'finder_stuck_pdf', 'Stuck PDFs', 'monthly · scheduled SLA 40d', 'monthly_sla', 'gha', true, 20,
+    array['stuck', 'reprobed', 'still_stuck'],
+    array['stuck', 'reprobed', 'still_stuck', 'pr_url', 'run_url']
+  ),
+  (
+    'finder_landing_hints', 'Landing hints', 'monthly · scheduled SLA 40d', 'monthly_sla', 'gha', true, 30,
+    array['proposals', 'promoted'],
+    array['proposals', 'promoted', 'pr_url', 'run_url']
+  ),
+  (
+    'archive_enqueue', 'Enqueue', 'daily · SLA 36h', 'daily_sla', 'pg_cron', true, 40,
+    array['queued', 'skipped', 'errors'],
+    array['queued', 'skipped', 'errors', 'pr_url', 'run_url']
+  ),
+  (
+    'archive_process', 'Process', 'every 30s', 'continuous_sla', 'pg_cron', true, 50,
+    array['dequeued', 'queue_depth', 'inserted', 'refreshed', 'walled', 'events_written'],
+    array['dequeued', 'queue_depth', 'inserted', 'refreshed', 'walled', 'events_written', 'pr_url', 'run_url']
+  ),
+  (
+    'extraction_worker', 'Extract', 'daily · pending drain', 'daily_sla', 'gha', true, 60,
+    array['extracted', 'failed', 'pending_remaining', 'stopped_reason'],
+    array['extracted', 'failed', 'pending_remaining', 'stopped_reason', 'llm_fallback', 'pr_url', 'run_url']
+  ),
+  (
+    'coverage_refresh', 'Coverage', 'hourly · SLA 3h', 'hourly_sla', 'pg_cron', true, 70,
+    array['current', 'stale', 'inaccessible', 'never_found'],
+    array['current', 'stale', 'inaccessible', 'never_found', 'overrides_stale', 'pr_url', 'run_url']
+  ),
+  (
+    'serving_cache_refresh', 'Serving caches', 'hourly · SLA 3h', 'hourly_sla', 'sql', true, 80,
+    array['ok'],
+    array['ok', 'pr_url', 'run_url']
+  ),
+  (
+    'ipeds_release_probe', 'IPEDS probe', 'monthly · scheduled SLA 40d', 'monthly_sla', 'gha', true, 90,
+    array['new_release', 'issue_opened'],
+    array['new_release', 'issue_opened', 'pr_url', 'run_url']
+  ),
+  (
+    'schema_build', 'Schema', 'yearly · slate until a heartbeat', 'yearly', 'operator', true, 100,
+    array['years'],
+    array['years', 'pr_url', 'run_url']
+  ),
+  (
+    'scorecard_load', 'Scorecard', 'yearly · slate until a heartbeat', 'yearly', 'operator', true, 110,
+    array['vintage', 'rows'],
+    array['vintage', 'rows', 'pr_url', 'run_url']
+  ),
+  (
+    'directory_enqueue', 'Directory enqueue', 'manual', 'adhoc', 'operator', false, 200,
+    array['seeded'],
+    array['seeded', 'pr_url', 'run_url']
+  ),
+  (
+    'mirror_ingest', 'Mirror ingest', 'manual', 'adhoc', 'operator', false, 210,
+    array['source', 'rows_added'],
+    array['source', 'rows_added', 'pr_url', 'run_url']
+  );
+
+insert into public.pipeline_heartbeats (station_id)
+select station_id from public.pipeline_stations;
+
+alter table public.pipeline_stations enable row level security;
+alter table public.pipeline_heartbeats enable row level security;
+
+revoke all on table public.pipeline_stations from public;
+revoke all on table public.pipeline_stations from anon, authenticated;
+grant all on table public.pipeline_stations to service_role;
+
+revoke all on table public.pipeline_heartbeats from public;
+revoke all on table public.pipeline_heartbeats from anon, authenticated;
+grant all on table public.pipeline_heartbeats to service_role;
+
+create or replace function public.pipeline_sanitize_source_url(p_url text)
+returns text
+language sql
+immutable
+parallel safe
+as $$
+  select case
+    when p_url is null then null
+    when p_url ~ '^https://github\.com/bolewood/collegedata-fyi/(actions/runs|pull)/[0-9]+/?$'
+      then regexp_replace(p_url, '/$', '')
+    else null
+  end;
+$$;
+
+comment on function public.pipeline_sanitize_source_url(text) is
+  'Allowlist for public heartbeat URLs: Actions run pages and repo pull requests only.';
+
+revoke all on function public.pipeline_sanitize_source_url(text) from public;
+revoke all on function public.pipeline_sanitize_source_url(text) from anon, authenticated;
+grant execute on function public.pipeline_sanitize_source_url(text) to service_role;
+
+create or replace function public.record_pipeline_heartbeat(
+  p_station_id text,
+  p_status text,
+  p_trigger text,
+  p_summary jsonb,
+  p_error_code text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  registry public.pipeline_stations%rowtype;
+  filtered jsonb := '{}'::jsonb;
+  key text;
+  value jsonb;
+  status_out text;
+  error_out text;
+  source_out text;
+  is_finish boolean;
+  missing boolean := false;
+  required_key text;
+begin
+  if p_station_id is null then
+    raise exception 'record_pipeline_heartbeat: station_id is required';
+  end if;
+
+  select * into registry
+  from public.pipeline_stations
+  where station_id = p_station_id;
+
+  if not found then
+    raise exception 'record_pipeline_heartbeat: unknown station_id %', p_station_id;
+  end if;
+
+  if p_status not in ('running', 'ok', 'error') then
+    raise exception 'record_pipeline_heartbeat: invalid status %', p_status;
+  end if;
+
+  if p_trigger not in ('schedule', 'dispatch', 'operator', 'cron') then
+    raise exception 'record_pipeline_heartbeat: invalid trigger %', p_trigger;
+  end if;
+
+  if p_error_code is null or p_error_code not in (
+    'search_provider_rejected',
+    'missing_required_secret',
+    'heartbeat_summary_malformed',
+    'worker_timeout',
+    'job_failed',
+    'none'
+  ) then
+    raise exception 'record_pipeline_heartbeat: invalid error_code %', p_error_code;
+  end if;
+
+  for key, value in
+    select * from jsonb_each(coalesce(p_summary, '{}'::jsonb))
+  loop
+    if key = any (registry.allowed_keys) then
+      if key in ('run_url', 'pr_url') then
+        if jsonb_typeof(value) = 'string' then
+          source_out := public.pipeline_sanitize_source_url(value #>> '{}');
+          if source_out is not null then
+            filtered := filtered || jsonb_build_object(key, to_jsonb(source_out));
+          end if;
+        end if;
+      else
+        filtered := filtered || jsonb_build_object(key, value);
+      end if;
+    end if;
+  end loop;
+
+  is_finish := p_status in ('ok', 'error');
+  status_out := p_status;
+  error_out := p_error_code;
+
+  if is_finish then
+    foreach required_key in array registry.required_keys
+    loop
+      if not (filtered ? required_key) then
+        missing := true;
+        exit;
+      end if;
+    end loop;
+    if missing then
+      status_out := 'error';
+      error_out := 'heartbeat_summary_malformed';
+    end if;
+  end if;
+
+  if source_out is null and filtered ? 'run_url' then
+    source_out := public.pipeline_sanitize_source_url(filtered ->> 'run_url');
+  end if;
+  if source_out is null and filtered ? 'pr_url' then
+    source_out := public.pipeline_sanitize_source_url(filtered ->> 'pr_url');
+  end if;
+
+  insert into public.pipeline_heartbeats as h (
+    station_id,
+    last_started_at,
+    last_finished_at,
+    last_status,
+    last_trigger,
+    last_summary,
+    last_scheduled_finished_at,
+    last_scheduled_status,
+    last_scheduled_summary,
+    last_scheduled_error_code,
+    last_error_code,
+    source_url,
+    updated_at
+  ) values (
+    p_station_id,
+    case when p_status = 'running' then now() else null end,
+    case when is_finish then now() else null end,
+    status_out,
+    p_trigger,
+    filtered,
+    case
+      when is_finish and p_trigger in ('schedule', 'cron') then now()
+      else null
+    end,
+    case
+      when is_finish and p_trigger in ('schedule', 'cron') then status_out
+      else 'never'
+    end,
+    case
+      when is_finish and p_trigger in ('schedule', 'cron') then filtered
+      else '{}'::jsonb
+    end,
+    case
+      when is_finish and p_trigger in ('schedule', 'cron') then error_out
+      else 'none'
+    end,
+    error_out,
+    source_out,
+    now()
+  )
+  on conflict (station_id) do update set
+    last_started_at = case
+      when p_status = 'running' then now()
+      else coalesce(h.last_started_at, excluded.last_started_at)
+    end,
+    last_finished_at = case
+      when is_finish then now()
+      else h.last_finished_at
+    end,
+    last_status = excluded.last_status,
+    last_trigger = excluded.last_trigger,
+    last_summary = excluded.last_summary,
+    last_scheduled_finished_at = case
+      when is_finish and p_trigger in ('schedule', 'cron') then now()
+      else h.last_scheduled_finished_at
+    end,
+    last_scheduled_status = case
+      when is_finish and p_trigger in ('schedule', 'cron') then excluded.last_status
+      else h.last_scheduled_status
+    end,
+    last_scheduled_summary = case
+      when is_finish and p_trigger in ('schedule', 'cron') then excluded.last_summary
+      else h.last_scheduled_summary
+    end,
+    last_scheduled_error_code = case
+      when is_finish and p_trigger in ('schedule', 'cron') then excluded.last_error_code
+      else h.last_scheduled_error_code
+    end,
+    last_error_code = excluded.last_error_code,
+    source_url = coalesce(excluded.source_url, h.source_url),
+    updated_at = now();
+end;
+$$;
+
+comment on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) is
+  'Service-role writer for pipeline_heartbeats. Drops unknown JSON keys, strips nested counts by allowlist, and refuses to persist ok when required finish keys are missing.';
+
+revoke all on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) from public;
+revoke all on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) from anon, authenticated;
+grant execute on function public.record_pipeline_heartbeat(text, text, text, jsonb, text) to service_role;
+
+create or replace function public.pipeline_station_facts()
+returns table (
+  station_id text,
+  display_name text,
+  cadence_label text,
+  class text,
+  on_board boolean,
+  sort_order integer,
+  last_started_at timestamptz,
+  last_finished_at timestamptz,
+  last_status text,
+  last_trigger text,
+  last_summary jsonb,
+  last_scheduled_finished_at timestamptz,
+  last_scheduled_status text,
+  last_scheduled_summary jsonb,
+  last_scheduled_error_code text,
+  last_error_code text,
+  source_url text,
+  queue_unfinished bigint,
+  extraction_pending bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with live as (
+    select
+      (select count(*) from public.archive_queue q where q.status in ('ready', 'processing')) as queue_unfinished,
+      (select count(*) from public.cds_documents d where d.extraction_status = 'extraction_pending') as extraction_pending
+  )
+  select
+    s.station_id,
+    s.display_name,
+    s.cadence_label,
+    s.class,
+    s.on_board,
+    s.sort_order,
+    h.last_started_at,
+    h.last_finished_at,
+    h.last_status,
+    h.last_trigger,
+    h.last_summary,
+    h.last_scheduled_finished_at,
+    h.last_scheduled_status,
+    h.last_scheduled_summary,
+    h.last_scheduled_error_code,
+    h.last_error_code,
+    h.source_url,
+    case when s.station_id = 'archive_process' then live.queue_unfinished else null end,
+    case when s.station_id = 'extraction_worker' then live.extraction_pending else null end
+  from public.pipeline_stations s
+  join public.pipeline_heartbeats h using (station_id)
+  cross join live
+  order by s.sort_order;
+$$;
+
+comment on function public.pipeline_station_facts() is
+  'Anon-readable SECURITY DEFINER snapshot of pipeline clocks plus live unfinished/pending counts. Not a view: owner-rights views reintroduce the advisor warning cleared in 20260614141000.';
+
+revoke all on function public.pipeline_station_facts() from public;
+grant execute on function public.pipeline_station_facts() to anon, authenticated, service_role;
+
+create or replace function public.refresh_public_serving_caches()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  merit_count integer;
+  stats_count integer;
+  result jsonb;
+begin
+  begin
+    merit_count := public.refresh_school_merit_profile_cache();
+    stats_count := public.refresh_site_stats_cache();
+    result := jsonb_build_object(
+      'school_merit_profile_cache', merit_count,
+      'site_stats_cache', stats_count
+    );
+    perform public.record_pipeline_heartbeat(
+      'serving_cache_refresh',
+      'ok',
+      'cron',
+      jsonb_build_object('ok', true),
+      'none'
+    );
+    return result;
+  exception
+    when others then
+      begin
+        perform public.record_pipeline_heartbeat(
+          'serving_cache_refresh',
+          'error',
+          'cron',
+          jsonb_build_object('ok', false),
+          'job_failed'
+        );
+      exception
+        when others then
+          raise warning 'pipeline heartbeat failed for serving_cache_refresh: %', sqlerrm;
+      end;
+      raise;
+  end;
+end;
+$$;
+
+comment on function public.refresh_public_serving_caches() is
+  'Refreshes materialized public serving caches and writes the serving_cache_refresh heartbeat.';
+
+revoke all on table public.archive_queue from public;
+revoke all on table public.archive_queue from anon, authenticated;
+grant all on table public.archive_queue to service_role;
+
+revoke all on public.bot_challenged_documents from public;
+revoke select on public.bot_challenged_documents from anon, authenticated;
+grant select on public.bot_challenged_documents to service_role;
+
+revoke all on public.latest_school_hosting from public;
+revoke select on public.latest_school_hosting from anon, authenticated;
+grant select on public.latest_school_hosting to service_role;
+
+-- Self-tests. Reset seed rows afterward so first public paint is still never.
+
+do $$
+declare
+  summary jsonb;
+  status_out text;
+  error_out text;
+  source_out text;
+begin
+  if has_function_privilege('anon', 'public.record_pipeline_heartbeat(text, text, text, jsonb, text)', 'execute') then
+    raise exception 'anon must not execute record_pipeline_heartbeat';
+  end if;
+  if has_function_privilege('authenticated', 'public.record_pipeline_heartbeat(text, text, text, jsonb, text)', 'execute') then
+    raise exception 'authenticated must not execute record_pipeline_heartbeat';
+  end if;
+  if not has_function_privilege('anon', 'public.pipeline_station_facts()', 'execute') then
+    raise exception 'anon must execute pipeline_station_facts';
+  end if;
+  if has_table_privilege('anon', 'public.pipeline_heartbeats', 'select') then
+    raise exception 'anon must not select pipeline_heartbeats';
+  end if;
+  if has_table_privilege('anon', 'public.pipeline_stations', 'select') then
+    raise exception 'anon must not select pipeline_stations';
+  end if;
+  if has_table_privilege('anon', 'public.archive_queue', 'select') then
+    raise exception 'anon must not select archive_queue';
+  end if;
+  if has_table_privilege('anon', 'public.bot_challenged_documents', 'select') then
+    raise exception 'anon must not select bot_challenged_documents';
+  end if;
+  if to_regclass('public.latest_school_hosting') is not null
+     and has_table_privilege('anon', 'public.latest_school_hosting', 'select') then
+    raise exception 'anon must not select latest_school_hosting';
+  end if;
+
+  if public.pipeline_sanitize_source_url('https://github.com/bolewood/collegedata-fyi/actions/runs/123')
+     is distinct from 'https://github.com/bolewood/collegedata-fyi/actions/runs/123' then
+    raise exception 'run URL sanitizer rejected a valid Actions URL';
+  end if;
+  if public.pipeline_sanitize_source_url('https://github.com/bolewood/collegedata-fyi/pull/99')
+     is distinct from 'https://github.com/bolewood/collegedata-fyi/pull/99' then
+    raise exception 'PR URL sanitizer rejected a valid pull URL';
+  end if;
+  if public.pipeline_sanitize_source_url('https://github.com/bolewood/collegedata-fyi/actions/runs/123?token=abc') is not null then
+    raise exception 'sanitizer allowed a query string';
+  end if;
+  if public.pipeline_sanitize_source_url('https://evil.example/steal') is not null then
+    raise exception 'sanitizer allowed a non-allowlisted URL';
+  end if;
+
+  perform public.record_pipeline_heartbeat(
+    'archive_process',
+    'ok',
+    'cron',
+    jsonb_build_object(
+      'dequeued', 1,
+      'queue_depth', 3,
+      'inserted', 0,
+      'refreshed', 0,
+      'walled', 0,
+      'events_written', 0,
+      'stack', 'SecretError: boom',
+      'counts', jsonb_build_object('x', 1)
+    ),
+    'none'
+  );
+  select last_summary, last_scheduled_status, last_error_code
+    into summary, status_out, error_out
+  from public.pipeline_heartbeats
+  where station_id = 'archive_process';
+  if summary ? 'stack' or summary ? 'counts' then
+    raise exception 'record_pipeline_heartbeat kept forbidden keys: %', summary;
+  end if;
+  if (summary ->> 'queue_depth') is distinct from '3' then
+    raise exception 'record_pipeline_heartbeat dropped queue_depth';
+  end if;
+  if status_out is distinct from 'ok' then
+    raise exception 'allowlisted finish should stay ok';
+  end if;
+
+  perform public.record_pipeline_heartbeat(
+    'finder_brave',
+    'ok',
+    'schedule',
+    jsonb_build_object('probed', 1, 'run_url', 'https://evil.example/x'),
+    'none'
+  );
+  select last_scheduled_status, last_scheduled_error_code, source_url, last_summary
+    into status_out, error_out, source_out, summary
+  from public.pipeline_heartbeats
+  where station_id = 'finder_brave';
+  if status_out is distinct from 'error' or error_out is distinct from 'heartbeat_summary_malformed' then
+    raise exception 'malformed finish must persist error + heartbeat_summary_malformed';
+  end if;
+  if source_out is not null then
+    raise exception 'unsanitized run_url leaked into source_url';
+  end if;
+  if summary ? 'run_url' then
+    raise exception 'unsanitized run_url leaked into summary';
+  end if;
+
+  update public.pipeline_heartbeats
+  set
+    last_started_at = null,
+    last_finished_at = null,
+    last_status = 'never',
+    last_trigger = null,
+    last_summary = '{}'::jsonb,
+    last_scheduled_finished_at = null,
+    last_scheduled_status = 'never',
+    last_scheduled_summary = '{}'::jsonb,
+    last_scheduled_error_code = 'none',
+    last_error_code = 'none',
+    source_url = null,
+    updated_at = now()
+  where station_id in ('archive_process', 'finder_brave');
+end;
+$$;

--- a/tools/extraction_worker/test_extraction_heartbeat.py
+++ b/tools/extraction_worker/test_extraction_heartbeat.py
@@ -1,0 +1,63 @@
+import sys
+import unittest
+from pathlib import Path
+
+WORKER_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(WORKER_DIR))
+
+from worker import infer_stopped_reason, with_heartbeat_fields
+
+
+class ExtractionHeartbeatFieldsTests(unittest.TestCase):
+    def test_cap_when_limit_hit_and_pending_remain(self) -> None:
+        self.assertEqual(
+            infer_stopped_reason(
+                stopped_early=False,
+                hit_error=False,
+                limit=5,
+                processed_count=5,
+                pending_remaining=84,
+            ),
+            "cap",
+        )
+
+    def test_deadline_wins_over_cap(self) -> None:
+        self.assertEqual(
+            infer_stopped_reason(
+                stopped_early=True,
+                hit_error=False,
+                limit=5,
+                processed_count=3,
+                pending_remaining=80,
+            ),
+            "deadline",
+        )
+
+    def test_empty_drain_is_complete(self) -> None:
+        self.assertEqual(
+            infer_stopped_reason(
+                stopped_early=False,
+                hit_error=False,
+                limit=5,
+                processed_count=0,
+                pending_remaining=0,
+            ),
+            "complete",
+        )
+
+    def test_summary_contains_required_heartbeat_keys(self) -> None:
+        payload = with_heartbeat_fields(
+            {"processed_count": 5, "failure_count": 1},
+            stopped_reason="cap",
+            extracted=4,
+            failed=1,
+            pending_remaining=84,
+        )
+        self.assertEqual(payload["stopped_reason"], "cap")
+        self.assertEqual(payload["extracted"], 4)
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(payload["pending_remaining"], 84)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/extraction_worker/worker.py
+++ b/tools/extraction_worker/worker.py
@@ -247,6 +247,52 @@ def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
+def count_extraction_pending(client: Client) -> int:
+    try:
+        result = (
+            client.table("cds_documents")
+            .select("id", count="exact", head=True)
+            .eq("extraction_status", "extraction_pending")
+            .execute()
+        )
+        return int(result.count or 0)
+    except Exception:
+        return 0
+
+
+def infer_stopped_reason(
+    *,
+    stopped_early: bool,
+    hit_error: bool,
+    limit: int | None,
+    processed_count: int,
+    pending_remaining: int,
+) -> str:
+    if hit_error:
+        return "error"
+    if stopped_early:
+        return "deadline"
+    if limit and processed_count >= limit and pending_remaining > 0:
+        return "cap"
+    return "complete"
+
+
+def with_heartbeat_fields(
+    payload: dict[str, Any],
+    *,
+    stopped_reason: str,
+    extracted: int,
+    failed: int,
+    pending_remaining: int,
+) -> dict[str, Any]:
+    out = dict(payload)
+    out["stopped_reason"] = stopped_reason
+    out["extracted"] = extracted
+    out["failed"] = failed
+    out["pending_remaining"] = pending_remaining
+    return out
+
+
 def extraction_success(action: str) -> ExtractionOutcome:
     return ExtractionOutcome(action, refresh_projection=True)
 
@@ -2000,7 +2046,8 @@ def main() -> int:
             + (" after reconcile." if reconcile_counts.get("reconciled") else "."),
         )
         if args.summary_json:
-            write_run_summary(args.summary_json, {
+            pending_remaining = count_extraction_pending(client)
+            write_run_summary(args.summary_json, with_heartbeat_fields({
                 "started_at": started_at,
                 "finished_at": utc_now_iso(),
                 "dry_run": args.dry_run,
@@ -2017,7 +2064,13 @@ def main() -> int:
                 "reconcile_counts": dict(reconcile_counts),
                 "stopped_early": False,
                 "documents": [],
-            })
+            }, stopped_reason=infer_stopped_reason(
+                stopped_early=False,
+                hit_error=False,
+                limit=args.limit,
+                processed_count=0,
+                pending_remaining=pending_remaining,
+            ), extracted=0, failed=0, pending_remaining=pending_remaining))
         return 0
 
     print(
@@ -2152,7 +2205,9 @@ def main() -> int:
                 print(f"  {bucket:30s} {projection_counts[bucket]:5d}")
         if projection_counts["errors"] or projection_counts["setup_error"]:
             if args.summary_json:
-                write_run_summary(args.summary_json, {
+                pending_remaining = count_extraction_pending(client)
+                extracted = max(0, processed_count - failure_count)
+                write_run_summary(args.summary_json, with_heartbeat_fields({
                     "started_at": started_at,
                     "finished_at": utc_now_iso(),
                     "dry_run": args.dry_run,
@@ -2169,10 +2224,18 @@ def main() -> int:
                     "reconcile_counts": dict(reconcile_counts),
                     "stopped_early": stopped_early,
                     "documents": summary_docs,
-                })
+                }, stopped_reason=infer_stopped_reason(
+                    stopped_early=stopped_early,
+                    hit_error=True,
+                    limit=args.limit,
+                    processed_count=processed_count,
+                    pending_remaining=pending_remaining,
+                ), extracted=extracted, failed=failure_count, pending_remaining=pending_remaining))
             return 2
     if args.summary_json:
-        write_run_summary(args.summary_json, {
+        pending_remaining = count_extraction_pending(client)
+        extracted = max(0, processed_count - failure_count)
+        write_run_summary(args.summary_json, with_heartbeat_fields({
             "started_at": started_at,
             "finished_at": utc_now_iso(),
             "dry_run": args.dry_run,
@@ -2189,7 +2252,13 @@ def main() -> int:
             "reconcile_counts": dict(reconcile_counts),
             "stopped_early": stopped_early,
             "documents": summary_docs,
-        })
+        }, stopped_reason=infer_stopped_reason(
+            stopped_early=stopped_early,
+            hit_error=False,
+            limit=args.limit,
+            processed_count=processed_count,
+            pending_remaining=pending_remaining,
+        ), extracted=extracted, failed=failure_count, pending_remaining=pending_remaining))
     return extraction_run_exit_code(failure_count)
 
 

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -656,12 +656,15 @@ def process_school(school: dict, args: argparse.Namespace,
     if not url and search_tried:
         method = last_attempted_method
 
+    replaced = False
     if url:
-        if not args.dry_run:
-            existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
-            if should_replace_seed(existing, url):
+        existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
+        if should_replace_seed(existing, url):
+            replaced = True
+            if not args.dry_run:
                 school["discovery_seed_url"] = url
                 school["scrape_policy"] = "active"
+        if not args.dry_run:
             record_probe(school, "found", method, patterns_tried, search_tried)
     else:
         if not args.dry_run:
@@ -674,10 +677,30 @@ def process_school(school: dict, args: argparse.Namespace,
         "method": method,
         "patterns_tried": patterns_tried,
         "search_tried": search_tried,
+        "replaced": replaced,
     }
 
 
-def _save_yaml(data: dict) -> None:
+def write_probe_summary(
+    path: Path | None,
+    *,
+    probed: int,
+    found: int,
+    replaced: int,
+    budget_remaining: int | None,
+    still_stuck: int | None = None,
+) -> None:
+    if path is None:
+        return
+    payload = {
+        "probed": probed,
+        "found": found,
+        "replaced": replaced,
+        "budget_remaining": budget_remaining,
+        "still_stuck": still_stuck if still_stuck is not None else max(0, probed - found),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     """Dump data back to schools.yaml. Caller ensures single-threaded call."""
     SCHOOLS_YAML.write_text(
         yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
@@ -750,6 +773,8 @@ def main():
                          f"never responds and would otherwise wedge a worker "
                          f"for ~33 minutes cycling through pattern × subdomain "
                          f"× year combinations.")
+    ap.add_argument("--summary-json", type=Path,
+                    help="Write probed/found/replaced/budget_remaining for pipeline heartbeats.")
     args = ap.parse_args()
 
     data = yaml.safe_load(SCHOOLS_YAML.read_text())
@@ -830,14 +855,29 @@ def main():
     print(f"Probing {total} schools with {args.workers} workers (rps={args.rps} per worker)")
     if skipped:
         print(f"Skipped {skipped} schools due to {args.cooldown_days}-day cooldown")
+    tracker = env.get("brave_tracker") or {}
+    def budget_remaining() -> int | None:
+        budget = tracker.get("budget")
+        if budget is None:
+            return None
+        return max(0, int(budget) - int(tracker.get("calls") or 0))
     if total == 0:
         print("Nothing to probe. Exiting.")
+        write_probe_summary(
+            args.summary_json,
+            probed=0,
+            found=0,
+            replaced=0,
+            budget_remaining=budget_remaining(),
+            still_stuck=0,
+        )
         return
 
     # ── Threadpool execution ──
     found = 0
     failed = 0
     completed = 0
+    replaced = 0
 
     with ThreadPoolExecutor(max_workers=args.workers) as executor:
         # Submit all schools; keep a mapping so we can attribute results
@@ -855,6 +895,8 @@ def main():
                     continue
 
                 prefix = f"[{completed:>5}/{total}]"
+                if result.get("replaced"):
+                    replaced += 1
                 if result["url"]:
                     found += 1
                     tag = f"[{result['method']}] " if result["method"] != "pattern" else ""
@@ -876,13 +918,19 @@ def main():
                 _save_yaml(data)
                 print(f"  [partial progress saved to {SCHOOLS_YAML}]")
             print(f"\nProbed: {completed}, Found: {found}, Not found: {failed}")
+            write_probe_summary(
+                args.summary_json,
+                probed=completed,
+                found=found,
+                replaced=replaced,
+                budget_remaining=budget_remaining(),
+            )
             return
 
     print(f"\nProbed: {completed}, Found: {found}, Not found: {failed}", end="")
     if skipped:
         print(f", Skipped (cooldown): {skipped}", end="")
     print()
-    tracker = env.get("brave_tracker") or {}
     if tracker.get("calls"):
         print(f"Brave API calls this run: {tracker['calls']}")
 
@@ -892,6 +940,13 @@ def main():
             print(f"Cleared {len(cleared)} duplicate seed(s) shared across UNITIDs")
         _save_yaml(data)
         print(f"Updated {SCHOOLS_YAML}")
+    write_probe_summary(
+        args.summary_json,
+        probed=completed,
+        found=found,
+        replaced=replaced,
+        budget_remaining=budget_remaining(),
+    )
 
 
 if __name__ == "__main__":

--- a/tools/finder/promote_landing_hints.py
+++ b/tools/finder/promote_landing_hints.py
@@ -36,6 +36,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from collections import Counter
@@ -439,6 +440,11 @@ def main() -> int:
         type=Path,
         help="Limit proposals to school ids listed in this file.",
     )
+    ap.add_argument(
+        "--summary-json",
+        type=Path,
+        help="Write proposals/promoted counts for pipeline heartbeats.",
+    )
     args = ap.parse_args()
 
     schools_data = yaml.safe_load(args.schools_yaml.read_text())
@@ -533,15 +539,29 @@ def main() -> int:
     if args.apply:
         if not proposals:
             print("No proposals to apply.", file=sys.stderr)
+            write_landing_summary(args.summary_json, proposals=0, promoted=0)
             return 0
         applied = apply_proposals(args.schools_yaml, proposals)
         print(f"Rewrote {applied} discovery_seed_url lines in {args.schools_yaml}",
               file=sys.stderr)
+        write_landing_summary(args.summary_json, proposals=len(proposals), promoted=applied)
         return 0
 
     write_proposal_report(args.report, proposals, len(direct_doc_schools))
     print(f"Wrote {args.report}", file=sys.stderr)
+    write_landing_summary(args.summary_json, proposals=len(proposals), promoted=0)
     return 0
+
+
+def write_landing_summary(path: Path | None, *, proposals: int, promoted: int) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"proposals": proposals, "promoted": promoted}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/tools/ops/automation_health.py
+++ b/tools/ops/automation_health.py
@@ -21,8 +21,12 @@ DEFAULT_REPO = "bolewood/collegedata-fyi"
 CRON_JOBS = (
     "archive-enqueue-daily",
     "archive-process-every-30s",
-    "refresh-coverage-every-15min",
+    "refresh-coverage-hourly",
+    "refresh-public-serving-caches-hourly",
 )
+# TODO: read public.pipeline_heartbeats (via service role) and drop GitHub
+# Actions scraping once PRD 030 M0 has been live long enough to trust the
+# clocks. This script stays operator-only.
 
 
 class HealthError(RuntimeError):

--- a/tools/ops/record_heartbeat.py
+++ b/tools/ops/record_heartbeat.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Write a pipeline observation heartbeat via record_pipeline_heartbeat.
+
+Never fails the calling job. A POST/RPC error prints
+`::warning::pipeline heartbeat failed for <station>` and exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+VALID_STATUSES = {"running", "ok", "error"}
+VALID_TRIGGERS = {"schedule", "dispatch", "operator", "cron"}
+VALID_ERROR_CODES = {
+    "search_provider_rejected",
+    "missing_required_secret",
+    "heartbeat_summary_malformed",
+    "worker_timeout",
+    "job_failed",
+    "none",
+}
+
+# Mirrors public.pipeline_stations. CI asserts workflow --station values
+# are a subset of this list.
+REGISTRY_STATIONS = (
+    "finder_brave",
+    "finder_stuck_pdf",
+    "finder_landing_hints",
+    "archive_enqueue",
+    "archive_process",
+    "extraction_worker",
+    "coverage_refresh",
+    "serving_cache_refresh",
+    "ipeds_release_probe",
+    "schema_build",
+    "scorecard_load",
+    "directory_enqueue",
+    "mirror_ingest",
+)
+
+
+def load_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if path.exists():
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def warning_and_ok(station: str, detail: str) -> int:
+    print(f"::warning::pipeline heartbeat failed for {station}", file=sys.stderr)
+    print(detail, file=sys.stderr)
+    return 0
+
+
+def post_heartbeat(
+    *,
+    supabase_url: str,
+    service_role_key: str,
+    station_id: str,
+    status: str,
+    trigger: str,
+    summary: dict[str, Any],
+    error_code: str,
+    timeout_sec: float = 20,
+) -> None:
+    endpoint = supabase_url.rstrip("/") + "/rest/v1/rpc/record_pipeline_heartbeat"
+    payload = json.dumps({
+        "p_station_id": station_id,
+        "p_status": status,
+        "p_trigger": trigger,
+        "p_summary": summary,
+        "p_error_code": error_code,
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "apikey": service_role_key,
+            "Authorization": f"Bearer {service_role_key}",
+            "Prefer": "return=minimal",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout_sec) as response:
+        response.read()
+
+
+def load_summary(args: argparse.Namespace) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if args.summary:
+        parsed = json.loads(args.summary)
+        if not isinstance(parsed, dict):
+            raise ValueError("--summary must be a JSON object")
+        summary.update(parsed)
+    if args.summary_json:
+        parsed = json.loads(args.summary_json.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            raise ValueError("--summary-json must contain a JSON object")
+        summary.update(parsed)
+    if args.run_url:
+        summary["run_url"] = args.run_url
+    if args.pr_url:
+        summary["pr_url"] = args.pr_url
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--station", required=True)
+    parser.add_argument("--status", required=True, choices=sorted(VALID_STATUSES))
+    parser.add_argument("--trigger", required=True, choices=sorted(VALID_TRIGGERS))
+    parser.add_argument("--summary", default="", help="JSON object string")
+    parser.add_argument("--summary-json", type=Path, help="Path to a JSON object")
+    parser.add_argument("--error-code", default="none", choices=sorted(VALID_ERROR_CODES))
+    parser.add_argument("--run-url")
+    parser.add_argument("--pr-url")
+    parser.add_argument("--env", type=Path, default=Path(".env"))
+    args = parser.parse_args(argv)
+
+    station = args.station
+    if station not in REGISTRY_STATIONS:
+        return warning_and_ok(station, f"unknown station_id {station}")
+
+    env = load_env(args.env)
+    supabase_url = os.environ.get("SUPABASE_URL") or env.get("SUPABASE_URL") or ""
+    service_role_key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or env.get("SUPABASE_SERVICE_ROLE_KEY")
+        or ""
+    )
+    if not supabase_url or not service_role_key:
+        return warning_and_ok(station, "missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+
+    try:
+        summary = load_summary(args)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return warning_and_ok(station, f"invalid summary: {exc}")
+
+    try:
+        post_heartbeat(
+            supabase_url=supabase_url,
+            service_role_key=service_role_key,
+            station_id=station,
+            status=args.status,
+            trigger=args.trigger,
+            summary=summary,
+            error_code=args.error_code,
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+        return warning_and_ok(station, str(exc))
+    except Exception as exc:  # noqa: BLE001 — heartbeat must never fail the job
+        return warning_and_ok(station, f"{type(exc).__name__}: {exc}")
+
+    print(f"pipeline heartbeat wrote {station} status={args.status} trigger={args.trigger}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ops/test_automation_health.py
+++ b/tools/ops/test_automation_health.py
@@ -29,7 +29,7 @@ class AutomationHealthTests(unittest.TestCase):
             "database": {
                 "cron_jobs": [
                     {"jobname": "archive-process-every-30s", "active": True},
-                    {"jobname": "refresh-coverage-every-15min", "active": True},
+                    {"jobname": "refresh-coverage-hourly", "active": True},
                 ],
                 "cron_recent_failures": [],
                 "http_response_categories": {
@@ -64,7 +64,7 @@ class AutomationHealthTests(unittest.TestCase):
             "database": {
                 "cron_jobs": [
                     {"jobname": "archive-process-every-30s", "active": True},
-                    {"jobname": "refresh-coverage-every-15min", "active": True},
+                    {"jobname": "refresh-coverage-hourly", "active": True},
                 ],
                 "cron_recent_failures": [],
                 "http_response_categories": {

--- a/tools/ops/test_pipeline_writers.py
+++ b/tools/ops/test_pipeline_writers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from tools.ops.record_heartbeat import REGISTRY_STATIONS
+
+ROOT = Path(__file__).resolve().parents[2]
+FINDER = ROOT / ".github/workflows/ops-finder-probe.yml"
+EXTRACTION = ROOT / ".github/workflows/ops-extraction-worker.yml"
+IPEDS = ROOT / ".github/workflows/ipeds-release-probe.yml"
+STATION_RE = re.compile(r"--station\s+(\S+)")
+
+
+class PipelineWriterLintTests(unittest.TestCase):
+    def test_workflow_station_ids_are_in_the_registry(self) -> None:
+        stations: set[str] = set()
+        for path in (FINDER, EXTRACTION, IPEDS):
+            stations.update(STATION_RE.findall(path.read_text(encoding="utf-8")))
+        self.assertTrue(stations)
+        self.assertTrue(stations <= set(REGISTRY_STATIONS), stations - set(REGISTRY_STATIONS))
+
+    def test_scheduled_workflows_keep_on_schedule(self) -> None:
+        for path in (FINDER, EXTRACTION, IPEDS):
+            text = path.read_text(encoding="utf-8")
+            self.assertRegex(text, r"(?m)^  schedule:\s*$", msg=f"{path.name} lost on.schedule")
+            self.assertRegex(text, r"- cron:")
+
+    def test_finder_heartbeats_are_mode_guarded_and_id_keyed(self) -> None:
+        text = FINDER.read_text(encoding="utf-8")
+        self.assertIn("id: re_probe_stuck", text)
+        self.assertIn("id: probe_unknown", text)
+        self.assertIn("id: promote_landing_hints", text)
+        self.assertIn(
+            "if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf')",
+            text,
+        )
+        self.assertIn(
+            "if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown')",
+            text,
+        )
+        self.assertIn("if: always() && env.INPUT_APPLY_LANDING_HINTS == 'true'", text)
+        brave_finish = text.split("Heartbeat finder_brave finish", 1)[1]
+        self.assertNotIn("INPUT_MODE == 'stuck-pdf'", brave_finish.split("- name:", 1)[0])
+
+    def test_ipeds_noop_heartbeat_maps_available_count_to_new_release(self) -> None:
+        text = IPEDS.read_text(encoding="utf-8")
+        self.assertIn("Heartbeat ipeds_release_probe finish", text)
+        self.assertIn('"new_release": bool((summary.get("available_count") or 0) > 0)', text)
+        self.assertIn("issue_opened", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/test_record_heartbeat.py
+++ b/tools/ops/test_record_heartbeat.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from unittest import mock
+from urllib.error import URLError
+
+from tools.ops import record_heartbeat as hb
+
+
+class RecordHeartbeatTests(unittest.TestCase):
+    def test_unknown_station_exits_zero_with_warning(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch.object(hb.sys, "stderr", stderr):
+            code = hb.main([
+                "--station", "not_a_station",
+                "--status", "ok",
+                "--trigger", "schedule",
+            ])
+        self.assertEqual(code, 0)
+        self.assertIn("::warning::pipeline heartbeat failed for not_a_station", stderr.getvalue())
+
+    def test_post_failure_exits_zero_with_warning(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_SERVICE_ROLE_KEY": "service-role",
+            },
+            clear=False,
+        ), mock.patch.object(
+            hb.urllib.request,
+            "urlopen",
+            side_effect=URLError("connection refused"),
+        ), mock.patch.object(hb.sys, "stderr", stderr):
+            code = hb.main([
+                "--station", "finder_brave",
+                "--status", "ok",
+                "--trigger", "schedule",
+                "--summary", json.dumps({
+                    "probed": 1,
+                    "found": 0,
+                    "replaced": 0,
+                    "budget_remaining": 10,
+                }),
+            ])
+        self.assertEqual(code, 0)
+        self.assertIn("::warning::pipeline heartbeat failed for finder_brave", stderr.getvalue())
+
+    def test_missing_secrets_exits_zero_with_warning(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch.dict(
+            "os.environ",
+            {"SUPABASE_URL": "", "SUPABASE_SERVICE_ROLE_KEY": ""},
+            clear=False,
+        ), mock.patch.object(hb, "load_env", return_value={}), mock.patch.object(hb.sys, "stderr", stderr):
+            code = hb.main([
+                "--station", "finder_brave",
+                "--status", "running",
+                "--trigger", "schedule",
+            ])
+        self.assertEqual(code, 0)
+        self.assertIn("::warning::pipeline heartbeat failed for finder_brave", stderr.getvalue())
+
+    def test_post_payload_uses_rpc_argument_names(self) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeResponse:
+            def read(self) -> bytes:
+                return b""
+
+            def __enter__(self) -> FakeResponse:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+        def fake_urlopen(request, timeout=20):  # noqa: ANN001
+            captured["url"] = request.full_url
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_SERVICE_ROLE_KEY": "service-role",
+            },
+            clear=False,
+        ), mock.patch.object(hb.urllib.request, "urlopen", side_effect=fake_urlopen):
+            code = hb.main([
+                "--station", "ipeds_release_probe",
+                "--status", "ok",
+                "--trigger", "schedule",
+                "--summary", json.dumps({"new_release": False, "issue_opened": False}),
+                "--run-url", "https://github.com/bolewood/collegedata-fyi/actions/runs/99",
+            ])
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            captured["url"],
+            "https://example.supabase.co/rest/v1/rpc/record_pipeline_heartbeat",
+        )
+        body = captured["body"]
+        assert isinstance(body, dict)
+        self.assertEqual(body["p_station_id"], "ipeds_release_probe")
+        self.assertEqual(body["p_status"], "ok")
+        self.assertEqual(body["p_trigger"], "schedule")
+        self.assertEqual(body["p_error_code"], "none")
+        self.assertEqual(body["p_summary"]["new_release"], False)
+        self.assertEqual(
+            body["p_summary"]["run_url"],
+            "https://github.com/bolewood/collegedata-fyi/actions/runs/99",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/DESIGN_SYSTEM.md
+++ b/web/DESIGN_SYSTEM.md
@@ -144,6 +144,24 @@ None of these break functionality; they're palette-consistency debt.
 
 ---
 
+## Pipeline observation exception
+
+[`/pipeline-observation`](https://www.collegedata.fyi/pipeline-observation) is allowed to use page-local lamp colors. Site chrome (nav, footer, other routes) stays paper/ink/forest. The exception lives in [`web/src/app/pipeline-observation/pipeline-observation.css`](src/app/pipeline-observation/pipeline-observation.css) and must not leak teal or blue.
+
+| Token | Hex | Role |
+|---|---|---|
+| `--lamp-down` | `#d7263d` | overdue / error |
+| `--lamp-late` | `#e0a106` | extraction backlog (ink `#1c1400`) |
+| `--lamp-ok` | `#1f7a4d` | scheduled clock healthy |
+| `--lamp-slate` | `#5c5a54` | yearly, no heartbeat yet |
+| `--lamp-lock` | `#6b3fa0` | M1 vendor lock chips |
+| `--lamp-sso` | `#7a2f6a` | M1 SSO chips |
+| `--lamp-waf` | `#c45c14` | M1 bot-challenge chips |
+
+`run` reuses `--lamp-ok` with a CSS hatch plus the word `RUN`. Do not add a teal `--lamp-run`. Door cards (M1) stay `--paper` / `.cd-card`.
+
+---
+
 ## How to consult the reference
 
 Two ways to look at the system:

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,12 +1,15 @@
 import type { NextConfig } from "next";
 import retiredSchoolAliases from "./src/data/school-redirects.json";
 import { APEX_TO_WWW_REDIRECTS } from "./src/lib/apex-redirect";
+import { PIPELINE_OBSERVATION_REDIRECTS } from "./src/lib/pipeline-redirect";
 import { buildRetiredSchoolRedirects } from "./src/lib/school-alias";
 
 const nextConfig: NextConfig = {
+  trailingSlash: false,
   async redirects() {
     return [
       ...APEX_TO_WWW_REDIRECTS,
+      ...PIPELINE_OBSERVATION_REDIRECTS,
       ...buildRetiredSchoolRedirects(retiredSchoolAliases),
     ];
   },

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -15,6 +15,7 @@ Use these no-auth JSON endpoints for agent and CLI workflows:
 - Compare schools: https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chicago
 - Field dictionary: https://www.collegedata.fyi/api/fields
 - OpenAPI: https://www.collegedata.fyi/openapi.json
+- Pipeline clocks: https://www.collegedata.fyi/pipeline-observation.json
 
 Endowment health (IPEDS Finance Part H, fiscal years 2020+): request categories=finance for
 per-school endowment values, gifts, investment return, spending distribution, and the residual

--- a/web/src/app/pipeline-observation.json/route.ts
+++ b/web/src/app/pipeline-observation.json/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { fetchPipelineObservation, toPublicJson } from "@/lib/pipeline-observation";
+
+export const revalidate = 60;
+
+export async function GET() {
+  const snapshot = await fetchPipelineObservation();
+  return NextResponse.json(toPublicJson(snapshot), {
+    headers: {
+      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+    },
+  });
+}

--- a/web/src/app/pipeline-observation/page.tsx
+++ b/web/src/app/pipeline-observation/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import { fetchPipelineObservation } from "@/lib/pipeline-observation";
+import type { Lamp } from "@/lib/pipeline-lamps";
+import "./pipeline-observation.css";
+
+export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: "Pipeline observation — collegedata.fyi",
+  description:
+    "Every dispatch station on collegedata.fyi, when it last ran on schedule, and what it found. Missing heartbeats are red.",
+  alternates: { canonical: "/pipeline-observation" },
+};
+
+const LAMP_WORD: Record<Lamp, string> = {
+  down: "DOWN",
+  late: "LATE",
+  ok: "OK",
+  run: "RUN",
+  slate: "SLATE",
+};
+
+export default async function PipelineObservationPage() {
+  const snapshot = await fetchPipelineObservation();
+
+  return (
+    <div className="po-page mx-auto max-w-5xl px-4 sm:px-6 py-8">
+      <div className="meta">§ Pipeline observation</div>
+      <div
+        className={`po-strip po-strip--${snapshot.strip.lamp}`}
+        role="status"
+        aria-live="polite"
+      >
+        {snapshot.strip.text}
+      </div>
+      <header style={{ paddingTop: 16, paddingBottom: 8 }}>
+        <h1
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: "clamp(40px, 6vw, 64px)",
+            lineHeight: 1.05,
+            margin: 0,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          The clocks, <em>and the locked doors.</em>
+        </h1>
+        <p
+          style={{
+            marginTop: 18,
+            fontSize: 16,
+            lineHeight: 1.55,
+            color: "var(--ink-2)",
+            maxWidth: 720,
+          }}
+        >
+          Every dispatch station on collegedata.fyi, when it last ran on
+          schedule, and what it found. If a step goes quiet, the lamp turns
+          red — including the monthly search that sat idle from April to
+          August 2026. Locked doors (Tableau, SharePoint IRM, SSO) ship in
+          the next slice; this page is the clocks.
+        </p>
+      </header>
+
+      <section>
+        <h2
+          className="serif"
+          style={{ fontSize: 22, lineHeight: 1.2, margin: "48px 0 16px" }}
+        >
+          Dispatch board
+        </h2>
+        <div className="po-board">
+          {snapshot.stations.map((station) => (
+            <article
+              key={station.station_id}
+              className={`po-tile po-tile--${station.lamp}`}
+              aria-label={`${station.display_name}: ${LAMP_WORD[station.lamp]}, ${station.ago_label}`}
+            >
+              <div>
+                <div className="po-tile-id">{station.cadence_label}</div>
+                <h3>{station.display_name}</h3>
+                <div className="po-tile-lamp">{LAMP_WORD[station.lamp]}</div>
+                <div className="po-tile-ago">{station.ago_label}</div>
+                <div className="po-tile-result">{station.result_line}</div>
+              </div>
+            </article>
+          ))}
+        </div>
+        <p className="po-manual">
+          Manual sources (not on the strip):{" "}
+          {snapshot.manual_sources
+            .map((source) => `${source.display_name} — ${source.ago_label}`)
+            .join(" · ")}
+        </p>
+      </section>
+
+      <section style={{ marginTop: 64 }}>
+        <h2
+          id="methodology"
+          className="serif"
+          style={{ fontSize: 22, lineHeight: 1.2, margin: "0 0 16px" }}
+        >
+          Methodology
+        </h2>
+        <div className="po-method">
+          <p style={{ margin: 0 }}>
+            Each station writes a public heartbeat when it starts and when it
+            finishes. Lamps are computed at read time from the{" "}
+            <strong>scheduled</strong> clock. A manual GitHub run cannot green
+            a missing cron. If the scheduled heartbeat is older than the SLA,
+            the lamp is red — including when a dispatch succeeded yesterday.
+            Missing data is red, not gray.
+          </p>
+          <p style={{ margin: 0 }}>
+            This page is not coverage. Coverage asks whether we have a CDS.
+            This board asks whether the machine is running. JSON snapshot:{" "}
+            <a href="/pipeline-observation.json">/pipeline-observation.json</a>.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/pipeline-observation/pipeline-observation.css
+++ b/web/src/app/pipeline-observation/pipeline-observation.css
@@ -1,0 +1,134 @@
+/* Pipeline observation exception. Site chrome stays paper/ink.
+   Lamps are page-local. run reuses --lamp-ok with a hatch. */
+
+.po-page {
+  --lamp-ok: #1f7a4d;
+  --lamp-late: #e0a106;
+  --lamp-down: #d7263d;
+  --lamp-lock: #6b3fa0;
+  --lamp-sso: #7a2f6a;
+  --lamp-waf: #c45c14;
+  --lamp-slate: #5c5a54;
+  --late-ink: #1c1400;
+}
+
+.po-strip {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.po-strip--down {
+  background: var(--lamp-down);
+  color: #fff;
+}
+
+.po-strip--late {
+  background: var(--lamp-late);
+  color: var(--late-ink);
+}
+
+.po-strip--ok {
+  background: var(--lamp-ok);
+  color: #fff;
+}
+
+.po-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 8px;
+}
+
+.po-tile {
+  min-height: 168px;
+  padding: 14px 14px 12px;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.po-tile--ok,
+.po-tile--run {
+  background: var(--lamp-ok);
+}
+
+.po-tile--run {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.18) 0 8px,
+    transparent 8px 16px
+  );
+}
+
+.po-tile--down {
+  background: var(--lamp-down);
+}
+
+.po-tile--late {
+  background: var(--lamp-late);
+  color: var(--late-ink);
+}
+
+.po-tile--slate {
+  background: var(--lamp-slate);
+}
+
+.po-tile-id {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.po-tile h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 1.1;
+  margin: 8px 0 0;
+}
+
+.po-tile-ago {
+  font-family: var(--mono);
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+  margin-top: 8px;
+}
+
+.po-tile-result {
+  font-size: 12px;
+  opacity: 0.92;
+  margin-top: 4px;
+}
+
+.po-tile-lamp {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-top: 10px;
+}
+
+.po-manual {
+  margin-top: 20px;
+  font-size: 13px;
+  color: var(--ink-3);
+  font-family: var(--mono);
+}
+
+.po-method {
+  max-width: 720px;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.65;
+  display: grid;
+  gap: 14px;
+}

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -32,6 +32,8 @@ export function Footer() {
           <a href="https://github.com/bolewood/collegedata-fyi" target="_blank" rel="noopener noreferrer">
             GitHub
           </a>
+          <a href="/coverage">Coverage</a>
+          <a href="/pipeline-observation">Pipeline</a>
           <a href="/recipes">Recipes</a>
           <a href="/api">API</a>
           <a href="/privacy">Privacy</a>

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -14,6 +14,7 @@ const PRIMARY_NAV_LINKS = [
 const SECONDARY_NAV_LINKS = [
   { href: "/browse", label: "Browser" },
   { href: "/coverage", label: "Coverage" },
+  { href: "/pipeline-observation", label: "Pipeline" },
   { href: "/recipes", label: "Recipes" },
   { href: "/about", label: "About" },
 ];

--- a/web/src/lib/pipeline-lamps.test.ts
+++ b/web/src/lib/pipeline-lamps.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOARD_STATION_IDS,
+  stationLamp,
+  stripLamp,
+  type HeartbeatStatus,
+  type StationClass,
+  type StationLampInput,
+} from "./pipeline-lamps";
+
+const NOW = new Date("2026-08-21T20:00:00.000Z");
+
+function hoursAgo(hours: number): string {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function daysAgo(days: number): string {
+  return hoursAgo(days * 24);
+}
+
+function base(overrides: Partial<StationLampInput> = {}): StationLampInput {
+  return {
+    stationId: "archive_enqueue",
+    class: "daily_sla",
+    lastStatus: "ok",
+    lastStartedAt: hoursAgo(11),
+    lastFinishedAt: hoursAgo(11),
+    lastScheduledStatus: "ok",
+    lastScheduledFinishedAt: hoursAgo(11),
+    lastScheduledSummary: {},
+    queueUnfinished: 0,
+    extractionPending: 0,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+const CLASSES: StationClass[] = [
+  "monthly_sla",
+  "daily_sla",
+  "hourly_sla",
+  "continuous_sla",
+  "yearly",
+  "adhoc",
+];
+const STATUSES: HeartbeatStatus[] = ["never", "running", "ok", "error"];
+
+describe("stationLamp", () => {
+  it("scheduled error yesterday + dispatch ok today is still down", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "finder_brave",
+          class: "monthly_sla",
+          lastStatus: "ok",
+          lastFinishedAt: hoursAgo(2),
+          lastScheduledStatus: "error",
+          lastScheduledFinishedAt: hoursAgo(20),
+        }),
+      ),
+    ).toBe("down");
+  });
+
+  it("seed never is down for SLA stations and slate for yearly", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "finder_brave",
+          class: "monthly_sla",
+          lastStatus: "never",
+          lastScheduledStatus: "never",
+          lastScheduledFinishedAt: null,
+          lastFinishedAt: null,
+        }),
+      ),
+    ).toBe("down");
+    expect(
+      stationLamp(
+        base({
+          stationId: "schema_build",
+          class: "yearly",
+          lastStatus: "never",
+          lastScheduledStatus: "never",
+          lastFinishedAt: null,
+        }),
+      ),
+    ).toBe("slate");
+  });
+
+  it("archive_process unfinished=0 cron 30s ago is ok; 3h ago is down; unfinished>0 20min is down", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "archive_process",
+          class: "continuous_sla",
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: new Date(NOW.getTime() - 30_000).toISOString(),
+          queueUnfinished: 0,
+        }),
+      ),
+    ).toBe("ok");
+    expect(
+      stationLamp(
+        base({
+          stationId: "archive_process",
+          class: "continuous_sla",
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: hoursAgo(3),
+          queueUnfinished: 0,
+        }),
+      ),
+    ).toBe("down");
+    expect(
+      stationLamp(
+        base({
+          stationId: "archive_process",
+          class: "continuous_sla",
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: hoursAgo(20 / 60),
+          queueUnfinished: 4,
+        }),
+      ),
+    ).toBe("down");
+  });
+
+  it("running longer than 8 hours is down", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "extraction_worker",
+          class: "daily_sla",
+          lastStatus: "running",
+          lastStartedAt: hoursAgo(9),
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: hoursAgo(10),
+        }),
+      ),
+    ).toBe("down");
+  });
+
+  it("finder/extraction running within 8 hours is run", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "finder_brave",
+          class: "monthly_sla",
+          lastStatus: "running",
+          lastStartedAt: hoursAgo(1),
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: daysAgo(12),
+        }),
+      ),
+    ).toBe("run");
+  });
+
+  it("extraction cap with pending remaining is late, not down", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "extraction_worker",
+          class: "daily_sla",
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: hoursAgo(20),
+          extractionPending: 84,
+          lastScheduledSummary: {
+            extracted: 5,
+            failed: 0,
+            pending_remaining: 84,
+            stopped_reason: "cap",
+          },
+        }),
+      ),
+    ).toBe("late");
+  });
+
+  it("extraction extracted=0 with pending is late", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "extraction_worker",
+          class: "daily_sla",
+          lastScheduledStatus: "ok",
+          lastScheduledFinishedAt: hoursAgo(4),
+          extractionPending: 12,
+          lastScheduledSummary: {
+            extracted: 0,
+            failed: 0,
+            pending_remaining: 12,
+            stopped_reason: "complete",
+          },
+        }),
+      ),
+    ).toBe("late");
+  });
+
+  it("yearly finish older than 18 months is down; recent finish stays slate", () => {
+    expect(
+      stationLamp(
+        base({
+          stationId: "scorecard_load",
+          class: "yearly",
+          lastFinishedAt: daysAgo(19 * 30),
+          lastStatus: "ok",
+        }),
+      ),
+    ).toBe("down");
+    expect(
+      stationLamp(
+        base({
+          stationId: "scorecard_load",
+          class: "yearly",
+          lastFinishedAt: daysAgo(40),
+          lastStatus: "ok",
+        }),
+      ),
+    ).toBe("slate");
+  });
+
+  it("covers the (class, status, age) matrix without throwing", () => {
+    const ages = [null, hoursAgo(0.1), hoursAgo(4), hoursAgo(40), daysAgo(50), daysAgo(600)];
+    const lamps = new Set<string>();
+    for (const stationClass of CLASSES) {
+      for (const status of STATUSES) {
+        for (const age of ages) {
+          lamps.add(
+            stationLamp(
+              base({
+                stationId:
+                  stationClass === "continuous_sla"
+                    ? "archive_process"
+                    : stationClass === "yearly"
+                      ? "schema_build"
+                      : stationClass === "adhoc"
+                        ? "directory_enqueue"
+                        : "finder_brave",
+                class: stationClass,
+                lastStatus: status,
+                lastStartedAt: age,
+                lastFinishedAt: age,
+                lastScheduledStatus: status,
+                lastScheduledFinishedAt: age,
+                queueUnfinished: stationClass === "continuous_sla" ? 1 : 0,
+                extractionPending: 0,
+              }),
+            ),
+          );
+        }
+      }
+    }
+    expect(lamps.has("down")).toBe(true);
+    expect(lamps.has("slate")).toBe(true);
+    expect(lamps.has("ok") || lamps.has("run") || lamps.has("late")).toBe(true);
+  });
+});
+
+describe("stripLamp", () => {
+  it("omits yearly slate and manual stations from the brick", () => {
+    expect(stripLamp(["ok", "ok", "slate", "run"])).toBe("ok");
+    expect(stripLamp(["ok", "late", "slate"])).toBe("late");
+    expect(stripLamp(["ok", "down", "late"])).toBe("down");
+  });
+
+  it("board has eleven stations", () => {
+    expect(BOARD_STATION_IDS).toHaveLength(11);
+    expect(BOARD_STATION_IDS).not.toContain("directory_enqueue");
+  });
+});

--- a/web/src/lib/pipeline-lamps.ts
+++ b/web/src/lib/pipeline-lamps.ts
@@ -1,0 +1,161 @@
+export type StationClass =
+  | "monthly_sla"
+  | "daily_sla"
+  | "hourly_sla"
+  | "continuous_sla"
+  | "yearly"
+  | "adhoc";
+
+export type HeartbeatStatus = "never" | "running" | "ok" | "error";
+
+export type Lamp = "down" | "late" | "ok" | "run" | "slate";
+
+export type StripLamp = "down" | "late" | "ok";
+
+export const LAMP_HEX = {
+  down: "#d7263d",
+  late: "#e0a106",
+  ok: "#1f7a4d",
+  lock: "#6b3fa0",
+  sso: "#7a2f6a",
+  waf: "#c45c14",
+  slate: "#5c5a54",
+  lateInk: "#1c1400",
+} as const;
+
+export const BOARD_STATION_IDS = [
+  "finder_brave",
+  "finder_stuck_pdf",
+  "finder_landing_hints",
+  "archive_enqueue",
+  "archive_process",
+  "extraction_worker",
+  "coverage_refresh",
+  "serving_cache_refresh",
+  "ipeds_release_probe",
+  "schema_build",
+  "scorecard_load",
+] as const;
+
+export const MANUAL_STATION_IDS = ["directory_enqueue", "mirror_ingest"] as const;
+
+export const RUN_STATION_IDS = new Set<string>([
+  "finder_brave",
+  "finder_stuck_pdf",
+  "finder_landing_hints",
+  "extraction_worker",
+]);
+
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+const THIRTY_SIX_HOURS_MS = 36 * 60 * 60 * 1000;
+const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
+const FORTY_DAYS_MS = 40 * 24 * 60 * 60 * 1000;
+const EIGHTEEN_MONTHS_MS = 18 * 30 * 24 * 60 * 60 * 1000;
+
+export type StationLampInput = {
+  stationId: string;
+  class: StationClass;
+  lastStatus: HeartbeatStatus | null;
+  lastStartedAt: string | null;
+  lastFinishedAt: string | null;
+  lastScheduledStatus: HeartbeatStatus | null;
+  lastScheduledFinishedAt: string | null;
+  lastScheduledSummary?: Record<string, unknown> | null;
+  queueUnfinished?: number | null;
+  extractionPending?: number | null;
+  now: Date;
+};
+
+function ageMs(iso: string | null | undefined, now: Date): number | null {
+  if (!iso) return null;
+  const ms = now.getTime() - new Date(iso).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function scheduledOkWithin(input: StationLampInput, windowMs: number): boolean {
+  if (input.lastScheduledStatus !== "ok") return false;
+  const age = ageMs(input.lastScheduledFinishedAt, input.now);
+  return age !== null && age <= windowMs;
+}
+
+function runningState(input: StationLampInput): "fresh" | "stale" | null {
+  if (input.lastStatus !== "running") return null;
+  const age = ageMs(input.lastStartedAt, input.now);
+  if (age === null || age > EIGHT_HOURS_MS) return "stale";
+  return "fresh";
+}
+
+function yearlyLamp(input: StationLampInput): Lamp {
+  const finishedAge = ageMs(input.lastFinishedAt, input.now);
+  if (input.lastFinishedAt && finishedAge !== null && finishedAge > EIGHTEEN_MONTHS_MS) {
+    return "down";
+  }
+  return "slate";
+}
+
+function extractionLamp(input: StationLampInput): Lamp {
+  if (!scheduledOkWithin(input, THIRTY_SIX_HOURS_MS)) return "down";
+  const summary = input.lastScheduledSummary ?? {};
+  const pending = Number(input.extractionPending ?? 0);
+  const extracted = Number(summary.extracted ?? 0);
+  const stoppedReason = String(summary.stopped_reason ?? "");
+  if (
+    pending > 0 &&
+    (stoppedReason === "cap" || stoppedReason === "deadline" || extracted === 0)
+  ) {
+    return "late";
+  }
+  return "ok";
+}
+
+function archiveProcessLamp(input: StationLampInput): Lamp {
+  const unfinished = Number(input.queueUnfinished ?? 0);
+  const scheduledAge = ageMs(input.lastScheduledFinishedAt, input.now);
+  if (unfinished > 0) {
+    if (input.lastScheduledStatus !== "ok") return "down";
+    if (scheduledAge === null || scheduledAge > FIFTEEN_MINUTES_MS) return "down";
+    return "ok";
+  }
+  if (scheduledAge === null || scheduledAge > TWO_HOURS_MS) return "down";
+  if (input.lastScheduledStatus === "error") return "down";
+  if (input.lastScheduledStatus === "ok") return "ok";
+  return "down";
+}
+
+function slaLamp(input: StationLampInput, windowMs: number): Lamp {
+  if (input.lastScheduledStatus === "error") return "down";
+  if (scheduledOkWithin(input, windowMs)) return "ok";
+  return "down";
+}
+
+export function stationLamp(input: StationLampInput): Lamp {
+  const running = runningState(input);
+  if (running === "stale") return "down";
+  if (running === "fresh" && RUN_STATION_IDS.has(input.stationId)) return "run";
+
+  switch (input.class) {
+    case "yearly":
+      return yearlyLamp(input);
+    case "adhoc":
+      return "slate";
+    case "continuous_sla":
+      return archiveProcessLamp(input);
+    case "monthly_sla":
+      return slaLamp(input, FORTY_DAYS_MS);
+    case "hourly_sla":
+      return slaLamp(input, THREE_HOURS_MS);
+    case "daily_sla":
+      if (input.stationId === "extraction_worker") return extractionLamp(input);
+      return slaLamp(input, THIRTY_SIX_HOURS_MS);
+    default:
+      return "down";
+  }
+}
+
+export function stripLamp(boardLamps: Lamp[]): StripLamp {
+  if (boardLamps.some((lamp) => lamp === "down")) return "down";
+  if (boardLamps.some((lamp) => lamp === "late")) return "late";
+  return "ok";
+}

--- a/web/src/lib/pipeline-observation.test.ts
+++ b/web/src/lib/pipeline-observation.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import nextConfig from "../../next.config";
+import { LAMP_HEX } from "./pipeline-lamps";
+import { PIPELINE_OBSERVATION_REDIRECTS } from "./pipeline-redirect";
+import {
+  seedPipelineSnapshot,
+  snapshotFromFacts,
+  toPublicJson,
+  type PipelineFactRow,
+} from "./pipeline-observation";
+
+const NOW = new Date("2026-08-21T20:00:00.000Z");
+
+const ALLOWED_HEX = new Set(
+  [
+    LAMP_HEX.down,
+    LAMP_HEX.late,
+    LAMP_HEX.ok,
+    LAMP_HEX.lock,
+    LAMP_HEX.sso,
+    LAMP_HEX.waf,
+    LAMP_HEX.slate,
+    LAMP_HEX.lateInk,
+    "#fff",
+    "#ffffff",
+  ].map((hex) => hex.toLowerCase()),
+);
+
+function fact(partial: Partial<PipelineFactRow> & Pick<PipelineFactRow, "station_id" | "class" | "display_name">): PipelineFactRow {
+  return {
+    cadence_label: "test",
+    on_board: true,
+    sort_order: 0,
+    last_started_at: null,
+    last_finished_at: null,
+    last_status: "never",
+    last_trigger: null,
+    last_summary: {},
+    last_scheduled_finished_at: null,
+    last_scheduled_status: "never",
+    last_scheduled_summary: {},
+    last_scheduled_error_code: "none",
+    last_error_code: "none",
+    source_url: null,
+    queue_unfinished: null,
+    extraction_pending: null,
+    ...partial,
+  };
+}
+
+describe("pipeline observation JSON", () => {
+  it("snapshot has as_of, precomputed lamps, empty locked_doors, no secret-shaped strings", () => {
+    const snapshot = snapshotFromFacts(
+      [
+        fact({
+          station_id: "finder_brave",
+          display_name: "Finder",
+          class: "monthly_sla",
+          last_scheduled_status: "error",
+          last_scheduled_finished_at: "2026-08-20T20:00:00.000Z",
+          last_scheduled_summary: { probed: 12, found: 1, replaced: 0, budget_remaining: 1700 },
+          last_scheduled_error_code: "search_provider_rejected",
+        }),
+        fact({
+          station_id: "archive_enqueue",
+          display_name: "Enqueue",
+          class: "daily_sla",
+          last_scheduled_status: "ok",
+          last_scheduled_finished_at: "2026-08-21T09:00:00.000Z",
+          last_scheduled_summary: { queued: 412, skipped: 1988, errors: 0 },
+        }),
+      ],
+      NOW,
+    );
+    const json = toPublicJson(snapshot);
+    expect(json.as_of).toBe(NOW.toISOString());
+    expect(json.locked_doors).toEqual([]);
+    expect(json.methodology_url).toContain("#methodology");
+    expect(json.stations.some((station) => station.lamp === "down")).toBe(true);
+    const blob = JSON.stringify(json);
+    expect(blob).not.toMatch(/service_role|sb_secret_|BRAVE_API_KEY|eyJhbGciOi/);
+    expect(blob).not.toMatch(/sharepoint\.com\/:x:|force_urls|H1 review/);
+    expect(json.strip.lamp).toBe("down");
+  });
+
+  it("facts fetch failure keeps seed lamps and a load-error strip", () => {
+    const seed = seedPipelineSnapshot(NOW, true);
+    expect(seed.load_error).toBe(true);
+    expect(seed.strip.text).toBe("Could not load station clocks.");
+    expect(seed.strip.lamp).toBe("down");
+  });
+
+  it("isStaticBuild seed paints SLA down and yearly slate", () => {
+    const seed = seedPipelineSnapshot(NOW, false);
+    expect(seed.load_error).toBe(false);
+    expect(seed.strip.lamp).toBe("down");
+    expect(seed.strip.text).not.toBe("Could not load station clocks.");
+    const yearly = seed.stations.filter((station) => station.station_id === "schema_build" || station.station_id === "scorecard_load");
+    expect(yearly.every((station) => station.lamp === "slate")).toBe(true);
+    const sla = seed.stations.filter((station) => station.station_id === "finder_brave");
+    expect(sla[0]?.lamp).toBe("down");
+    expect(seed.manual_sources.map((row) => row.station_id)).toEqual([
+      "directory_enqueue",
+      "mirror_ingest",
+    ]);
+  });
+});
+
+describe("pipeline observation CSS hex allowlist", () => {
+  it("uses only the PRD lamp hexes plus white; no teal, no blue", () => {
+    const cssPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../app/pipeline-observation/pipeline-observation.css",
+    );
+    const css = readFileSync(cssPath, "utf8");
+    expect(css.toLowerCase()).not.toContain("#2a9d8f");
+    expect(css.toLowerCase()).not.toMatch(/#[0-9a-f]{6}.*(blue|teal)/i);
+    const hexes = css.match(/#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/g) ?? [];
+    for (const hex of hexes) {
+      const normalized = hex.length === 4
+        ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`.toLowerCase()
+        : hex.toLowerCase();
+      expect(ALLOWED_HEX.has(normalized)).toBe(true);
+    }
+  });
+});
+
+describe("pipeline redirects", () => {
+  it("308s /pipeline to /pipeline-observation", async () => {
+    expect(PIPELINE_OBSERVATION_REDIRECTS).toEqual([
+      {
+        source: "/pipeline",
+        destination: "/pipeline-observation",
+        statusCode: 308,
+      },
+    ]);
+    const redirects = await nextConfig.redirects?.();
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/pipeline",
+          destination: "/pipeline-observation",
+          statusCode: 308,
+        }),
+      ]),
+    );
+  });
+
+  it("leaves trailingSlash unset/false so /pipeline-observation/ 308s to the canonical path", () => {
+    expect(nextConfig.trailingSlash).not.toBe(true);
+  });
+});

--- a/web/src/lib/pipeline-observation.ts
+++ b/web/src/lib/pipeline-observation.ts
@@ -1,0 +1,339 @@
+import { cache } from "react";
+import {
+  BOARD_STATION_IDS,
+  LAMP_HEX,
+  MANUAL_STATION_IDS,
+  stationLamp,
+  stripLamp,
+  type HeartbeatStatus,
+  type Lamp,
+  type StationClass,
+  type StripLamp,
+} from "./pipeline-lamps";
+
+export type PipelineFactRow = {
+  station_id: string;
+  display_name: string;
+  cadence_label: string;
+  class: StationClass;
+  on_board: boolean;
+  sort_order: number;
+  last_started_at: string | null;
+  last_finished_at: string | null;
+  last_status: HeartbeatStatus | null;
+  last_trigger: string | null;
+  last_summary: Record<string, unknown> | null;
+  last_scheduled_finished_at: string | null;
+  last_scheduled_status: HeartbeatStatus | null;
+  last_scheduled_summary: Record<string, unknown> | null;
+  last_scheduled_error_code: string | null;
+  last_error_code: string | null;
+  source_url: string | null;
+  queue_unfinished: number | null;
+  extraction_pending: number | null;
+};
+
+export type PipelineStationView = {
+  station_id: string;
+  display_name: string;
+  cadence_label: string;
+  class: StationClass;
+  on_board: boolean;
+  lamp: Lamp;
+  last_scheduled_finished_at: string | null;
+  last_scheduled_status: HeartbeatStatus | null;
+  last_finished_at: string | null;
+  last_started_at: string | null;
+  last_trigger: string | null;
+  last_status: HeartbeatStatus | null;
+  summary: Record<string, unknown>;
+  error_code: string;
+  source_url: string | null;
+  result_line: string;
+  ago_label: string;
+  queue_unfinished: number | null;
+  extraction_pending: number | null;
+};
+
+export type PipelineSnapshot = {
+  as_of: string;
+  load_error: boolean;
+  strip: { lamp: StripLamp; text: string };
+  stations: PipelineStationView[];
+  locked_doors: [];
+  manual_sources: Array<{
+    station_id: string;
+    display_name: string;
+    last_finished_at: string | null;
+    ago_label: string;
+  }>;
+  methodology_url: string;
+};
+
+const SEED_META: Array<{
+  station_id: (typeof BOARD_STATION_IDS)[number] | (typeof MANUAL_STATION_IDS)[number];
+  display_name: string;
+  cadence_label: string;
+  class: StationClass;
+  on_board: boolean;
+}> = [
+  { station_id: "finder_brave", display_name: "Finder", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
+  { station_id: "finder_stuck_pdf", display_name: "Stuck PDFs", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
+  { station_id: "finder_landing_hints", display_name: "Landing hints", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
+  { station_id: "archive_enqueue", display_name: "Enqueue", cadence_label: "daily · SLA 36h", class: "daily_sla", on_board: true },
+  { station_id: "archive_process", display_name: "Process", cadence_label: "every 30s", class: "continuous_sla", on_board: true },
+  { station_id: "extraction_worker", display_name: "Extract", cadence_label: "daily · pending drain", class: "daily_sla", on_board: true },
+  { station_id: "coverage_refresh", display_name: "Coverage", cadence_label: "hourly · SLA 3h", class: "hourly_sla", on_board: true },
+  { station_id: "serving_cache_refresh", display_name: "Serving caches", cadence_label: "hourly · SLA 3h", class: "hourly_sla", on_board: true },
+  { station_id: "ipeds_release_probe", display_name: "IPEDS probe", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
+  { station_id: "schema_build", display_name: "Schema", cadence_label: "yearly · slate until a heartbeat", class: "yearly", on_board: true },
+  { station_id: "scorecard_load", display_name: "Scorecard", cadence_label: "yearly · slate until a heartbeat", class: "yearly", on_board: true },
+  { station_id: "directory_enqueue", display_name: "Directory enqueue", cadence_label: "manual", class: "adhoc", on_board: false },
+  { station_id: "mirror_ingest", display_name: "Mirror ingest", cadence_label: "manual", class: "adhoc", on_board: false },
+];
+
+const ERROR_COPY: Record<string, string> = {
+  search_provider_rejected: "Search provider rejected the request.",
+  missing_required_secret: "A required secret is missing.",
+  heartbeat_summary_malformed: "Heartbeat summary was missing required keys.",
+  worker_timeout: "Worker hit its deadline without a clean finish.",
+  job_failed: "The job finished in error.",
+  none: "",
+};
+
+type UntypedRpc = {
+  rpc: (
+    fn: string,
+  ) => Promise<{ data: PipelineFactRow[] | null; error: { message: string } | null }>;
+};
+
+function isStaticBuild(): boolean {
+  return (
+    process.env.NEXT_PHASE === "phase-production-build" ||
+    process.env.npm_lifecycle_event === "build"
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function asStatus(value: unknown): HeartbeatStatus | null {
+  if (value === "never" || value === "running" || value === "ok" || value === "error") {
+    return value;
+  }
+  return null;
+}
+
+export function formatAgo(iso: string | null | undefined, now: Date): string {
+  if (!iso) return "no heartbeat";
+  const ms = now.getTime() - new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return "no heartbeat";
+  const sec = Math.max(0, Math.round(ms / 1000));
+  if (sec < 60) return `${sec} sec`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min} min`;
+  const hours = Math.round(min / 60);
+  if (hours < 48) return hours === 1 ? "1 hour" : `${hours} hours`;
+  const days = Math.round(hours / 24);
+  return days === 1 ? "1 day" : `${days} days`;
+}
+
+function resultLine(row: PipelineFactRow, lamp: Lamp): string {
+  const summary = asRecord(row.last_scheduled_summary);
+  const errorCode = row.last_scheduled_error_code ?? row.last_error_code ?? "none";
+  const errorCopy = ERROR_COPY[errorCode] ?? "";
+  if (lamp === "down" && errorCopy) return errorCopy;
+  switch (row.station_id) {
+    case "finder_brave":
+      return `${num(summary.probed)} probed · ${num(summary.found)} found · ${num(summary.budget_remaining)} budget left`;
+    case "finder_stuck_pdf":
+      return `${num(summary.stuck)} stuck · ${num(summary.reprobed)} reprobed · ${num(summary.still_stuck)} still stuck`;
+    case "finder_landing_hints":
+      return `${num(summary.proposals)} proposals · ${num(summary.promoted)} promoted`;
+    case "archive_enqueue":
+      return `${num(summary.queued)} queued · ${num(summary.skipped)} skipped`;
+    case "archive_process":
+      return `queue ${num(row.queue_unfinished ?? summary.queue_depth)} · ${num(summary.inserted)} inserted · ${num(summary.events_written)} events`;
+    case "extraction_worker":
+      return `${num(row.extraction_pending ?? summary.pending_remaining)} pending · ${String(summary.stopped_reason ?? "—")}`;
+    case "coverage_refresh":
+      return `${num(summary.current)} current · ${num(summary.stale)} stale`;
+    case "serving_cache_refresh":
+      return summary.ok === false ? "refresh failed" : "refresh_public_serving_caches";
+    case "ipeds_release_probe":
+      return summary.new_release === true ? "new release listed" : "no new release";
+    case "schema_build":
+      return Array.isArray(summary.years) ? `years ${summary.years.join(", ")}` : "Do not infer vintage from git.";
+    case "scorecard_load":
+      return summary.vintage ? `vintage ${String(summary.vintage)}` : "Do not infer vintage from git.";
+    default:
+      return lamp === "down" ? "No scheduled heartbeat." : "";
+  }
+}
+
+function num(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function seedFacts(): PipelineFactRow[] {
+  return SEED_META.map((meta) => ({
+    station_id: meta.station_id,
+    display_name: meta.display_name,
+    cadence_label: meta.cadence_label,
+    class: meta.class,
+    on_board: meta.on_board,
+    sort_order: 0,
+    last_started_at: null,
+    last_finished_at: null,
+    last_status: "never",
+    last_trigger: null,
+    last_summary: {},
+    last_scheduled_finished_at: null,
+    last_scheduled_status: "never",
+    last_scheduled_summary: {},
+    last_scheduled_error_code: "none",
+    last_error_code: "none",
+    source_url: null,
+    queue_unfinished: meta.station_id === "archive_process" ? 0 : null,
+    extraction_pending: meta.station_id === "extraction_worker" ? 0 : null,
+  }));
+}
+
+function stripText(lamp: StripLamp, stations: PipelineStationView[], loadError: boolean): string {
+  if (loadError) return "Could not load station clocks.";
+  const overdue = stations.filter((station) => station.on_board && station.lamp === "down");
+  const late = stations.filter((station) => station.on_board && station.lamp === "late");
+  if (lamp === "down") {
+    const first = overdue[0];
+    const detail = first
+      ? `${first.display_name} ${first.ago_label}`
+      : "scheduled clock missing";
+    return `${overdue.length} station${overdue.length === 1 ? "" : "s"} overdue · ${detail}`;
+  }
+  if (lamp === "late") {
+    const first = late[0];
+    return first
+      ? `${first.display_name} late · ${first.result_line}`
+      : "Extraction is behind.";
+  }
+  return "Every scheduled station is on the clock.";
+}
+
+export function snapshotFromFacts(
+  facts: PipelineFactRow[],
+  now: Date,
+  options: { loadError?: boolean } = {},
+): PipelineSnapshot {
+  const byId = new Map(facts.map((row) => [row.station_id, row]));
+  const merged = SEED_META.map((meta) => byId.get(meta.station_id) ?? seedFacts().find((row) => row.station_id === meta.station_id)!);
+  const stations = merged.map((row) => {
+    const lamp = stationLamp({
+      stationId: row.station_id,
+      class: row.class,
+      lastStatus: asStatus(row.last_status),
+      lastStartedAt: row.last_started_at,
+      lastFinishedAt: row.last_finished_at,
+      lastScheduledStatus: asStatus(row.last_scheduled_status),
+      lastScheduledFinishedAt: row.last_scheduled_finished_at,
+      lastScheduledSummary: asRecord(row.last_scheduled_summary),
+      queueUnfinished: row.queue_unfinished,
+      extractionPending: row.extraction_pending,
+      now,
+    });
+    const clockIso =
+      row.class === "yearly" ? row.last_finished_at : row.last_scheduled_finished_at;
+    return {
+      station_id: row.station_id,
+      display_name: row.display_name,
+      cadence_label: row.cadence_label,
+      class: row.class,
+      on_board: row.on_board,
+      lamp,
+      last_scheduled_finished_at: row.last_scheduled_finished_at,
+      last_scheduled_status: asStatus(row.last_scheduled_status),
+      last_finished_at: row.last_finished_at,
+      last_started_at: row.last_started_at,
+      last_trigger: row.last_trigger,
+      last_status: asStatus(row.last_status),
+      summary: asRecord(row.last_scheduled_summary),
+      error_code: row.last_scheduled_error_code ?? "none",
+      source_url: row.source_url,
+      result_line: resultLine(row, lamp),
+      ago_label: formatAgo(clockIso, now),
+      queue_unfinished: row.queue_unfinished,
+      extraction_pending: row.extraction_pending,
+    };
+  });
+  const board = stations.filter((station) => station.on_board);
+  const lamp = options.loadError ? "down" : stripLamp(board.map((station) => station.lamp));
+  return {
+    as_of: now.toISOString(),
+    load_error: Boolean(options.loadError),
+    strip: { lamp, text: stripText(lamp, stations, Boolean(options.loadError)) },
+    stations: board,
+    locked_doors: [],
+    manual_sources: stations
+      .filter((station) => !station.on_board)
+      .map((station) => ({
+        station_id: station.station_id,
+        display_name: station.display_name,
+        last_finished_at: station.last_finished_at,
+        ago_label: formatAgo(station.last_finished_at, now),
+      })),
+    methodology_url: "https://www.collegedata.fyi/pipeline-observation#methodology",
+  };
+}
+
+export function seedPipelineSnapshot(
+  now = new Date(),
+  loadError = false,
+): PipelineSnapshot {
+  return snapshotFromFacts(seedFacts(), now, { loadError });
+}
+
+export function toPublicJson(snapshot: PipelineSnapshot) {
+  return {
+    as_of: snapshot.as_of,
+    strip: snapshot.strip,
+    stations: snapshot.stations.map((station) => ({
+      station_id: station.station_id,
+      lamp: station.lamp,
+      label: station.display_name,
+      last_scheduled_finished_at: station.last_scheduled_finished_at,
+      last_scheduled_status: station.last_scheduled_status,
+      last_finished_at: station.last_finished_at,
+      last_trigger: station.last_trigger,
+      summary: station.summary,
+      error_code: station.error_code,
+    })),
+    locked_doors: snapshot.locked_doors,
+    manual_sources: snapshot.manual_sources.map((source) => ({
+      station_id: source.station_id,
+      last_finished_at: source.last_finished_at,
+    })),
+    methodology_url: snapshot.methodology_url,
+  };
+}
+
+export { LAMP_HEX };
+
+export const fetchPipelineObservation = cache(async function fetchPipelineObservation(): Promise<PipelineSnapshot> {
+  const now = new Date();
+  if (isStaticBuild()) return seedPipelineSnapshot(now, false);
+  try {
+    const { supabase } = await import("./supabase");
+    const { data, error } = await (supabase as unknown as UntypedRpc).rpc(
+      "pipeline_station_facts",
+    );
+    if (error) throw new Error(error.message);
+    if (!data?.length) return seedPipelineSnapshot(now, true);
+    return snapshotFromFacts(data, now);
+  } catch {
+    return seedPipelineSnapshot(now, true);
+  }
+});

--- a/web/src/lib/pipeline-redirect.ts
+++ b/web/src/lib/pipeline-redirect.ts
@@ -1,0 +1,8 @@
+/** /pipeline → /pipeline-observation is a 308. Apex→www stays 301. */
+export const PIPELINE_OBSERVATION_REDIRECTS = [
+  {
+    source: "/pipeline",
+    destination: "/pipeline-observation",
+    statusCode: 308,
+  },
+];

--- a/web/src/lib/sitemap-static.test.ts
+++ b/web/src/lib/sitemap-static.test.ts
@@ -4,6 +4,12 @@ import { SITEMAP_STATIC_PATHS, SITE_URL, staticSitemapEntries } from "./sitemap-
 describe("static sitemap entries", () => {
   it("includes browse, public recipes, and the About source pages", () => {
     expect(SITEMAP_STATIC_PATHS).toContain("/browse");
+    expect(SITEMAP_STATIC_PATHS).toContain("/pipeline-observation");
+    const pipeline = staticSitemapEntries().find((entry) =>
+      entry.url.endsWith("/pipeline-observation"),
+    );
+    expect(pipeline?.changeFrequency).toBe("daily");
+    expect(pipeline?.priority).toBe(0.7);
     expect(SITEMAP_STATIC_PATHS).toContain("/recipes/waitlist-odds");
     expect(SITEMAP_STATIC_PATHS).toContain("/recipes/endowment-draw-rate");
     expect(SITEMAP_STATIC_PATHS).toContain("/about/common-data-set");

--- a/web/src/lib/sitemap-static.ts
+++ b/web/src/lib/sitemap-static.ts
@@ -14,6 +14,7 @@ const STATIC_PAGES: StaticEntry[] = [
   { path: "/browse", changeFrequency: "daily", priority: 0.7 },
   { path: "/match", changeFrequency: "daily", priority: 0.8 },
   { path: "/coverage", changeFrequency: "daily", priority: 0.7 },
+  { path: "/pipeline-observation", changeFrequency: "daily", priority: 0.7 },
   { path: "/about", changeFrequency: "monthly", priority: 0.5 },
   { path: "/about/common-data-set", changeFrequency: "monthly", priority: 0.6 },
   { path: "/about/college-scorecard", changeFrequency: "monthly", priority: 0.6 },


### PR DESCRIPTION
## Summary
- Public dispatch board at `/pipeline-observation` (and `/pipeline` 308) so a quiet scheduled job is a red lamp, not a four-month surprise. Manual dispatch cannot green a dead cron.
- Writers ship with the UI: finder / extraction / IPEDS Actions, archive enqueue+process, coverage refresh, and `refresh_public_serving_caches()`. Heartbeat POST failures warn and exit 0.
- JSON snapshot at `/pipeline-observation.json`. Locked-door wall is **not** in this PR (M1).

## Test plan
- [ ] CI green (Python ops tests, Deno heartbeat helper, web lamps/JSON/redirect/sitemap)
- [ ] After merge: `supabase db push --linked` from the main checkout, then deploy `archive-enqueue`, `archive-process`, `refresh-coverage`
- [ ] `/pipeline-observation` paints; seed SLA lamps are red / yearly slate until writers fire
- [ ] `/pipeline` 308s to `/pipeline-observation`; `/pipeline-observation.json` has `locked_doors: []` and no secret-shaped strings
- [ ] Finder `stuck-pdf` mode does not write `finder_brave`


Made with [Cursor](https://cursor.com)