### PR TITLE
feat: explain each pipeline tile in a hover tooltip

### DIFF
--- a/web/src/app/pipeline-observation/page.tsx
+++ b/web/src/app/pipeline-observation/page.tsx
@@ -75,7 +75,9 @@ export default async function PipelineObservationPage() {
             <article
               key={station.station_id}
               className={`po-tile po-tile--${station.lamp}`}
+              tabIndex={0}
               aria-label={`${station.display_name}: ${LAMP_WORD[station.lamp]}, ${station.ago_label}`}
+              aria-describedby={`po-tip-${station.station_id}`}
             >
               <div>
                 <div className="po-tile-id">{station.cadence_label}</div>
@@ -84,6 +86,14 @@ export default async function PipelineObservationPage() {
                 <div className="po-tile-ago">{station.ago_label}</div>
                 <div className="po-tile-result">{station.result_line}</div>
               </div>
+              <p
+                id={`po-tip-${station.station_id}`}
+                className="po-tile-tip"
+                role="tooltip"
+              >
+                <span className="po-tile-tip-kicker">What this does</span>
+                {station.help}
+              </p>
             </article>
           ))}
         </div>

--- a/web/src/app/pipeline-observation/pipeline-observation.css
+++ b/web/src/app/pipeline-observation/pipeline-observation.css
@@ -15,7 +15,7 @@
 .po-strip {
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 4;
   margin: 16px 0 0;
   padding: 14px 18px;
   font-family: var(--mono);
@@ -43,15 +43,32 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
   gap: 8px;
+  overflow: visible;
 }
 
 .po-tile {
+  position: relative;
   min-height: 168px;
   padding: 14px 14px 12px;
   color: #fff;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  cursor: help;
+}
+
+.po-tile:hover,
+.po-tile:focus-within {
+  z-index: 3;
+}
+
+.po-tile:focus {
+  outline: none;
+}
+
+.po-tile:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
 }
 
 .po-tile--ok,
@@ -115,6 +132,93 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   margin-top: 10px;
+}
+
+/* Paper slip over the lamp. Variables only — this file's hex allowlist
+   test rejects new colors. Place below the tile so the sticky strip
+   does not eat first-row copy. Center with margin, not transform, so
+   prefers-reduced-motion can still cancel the 4px slide. */
+.po-tile-tip {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 8px);
+  z-index: 3;
+  width: auto;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 12px 13px 13px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--rule-strong);
+  border-radius: 2px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.45;
+  text-transform: none;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease, visibility 0.12s;
+}
+
+.po-tile-tip::before {
+  content: "";
+  position: absolute;
+  top: -5px;
+  left: 16px;
+  width: 9px;
+  height: 9px;
+  background: var(--paper);
+  border-left: 1px solid var(--rule-strong);
+  border-top: 1px solid var(--rule-strong);
+  transform: rotate(45deg);
+}
+
+@media (min-width: 640px) {
+  .po-tile-tip {
+    left: 50%;
+    right: auto;
+    width: 228px;
+    margin-left: -114px;
+  }
+
+  .po-tile-tip::before {
+    left: 50%;
+    margin-left: -5px;
+  }
+}
+
+.po-tile-tip-kicker {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 6px;
+}
+
+.po-tile:hover .po-tile-tip,
+.po-tile:focus-within .po-tile-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.po-board:focus-within .po-tile:hover:not(:focus-within) .po-tile-tip {
+  opacity: 0;
+  visibility: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .po-tile-tip {
+    transition: none;
+    transform: none;
+  }
 }
 
 .po-manual {

--- a/web/src/lib/pipeline-observation.test.ts
+++ b/web/src/lib/pipeline-observation.test.ts
@@ -93,6 +93,17 @@ describe("pipeline observation JSON", () => {
     expect(seed.strip.lamp).toBe("down");
   });
 
+  it("every board station has plain-English help copy", () => {
+    const seed = seedPipelineSnapshot(NOW, false);
+    expect(seed.stations.length).toBeGreaterThan(0);
+    for (const station of seed.stations) {
+      expect(station.help.trim().length).toBeGreaterThan(40);
+      expect(station.help).not.toMatch(/\b(SLA|cron|GHA|RPC|service_role)\b/i);
+    }
+    const json = toPublicJson(seed);
+    expect(json.stations[0]).not.toHaveProperty("help");
+  });
+
   it("isStaticBuild seed paints SLA down and yearly slate", () => {
     const seed = seedPipelineSnapshot(NOW, false);
     expect(seed.load_error).toBe(false);

--- a/web/src/lib/pipeline-observation.ts
+++ b/web/src/lib/pipeline-observation.ts
@@ -51,6 +51,7 @@ export type PipelineStationView = {
   source_url: string | null;
   result_line: string;
   ago_label: string;
+  help: string;
   queue_unfinished: number | null;
   extraction_pending: number | null;
 };
@@ -76,20 +77,112 @@ const SEED_META: Array<{
   cadence_label: string;
   class: StationClass;
   on_board: boolean;
+  help: string;
 }> = [
-  { station_id: "finder_brave", display_name: "Finder", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
-  { station_id: "finder_stuck_pdf", display_name: "Stuck PDFs", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
-  { station_id: "finder_landing_hints", display_name: "Landing hints", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
-  { station_id: "archive_enqueue", display_name: "Enqueue", cadence_label: "daily · SLA 36h", class: "daily_sla", on_board: true },
-  { station_id: "archive_process", display_name: "Process", cadence_label: "every 30s", class: "continuous_sla", on_board: true },
-  { station_id: "extraction_worker", display_name: "Extract", cadence_label: "daily · pending drain", class: "daily_sla", on_board: true },
-  { station_id: "coverage_refresh", display_name: "Coverage", cadence_label: "hourly · SLA 3h", class: "hourly_sla", on_board: true },
-  { station_id: "serving_cache_refresh", display_name: "Serving caches", cadence_label: "hourly · SLA 3h", class: "hourly_sla", on_board: true },
-  { station_id: "ipeds_release_probe", display_name: "IPEDS probe", cadence_label: "monthly · scheduled SLA 40d", class: "monthly_sla", on_board: true },
-  { station_id: "schema_build", display_name: "Schema", cadence_label: "yearly · slate until a heartbeat", class: "yearly", on_board: true },
-  { station_id: "scorecard_load", display_name: "Scorecard", cadence_label: "yearly · slate until a heartbeat", class: "yearly", on_board: true },
-  { station_id: "directory_enqueue", display_name: "Directory enqueue", cadence_label: "manual", class: "adhoc", on_board: false },
-  { station_id: "mirror_ingest", display_name: "Mirror ingest", cadence_label: "manual", class: "adhoc", on_board: false },
+  {
+    station_id: "finder_brave",
+    display_name: "Finder",
+    cadence_label: "monthly · scheduled SLA 40d",
+    class: "monthly_sla",
+    on_board: true,
+    help: "Once a month we ask Brave Search to find Common Data Set pages for schools that still have no listing. If this goes quiet, we stop discovering new files.",
+  },
+  {
+    station_id: "finder_stuck_pdf",
+    display_name: "Stuck PDFs",
+    cadence_label: "monthly · scheduled SLA 40d",
+    class: "monthly_sla",
+    on_board: true,
+    help: "Many seeds point at a single old PDF. This step re-checks those schools so we can find the office's actual CDS listing instead of one frozen year.",
+  },
+  {
+    station_id: "finder_landing_hints",
+    display_name: "Landing hints",
+    cadence_label: "monthly · scheduled SLA 40d",
+    class: "monthly_sla",
+    on_board: true,
+    help: "When a PDF seed is really a landing page — the office's CDS index — we rewrite it so weekly archive can collect every year they publish.",
+  },
+  {
+    station_id: "archive_enqueue",
+    display_name: "Enqueue",
+    cadence_label: "daily · SLA 36h",
+    class: "daily_sla",
+    on_board: true,
+    help: "Every night we decide which schools are due for a fresh look and put them on the archive queue. Schools we already checked recently are skipped.",
+  },
+  {
+    station_id: "archive_process",
+    display_name: "Process",
+    cadence_label: "every 30s",
+    class: "continuous_sla",
+    on_board: true,
+    help: "About every 30 seconds we take one school off the queue, download what we can, and archive it. This is the machine's pulse.",
+  },
+  {
+    station_id: "extraction_worker",
+    display_name: "Extract",
+    cadence_label: "daily · pending drain",
+    class: "daily_sla",
+    on_board: true,
+    help: "After a file is archived, we pull the numbers out of it. The daily job only drains a handful, so a backlog here is late — not necessarily a crash.",
+  },
+  {
+    station_id: "coverage_refresh",
+    display_name: "Coverage",
+    cadence_label: "hourly · SLA 3h",
+    class: "hourly_sla",
+    on_board: true,
+    help: "Hourly we rebuild the public coverage ledger: which schools have a current CDS, an older one, or none we could find.",
+  },
+  {
+    station_id: "serving_cache_refresh",
+    display_name: "Serving caches",
+    cadence_label: "hourly · SLA 3h",
+    class: "hourly_sla",
+    on_board: true,
+    help: "Hourly we refresh the homepage and API caches so the public site is not reading live tables on every visit.",
+  },
+  {
+    station_id: "ipeds_release_probe",
+    display_name: "IPEDS probe",
+    cadence_label: "monthly · scheduled SLA 40d",
+    class: "monthly_sla",
+    on_board: true,
+    help: "Once a month we check whether NCES has posted a new IPEDS Access database. A quiet \"no new release\" is still a healthy tick.",
+  },
+  {
+    station_id: "schema_build",
+    display_name: "Schema",
+    cadence_label: "yearly · slate until a heartbeat",
+    class: "yearly",
+    on_board: true,
+    help: "Once a year an operator loads the new CDS year schema. Gray until that happens; red only if it has been more than 18 months.",
+  },
+  {
+    station_id: "scorecard_load",
+    display_name: "Scorecard",
+    cadence_label: "yearly · slate until a heartbeat",
+    class: "yearly",
+    on_board: true,
+    help: "Once a year an operator loads College Scorecard. Gray until that load is recorded; red if it is more than 18 months old.",
+  },
+  {
+    station_id: "directory_enqueue",
+    display_name: "Directory enqueue",
+    cadence_label: "manual",
+    class: "adhoc",
+    on_board: false,
+    help: "Operator-only: seed the archive queue from the IPEDS directory. Not on the status strip.",
+  },
+  {
+    station_id: "mirror_ingest",
+    display_name: "Mirror ingest",
+    cadence_label: "manual",
+    class: "adhoc",
+    on_board: false,
+    help: "Operator-only: ingest a secondary-source mirror. Not on the status strip.",
+  },
 ];
 
 const ERROR_COPY: Record<string, string> = {
@@ -265,6 +358,7 @@ export function snapshotFromFacts(
       source_url: row.source_url,
       result_line: resultLine(row, lamp),
       ago_label: formatAgo(clockIso, now),
+      help: SEED_META.find((meta) => meta.station_id === row.station_id)?.help ?? "",
       queue_unfinished: row.queue_unfinished,
       extraction_pending: row.extraction_pending,
     };

--- a/web/tests/pipeline-observation.spec.ts
+++ b/web/tests/pipeline-observation.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+test("dispatch tiles explain themselves on hover and focus", async ({
+  page,
+  isMobile,
+}) => {
+  await page.goto("/pipeline-observation");
+  await expect(
+    page.getByRole("heading", { name: /The clocks/i }),
+  ).toBeVisible();
+
+  const finder = page.getByRole("article", { name: /Finder:/ });
+  const finderTip = page.locator("#po-tip-finder_brave");
+  const scorecard = page.getByRole("article", { name: /Scorecard:/ });
+  const scorecardTip = page.locator("#po-tip-scorecard_load");
+  await expect(finderTip).toBeHidden();
+
+  if (isMobile) {
+    await finder.tap();
+    await expect(finderTip).toBeVisible();
+    await expect(finderTip).toContainText("Brave Search");
+    await scorecard.tap();
+    await expect(scorecardTip).toBeVisible();
+    await expect(scorecardTip).toContainText("College Scorecard");
+    return;
+  }
+
+  await finder.hover();
+  await expect(finderTip).toBeVisible();
+  await expect(finderTip).toContainText("Brave Search");
+  await expect(finderTip).toContainText("What this does");
+
+  await page.getByRole("heading", { name: /The clocks/i }).hover();
+  await expect(finderTip).toBeHidden();
+
+  await scorecard.focus();
+  await expect(scorecardTip).toBeVisible();
+  await expect(scorecardTip).toContainText("College Scorecard");
+});


### PR DESCRIPTION
## Summary
- Adds a paper-slip tooltip on each dispatch-board tile that explains the station in plain English.
- Hover, keyboard focus, and tap all work; the public JSON snapshot stays unchanged.

## Test plan
- [x] `npm test -- src/lib/pipeline-observation.test.ts` (help copy + hex allowlist)
- [x] Playwright: hover Finder and focus Scorecard on `/pipeline-observation` (desktop + Pixel 5)
- [ ] Spot-check first-row vs last-row tiles on `/pipeline-observation` after deploy so the slip is not eaten by the sticky strip


Made with [Cursor](https://cursor.com)