### PR TITLE
fix: land Friday's Brave finds and stop losing the next run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Audit retired school redirects
         run: python tools/finder/school_redirect_guard.py
       - name: Run finder identity tests
-        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls tools.finder.test_stuck_pdf_seeds
+        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls tools.finder.test_stuck_pdf_seeds tools.finder.test_apply_probe_log tools.finder.test_promote_landing_hints
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
       - name: Run IPEDS loader tests
@@ -52,7 +52,7 @@ jobs:
       - name: Run discovery policy and engine tests
         run: python -m pytest tools/discovery -q
       - name: Run ops tests
-        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit
+        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit tools.ops.test_enqueue_changed_seeds
       - name: Run data-integrity audit support tests
         run: python -m unittest tools.data_quality.test_audit_support
 

--- a/.github/workflows/ops-archive-seed-catchup.yml
+++ b/.github/workflows/ops-archive-seed-catchup.yml
@@ -1,0 +1,47 @@
+name: Ops archive seed catchup
+
+# After finder seeds land on main, weekly archive would otherwise wait out
+# the 7-day success cooldown. Dispatch this once the updated archive-enqueue
+# (school_ids + force_recheck) is deployed. Do not auto-fire on push until
+# that function is in production — a missing school_ids filter plus
+# force_recheck would re-queue the whole corpus.
+
+on:
+  workflow_dispatch:
+    inputs:
+      before_ref:
+        description: "git ref for schools.yaml before the seed change (default: previous commit on main)"
+        required: false
+        default: "HEAD^"
+
+permissions:
+  contents: read
+
+jobs:
+  enqueue:
+    name: Enqueue changed seeds
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/ci-requirements.txt
+
+      - name: Install Python dependencies
+        run: python -m pip install -r tools/ci-requirements.txt
+
+      - name: Enqueue schools whose discovery seed changed
+        run: |
+          git show "${{ inputs.before_ref }}:tools/finder/schools.yaml" > /tmp/schools-before.yaml
+          python tools/ops/enqueue_changed_seeds.py \
+            --before /tmp/schools-before.yaml \
+            --after tools/finder/schools.yaml \
+            --apply

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -49,6 +49,8 @@ jobs:
     name: Probe CDS listing URLs
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    outputs:
+      create_pr: ${{ steps.flags.outputs.create_pr }}
     env:
       BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -66,6 +68,14 @@ jobs:
       PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v5
+
+      - name: Snapshot schools.yaml at start
+        run: |
+          mkdir -p finder-probe
+          cp tools/finder/schools.yaml finder-probe/schools-base.yaml
+
+      - id: flags
+        run: echo "create_pr=${INPUT_CREATE_PR}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v6
         with:
@@ -316,18 +326,68 @@ jobs:
               print("Created coverage issue")
           PY
 
+      - name: Snapshot probed schools.yaml
+        if: always()
+        run: |
+          mkdir -p finder-probe
+          cp tools/finder/schools.yaml finder-probe/schools.yaml
+          git diff -- tools/finder/schools.yaml > finder-probe/schools.yaml.diff || true
+
+      - name: Upload probe artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: finder-probe
+          path: finder-probe/
+          if-no-files-found: warn
+
+  publish-seeds:
+    name: Open seed PR from latest main
+    needs: probe
+    if: success() && needs.probe.outputs.create_pr == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INPUT_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'both' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: finder-probe
+          path: finder-probe
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: python -m pip install pyyaml
+
+      - name: Overlay probed seeds onto current main
+        run: |
+          python tools/finder/merge_schools_yaml.py \
+            --base finder-probe/schools-base.yaml \
+            --main tools/finder/schools.yaml \
+            --probed finder-probe/schools.yaml \
+            --out tools/finder/schools.yaml
+
       - name: Open PR for seed updates
-        if: success() && (env.INPUT_CREATE_PR == 'true')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add tools/finder/schools.yaml
           if git diff --cached --quiet; then
-            echo "No schools.yaml changes."
+            echo "No schools.yaml changes against origin/main."
             exit 0
           fi
           branch="chore/finder-probe-${GITHUB_RUN_ID}"
-          git checkout -b "$branch"
+          git checkout -B "$branch"
           git commit -m "$(cat <<'EOF'
           chore: refresh CDS discovery seeds from monthly finder probe
 
@@ -345,14 +405,6 @@ jobs:
 
           ## Test plan
           - [ ] Skim the PR diff for accidental satellite-campus seed copies
-          - [ ] After merge, weekly \`archive-enqueue\` picks up new listing seeds
+          - [ ] After merge, \`ops-archive-seed-catchup\` enqueues schools whose seed URL changed
           EOF
           )"
-
-      - name: Upload probe artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: finder-probe
-          path: finder-probe/
-          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This project uses four-part semantic versioning.
 - Stop copying Ohio University's main-campus CDS URL onto the five regional UNITIDs that share ohio.edu.
 - Mark coverage `cds_available_stale` when the latest extracted year is older than the finder freshness floor, even if weekly archive re-verified the same file.
 - Point Ohio University's main-campus seed at the IEA university-data listing instead of a 404 `/instres` PDF.
+- Keep monthly finder seed PRs based on current `main` and artifact `schools.yaml`, so a mid-run workflow edit cannot reject the push and eat a 2h45m Brave run.
+- Restore finder checkpoint saves (`_save_yaml`) that the pipeline-board heartbeat patch accidentally deleted.
+- Let landing-hint promotion read `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` from the Actions environment instead of requiring a `.env` file on the runner.
+- Recover 216 listing/seed replacements from the 2026-08-21 Brave run logs (the seed PR never left the runner) and skip search-junk URLs so news pages and non-CDS PDFs do not become seeds.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/supabase/functions/archive-enqueue/index.ts
+++ b/supabase/functions/archive-enqueue/index.ts
@@ -42,6 +42,8 @@ import {
   archiveCooldownDaysForOutcome,
   archiveEnqueueRunId,
   parseCooldownDaysOverride,
+  parseSchoolIdsOverride,
+  restrictSchoolsToIds,
 } from "./schedule.ts";
 import { recordPipelineHeartbeat } from "../_shared/pipeline_heartbeat.ts";
 
@@ -114,6 +116,27 @@ Deno.serve(async (req: Request) => {
     return await send({
       error: `schools.yaml fetch failed: ${err.message}`,
     }, 502);
+  }
+
+  let schoolIdsFilter: string[] | null;
+  try {
+    schoolIdsFilter = parseSchoolIdsOverride(
+      url.searchParams.get("school_ids"),
+    );
+  } catch (error) {
+    return await send({ error: (error as Error).message }, 400);
+  }
+  if (schoolIdsFilter) {
+    const before = allSchools.length;
+    allSchools = restrictSchoolsToIds(allSchools, schoolIdsFilter);
+    logEvent({
+      event: "school_ids_filter",
+      run_id: runId,
+      requested: schoolIdsFilter.length,
+      matched: allSchools.length,
+      unmatched: schoolIdsFilter.length - allSchools.length,
+      before,
+    });
   }
 
   if (skippedInvalid > 0) {

--- a/supabase/functions/archive-enqueue/schedule.test.ts
+++ b/supabase/functions/archive-enqueue/schedule.test.ts
@@ -5,6 +5,8 @@ import {
   archiveEnqueueRunId,
   archiveEnqueueRunKey,
   parseCooldownDaysOverride,
+  parseSchoolIdsOverride,
+  restrictSchoolsToIds,
 } from "./schedule.ts";
 
 Deno.test("archiveEnqueueRunKey uses daily attempt buckets year-round", () => {
@@ -130,4 +132,22 @@ Deno.test("parseCooldownDaysOverride validates and bounds operator input", () =>
     }
     assertEquals(threw, true, `expected '${invalid}' to be rejected`);
   }
+});
+
+Deno.test("parseSchoolIdsOverride splits and rejects empty lists", () => {
+  assertEquals(parseSchoolIdsOverride(null), null);
+  assertEquals(parseSchoolIdsOverride("ou, uf"), ["ou", "uf"]);
+  let threw = false;
+  try {
+    parseSchoolIdsOverride("  ,  ");
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("restrictSchoolsToIds keeps only requested ids", () => {
+  const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+  assertEquals(restrictSchoolsToIds(rows, null), rows);
+  assertEquals(restrictSchoolsToIds(rows, ["c", "a"]), [{ id: "a" }, { id: "c" }]);
 });

--- a/supabase/functions/archive-enqueue/schedule.ts
+++ b/supabase/functions/archive-enqueue/schedule.ts
@@ -30,6 +30,24 @@ export function parseCooldownDaysOverride(raw: string | null): number | null {
   return days;
 }
 
+export function parseSchoolIdsOverride(raw: string | null): string[] | null {
+  if (raw === null) return null;
+  const ids = raw.split(/[,\s]+/).map((value) => value.trim()).filter(Boolean);
+  if (ids.length === 0) {
+    throw new Error("school_ids must list at least one school id");
+  }
+  return ids;
+}
+
+export function restrictSchoolsToIds<T extends { id: string }>(
+  schools: T[],
+  ids: string[] | null,
+): T[] {
+  if (ids === null) return schools;
+  const allow = new Set(ids);
+  return schools.filter((school) => allow.has(school.id));
+}
+
 export function archiveEnqueueRunKey(now: Date): string {
   const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
   const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");

--- a/tools/finder/apply_probe_log.py
+++ b/tools/finder/apply_probe_log.py
@@ -1,0 +1,282 @@
+"""Replay a finder probe log onto schools.yaml without a Brave re-run.
+
+Friday 2026-08-21's probe rewrote seeds on the runner, then lost them when
+the seed PR push was rejected. The logs still have every FOUND / not found
+line. This reapplies `should_replace_seed` (listings replace PDFs; PDFs
+do not replace listings) and records probe_state so the next monthly run
+does not burn the budget twice.
+
+Line-based YAML edits on purpose: PyYAML round-trip would strip comments
+across the 27k-line manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml  # noqa: E402
+
+from tools.finder.probe_urls import (  # noqa: E402
+    host_belongs_to_domain,
+    looks_like_article_slug,
+    looks_like_news_or_blog,
+    looks_like_non_cds_document,
+    looks_like_search_junk,
+    record_probe,
+    should_replace_seed,
+)
+
+FOUND_RE = re.compile(
+    r"^\[\s*\d+/\d+\]\s+(?P<name>.+) \((?P<domain>[^)]+)\) \.\.\. "
+    r"(?:\[(?P<method>\w+)\] )?FOUND: (?P<url>\S+)\s*$"
+)
+MISS_RE = re.compile(
+    r"^\[\s*\d+/\d+\]\s+(?P<name>.+) \((?P<domain>[^)]+)\) \.\.\. not found\s*$"
+)
+ID_RE = re.compile(r"^- id: (\S+)\s*$")
+SEED_RE = re.compile(r"^(  )(?:discovery_seed_url|cds_url_hint)(: )(\S+.*)$")
+POLICY_RE = re.compile(r"^(  scrape_policy: )(\S+)\s*$")
+PROBED_AT_RE = re.compile(r"^(    last_probed_at: )(.+)$")
+LAST_RESULT_RE = re.compile(r"^(    last_result: )(\S+)\s*$")
+LAST_METHOD_RE = re.compile(r"^(    last_method: )(\S+)\s*$")
+
+
+@dataclass(frozen=True)
+class ProbeHit:
+    name: str
+    domain: str | None
+    url: str | None
+    method: str
+    found: bool
+
+
+def parse_probe_log(text: str) -> list[ProbeHit]:
+    hits: list[ProbeHit] = []
+    for raw in text.splitlines():
+        found = FOUND_RE.match(raw)
+        if found:
+            domain = found.group("domain")
+            hits.append(
+                ProbeHit(
+                    name=found.group("name"),
+                    domain=None if domain in {"None", ""} else domain,
+                    url=found.group("url"),
+                    method=found.group("method") or "pattern",
+                    found=True,
+                )
+            )
+            continue
+        miss = MISS_RE.match(raw)
+        if miss:
+            domain = miss.group("domain")
+            hits.append(
+                ProbeHit(
+                    name=miss.group("name"),
+                    domain=None if domain in {"None", ""} else domain,
+                    url=None,
+                    method="brave",
+                    found=False,
+                )
+            )
+    return hits
+
+
+def index_schools(schools: list[dict]) -> dict[tuple[str, str], dict]:
+    out: dict[tuple[str, str], dict] = {}
+    for school in schools:
+        name = str(school.get("name") or "")
+        domain = str(school.get("domain") or "")
+        out[(name, domain)] = school
+    return out
+
+
+def resolve_school(hit: ProbeHit, by_key: dict[tuple[str, str], dict]) -> dict | None:
+    if hit.domain:
+        return by_key.get((hit.name, hit.domain))
+    matches = [school for (name, _domain), school in by_key.items() if name == hit.name]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def url_is_usable(url: str, domain: str | None) -> bool:
+    if (
+        looks_like_search_junk(url)
+        or looks_like_article_slug(url)
+        or looks_like_news_or_blog(url)
+        or looks_like_non_cds_document(url)
+    ):
+        return False
+    if domain and not host_belongs_to_domain(url, domain):
+        return False
+    return True
+
+
+def apply_hit(school: dict, hit: ProbeHit, probed_at: str) -> str:
+    """Mutate school. Returns action: replaced, found_kept, not_found, skipped_junk."""
+    if hit.found:
+        url = hit.url or ""
+        if not url_is_usable(url, hit.domain or school.get("domain")):
+            return "skipped_junk"
+        existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
+        if should_replace_seed(existing, url):
+            school["discovery_seed_url"] = url
+            school["scrape_policy"] = "active"
+            record_probe(school, "found", hit.method, 0, hit.method != "pattern")
+            school["probe_state"]["last_probed_at"] = probed_at
+            return "replaced"
+        record_probe(school, "found", hit.method, 0, hit.method != "pattern")
+        school["probe_state"]["last_probed_at"] = probed_at
+        return "found_kept"
+    record_probe(school, "not_found", hit.method, 0, True)
+    school["probe_state"]["last_probed_at"] = probed_at
+    return "not_found"
+
+
+def write_school_updates(schools_yaml: Path, schools: list[dict], changed_ids: set[str]) -> int:
+    """Rewrite seed, scrape_policy, and probe_state lines for changed ids."""
+    by_id = {str(school.get("id")): school for school in schools}
+    lines = schools_yaml.read_text().splitlines(keepends=True)
+    out: list[str] = []
+    current_sid: str | None = None
+    wrote_seed = False
+    applied = 0
+
+    def flush_missing_seed() -> None:
+        nonlocal applied
+        if current_sid not in changed_ids or wrote_seed:
+            return
+        school = by_id.get(current_sid or "")
+        url = school.get("discovery_seed_url") if school else None
+        if not url:
+            return
+        out.append(f"  discovery_seed_url: {url}\n")
+        applied += 1
+
+    for line in lines:
+        matched_id = ID_RE.match(line)
+        if matched_id:
+            flush_missing_seed()
+            current_sid = matched_id.group(1)
+            wrote_seed = False
+            out.append(line)
+            continue
+
+        school = by_id.get(current_sid or "")
+        if current_sid not in changed_ids or school is None:
+            out.append(line)
+            continue
+
+        seed_match = SEED_RE.match(line)
+        if seed_match:
+            url = school.get("discovery_seed_url")
+            if url:
+                out.append(f"{seed_match.group(1)}discovery_seed_url{seed_match.group(2)}{url}\n")
+                wrote_seed = True
+                applied += 1
+                continue
+
+        policy_match = POLICY_RE.match(line)
+        if policy_match and school.get("scrape_policy"):
+            out.append(f"{policy_match.group(1)}{school['scrape_policy']}\n")
+            continue
+
+        probed_match = PROBED_AT_RE.match(line)
+        if probed_match and school.get("probe_state"):
+            stamped = school["probe_state"].get("last_probed_at")
+            out.append(f"{probed_match.group(1)}'{stamped}'\n")
+            continue
+
+        result_match = LAST_RESULT_RE.match(line)
+        if result_match and school.get("probe_state"):
+            out.append(
+                f"{result_match.group(1)}{school['probe_state'].get('last_result')}\n"
+            )
+            continue
+
+        method_match = LAST_METHOD_RE.match(line)
+        if method_match and school.get("probe_state"):
+            out.append(
+                f"{method_match.group(1)}{school['probe_state'].get('last_method')}\n"
+            )
+            continue
+
+        out.append(line)
+
+    flush_missing_seed()
+    schools_yaml.write_text("".join(out))
+    return applied
+
+
+def apply_logs(
+    schools_yaml: Path,
+    log_paths: list[Path],
+    *,
+    probed_at: str,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    data = yaml.safe_load(schools_yaml.read_text())
+    schools = data.get("schools") or []
+    by_key = index_schools(schools)
+    counts = {
+        "hits": 0,
+        "unmatched": 0,
+        "replaced": 0,
+        "found_kept": 0,
+        "not_found": 0,
+        "skipped_junk": 0,
+    }
+    changed: set[str] = set()
+    for log_path in log_paths:
+        for hit in parse_probe_log(log_path.read_text()):
+            counts["hits"] += 1
+            school = resolve_school(hit, by_key)
+            if school is None:
+                counts["unmatched"] += 1
+                print(f"unmatched: {hit.name} ({hit.domain})", file=sys.stderr)
+                continue
+            action = apply_hit(school, hit, probed_at)
+            counts[action] = counts.get(action, 0) + 1
+            sid = str(school.get("id") or "")
+            if sid and action != "skipped_junk":
+                changed.add(sid)
+    if not dry_run:
+        write_school_updates(schools_yaml, schools, changed)
+    return counts
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
+    ap.add_argument("--schools-yaml", type=Path, default=Path("tools/finder/schools.yaml"))
+    ap.add_argument("--log", type=Path, action="append", required=True)
+    ap.add_argument(
+        "--probed-at",
+        default=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--summary-json", type=Path)
+    args = ap.parse_args()
+    counts = apply_logs(
+        args.schools_yaml,
+        args.log,
+        probed_at=args.probed_at,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(counts, indent=2, sort_keys=True))
+    if args.summary_json:
+        args.summary_json.write_text(json.dumps(counts, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/finder/merge_schools_yaml.py
+++ b/tools/finder/merge_schools_yaml.py
@@ -1,0 +1,108 @@
+"""Three-way merge of finder schools.yaml at school-id grain.
+
+A 2h45m probe checks out main at start. If main's workflow or seeds move
+before the seed PR push, GitHub treats the stale workflow tree as a
+workflow update and rejects the GitHub App. Publish from current main and
+overlay only schools the probe actually changed relative to the start SHA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+SEED_FIELDS = ("discovery_seed_url", "cds_url_hint", "scrape_policy", "probe_state")
+
+
+def load_schools(path: Path) -> tuple[dict, list[dict]]:
+    data = yaml.safe_load(path.read_text())
+    schools = data.get("schools") or []
+    return data, schools
+
+
+def by_id(schools: list[dict]) -> dict[str, dict]:
+    return {str(school.get("id")): school for school in schools if school.get("id")}
+
+
+def seed_signature(school: dict | None) -> tuple:
+    if not school:
+        return ()
+    ps = school.get("probe_state") or {}
+    return (
+        school.get("discovery_seed_url") or school.get("cds_url_hint"),
+        school.get("scrape_policy"),
+        ps.get("last_result"),
+        ps.get("last_probed_at"),
+        ps.get("last_method"),
+    )
+
+
+def overlay_seed_fields(target: dict, source: dict) -> dict:
+    merged = dict(target)
+    for field in SEED_FIELDS:
+        if field in source:
+            merged[field] = source[field]
+        elif field in merged and field not in source:
+            if field == "cds_url_hint":
+                continue
+    return merged
+
+
+def merge_school_lists(
+    base: list[dict],
+    main: list[dict],
+    probed: list[dict],
+) -> tuple[list[dict], list[str]]:
+    base_map = by_id(base)
+    probed_map = by_id(probed)
+    changed_ids: list[str] = []
+    out: list[dict] = []
+    seen: set[str] = set()
+    for school in main:
+        sid = str(school.get("id") or "")
+        seen.add(sid)
+        probed_school = probed_map.get(sid)
+        if probed_school is not None and seed_signature(probed_school) != seed_signature(
+            base_map.get(sid)
+        ):
+            out.append(overlay_seed_fields(school, probed_school))
+            changed_ids.append(sid)
+        else:
+            out.append(school)
+    for sid, probed_school in probed_map.items():
+        if sid not in seen:
+            out.append(probed_school)
+            changed_ids.append(sid)
+    return out, changed_ids
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
+    ap.add_argument("--base", type=Path, required=True)
+    ap.add_argument("--main", type=Path, required=True)
+    ap.add_argument("--probed", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+    _base_doc, base = load_schools(args.base)
+    main_doc, main_schools = load_schools(args.main)
+    _probed_doc, probed = load_schools(args.probed)
+    merged, changed_ids = merge_school_lists(base, main_schools, probed)
+    if args.out.resolve() != args.main.resolve():
+        args.out.write_text(args.main.read_text())
+    from tools.finder.apply_probe_log import write_school_updates
+
+    write_school_updates(args.out, merged, set(changed_ids))
+    print(json.dumps({"changed": len(changed_ids), "ids": changed_ids[:50]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -533,10 +533,54 @@ def brave_search(domain: str, api_key: str, tracker: dict | None = None) -> str 
         return None
 
     results = data.get("web", {}).get("results", [])
-    return select_brave_cds_url(results)
+    return select_brave_cds_url(results, domain)
 
 
-def select_brave_cds_url(results: list[dict]) -> str | None:
+def host_belongs_to_domain(url: str, domain: str) -> bool:
+    """True when the URL is on the school's own host, not a random search hit."""
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    domain = domain.lower().removeprefix("www.")
+    if not host or not domain:
+        return False
+    return host == domain or host.endswith("." + domain)
+
+
+def looks_like_search_junk(url: str) -> bool:
+    """Brave sometimes returns rewritten search-result URLs, not IR pages."""
+    path = (urllib.parse.urlparse(url).path or "").lower()
+    return "+" in path and "common+data" in path
+
+
+def looks_like_article_slug(url: str) -> bool:
+    """Drop SEO/blog slugs that matched 'Common Data Set' in a snippet."""
+    last = (urllib.parse.urlparse(url).path or "").rstrip("/").split("/")[-1]
+    last = last.lower()
+    if re.search(r"cds|common[-_]?data", last):
+        return False
+    if re.match(r"^(does|what|why|how|should|is|can|will)-", last):
+        return True
+    return last.count("-") >= 5
+
+
+def looks_like_news_or_blog(url: str) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    path = (parsed.path or "").lower()
+    if re.search(r"/(news|blog|stories|noteworthy)(/|$)", path):
+        return True
+    return "page=" in (parsed.query or "").lower()
+
+
+def looks_like_non_cds_document(url: str) -> bool:
+    """A PDF/XLSX/DOCX whose filename does not mention CDS is usually a miss."""
+    path = (urllib.parse.urlparse(url).path or "").lower()
+    if not re.search(r"\.(pdf|xlsx|docx)$", path):
+        return False
+    return not re.search(r"cds|common[-_]?data", path)
+
+
+def select_brave_cds_url(results: list[dict], domain: str | None = None) -> str | None:
     """Pick a discovery seed from Brave web results.
 
     Prefer an HTML listing over a year-specific PDF. A PDF seed locks the
@@ -562,6 +606,14 @@ def select_brave_cds_url(results: list[dict]) -> str | None:
     for r in results:
         link = r.get("url", "")
         if not link or looks_like_template(link):
+            continue
+        if looks_like_search_junk(link):
+            continue
+        if looks_like_article_slug(link) or looks_like_news_or_blog(link):
+            continue
+        if looks_like_non_cds_document(link):
+            continue
+        if domain and not host_belongs_to_domain(link, domain):
             continue
         if link.lower().endswith(".pdf"):
             if pdf is None:
@@ -701,6 +753,9 @@ def write_probe_summary(
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _save_yaml(data: dict) -> None:
     """Dump data back to schools.yaml. Caller ensures single-threaded call."""
     SCHOOLS_YAML.write_text(
         yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/tools/finder/promote_landing_hints.py
+++ b/tools/finder/promote_landing_hints.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections import Counter
@@ -54,6 +55,29 @@ try:
     from supabase import create_client
 except ImportError:
     create_client = None  # DB lookup will be skipped gracefully
+
+
+def supabase_credentials(env_path: Path) -> dict[str, str]:
+    """Prefer process env (GitHub Actions secrets) over a local .env file.
+
+    load_env() reads a file literally and raises if it is missing. The
+    finder workflow already has SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+    in the job environment; requiring `.env` on the runner dropped every
+    cds_documents landing proposal on 2026-08-21.
+    """
+    file_env: dict[str, str] = {}
+    if env_path.exists():
+        file_env = load_env(env_path)
+    url = os.environ.get("SUPABASE_URL") or file_env.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or file_env.get(
+        "SUPABASE_SERVICE_ROLE_KEY"
+    )
+    if not url or not key:
+        raise RuntimeError(
+            "missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY "
+            f"(looked at env and {env_path})"
+        )
+    return {"SUPABASE_URL": url, "SUPABASE_SERVICE_ROLE_KEY": key}
 
 
 DOCUMENT_EXT_RE = re.compile(r"\.(pdf|xlsx|docx)(\?|#|$)", re.I)
@@ -461,8 +485,8 @@ def main() -> int:
     sb = None
     if not args.skip_db and create_client is not None:
         try:
-            env = load_env(args.env)
-            sb = create_client(env["SUPABASE_URL"], env["SUPABASE_SERVICE_ROLE_KEY"])
+            creds = supabase_credentials(args.env)
+            sb = create_client(creds["SUPABASE_URL"], creds["SUPABASE_SERVICE_ROLE_KEY"])
             print("Supabase client: ready", file=sys.stderr)
         except Exception as e:
             print(f"warn: Supabase client init failed ({e}); continuing with manual_urls only",

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -68,6 +68,7 @@ schools:
   domain: amherst.edu
   ipeds_id: '164465'
   scrape_policy: active
+  discovery_seed_url: https://www.amherst.edu/about/facts/common_data_sets
 - id: barnard
   name: Barnard College
   domain: barnard.edu
@@ -600,6 +601,7 @@ schools:
   domain: ucsd.edu
   ipeds_id: '110680'
   scrape_policy: active
+  discovery_seed_url: https://ir.ucsd.edu/stats/undergrad/common-data-set.html
 - id: uc-santa-barbara
   name: University of California, Santa Barbara
   domain: ucsb.edu
@@ -819,7 +821,7 @@ schools:
   ipeds_id: '177834'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -830,7 +832,7 @@ schools:
   ipeds_id: '180203'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -841,7 +843,7 @@ schools:
   ipeds_id: '222178'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -852,7 +854,7 @@ schools:
   ipeds_id: '497037'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -863,7 +865,7 @@ schools:
   ipeds_id: '138558'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -874,7 +876,7 @@ schools:
   ipeds_id: '451079'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -885,7 +887,7 @@ schools:
   ipeds_id: '497718'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -896,7 +898,7 @@ schools:
   ipeds_id: '457271'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -907,7 +909,7 @@ schools:
   ipeds_id: '108269'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -918,7 +920,7 @@ schools:
   ipeds_id: '384306'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -953,7 +955,7 @@ schools:
   ipeds_id: '374024'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -964,7 +966,7 @@ schools:
   ipeds_id: '142832'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -975,7 +977,7 @@ schools:
   ipeds_id: '168528'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -986,7 +988,7 @@ schools:
   ipeds_id: '133872'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -997,7 +999,7 @@ schools:
   ipeds_id: '496399'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1020,7 +1022,7 @@ schools:
   ipeds_id: '498915'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1043,7 +1045,7 @@ schools:
   ipeds_id: '200697'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1054,7 +1056,7 @@ schools:
   ipeds_id: '100654'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1065,7 +1067,7 @@ schools:
   ipeds_id: '483975'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1076,7 +1078,7 @@ schools:
   ipeds_id: '100724'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -1088,7 +1090,7 @@ schools:
   ipeds_id: '222497'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1099,7 +1101,7 @@ schools:
   ipeds_id: '102580'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1110,7 +1112,7 @@ schools:
   ipeds_id: '102669'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1121,7 +1123,7 @@ schools:
   ipeds_id: '188526'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1132,7 +1134,7 @@ schools:
   ipeds_id: '188535'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1143,7 +1145,7 @@ schools:
   ipeds_id: '188580'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1166,7 +1168,7 @@ schools:
   ipeds_id: '385415'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1189,19 +1191,19 @@ schools:
   ipeds_id: '168546'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.albion.edu/wp-content/uploads/2024/06/NEW-FORM-OFFICIAL-CDS_2023-2024-rev-4-24-24-pdf.pdf
+  discovery_seed_url: https://www.albion.edu/offices/registrar/institutional-data/
 - id: albizu-university-miami
   name: Albizu University-Miami
   domain: albizu.edu
   ipeds_id: '132842'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1212,7 +1214,7 @@ schools:
   ipeds_id: '210571'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1223,7 +1225,7 @@ schools:
   ipeds_id: '175342'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1234,7 +1236,7 @@ schools:
   ipeds_id: '495192'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1245,7 +1247,7 @@ schools:
   ipeds_id: '237118'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1268,7 +1270,7 @@ schools:
   ipeds_id: '156189'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1291,7 +1293,7 @@ schools:
   ipeds_id: '200873'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1302,7 +1304,7 @@ schools:
   ipeds_id: '152798'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1313,7 +1315,7 @@ schools:
   ipeds_id: '217624'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1324,7 +1326,7 @@ schools:
   ipeds_id: '194161'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1333,20 +1335,21 @@ schools:
   name: Alma College
   domain: alma.edu
   ipeds_id: '168591'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.alma.edu/academics/institutional-effectiveness/
 - id: alpena-community-college
   name: Alpena Community College
   domain: alpenacc.edu
   ipeds_id: '168607'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1357,7 +1360,7 @@ schools:
   ipeds_id: '210775'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1368,7 +1371,7 @@ schools:
   ipeds_id: '238193'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1379,7 +1382,7 @@ schools:
   ipeds_id: '222628'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1390,7 +1393,7 @@ schools:
   ipeds_id: '490081'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1401,7 +1404,7 @@ schools:
   ipeds_id: '219505'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1412,7 +1415,7 @@ schools:
   ipeds_id: '210809'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1423,7 +1426,7 @@ schools:
   ipeds_id: '485698'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1434,7 +1437,7 @@ schools:
   ipeds_id: '108870'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1457,7 +1460,7 @@ schools:
   ipeds_id: '142957'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1468,7 +1471,7 @@ schools:
   ipeds_id: '116846'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1479,7 +1482,7 @@ schools:
   ipeds_id: '188854'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1502,7 +1505,7 @@ schools:
   ipeds_id: '100690'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1513,7 +1516,7 @@ schools:
   ipeds_id: '483595'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1524,7 +1527,7 @@ schools:
   ipeds_id: '151865'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1535,7 +1538,7 @@ schools:
   ipeds_id: '150066'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1546,7 +1549,7 @@ schools:
   ipeds_id: '217633'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1557,7 +1560,7 @@ schools:
   ipeds_id: '138761'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1568,7 +1571,7 @@ schools:
   ipeds_id: '168740'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1591,19 +1594,19 @@ schools:
   ipeds_id: '164492'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://annamaria.edu/wp-content/uploads/2020/10/Section-C-First-time-First-Year-Freshmen-Admission-2019-2020.pdf
+  discovery_seed_url: https://resources.annamaria.edu/college-data/
 - id: antelope-valley-community-college-district
   name: Antelope Valley Community College District
   domain: avc.edu
   ipeds_id: '109350'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1614,19 +1617,19 @@ schools:
   ipeds_id: '483018'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://antiochcollege.edu/wp-content/uploads/2022/07/CDS_2021-2022-Antioch-College_REV.pdf
+  discovery_seed_url: https://antiochcollege.edu/academics/office-institutional-effectiveness-research/
 - id: antioch-university
   name: Antioch University
   domain: antioch.edu
   ipeds_id: '245892'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1637,7 +1640,7 @@ schools:
   ipeds_id: '245838'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1648,7 +1651,7 @@ schools:
   ipeds_id: '245865'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1659,7 +1662,7 @@ schools:
   ipeds_id: '245847'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1670,7 +1673,7 @@ schools:
   ipeds_id: '245883'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1681,7 +1684,7 @@ schools:
   ipeds_id: '440138'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1692,7 +1695,7 @@ schools:
   ipeds_id: '237136'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1703,7 +1706,7 @@ schools:
   ipeds_id: '449922'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1714,7 +1717,7 @@ schools:
   ipeds_id: '432348'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1737,19 +1740,19 @@ schools:
   ipeds_id: '168786'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.aquinas.edu/_files/2022-2023%20Aquinas%20College%20Common%20Data%20Set-1.pdf
+  discovery_seed_url: https://www.aquinas.edu/offices/academic-affairs/student-right-know-information.html
 - id: aquinas-institute-of-theology
   name: Aquinas Institute of Theology
   domain: ai.edu
   ipeds_id: '176600'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1760,31 +1763,31 @@ schools:
   ipeds_id: '126289'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.arapahoe.edu/2017-2018-common-data-set.pdf
+  discovery_seed_url: https://www.arapahoe.edu/more-about-acc/office-institutional-research/general-acc-information
 - id: arcadia-university
   name: Arcadia University
   domain: arcadia.edu
   ipeds_id: '211088'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.arcadia.edu/wp-content/uploads/2024/04/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.arcadia.edu/about-arcadia/offices-facilities-services/institutional-research-effectiveness/external-reporting/
 - id: arizona-board-of-regents
   name: Arizona Board of Regents
   domain: azregents.edu
   ipeds_id: '420802'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1795,7 +1798,7 @@ schools:
   ipeds_id: '105899'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1831,7 +1834,7 @@ schools:
   ipeds_id: '106306'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1842,7 +1845,7 @@ schools:
   ipeds_id: '488527'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1853,19 +1856,19 @@ schools:
   ipeds_id: '106458'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.astate.edu/a/irp/files/cds/CDS_2022-2023.pdf
+  discovery_seed_url: https://kb.astate.edu/books/common-data-set
 - id: arkansas-state-university-system
   name: Arkansas State University System
   domain: asusystem.edu
   ipeds_id: '448336'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1888,7 +1891,7 @@ schools:
   ipeds_id: '222877'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1899,7 +1902,7 @@ schools:
   ipeds_id: '201061'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1910,19 +1913,19 @@ schools:
   ipeds_id: '109651'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://cms.artcenter.edu/assets/21357/src/ArtCenter-CDS_2022-2023_Final.pdf
+  discovery_seed_url: https://www.artcenter.edu/academics/academic-resources/academic-affairs.html
 - id: asbury-theological-seminary
   name: Asbury Theological Seminary
   domain: asburyseminary.edu
   ipeds_id: '156222'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1933,7 +1936,7 @@ schools:
   ipeds_id: '156213'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1944,7 +1947,7 @@ schools:
   ipeds_id: '458113'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1955,19 +1958,19 @@ schools:
   ipeds_id: '201104'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ashland.edu/sites/default/files/2025-03/CDS%202023_2024.pdf
+  discovery_seed_url: https://www.ashland.edu/university-data
 - id: associated-beth-rivkah-schools
   name: Associated Beth Rivkah Schools
   domain: bethrivkah.edu
   ipeds_id: '188942'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1978,7 +1981,7 @@ schools:
   ipeds_id: '164562'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -1989,7 +1992,7 @@ schools:
   ipeds_id: '201140'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2000,7 +2003,7 @@ schools:
   ipeds_id: '100812'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2011,7 +2014,7 @@ schools:
   ipeds_id: '138901'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2022,7 +2025,7 @@ schools:
   ipeds_id: '439446'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2069,7 +2072,7 @@ schools:
   ipeds_id: '482149'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2080,12 +2083,12 @@ schools:
   ipeds_id: '143084'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.augustana.edu/files/2022-03/CDS_2020-21_Augustana_College_IL.pdf
+  discovery_seed_url: https://www.augustana.edu/academics/institutional-research/common-data-set
 - id: augustana-university
   name: Augustana University
   domain: augie.edu
@@ -2104,7 +2107,7 @@ schools:
   ipeds_id: '201177'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2115,12 +2118,12 @@ schools:
   ipeds_id: '143118'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://aurora.edu/documents/about/cds-2023-2024.pdf
+  discovery_seed_url: https://aurora.edu/about/administration/institutional-effectiveness/common-data-set.html
 - id: austin-college
   name: Austin College
   domain: austincollege.edu
@@ -2139,7 +2142,7 @@ schools:
   ipeds_id: '222992'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2162,7 +2165,7 @@ schools:
   ipeds_id: '223001'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2173,7 +2176,7 @@ schools:
   ipeds_id: '442295'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2195,7 +2198,7 @@ schools:
   ipeds_id: '231420'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2206,7 +2209,7 @@ schools:
   ipeds_id: '176628'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2241,7 +2244,7 @@ schools:
   ipeds_id: '206817'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2252,7 +2255,7 @@ schools:
   ipeds_id: '128586'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2263,7 +2266,7 @@ schools:
   ipeds_id: '476601'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2274,7 +2277,7 @@ schools:
   ipeds_id: '245777'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2285,7 +2288,7 @@ schools:
   ipeds_id: '490513'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2296,7 +2299,7 @@ schools:
   ipeds_id: '495031'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2307,7 +2310,7 @@ schools:
   ipeds_id: '449658'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2318,30 +2321,31 @@ schools:
   ipeds_id: '168847'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://my.baker.edu/icsfileserver/docs/docs/about_us/institutional_effectiveness/common_data_set/CDS_2021-2022.pdf
+  discovery_seed_url: https://my.baker.edu/ICS/About_Us/Institutional_Effectiveness__Research/Common_Data_Set.jnz?portlet=Free-form_Content
 - id: baker-university
   name: Baker University
   domain: bakeru.edu
   ipeds_id: '154688'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:55Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.bakeru.edu/about-baker/careers-baker
 - id: bakersfield-college
   name: Bakersfield College
   domain: bakersfieldcollege.edu
   ipeds_id: '109819'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2352,7 +2356,7 @@ schools:
   ipeds_id: '420705'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2363,19 +2367,19 @@ schools:
   ipeds_id: '201195'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.bw.edu/about/offices/institutional-research-assessment/_files/common-data-set-2020-21.pdf
+  discovery_seed_url: https://www.bw.edu/about/offices/institutional-research-assessment/
 - id: ball-state-university
   name: Ball State University
   domain: bsu.edu
   ipeds_id: '150136'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -2387,7 +2391,7 @@ schools:
   ipeds_id: '189015'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2398,7 +2402,7 @@ schools:
   ipeds_id: '219639'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2409,7 +2413,7 @@ schools:
   ipeds_id: '223117'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2420,7 +2424,7 @@ schools:
   ipeds_id: '132408'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2431,7 +2435,7 @@ schools:
   ipeds_id: '444398'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2442,7 +2446,7 @@ schools:
   ipeds_id: '155070'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2465,7 +2469,7 @@ schools:
   ipeds_id: '167792'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2476,7 +2480,7 @@ schools:
   ipeds_id: '177719'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2487,31 +2491,31 @@ schools:
   ipeds_id: '132471'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.barry.edu/media/cmcneb2h/2007-2008-cds.pdf
+  discovery_seed_url: https://www.barry.edu/en/institutional-research/common-data-set-archive
 - id: barton-college
   name: Barton College
   domain: barton.edu
   ipeds_id: '197911'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:16:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.barton.edu/wp-content/uploads/2022/08/cds-2021-2022.pdf
+  discovery_seed_url: https://www.barton.edu/about/institutional-research/
 - id: bastyr-university
   name: Bastyr University
   domain: bastyr.edu
   ipeds_id: '235547'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2522,7 +2526,7 @@ schools:
   ipeds_id: '380359'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2533,7 +2537,7 @@ schools:
   ipeds_id: '164632'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2544,7 +2548,7 @@ schools:
   ipeds_id: '223223'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2567,7 +2571,7 @@ schools:
   ipeds_id: '476717'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2578,7 +2582,7 @@ schools:
   ipeds_id: '384254'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2589,7 +2593,7 @@ schools:
   ipeds_id: '444413'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2600,7 +2604,7 @@ schools:
   ipeds_id: '175421'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:16:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2623,7 +2627,7 @@ schools:
   ipeds_id: '234669'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2634,7 +2638,7 @@ schools:
   ipeds_id: '180814'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2645,7 +2649,7 @@ schools:
   ipeds_id: '238324'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2656,7 +2660,7 @@ schools:
   ipeds_id: '234696'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2667,7 +2671,7 @@ schools:
   ipeds_id: '197984'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2702,7 +2706,7 @@ schools:
   ipeds_id: '173124'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2713,7 +2717,7 @@ schools:
   ipeds_id: '217721'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2724,7 +2728,7 @@ schools:
   ipeds_id: '154712'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2747,7 +2751,7 @@ schools:
   ipeds_id: '165884'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2758,7 +2762,7 @@ schools:
   ipeds_id: '197993'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2798,7 +2802,7 @@ schools:
   ipeds_id: '461643'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2809,7 +2813,7 @@ schools:
   ipeds_id: '108861'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2832,7 +2836,7 @@ schools:
   ipeds_id: '139144'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2843,7 +2847,7 @@ schools:
   ipeds_id: '485999'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2854,7 +2858,7 @@ schools:
   ipeds_id: '189273'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2865,7 +2869,7 @@ schools:
   ipeds_id: '183804'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2876,7 +2880,7 @@ schools:
   ipeds_id: '486196'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2887,7 +2891,7 @@ schools:
   ipeds_id: '488314'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2898,7 +2902,7 @@ schools:
   ipeds_id: '154721'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2909,7 +2913,7 @@ schools:
   ipeds_id: '237181'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2920,7 +2924,7 @@ schools:
   ipeds_id: '486284'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2931,7 +2935,7 @@ schools:
   ipeds_id: '173142'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2942,7 +2946,7 @@ schools:
   ipeds_id: '143233'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2953,7 +2957,7 @@ schools:
   ipeds_id: '154749'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2964,7 +2968,7 @@ schools:
   ipeds_id: '150145'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2973,10 +2977,10 @@ schools:
   name: Bethel University
   domain: bethel.edu
   ipeds_id: '173160'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:07Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -2987,7 +2991,7 @@ schools:
   ipeds_id: '219718'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -2998,7 +3002,7 @@ schools:
   ipeds_id: '110060'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3009,7 +3013,7 @@ schools:
   ipeds_id: '486053'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3020,7 +3024,7 @@ schools:
   ipeds_id: '132602'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -3032,7 +3036,7 @@ schools:
   ipeds_id: '139153'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3043,7 +3047,7 @@ schools:
   ipeds_id: '443702'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3054,7 +3058,7 @@ schools:
   ipeds_id: '234711'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3089,7 +3093,7 @@ schools:
   ipeds_id: '100937'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3100,7 +3104,7 @@ schools:
   ipeds_id: '200022'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3111,7 +3115,7 @@ schools:
   ipeds_id: '219046'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3122,7 +3126,7 @@ schools:
   ipeds_id: '143288'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3133,7 +3137,7 @@ schools:
   ipeds_id: '180054'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3144,7 +3148,7 @@ schools:
   ipeds_id: '143297'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3155,7 +3159,7 @@ schools:
   ipeds_id: '183822'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3166,7 +3170,7 @@ schools:
   ipeds_id: '175430'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3189,7 +3193,7 @@ schools:
   ipeds_id: '231554'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3200,7 +3204,7 @@ schools:
   ipeds_id: '201371'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3211,7 +3215,7 @@ schools:
   ipeds_id: '175999'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3222,7 +3226,7 @@ schools:
   ipeds_id: '217749'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3233,7 +3237,7 @@ schools:
   ipeds_id: '142090'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3244,19 +3248,19 @@ schools:
   ipeds_id: '142115'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.boisestate.edu/ie/wp-content/uploads/sites/501/2022/05/CDS_2021-22-5.23.22.pdf
+  discovery_seed_url: https://www.boisestate.edu/ie/data-and-reporting/common-data-set/
 - id: bolivar-technical-college
   name: Bolivar Technical College
   domain: bolivarcollege.edu
   ipeds_id: '490203'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3267,7 +3271,7 @@ schools:
   ipeds_id: '233356'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3278,7 +3282,7 @@ schools:
   ipeds_id: '189413'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3289,7 +3293,7 @@ schools:
   ipeds_id: '164872'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3300,7 +3304,7 @@ schools:
   ipeds_id: '164614'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3311,7 +3315,7 @@ schools:
   ipeds_id: '164915'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3334,7 +3338,7 @@ schools:
   ipeds_id: '201432'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3369,7 +3373,7 @@ schools:
   ipeds_id: '223506'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3380,7 +3384,7 @@ schools:
   ipeds_id: '139199'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -3392,7 +3396,7 @@ schools:
   ipeds_id: '156356'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3403,7 +3407,7 @@ schools:
   ipeds_id: '198066'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3414,7 +3418,7 @@ schools:
   ipeds_id: '139205'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3425,7 +3429,7 @@ schools:
   ipeds_id: '152992'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3436,7 +3440,7 @@ schools:
   ipeds_id: '497408'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3483,7 +3487,7 @@ schools:
   ipeds_id: '230047'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3494,7 +3498,7 @@ schools:
   ipeds_id: '142522'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3505,7 +3509,7 @@ schools:
   ipeds_id: '450304'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3516,7 +3520,7 @@ schools:
   ipeds_id: '189501'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3527,7 +3531,7 @@ schools:
   ipeds_id: '132709'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3538,7 +3542,7 @@ schools:
   ipeds_id: '180878'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3549,7 +3553,7 @@ schools:
   ipeds_id: '219790'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3560,7 +3564,7 @@ schools:
   ipeds_id: '188517'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3571,7 +3575,7 @@ schools:
   ipeds_id: '189583'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3582,7 +3586,7 @@ schools:
   ipeds_id: '189592'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3593,7 +3597,7 @@ schools:
   ipeds_id: '480091'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3604,7 +3608,7 @@ schools:
   ipeds_id: '201469'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3615,7 +3619,7 @@ schools:
   ipeds_id: '189565'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3626,7 +3630,7 @@ schools:
   ipeds_id: '231785'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3637,7 +3641,7 @@ schools:
   ipeds_id: '451750'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3648,7 +3652,7 @@ schools:
   ipeds_id: '217165'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3659,7 +3663,7 @@ schools:
   ipeds_id: '210492'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3682,7 +3686,7 @@ schools:
   ipeds_id: '153001'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3693,7 +3697,7 @@ schools:
   ipeds_id: '209409'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3703,13 +3707,14 @@ schools:
   domain: butler.edu
   ipeds_id: '150163'
   scrape_policy: active
+  discovery_seed_url: https://www.butler.edu/academics/institutional-research/about-institutional-research/common-data-set/
 - id: byzantine-catholic-seminary-of-saints-cyril-and-methodius
   name: Byzantine Catholic Seminary of Saints Cyril and Methodius
   domain: bcs.edu
   ipeds_id: '444103'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3720,7 +3725,7 @@ schools:
   ipeds_id: '198109'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3731,19 +3736,19 @@ schools:
   ipeds_id: '211352'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.cabrini.edu/contentassets/3f32c757281f4ebd9cc55391b1a79e8c/cds_2021-2022.pdf
+  discovery_seed_url: https://www.cabrini.edu/about/departments/academic-affairs/academic-research/common-data-set
 - id: cairn-university-langhorne
   name: Cairn University-Langhorne
   domain: cairn.edu
   ipeds_id: '215114'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3754,7 +3759,7 @@ schools:
   ipeds_id: '183910'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3765,19 +3770,19 @@ schools:
   ipeds_id: '110361'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://calbaptist.edu/about/leadership/provost/educational-effectiveness/institutional-research/pdfs/CDS_2023_2024_v2.3.pdf
+  discovery_seed_url: https://calbaptist.edu/about/leadership/provost/educational-effectiveness/institutional-research/data
 - id: california-christian-college
   name: California Christian College
   domain: calchristiancollege.edu
   ipeds_id: '110918'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3788,7 +3793,7 @@ schools:
   ipeds_id: '112570'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3799,7 +3804,7 @@ schools:
   ipeds_id: '110370'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3810,7 +3815,7 @@ schools:
   ipeds_id: '487649'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3821,7 +3826,7 @@ schools:
   ipeds_id: '110316'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3844,7 +3849,7 @@ schools:
   ipeds_id: '111081'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3855,7 +3860,7 @@ schools:
   ipeds_id: '486488'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3866,12 +3871,12 @@ schools:
   ipeds_id: '110413'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://earth.callutheran.edu/fact_book/documents/2013-2014CommonDataSet.pdf
+  discovery_seed_url: https://www.callutheran.edu/about/factbook/common-data-set.html
 - id: california-polytechnic-state-university-san-luis-obispo
   name: California Polytechnic State University-San Luis Obispo
   domain: calpoly.edu
@@ -3938,7 +3943,7 @@ schools:
   ipeds_id: '110501'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3960,19 +3965,19 @@ schools:
   ipeds_id: '110538'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.csuchico.edu/ir/_assets/documents/cds-1617.pdf
+  discovery_seed_url: https://www.csuchico.edu/ir/additional-data/common-data-set.shtml
 - id: california-state-university-dominguez-hills
   name: California State University-Dominguez Hills
   domain: csudh.edu
   ipeds_id: '110547'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -3983,7 +3988,7 @@ schools:
   ipeds_id: '110574'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4102,12 +4107,12 @@ schools:
   ipeds_id: '110495'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.csustan.edu/sites/default/files/groups/Institutional Effectiveness
+  discovery_seed_url: https://www.csustan.edu/iea/common-data-set
     & Analytics/IEA1/updated_2018-2019_common_data_set.pdf
 - id: california-university-of-science-and-medicine
   name: California University of Science and Medicine
@@ -4115,7 +4120,7 @@ schools:
   ipeds_id: '496043'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4126,7 +4131,7 @@ schools:
   ipeds_id: '497666'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4137,7 +4142,7 @@ schools:
   ipeds_id: '111391'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4148,7 +4153,7 @@ schools:
   ipeds_id: '150172'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4171,7 +4176,7 @@ schools:
   ipeds_id: '169099'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4218,7 +4223,7 @@ schools:
   ipeds_id: '198136'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4241,12 +4246,12 @@ schools:
   ipeds_id: '189705'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.canisius.edu/sites/default/files/documents/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.canisius.edu/media/12866/download?attachment=
 - id: capital-university
   name: Capital University
   domain: capital.edu
@@ -4265,7 +4270,7 @@ schools:
   ipeds_id: '162061'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4276,7 +4281,7 @@ schools:
   ipeds_id: '238430'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4299,7 +4304,7 @@ schools:
   ipeds_id: '211431'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4310,7 +4315,7 @@ schools:
   ipeds_id: '199971'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4321,7 +4326,7 @@ schools:
   ipeds_id: '461032'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4332,7 +4337,7 @@ schools:
   ipeds_id: '489937'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4343,7 +4348,7 @@ schools:
   ipeds_id: '433174'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4366,7 +4371,7 @@ schools:
   ipeds_id: '238458'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4377,7 +4382,7 @@ schools:
   ipeds_id: '219806'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4400,7 +4405,7 @@ schools:
   ipeds_id: '111638'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4411,7 +4416,7 @@ schools:
   ipeds_id: '439190'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4434,7 +4439,7 @@ schools:
   ipeds_id: '230834'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4457,7 +4462,7 @@ schools:
   ipeds_id: '475398'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4468,7 +4473,7 @@ schools:
   ipeds_id: '143659'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4479,7 +4484,7 @@ schools:
   ipeds_id: '189848'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4490,7 +4495,7 @@ schools:
   ipeds_id: '439367'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4499,13 +4504,14 @@ schools:
   name: Cedar Crest College
   domain: cedarcrest.edu
   ipeds_id: '211468'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:35Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.cedarcrest.edu/institutional-research/
 - id: cedarville-university
   name: Cedarville University
   domain: cedarville.edu
@@ -4524,7 +4530,7 @@ schools:
   ipeds_id: '158477'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4535,7 +4541,7 @@ schools:
   ipeds_id: '183974'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4546,7 +4552,7 @@ schools:
   ipeds_id: '232618'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4557,7 +4563,7 @@ schools:
   ipeds_id: '106713'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4566,20 +4572,21 @@ schools:
   name: Central Christian College of Kansas
   domain: centralchristian.edu
   ipeds_id: '154855'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:36Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.centralchristian.edu/about/institutional-research/
 - id: central-christian-college-of-the-bible
   name: Central Christian College of the Bible
   domain: cccb.edu
   ipeds_id: '176910'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4602,19 +4609,19 @@ schools:
   ipeds_id: '128771'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://docs.ccsu.edu/oira/institutionalData/commonDataSet/Common_Data_Set_2008-2009.pdf
+  discovery_seed_url: https://www.ccsu.edu/oira/common-data-set
 - id: central-methodist-university-college-of-graduate-and
   name: Central Methodist University-College of Graduate and Extended Studies
   domain: centralmethodist.edu
   ipeds_id: '445267'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4625,7 +4632,7 @@ schools:
   ipeds_id: '176947'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4636,7 +4643,7 @@ schools:
   ipeds_id: '169248'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -4648,7 +4655,7 @@ schools:
   ipeds_id: '201672'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4659,7 +4666,7 @@ schools:
   ipeds_id: '201690'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4682,7 +4689,7 @@ schools:
   ipeds_id: '240514'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4693,7 +4700,7 @@ schools:
   ipeds_id: '488004'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4704,7 +4711,7 @@ schools:
   ipeds_id: '189857'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4715,7 +4722,7 @@ schools:
   ipeds_id: '234845'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4738,7 +4745,7 @@ schools:
   ipeds_id: '180948'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4749,7 +4756,7 @@ schools:
   ipeds_id: '141486'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4760,7 +4767,7 @@ schools:
   ipeds_id: '492069'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4795,7 +4802,7 @@ schools:
   ipeds_id: '111966'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4806,7 +4813,7 @@ schools:
   ipeds_id: '217688'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4817,7 +4824,7 @@ schools:
   ipeds_id: '444778'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4828,7 +4835,7 @@ schools:
   ipeds_id: '128780'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4851,7 +4858,7 @@ schools:
   ipeds_id: '208390'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4862,7 +4869,7 @@ schools:
   ipeds_id: '211583'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4873,7 +4880,7 @@ schools:
   ipeds_id: '211608'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4884,7 +4891,7 @@ schools:
   ipeds_id: '181145'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4895,7 +4902,7 @@ schools:
   ipeds_id: '144005'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4906,7 +4913,7 @@ schools:
   ipeds_id: '144014'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4917,7 +4924,7 @@ schools:
   ipeds_id: '133021'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4928,7 +4935,7 @@ schools:
   ipeds_id: '198303'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4939,7 +4946,7 @@ schools:
   ipeds_id: '494630'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4950,7 +4957,7 @@ schools:
   ipeds_id: '219833'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4961,7 +4968,7 @@ schools:
   ipeds_id: '150215'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4972,19 +4979,19 @@ schools:
   ipeds_id: '231712'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://cnu.edu/institutionalresearch/_pdf/commondataset/cds2012-2013.pdf
+  discovery_seed_url: https://cnu.edu/institutionalresearch/statistics/
 - id: church-divinity-school-of-the-pacific
   name: Church Divinity School of the Pacific
   domain: cdsp.edu
   ipeds_id: '112127'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -4995,7 +5002,7 @@ schools:
   ipeds_id: '201867'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5006,7 +5013,7 @@ schools:
   ipeds_id: '201928'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5029,7 +5036,7 @@ schools:
   ipeds_id: '234915'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5040,7 +5047,7 @@ schools:
   ipeds_id: '457697'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5051,7 +5058,7 @@ schools:
   ipeds_id: '217873'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5062,7 +5069,7 @@ schools:
   ipeds_id: '112251'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5073,7 +5080,7 @@ schools:
   ipeds_id: '488387'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5084,7 +5091,7 @@ schools:
   ipeds_id: '124283'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5106,7 +5113,7 @@ schools:
   ipeds_id: '234933'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5117,7 +5124,7 @@ schools:
   ipeds_id: '201973'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5138,20 +5145,21 @@ schools:
   name: Clarke University
   domain: clarke.edu
   ipeds_id: '153126'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:47Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.clarke.edu/wp-content/uploads/CDS_2019-2020.pdf
 - id: clarks-summit-university
   name: Clarks Summit University
   domain: clarkssummitu.edu
   ipeds_id: '211024'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5162,7 +5170,7 @@ schools:
   ipeds_id: '180832'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5173,7 +5181,7 @@ schools:
   ipeds_id: '190044'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5184,7 +5192,7 @@ schools:
   ipeds_id: '139311'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5195,7 +5203,7 @@ schools:
   ipeds_id: '156417'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5206,7 +5214,7 @@ schools:
   ipeds_id: '169327'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5217,7 +5225,7 @@ schools:
   ipeds_id: '202046'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5228,7 +5236,7 @@ schools:
   ipeds_id: '202073'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5251,7 +5259,7 @@ schools:
   ipeds_id: '177038'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5262,7 +5270,7 @@ schools:
   ipeds_id: '217891'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5273,7 +5281,7 @@ schools:
   ipeds_id: '234951'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5296,7 +5304,7 @@ schools:
   ipeds_id: '153144'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5307,7 +5315,7 @@ schools:
   ipeds_id: '217907'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5318,7 +5326,7 @@ schools:
   ipeds_id: '182634'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5329,7 +5337,7 @@ schools:
   ipeds_id: '190080'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5352,7 +5360,7 @@ schools:
   ipeds_id: '169442'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5363,7 +5371,7 @@ schools:
   ipeds_id: '493974'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5374,7 +5382,7 @@ schools:
   ipeds_id: '388520'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5408,19 +5416,19 @@ schools:
   ipeds_id: '139250'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
-    last_method: brave
+    last_method: pattern
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ccga.edu/wp-content/uploads/2024/11/CDS_2023-2024.pdf
+  discovery_seed_url: https://ccga.edu/institutional-research/common-data-set/
 - id: college-of-menominee-nation
   name: College of Menominee Nation
   domain: menominee.edu
   ipeds_id: '413617'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5454,7 +5462,7 @@ schools:
   ipeds_id: '181604'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5477,7 +5485,7 @@ schools:
   ipeds_id: '182005'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5488,7 +5496,7 @@ schools:
   ipeds_id: '190558'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5523,7 +5531,7 @@ schools:
   ipeds_id: '226408'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5534,7 +5542,7 @@ schools:
   ipeds_id: '178697'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5545,7 +5553,7 @@ schools:
   ipeds_id: '493822'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5556,19 +5564,19 @@ schools:
   ipeds_id: '247834'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.collin.edu/aboutus/statistics/pdf_common_data_set/2021-2022%20CDS%20Collin%20College.pdf
+  discovery_seed_url: https://www.collin.edu/about/statistics/
 - id: colorado-christian-university
   name: Colorado Christian University
   domain: ccu.edu
   ipeds_id: '126669'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5615,7 +5623,7 @@ schools:
   ipeds_id: '476975'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5626,19 +5634,19 @@ schools:
   ipeds_id: '128106'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:17:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.csupueblo.edu/institutional-research/_doc/2022-2023-data-set/2022-23-section-a-general-information.pdf
+  discovery_seed_url: https://www.csupueblo.edu/institutional-research/institutional-data/common-data-set.html
 - id: colorado-state-university-system-office
   name: Colorado State University-System Office
   domain: csusystem.edu
   ipeds_id: '446978'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5649,7 +5657,7 @@ schools:
   ipeds_id: '234979'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5658,10 +5666,10 @@ schools:
   name: Columbia College
   domain: ccis.edu
   ipeds_id: '177065'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:57Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -5672,7 +5680,7 @@ schools:
   ipeds_id: '217934'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5695,7 +5703,7 @@ schools:
   ipeds_id: '217925'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5706,7 +5714,7 @@ schools:
   ipeds_id: '139348'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5717,7 +5725,7 @@ schools:
   ipeds_id: '202170'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5751,13 +5759,14 @@ schools:
   domain: ccd.edu
   ipeds_id: '126942'
   scrape_policy: active
+  discovery_seed_url: https://www.ccd.edu/docs/common-data-set
 - id: compass-college-of-film-and-media
   name: Compass College of Film and Media
   domain: null
   ipeds_id: '459417'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5768,7 +5777,7 @@ schools:
   ipeds_id: '177083'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5791,7 +5800,7 @@ schools:
   ipeds_id: '173300'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5802,7 +5811,7 @@ schools:
   ipeds_id: '177092'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:17:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5813,7 +5822,7 @@ schools:
   ipeds_id: '150288'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5824,7 +5833,7 @@ schools:
   ipeds_id: '169363'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5847,19 +5856,19 @@ schools:
   ipeds_id: '144351'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.cuchicago.edu/contentassets/93f2ca3c48f74ff084ea1bee21364e9a/cuc-cds-2022-2023completeallsections_2-22-2023.pdf
+  discovery_seed_url: https://www.cuchicago.edu/about-us/consumer-information/
 - id: concordia-university-irvine
   name: Concordia University-Irvine
   domain: cui.edu
   ipeds_id: '112075'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5870,7 +5879,7 @@ schools:
   ipeds_id: '180984'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5881,7 +5890,7 @@ schools:
   ipeds_id: '173328'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5892,7 +5901,7 @@ schools:
   ipeds_id: '238616'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5903,7 +5912,7 @@ schools:
   ipeds_id: '493600'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5930,7 +5939,7 @@ schools:
   ipeds_id: '217961'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5941,7 +5950,7 @@ schools:
   ipeds_id: '165495'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5952,7 +5961,7 @@ schools:
   ipeds_id: '162283'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5963,7 +5972,7 @@ schools:
   ipeds_id: '210331'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5974,19 +5983,19 @@ schools:
   ipeds_id: '153162'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.cornellcollege.edu/institutional-research/pdf/2019-2020%20Common%20Data%20Set.pdf
+  discovery_seed_url: https://www.cornellcollege.edu/institutional-research/institutional-profile/common-data-sets.shtml
 - id: cornerstone-university
   name: Cornerstone University
   domain: cornerstone.edu
   ipeds_id: '170037'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -5997,7 +6006,7 @@ schools:
   ipeds_id: '235024'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6008,7 +6017,7 @@ schools:
   ipeds_id: '177117'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6019,7 +6028,7 @@ schools:
   ipeds_id: '139393'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6030,7 +6039,7 @@ schools:
   ipeds_id: '177126'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6041,7 +6050,7 @@ schools:
   ipeds_id: '176770'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6052,7 +6061,7 @@ schools:
   ipeds_id: '169424'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6075,7 +6084,7 @@ schools:
   ipeds_id: '475608'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6086,7 +6095,7 @@ schools:
   ipeds_id: '106810'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6097,7 +6106,7 @@ schools:
   ipeds_id: '174862'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6108,7 +6117,7 @@ schools:
   ipeds_id: '190503'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6119,7 +6128,7 @@ schools:
   ipeds_id: '177144'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6130,7 +6139,7 @@ schools:
   ipeds_id: '219949'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6153,7 +6162,7 @@ schools:
   ipeds_id: '190549'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6176,7 +6185,7 @@ schools:
   ipeds_id: '190576'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6187,7 +6196,7 @@ schools:
   ipeds_id: '190594'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6198,7 +6207,7 @@ schools:
   ipeds_id: '190600'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -6210,7 +6219,7 @@ schools:
   ipeds_id: '190637'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6221,7 +6230,7 @@ schools:
   ipeds_id: '190646'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6232,7 +6241,7 @@ schools:
   ipeds_id: '190655'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6243,19 +6252,19 @@ schools:
   ipeds_id: '190664'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.qc.cuny.edu/oie/wp-content/uploads/sites/39/2021/03/CDS_2017-2018_A.pdf
+  discovery_seed_url: https://www.qc.cuny.edu/oie/college-rankings-and-ratings/
 - id: cuny-school-of-law
   name: CUNY School of Law
   domain: law.cuny.edu
   ipeds_id: '190682'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6266,7 +6275,7 @@ schools:
   ipeds_id: '190035'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6289,7 +6298,7 @@ schools:
   ipeds_id: '165529'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6300,7 +6309,7 @@ schools:
   ipeds_id: '211893'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6311,7 +6320,7 @@ schools:
   ipeds_id: '113236'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6322,7 +6331,7 @@ schools:
   ipeds_id: '190716'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6333,31 +6342,31 @@ schools:
   ipeds_id: '190725'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.daemen.edu/sites/daemen/files/CDS_UNL2_2023_2024%20V3.pdf
+  discovery_seed_url: https://www.daemen.edu/about/fast-facts/institutional-research
 - id: dakota-state-university
   name: Dakota State University
   domain: dsu.edu
   ipeds_id: '219082'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://blogs.dsu.edu/wp-content/uploads/sites/19/2019/04/common_data_set_d__transfer_admission___2019.pdf
+  discovery_seed_url: https://blogs.dsu.edu/public-info-institutional-research/common-data-set/
 - id: dakota-wesleyan-university
   name: Dakota Wesleyan University
   domain: dwu.edu
   ipeds_id: '219091'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6368,7 +6377,7 @@ schools:
   ipeds_id: '224226'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6379,7 +6388,7 @@ schools:
   ipeds_id: '224244'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6390,7 +6399,7 @@ schools:
   ipeds_id: '224615'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6401,7 +6410,7 @@ schools:
   ipeds_id: '224305'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6423,7 +6432,7 @@ schools:
   ipeds_id: '169479'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6446,7 +6455,7 @@ schools:
   ipeds_id: '237358'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6457,7 +6466,7 @@ schools:
   ipeds_id: '194569'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6468,7 +6477,7 @@ schools:
   ipeds_id: '496469'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6479,7 +6488,7 @@ schools:
   ipeds_id: '133386'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6490,7 +6499,7 @@ schools:
   ipeds_id: '165574'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6501,7 +6510,7 @@ schools:
   ipeds_id: '202514'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6512,7 +6521,7 @@ schools:
   ipeds_id: '224350'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6535,7 +6544,7 @@ schools:
   ipeds_id: '130882'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6546,7 +6555,7 @@ schools:
   ipeds_id: '130907'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6567,13 +6576,14 @@ schools:
   name: Delta State University
   domain: deltastate.edu
   ipeds_id: '175616'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:13Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.deltastate.edu/PDFFiles/irp/CDS2010_2011_1.pdf
 - id: denison-university
   name: Denison University
   domain: denison.edu
@@ -6592,7 +6602,7 @@ schools:
   ipeds_id: '126979'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6627,7 +6637,7 @@ schools:
   ipeds_id: '154156'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6650,7 +6660,7 @@ schools:
   ipeds_id: '113616'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6671,32 +6681,33 @@ schools:
   name: Dickinson State University
   domain: dickinsonstate.edu
   ipeds_id: '200059'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:15Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.dickinsonstate.edu/about/institutional-research/
 - id: dillard-university
   name: Dillard University
   domain: dillard.edu
   ipeds_id: '158802'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.dillard.edu/wp-content/uploads/dillard-university-common-data-set-2021-22.pdf
+  discovery_seed_url: https://www.dillard.edu/about/administration/institutional-research-and-effectiveness/
 - id: dine-college
   name: Dine College
   domain: dinecollege.edu
   ipeds_id: '105297'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6707,7 +6718,7 @@ schools:
   ipeds_id: '445869'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6718,7 +6729,7 @@ schools:
   ipeds_id: '153241'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6729,7 +6740,7 @@ schools:
   ipeds_id: '181020'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6740,7 +6751,7 @@ schools:
   ipeds_id: '113704'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6763,7 +6774,7 @@ schools:
   ipeds_id: '190761'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6774,7 +6785,7 @@ schools:
   ipeds_id: '113698'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -6786,7 +6797,7 @@ schools:
   ipeds_id: '122117'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6797,7 +6808,7 @@ schools:
   ipeds_id: '155007'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6808,7 +6819,7 @@ schools:
   ipeds_id: '153250'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6819,7 +6830,7 @@ schools:
   ipeds_id: '449481'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6842,7 +6853,7 @@ schools:
   ipeds_id: '184348'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6853,12 +6864,12 @@ schools:
   ipeds_id: '177214'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.drury.edu/wp-content/uploads/files/academic-affairs/pdf/institutional_research/CDS_2023-2024_DruryU.pdf
+  discovery_seed_url: https://www.drury.edu/academic-affairs/institutional-research-and-effectiveness/
 - id: drury-university-college-of-continuing-professional-studies
   name: Drury University-College of Continuing Professional Studies
   domain: drury.edu
@@ -6878,7 +6889,7 @@ schools:
   ipeds_id: '175227'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6925,7 +6936,7 @@ schools:
   ipeds_id: '207041'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6936,7 +6947,7 @@ schools:
   ipeds_id: '139621'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6947,31 +6958,31 @@ schools:
   ipeds_id: '212115'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.esu.edu/institutional-research/documents/21-22/CDS201718EA.pdf
+  discovery_seed_url: https://www.esu.edu/oiepa/research/common_data_set.cfm
 - id: east-tennessee-state-university
   name: East Tennessee State University
   domain: etsu.edu
   ipeds_id: '220075'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.etsu.edu/provost/pds/ir/documents/cds0405.pdf
+  discovery_seed_url: https://www.etsu.edu/provost/pds/ir/external_gov/cds.php
 - id: east-texas-baptist-university
   name: East Texas Baptist University
   domain: etbu.edu
   ipeds_id: '224527'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6982,7 +6993,7 @@ schools:
   ipeds_id: '144883'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -6993,19 +7004,19 @@ schools:
   ipeds_id: '129215'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.easternct.edu/planning-and-institutional-research/_documents/cds2223a.pdf
+  discovery_seed_url: https://www.easternct.edu/planning-and-institutional-research/institutional-data/common-data-set.html
 - id: eastern-florida-state-college
   name: Eastern Florida State College
   domain: easternflorida.edu
   ipeds_id: '132693'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7028,8 +7039,8 @@ schools:
   ipeds_id: '156620'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:22Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -7040,31 +7051,31 @@ schools:
   ipeds_id: '232043'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://emu.edu/ir/docs/CDS_2016-2017.pdf
+  discovery_seed_url: https://emu.edu/ir/data-reports/common-data-set
 - id: eastern-michigan-university
   name: Eastern Michigan University
   domain: emich.edu
   ipeds_id: '169798'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.emich.edu/irim/documents/common-data-sets/cds2024v3.pdf
+  discovery_seed_url: https://www.emich.edu/irim/institutional-data/common-data-sets/index.php
 - id: eastern-nazarene-college
   name: Eastern Nazarene College
   domain: enc.edu
   ipeds_id: '165644'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7075,12 +7086,12 @@ schools:
   ipeds_id: '187648'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://my.enmu.edu/c/document_library/get_file?uuid=26589e87-9a73-40a5-b937-af8586f7dd39&groupId=2878891&filename=CDS_2019-2020.pdf
+  discovery_seed_url: https://my.enmu.edu/web/institutional-research/common-data-set
 - id: eastern-oregon-university
   name: Eastern Oregon University
   domain: eou.edu
@@ -7158,7 +7169,7 @@ schools:
   ipeds_id: '247162'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7169,7 +7180,7 @@ schools:
   ipeds_id: '177278'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7180,7 +7191,7 @@ schools:
   ipeds_id: '238661'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7191,7 +7202,7 @@ schools:
   ipeds_id: '235103'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7202,7 +7213,7 @@ schools:
   ipeds_id: '442806'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7213,7 +7224,7 @@ schools:
   ipeds_id: '133526'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7224,7 +7235,7 @@ schools:
   ipeds_id: '488305'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7235,7 +7246,7 @@ schools:
   ipeds_id: '212197'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7246,7 +7257,7 @@ schools:
   ipeds_id: '486080'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7257,7 +7268,7 @@ schools:
   ipeds_id: '144962'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7268,7 +7279,7 @@ schools:
   ipeds_id: '190983'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7291,7 +7302,7 @@ schools:
   ipeds_id: '133553'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7302,7 +7313,7 @@ schools:
   ipeds_id: '104586'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7313,7 +7324,7 @@ schools:
   ipeds_id: '426314'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7329,7 +7340,7 @@ schools:
   ipeds_id: '165671'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7340,7 +7351,7 @@ schools:
   ipeds_id: '139630'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7351,7 +7362,7 @@ schools:
   ipeds_id: '153302'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -7363,7 +7374,7 @@ schools:
   ipeds_id: '232025'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7374,7 +7385,7 @@ schools:
   ipeds_id: '196264'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7385,19 +7396,19 @@ schools:
   ipeds_id: '155025'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.emporia.edu/documents/1387/CDS2005_2006.pdf
+  discovery_seed_url: https://www.emporia.edu/office-institutional-effectiveness/institutional-research/common-data-set/
 - id: endicott-college
   name: Endicott College
   domain: endicott.edu
   ipeds_id: '165699'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7408,7 +7419,7 @@ schools:
   ipeds_id: '230418'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7419,7 +7430,7 @@ schools:
   ipeds_id: '124487'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7430,7 +7441,7 @@ schools:
   ipeds_id: '224712'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7441,7 +7452,7 @@ schools:
   ipeds_id: '409254'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7452,7 +7463,7 @@ schools:
   ipeds_id: '217998'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7463,7 +7474,7 @@ schools:
   ipeds_id: '144971'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7474,7 +7485,7 @@ schools:
   ipeds_id: '177339'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7485,7 +7496,7 @@ schools:
   ipeds_id: '497824'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7496,7 +7507,7 @@ schools:
   ipeds_id: '235149'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7507,7 +7518,7 @@ schools:
   ipeds_id: '385619'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7518,7 +7529,7 @@ schools:
   ipeds_id: '196680'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7529,7 +7540,7 @@ schools:
   ipeds_id: '460376'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7575,20 +7586,21 @@ schools:
   name: Fairmont State University
   domain: fairmontstate.edu
   ipeds_id: '237367'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:31Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.fairmontstate.edu/academics/programs/civil-engineering-technology.aspx
 - id: faith-baptist-bible-college-and-theological-seminary
   name: Faith Baptist Bible College and Theological Seminary
   domain: faith.edu
   ipeds_id: '153320'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7599,7 +7611,7 @@ schools:
   ipeds_id: '443049'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7610,7 +7622,7 @@ schools:
   ipeds_id: '494597'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7621,7 +7633,7 @@ schools:
   ipeds_id: '443058'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7656,7 +7668,7 @@ schools:
   ipeds_id: '101189'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7667,7 +7679,7 @@ schools:
   ipeds_id: '198543'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7678,7 +7690,7 @@ schools:
   ipeds_id: '114433'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7689,7 +7701,7 @@ schools:
   ipeds_id: '184612'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7700,12 +7712,12 @@ schools:
   ipeds_id: '169910'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ferris.edu/admissions/testing/resources/common/CDS2021-2022.pdf
+  discovery_seed_url: https://www.ferris.edu/admissions/testing/resources/common/homepage.htm
 - id: ferrum-college
   name: Ferrum College
   domain: ferrum.edu
@@ -7724,7 +7736,7 @@ schools:
   ipeds_id: '114549'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7735,7 +7747,7 @@ schools:
   ipeds_id: '172440'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7746,7 +7758,7 @@ schools:
   ipeds_id: '165802'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7757,7 +7769,7 @@ schools:
   ipeds_id: '220181'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7780,24 +7792,24 @@ schools:
   ipeds_id: '133711'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.flagler.edu/sites/default/files/2024-12/CDS%202023-2024.pdf
+  discovery_seed_url: https://www.flagler.edu/about/office-services/academic-affairs/institutional-research-and-effectiveness/explore-data
 - id: florida-agricultural-and-mechanical-university
   name: Florida Agricultural and Mechanical University
   domain: famu.edu
   ipeds_id: '133650'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.famu.edu/administration/strategic-planning-analysis-and-institutional-effectiveness/institutional-research/surveys/pdf/cds/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.famu.edu/administration/strategic-planning-analysis-and-institutional-effectiveness/institutional-research/surveys/common-data-set.php
 - id: florida-atlantic-university
   name: Florida Atlantic University
   domain: fau.edu
@@ -7816,7 +7828,7 @@ schools:
   ipeds_id: '133809'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7827,7 +7839,7 @@ schools:
   ipeds_id: '135160'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7887,7 +7899,7 @@ schools:
   ipeds_id: '133979'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7898,19 +7910,19 @@ schools:
   ipeds_id: '482936'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://floridapoly.edu/wp-content/uploads/2025/09/cds_flpoly_2023_2024_04302024_final.pdf
+  discovery_seed_url: https://floridapoly.edu/cds_flpoly_2023_2024_04302024_final/
 - id: florida-southern-college
   name: Florida Southern College
   domain: flsouthern.edu
   ipeds_id: '134079'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7921,8 +7933,8 @@ schools:
   ipeds_id: '133508'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:38Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -7933,7 +7945,7 @@ schools:
   ipeds_id: '133702'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7956,7 +7968,7 @@ schools:
   ipeds_id: '380368'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7967,7 +7979,7 @@ schools:
   ipeds_id: '177418'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7978,7 +7990,7 @@ schools:
   ipeds_id: '114716'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -7989,7 +8001,7 @@ schools:
   ipeds_id: '114831'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8012,12 +8024,12 @@ schools:
   ipeds_id: '155061'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.fhsu.edu/administrative/adminfin/documents/Common-Data-Sets-docs/Common-Data-Set-2014-15-Correction.pdf
+  discovery_seed_url: https://fhsu.edu/administrative/adminfin/budget-and-planning/common-data-set/index
 - id: fort-lewis-college
   name: Fort Lewis College
   domain: fortlewis.edu
@@ -8036,7 +8048,7 @@ schools:
   ipeds_id: '139719'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -8046,20 +8058,21 @@ schools:
   name: Francis Marion University
   domain: fmarion.edu
   ipeds_id: '218061'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:40Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.fmarion.edu/provost/studentachievementandsuccess/
 - id: franciscan-missionaries-of-our-lady-university
   name: Franciscan Missionaries of Our Lady University
   domain: franu.edu
   ipeds_id: '160074'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8070,7 +8083,7 @@ schools:
   ipeds_id: '114734'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8081,7 +8094,7 @@ schools:
   ipeds_id: '205957'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8104,7 +8117,7 @@ schools:
   ipeds_id: '150604'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8115,7 +8128,7 @@ schools:
   ipeds_id: '182795'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8126,7 +8139,7 @@ schools:
   ipeds_id: '202806'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8147,20 +8160,21 @@ schools:
   name: Freed-Hardeman University
   domain: fhu.edu
   ipeds_id: '220215'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:42Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://fhu.edu/about/institutional-research-planning-and-assessment/institutional-research/
 - id: fresno-pacific-university
   name: Fresno Pacific University
   domain: fresno.edu
   ipeds_id: '114813'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8171,7 +8185,7 @@ schools:
   ipeds_id: '155089'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8194,7 +8208,7 @@ schools:
   ipeds_id: '156727'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8205,19 +8219,19 @@ schools:
   ipeds_id: '162584'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.frostburg.edu/academics/air/institutional-research/CDS_2020-2021.pdf
+  discovery_seed_url: https://www.frostburg.edu/academics/air/institutional-research/common-data-sets.php
 - id: fuller-theological-seminary
   name: Fuller Theological Seminary
   domain: fuller.edu
   ipeds_id: '114840'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8240,7 +8254,7 @@ schools:
   ipeds_id: '481030'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8251,30 +8265,31 @@ schools:
   ipeds_id: '131450'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://gallaudet.edu/wp-content/uploads/2023/03/CDS_2022-2023_final_xlsx.pdf
+  discovery_seed_url: https://gallaudet.edu/academic-affairs/institutional-research/reports-and-surveys/common-data-set-cds-reports/
 - id: galveston-college
   name: Galveston College
   domain: gc.edu
   ipeds_id: '224961'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:44Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://gc.edu/about-gc/institutional-effectiveness/documents/CDS_2021-2022-GC.pdf
 - id: gannon-university
   name: Gannon University
   domain: gannon.edu
   ipeds_id: '212601'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8285,7 +8300,7 @@ schools:
   ipeds_id: '198561'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8296,7 +8311,7 @@ schools:
   ipeds_id: '145275'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8307,7 +8322,7 @@ schools:
   ipeds_id: '105145'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8330,7 +8345,7 @@ schools:
   ipeds_id: '212656'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8353,7 +8368,7 @@ schools:
   ipeds_id: '232186'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8364,7 +8379,7 @@ schools:
   ipeds_id: '156745'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8375,7 +8390,7 @@ schools:
   ipeds_id: '139861'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -8399,7 +8414,7 @@ schools:
   ipeds_id: '139700'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8410,7 +8425,7 @@ schools:
   ipeds_id: '485111'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8421,19 +8436,19 @@ schools:
   ipeds_id: '139931'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://ww2.georgiasouthern.edu/em/ir/wp-content/uploads/sites/5/cds21-22-1.pdf
+  discovery_seed_url: https://digitalcommons.georgiasouthern.edu/common-data-sets/
 - id: georgia-southwestern-state-university
   name: Georgia Southwestern State University
   domain: gsw.edu
   ipeds_id: '139764'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8456,7 +8471,7 @@ schools:
   ipeds_id: '184773'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8479,7 +8494,7 @@ schools:
   ipeds_id: '494551'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8490,7 +8505,7 @@ schools:
   ipeds_id: '104708'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8501,7 +8516,7 @@ schools:
   ipeds_id: '237385'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8512,7 +8527,7 @@ schools:
   ipeds_id: '230889'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8523,7 +8538,7 @@ schools:
   ipeds_id: '202903'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8534,7 +8549,7 @@ schools:
   ipeds_id: '115083'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8545,7 +8560,7 @@ schools:
   ipeds_id: '130989'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8568,7 +8583,7 @@ schools:
   ipeds_id: '202912'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8579,7 +8594,7 @@ schools:
   ipeds_id: '129154'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8613,7 +8628,7 @@ schools:
   ipeds_id: '165945'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8636,31 +8651,31 @@ schools:
   ipeds_id: '162654'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.goucher.edu/institutional-effectiveness/documents/cds_2022_2023.pdf
+  discovery_seed_url: https://www.goucher.edu/institutional-effectiveness/common-data-sets
 - id: governors-state-university
   name: Governors State University
   domain: govst.edu
   ipeds_id: '145336'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.govst.edu/uploadedFiles/About/University_Governance/gsu/CDS_2023-2024.pdf
+  discovery_seed_url: https://opus.govst.edu/commondata/
 - id: grace-christian-university
   name: Grace Christian University
   domain: gracechristian.edu
   ipeds_id: '170000'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8671,7 +8686,7 @@ schools:
   ipeds_id: '150677'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8682,7 +8697,7 @@ schools:
   ipeds_id: '481058'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8693,7 +8708,7 @@ schools:
   ipeds_id: '481401'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8716,7 +8731,7 @@ schools:
   ipeds_id: '115214'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8751,7 +8766,7 @@ schools:
   ipeds_id: '153375'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8762,7 +8777,7 @@ schools:
   ipeds_id: '212771'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8773,7 +8788,7 @@ schools:
   ipeds_id: '235334'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8784,7 +8799,7 @@ schools:
   ipeds_id: '225070'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8806,7 +8821,7 @@ schools:
   ipeds_id: '170091'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8817,7 +8832,7 @@ schools:
   ipeds_id: '497213'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8828,7 +8843,7 @@ schools:
   ipeds_id: '235343'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8839,7 +8854,7 @@ schools:
   ipeds_id: '198598'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8850,7 +8865,7 @@ schools:
   ipeds_id: '218113'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8861,7 +8876,7 @@ schools:
   ipeds_id: '145372'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8884,7 +8899,7 @@ schools:
   ipeds_id: '212805'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8929,20 +8944,21 @@ schools:
   name: Gwynedd Mercy University
   domain: gmercyu.edu
   ipeds_id: '212832'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:57Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.gmercyu.edu/pdfs/legacy-cds_2024-2025_updated_4_11_2025_compressed.pdf
 - id: hackensack-meridian-school-of-medicine
   name: Hackensack Meridian School of Medicine
   domain: hmsom.org
   ipeds_id: '495314'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -8953,7 +8969,7 @@ schools:
   ipeds_id: '225201'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9000,7 +9016,7 @@ schools:
   ipeds_id: '232265'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9011,7 +9027,7 @@ schools:
   ipeds_id: '177542'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9022,7 +9038,7 @@ schools:
   ipeds_id: '150756'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9033,7 +9049,7 @@ schools:
   ipeds_id: '225247'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -9045,7 +9061,7 @@ schools:
   ipeds_id: '107044'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9056,7 +9072,7 @@ schools:
   ipeds_id: '177551'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9067,7 +9083,7 @@ schools:
   ipeds_id: '446640'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9078,7 +9094,7 @@ schools:
   ipeds_id: '129491'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9089,19 +9105,19 @@ schools:
   ipeds_id: '191533'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:18:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.hartwick.edu/wp-content/uploads/2022/01/IRCDS2020-2021Webpage011422.pdf
+  discovery_seed_url: https://www.hartwick.edu/about-us/institutional-research-effectiveness/hartwick-data/
 - id: haskell-indian-nations-university
   name: Haskell Indian Nations University
   domain: haskell.edu
   ipeds_id: '155140'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:18:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9110,20 +9126,21 @@ schools:
   name: Hastings College
   domain: hastings.edu
   ipeds_id: '181127'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:00Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.hastings.edu/admissions/cost-aid/consumer-information/
 - id: haven-university
   name: Haven University
   domain: haven.edu
   ipeds_id: '111045'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9144,20 +9161,21 @@ schools:
   name: Hawaii Pacific University
   domain: hpu.edu
   ipeds_id: '141644'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:00Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.hpu.edu/about-us/information/hpu-by-the-numbers.html
 - id: hazelden-betty-ford-graduate-school
   name: Hazelden Betty Ford Graduate School
   domain: hazeldenbettyford.org
   ipeds_id: '173683'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9168,7 +9186,7 @@ schools:
   ipeds_id: '166045'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9179,7 +9197,7 @@ schools:
   ipeds_id: '145497'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9190,7 +9208,7 @@ schools:
   ipeds_id: '203067'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9201,7 +9219,7 @@ schools:
   ipeds_id: '203085'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9212,7 +9230,7 @@ schools:
   ipeds_id: '191597'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9234,7 +9252,7 @@ schools:
   ipeds_id: '107071'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9257,7 +9275,7 @@ schools:
   ipeds_id: '170240'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9268,7 +9286,7 @@ schools:
   ipeds_id: '198677'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9279,7 +9297,7 @@ schools:
   ipeds_id: '101453'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9290,7 +9308,7 @@ schools:
   ipeds_id: '235422'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9301,7 +9319,7 @@ schools:
   ipeds_id: '200785'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9312,7 +9330,7 @@ schools:
   ipeds_id: '140340'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9323,7 +9341,7 @@ schools:
   ipeds_id: '101365'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9334,7 +9352,7 @@ schools:
   ipeds_id: '459851'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9345,7 +9363,7 @@ schools:
   ipeds_id: '459842'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9356,7 +9374,7 @@ schools:
   ipeds_id: '240392'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9367,7 +9385,7 @@ schools:
   ipeds_id: '174154'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9378,7 +9396,7 @@ schools:
   ipeds_id: '499149'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9389,7 +9407,7 @@ schools:
   ipeds_id: '433536'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9400,7 +9418,7 @@ schools:
   ipeds_id: '386472'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9411,7 +9429,7 @@ schools:
   ipeds_id: '496973'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9422,7 +9440,7 @@ schools:
   ipeds_id: '155177'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9433,7 +9451,7 @@ schools:
   ipeds_id: '198695'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9444,7 +9462,7 @@ schools:
   ipeds_id: '485403'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9455,7 +9473,7 @@ schools:
   ipeds_id: '235431'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9478,7 +9496,7 @@ schools:
   ipeds_id: '134495'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9489,7 +9507,7 @@ schools:
   ipeds_id: '170286'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -9513,7 +9531,7 @@ schools:
   ipeds_id: '246789'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9536,7 +9554,7 @@ schools:
   ipeds_id: '134510'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9547,7 +9565,7 @@ schools:
   ipeds_id: '367884'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9582,7 +9600,7 @@ schools:
   ipeds_id: '129534'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9593,7 +9611,7 @@ schools:
   ipeds_id: '150774'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9616,7 +9634,7 @@ schools:
   ipeds_id: '115728'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9627,7 +9645,7 @@ schools:
   ipeds_id: '457086'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9638,7 +9656,7 @@ schools:
   ipeds_id: '162760'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9649,7 +9667,7 @@ schools:
   ipeds_id: '443076'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9660,30 +9678,31 @@ schools:
   ipeds_id: '170301'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://hope.edu/offices/frost-research-center/institutional-research/data-resources/common-data-sets/2024-2025-common-data-set.pdf
+  discovery_seed_url: https://hope.edu/offices/frost-research-center/institutional-research/data-resources/index.html
 - id: hope-international-university
   name: Hope International University
   domain: hiu.edu
   ipeds_id: '120537'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:10Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.hiu.edu/pdf/CDS20252026_HIU.pdf
 - id: horizon-university
   name: Horizon University
   domain: horizonuniversity.edu
   ipeds_id: '457226'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9694,7 +9713,7 @@ schools:
   ipeds_id: '191676'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9705,12 +9724,12 @@ schools:
   ipeds_id: '225399'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://hc.edu/about-hcu/wp-content/uploads/sites/26/2023/03/CDS_2022-2023-HCU_c.pdf
+  discovery_seed_url: https://hc.edu/about-hcu/university-leadership/office-of-the-provost/office-of-institutional-research-and-effectiveness/institutional-research-reports/
 - id: houston-community-college
   name: Houston Community College
   domain: hccs.edu
@@ -9729,7 +9748,7 @@ schools:
   ipeds_id: '246345'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9740,7 +9759,7 @@ schools:
   ipeds_id: '225548'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9763,7 +9782,7 @@ schools:
   ipeds_id: '164368'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9774,7 +9793,7 @@ schools:
   ipeds_id: '115773'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9785,7 +9804,7 @@ schools:
   ipeds_id: '101435'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9808,7 +9827,7 @@ schools:
   ipeds_id: '449348'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9819,7 +9838,7 @@ schools:
   ipeds_id: '487524'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -9829,20 +9848,21 @@ schools:
   name: Huston-Tillotson University
   domain: htu.edu
   ipeds_id: '225575'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:12Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://htu.edu/offices/institutional-research/
 - id: icahn-school-of-medicine-at-mount-sinai
   name: Icahn School of Medicine at Mount Sinai
   domain: icahn.mssm.edu
   ipeds_id: '193405'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9853,19 +9873,19 @@ schools:
   ipeds_id: '142276'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.isu.edu/media/libraries/academic-affairs/institutional-research/argos-reports-listing/ISU-CDS-2021-2022.pdf
+  discovery_seed_url: https://www.isu.edu/institutionalresearch/Common%20Data%20Sets
 - id: iliff-school-of-theology
   name: Iliff School of Theology
   domain: iliff.edu
   ipeds_id: '127273'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9876,7 +9896,7 @@ schools:
   ipeds_id: '434584'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9887,7 +9907,7 @@ schools:
   ipeds_id: '145691'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9898,7 +9918,7 @@ schools:
   ipeds_id: '145628'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9945,19 +9965,19 @@ schools:
   ipeds_id: '213011'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.immaculata.edu/wp-content/uploads/2023/08/Common-Data-Set-2022-2023-Immaculata-University.pdf
+  discovery_seed_url: https://www.immaculata.edu/about/institutional-research-effectiveness/
 - id: indian-bible-college
   name: Indian Bible College
   domain: indianbible.org
   ipeds_id: '495280'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9968,7 +9988,7 @@ schools:
   ipeds_id: '134608'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9979,7 +9999,7 @@ schools:
   ipeds_id: '151290'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -9990,7 +10010,7 @@ schools:
   ipeds_id: '492962'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10001,31 +10021,31 @@ schools:
   ipeds_id: '151324'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://irt2.indstate.edu/cms7/ir/assets/File/CDS22.pdf
+  discovery_seed_url: https://irt2.indstate.edu/cms7/ir/index.cfm/isu-data/common-data-set/
 - id: indiana-university-of-pennsylvania-main-campus
   name: Indiana University of Pennsylvania-Main Campus
   domain: iup.edu
   ipeds_id: '213020'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.iup.edu/planningandassessment/files/university_data/common_data_set/cds_2021-2022-3.pdf
+  discovery_seed_url: https://www.iup.edu/planningandassessment/university-data/common-data-set/index.html
 - id: indiana-university-east
   name: Indiana University-East
   domain: iue.edu
   ipeds_id: '151388'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10048,7 +10068,7 @@ schools:
   ipeds_id: '151333'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10059,7 +10079,7 @@ schools:
   ipeds_id: '151360'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10070,7 +10090,7 @@ schools:
   ipeds_id: '151342'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10081,7 +10101,7 @@ schools:
   ipeds_id: '151379'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10092,7 +10112,7 @@ schools:
   ipeds_id: '151801'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10103,7 +10123,7 @@ schools:
   ipeds_id: '488679'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10114,7 +10134,7 @@ schools:
   ipeds_id: '145886'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10125,7 +10145,7 @@ schools:
   ipeds_id: '462044'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10136,7 +10156,7 @@ schools:
   ipeds_id: '187745'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10147,7 +10167,7 @@ schools:
   ipeds_id: '489335'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10158,7 +10178,7 @@ schools:
   ipeds_id: '493363'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10169,7 +10189,7 @@ schools:
   ipeds_id: '454838'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10180,7 +10200,7 @@ schools:
   ipeds_id: '455804'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10191,7 +10211,7 @@ schools:
   ipeds_id: '140146'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10202,7 +10222,7 @@ schools:
   ipeds_id: '436614'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10213,7 +10233,7 @@ schools:
   ipeds_id: '448691'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10224,7 +10244,7 @@ schools:
   ipeds_id: '191931'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10235,7 +10255,7 @@ schools:
   ipeds_id: '153621'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10246,7 +10266,7 @@ schools:
   ipeds_id: '441238'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10269,7 +10289,7 @@ schools:
   ipeds_id: '170444'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10292,7 +10312,7 @@ schools:
   ipeds_id: '497453'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10315,7 +10335,7 @@ schools:
   ipeds_id: '134945'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -10327,7 +10347,7 @@ schools:
   ipeds_id: '203678'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10350,7 +10370,7 @@ schools:
   ipeds_id: '225885'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10361,7 +10381,7 @@ schools:
   ipeds_id: '192040'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10372,7 +10392,7 @@ schools:
   ipeds_id: '107141'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10383,19 +10403,19 @@ schools:
   ipeds_id: '203368'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://visit.jcu.edu/sites/default/files/2023-02/CDS_2022-2023%20for%20webpage%202923.pdf
+  discovery_seed_url: https://jcu.edu/institutional-effectiveness/institutional-research
 - id: john-paul-the-great-catholic-university
   name: John Paul the Great Catholic University
   domain: jpcatholic.edu
   ipeds_id: '462354'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10404,20 +10424,21 @@ schools:
   name: Johnson & Wales University-Charlotte
   domain: jwu.edu
   ipeds_id: '445708'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:23Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.jwu.edu/about-jwu/terms-of-use.html
 - id: johnson-and-wales-university-online
   name: Johnson & Wales University-Online
   domain: online.jwu.edu
   ipeds_id: '460349'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10426,13 +10447,14 @@ schools:
   name: Johnson & Wales University-Providence
   domain: jwu.edu
   ipeds_id: '217235'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:23Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.jwu.edu/about-jwu/terms-of-use.html
 - id: johnson-c-smith-university
   name: Johnson C Smith University
   domain: jcsu.edu
@@ -10451,7 +10473,7 @@ schools:
   ipeds_id: '220473'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10462,7 +10484,7 @@ schools:
   ipeds_id: '132879'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10473,7 +10495,7 @@ schools:
   ipeds_id: '146339'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10484,7 +10506,7 @@ schools:
   ipeds_id: '461139'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10507,7 +10529,7 @@ schools:
   ipeds_id: '219240'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10530,7 +10552,7 @@ schools:
   ipeds_id: '155308'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10541,7 +10563,7 @@ schools:
   ipeds_id: '177746'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10574,7 +10596,7 @@ schools:
   ipeds_id: '497693'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10597,7 +10619,7 @@ schools:
   ipeds_id: '155414'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -10609,7 +10631,7 @@ schools:
   ipeds_id: '185262'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10620,7 +10642,7 @@ schools:
   ipeds_id: '440031'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10631,19 +10653,19 @@ schools:
   ipeds_id: '183062'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
-    last_method: brave
+    last_method: pattern
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.keene.edu/ksc/assets/files/10353/cds_2016-2017_final.pdf
+  discovery_seed_url: https://keene.edu/ir/cds/
 - id: kehilath-yakov-rabbinical-seminary
   name: Kehilath Yakov Rabbinical Seminary
   domain: kehilathyakov.com
   ipeds_id: '192165'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10654,7 +10676,7 @@ schools:
   ipeds_id: '135081'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10677,7 +10699,7 @@ schools:
   ipeds_id: '177816'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10791,7 +10813,7 @@ schools:
   ipeds_id: '157100'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10802,7 +10824,7 @@ schools:
   ipeds_id: '157030'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10813,12 +10835,12 @@ schools:
   ipeds_id: '157058'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kysu.edu/documents/institutional-research/cds-2019-2020.pdf
+  discovery_seed_url: https://www.kysu.edu/academics/institutional-research/common-data-sets.php
 - id: kentucky-wesleyan-college
   name: Kentucky Wesleyan College
   domain: kwc.edu
@@ -10837,7 +10859,7 @@ schools:
   ipeds_id: '461847'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10848,7 +10870,7 @@ schools:
   ipeds_id: '203544'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10871,7 +10893,7 @@ schools:
   ipeds_id: '192192'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10882,7 +10904,7 @@ schools:
   ipeds_id: '213303'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10893,7 +10915,7 @@ schools:
   ipeds_id: '220516'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10904,7 +10926,7 @@ schools:
   ipeds_id: '213321'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10915,31 +10937,31 @@ schools:
   ipeds_id: '146427'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.knox.edu/documents/OIRA/CDS_2019-2020.pdf
+  discovery_seed_url: https://www.knox.edu/offices/institutional-research/data-resources
 - id: kutztown-university-of-pennsylvania
   name: Kutztown University of Pennsylvania
   domain: kutztown.edu
   ipeds_id: '213349'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.kutztown.edu/Departments-Offices/G-L/InstitutionalResearch/Documents/CDS%202022-23.pdf
+  discovery_seed_url: https://www.kutztown.edu/about-ku/administrative-offices/institutional-research/common-data-set.html
 - id: kuyper-college
   name: Kuyper College
   domain: kuyper.edu
   ipeds_id: '171881'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10950,7 +10972,7 @@ schools:
   ipeds_id: '213358'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10961,7 +10983,7 @@ schools:
   ipeds_id: '213367'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10972,7 +10994,7 @@ schools:
   ipeds_id: '117627'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10983,7 +11005,7 @@ schools:
   ipeds_id: '165264'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -10994,7 +11016,7 @@ schools:
   ipeds_id: '260372'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11005,7 +11027,7 @@ schools:
   ipeds_id: '213376'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11028,7 +11050,7 @@ schools:
   ipeds_id: '140234'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11039,7 +11061,7 @@ schools:
   ipeds_id: '117168'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11050,7 +11072,7 @@ schools:
   ipeds_id: '203580'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11061,7 +11083,7 @@ schools:
   ipeds_id: '407629'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11084,7 +11106,7 @@ schools:
   ipeds_id: '146490'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11107,7 +11129,7 @@ schools:
   ipeds_id: '235699'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11118,7 +11140,7 @@ schools:
   ipeds_id: '135188'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11129,7 +11151,7 @@ schools:
   ipeds_id: '238980'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11140,7 +11162,7 @@ schools:
   ipeds_id: '146533'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11151,7 +11173,7 @@ schools:
   ipeds_id: '496706'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11162,7 +11184,7 @@ schools:
   ipeds_id: '226091'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -11174,7 +11196,7 @@ schools:
   ipeds_id: '213400'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11185,7 +11207,7 @@ schools:
   ipeds_id: '213446'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11196,7 +11218,7 @@ schools:
   ipeds_id: '218229'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11207,7 +11229,7 @@ schools:
   ipeds_id: '247649'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11218,7 +11240,7 @@ schools:
   ipeds_id: '220598'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11234,7 +11256,7 @@ schools:
   ipeds_id: '240620'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11245,7 +11267,7 @@ schools:
   ipeds_id: '226134'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11256,7 +11278,7 @@ schools:
   ipeds_id: '498234'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11267,7 +11289,7 @@ schools:
   ipeds_id: '166391'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11278,7 +11300,7 @@ schools:
   ipeds_id: '117283'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11289,12 +11311,12 @@ schools:
   ipeds_id: '170675'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://ltu.edu/wp-content/uploads/2024/06/2023_2024_CDS_EXTERNAL.pdf
+  discovery_seed_url: https://ltu.edu/about/consumer-information/
 - id: lawrence-university
   name: Lawrence University
   domain: lawrence.edu
@@ -11313,19 +11335,19 @@ schools:
   ipeds_id: '192323'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.lemoyne.edu/Portals/0/BfmPdfs/IR/2019-2020/MASTER%20CDS_2019-2020%20%201.%20GENERAL%20INFORMATION.pdf
+  discovery_seed_url: https://www.lemoyne.edu/institutional-research/
 - id: le-moyne-owen-college
   name: Le Moyne-Owen College
   domain: loc.edu
   ipeds_id: '220604'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11336,7 +11358,7 @@ schools:
   ipeds_id: '213507'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11359,7 +11381,7 @@ schools:
   ipeds_id: '198808'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11369,13 +11391,14 @@ schools:
   domain: lr.edu
   ipeds_id: '198835'
   scrape_policy: active
+  discovery_seed_url: https://www.lr.edu/sites/default/files/2021-08/cds-section-b-enrollment-2016-2017.pdf
 - id: lesley-university
   name: Lesley University
   domain: lesley.edu
   ipeds_id: '166452'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11386,7 +11409,7 @@ schools:
   ipeds_id: '226231'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11409,12 +11432,12 @@ schools:
   ipeds_id: '146612'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.lewisu.edu/welcome/offices/provost/OIRP/pdf/Common%20Data%20Set_2024-25%2006-03-25.pdf
+  discovery_seed_url: https://www.lewisu.edu/welcome/offices/provost/OIRP/
 - id: lewis-clark-state-college
   name: Lewis-Clark State College
   domain: lcsc.edu
@@ -11433,7 +11456,7 @@ schools:
   ipeds_id: '157207'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11444,7 +11467,7 @@ schools:
   ipeds_id: '232557'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11455,7 +11478,7 @@ schools:
   ipeds_id: '117520'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11466,7 +11489,7 @@ schools:
   ipeds_id: '117104'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11475,31 +11498,33 @@ schools:
   name: Life University
   domain: life.edu
   ipeds_id: '140252'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://data.life.edu/university-data/
 - id: limestone-university
   name: Limestone University
   domain: limestone.edu
   ipeds_id: '218238'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://fac-staff-hb.limestone.edu/data-dictionary
 - id: lincoln-christian-university
   name: Lincoln Christian University
   domain: lincolnchristian.edu
   ipeds_id: '146667'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11510,7 +11535,7 @@ schools:
   ipeds_id: '220631'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11521,7 +11546,7 @@ schools:
   ipeds_id: '117557'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11532,19 +11557,19 @@ schools:
   ipeds_id: '177940'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.lincolnu.edu/about-lincoln/oira/common-data-set-2022-2023.pdf
+  discovery_seed_url: https://www.lincolnu.edu/web/oira/common-data-sets
 - id: lincoln-university-pa
   name: Lincoln University (PA)
   domain: lincoln.edu
   ipeds_id: '213598'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -11568,7 +11593,7 @@ schools:
   ipeds_id: '157216'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11591,19 +11616,19 @@ schools:
   ipeds_id: '219976'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://lipscomb.edu/sites/default/files/2025-10/CDS_2023_2024%20Lipscomb%20Revised.pdf
+  discovery_seed_url: https://lipscomb.edu/academics/academic-support/institutional-effectiveness/office-institutional-research
 - id: livingstone-college
   name: Livingstone College
   domain: livingstone.edu
   ipeds_id: '198862'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11614,7 +11639,7 @@ schools:
   ipeds_id: '177986'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11625,7 +11650,7 @@ schools:
   ipeds_id: '117636'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11636,19 +11661,19 @@ schools:
   ipeds_id: '227182'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.lonestar.edu/images/Common_Data_Set_2015-2016_Degrees_Conferred.pdf
+  discovery_seed_url: https://www.lonestar.edu/AIR-Common-Data-Sets.htm
 - id: long-island-university
   name: Long Island University
   domain: liu.edu
   ipeds_id: '192448'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11671,7 +11696,7 @@ schools:
   ipeds_id: '166489'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11682,7 +11707,7 @@ schools:
   ipeds_id: '203748'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11693,7 +11718,7 @@ schools:
   ipeds_id: '153825'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11704,7 +11729,7 @@ schools:
   ipeds_id: '117681'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11715,7 +11740,7 @@ schools:
   ipeds_id: '474863'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -11727,7 +11752,7 @@ schools:
   ipeds_id: '159568'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11750,7 +11775,7 @@ schools:
   ipeds_id: '159373'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11761,7 +11786,7 @@ schools:
   ipeds_id: '435000'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11772,7 +11797,7 @@ schools:
   ipeds_id: '159382'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11807,7 +11832,7 @@ schools:
   ipeds_id: '157298'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11818,7 +11843,7 @@ schools:
   ipeds_id: '203757'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11829,7 +11854,7 @@ schools:
   ipeds_id: '235750'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11888,7 +11913,7 @@ schools:
   ipeds_id: '226383'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11911,7 +11936,7 @@ schools:
   ipeds_id: '135364'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11922,7 +11947,7 @@ schools:
   ipeds_id: '173896'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11933,7 +11958,7 @@ schools:
   ipeds_id: '146728'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11956,19 +11981,19 @@ schools:
   ipeds_id: '132657'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.lynn.edu/uploads/pdf/Lynn-University-Common-Data-Set-23-24.pdf
+  discovery_seed_url: https://spiral.lynn.edu/common-data-set/
 - id: lyon-college
   name: Lyon College
   domain: lyon.edu
   ipeds_id: '106342'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -11991,7 +12016,7 @@ schools:
   ipeds_id: '192624'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12002,7 +12027,7 @@ schools:
   ipeds_id: '238263'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12013,7 +12038,7 @@ schools:
   ipeds_id: '170806'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12024,7 +12049,7 @@ schools:
   ipeds_id: '182917'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12035,7 +12060,7 @@ schools:
   ipeds_id: '153861'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12046,7 +12071,7 @@ schools:
   ipeds_id: '161509'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12057,7 +12082,7 @@ schools:
   ipeds_id: '161022'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12079,7 +12104,7 @@ schools:
   ipeds_id: '490753'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12090,7 +12115,7 @@ schools:
   ipeds_id: '203775'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -12102,7 +12127,7 @@ schools:
   ipeds_id: '151777'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12113,7 +12138,7 @@ schools:
   ipeds_id: '155496'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12124,19 +12149,19 @@ schools:
   ipeds_id: '192703'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://content.manhattan.edu/oie/cds_2015_2016_final.pdf
+  discovery_seed_url: https://inside.manhattan.edu/offices/institutional-research-assessment/institutional-research/externally-reported-data.php
 - id: manhattan-school-of-music
   name: Manhattan School of Music
   domain: msmnyc.edu
   ipeds_id: '192712'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12147,7 +12172,7 @@ schools:
   ipeds_id: '192749'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12158,7 +12183,7 @@ schools:
   ipeds_id: '461528'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12169,7 +12194,7 @@ schools:
   ipeds_id: '213774'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12180,7 +12205,7 @@ schools:
   ipeds_id: '239071'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12191,7 +12216,7 @@ schools:
   ipeds_id: '192785'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12202,7 +12227,7 @@ schools:
   ipeds_id: '151786'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12213,7 +12238,7 @@ schools:
   ipeds_id: '239080'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12224,7 +12249,7 @@ schools:
   ipeds_id: '497833'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12247,7 +12272,7 @@ schools:
   ipeds_id: '203881'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12282,7 +12307,7 @@ schools:
   ipeds_id: '198899'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12293,7 +12318,7 @@ schools:
   ipeds_id: '123943'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12304,7 +12329,7 @@ schools:
   ipeds_id: '237525'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -12316,7 +12341,7 @@ schools:
   ipeds_id: '173452'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12327,7 +12352,7 @@ schools:
   ipeds_id: '151810'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12338,7 +12363,7 @@ schools:
   ipeds_id: '232672'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12349,7 +12374,7 @@ schools:
   ipeds_id: '163295'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12360,7 +12385,7 @@ schools:
   ipeds_id: '164085'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12371,7 +12396,7 @@ schools:
   ipeds_id: '192864'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12382,19 +12407,19 @@ schools:
   ipeds_id: '232706'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://marymount.edu/wp-content/uploads/2023/12/CDS_2022-2023-Final.pdf
+  discovery_seed_url: https://marymount.edu/faculty-and-staff/office-of-planning-institutional-effectiveness/official-data/common-data-set/
 - id: maryville-college
   name: Maryville College
   domain: maryvillecollege.edu
   ipeds_id: '220710'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:19:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12405,7 +12430,7 @@ schools:
   ipeds_id: '178059'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -12415,20 +12440,21 @@ schools:
   name: Marywood University
   domain: marywood.edu
   ipeds_id: '213826'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:19:59Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.marywood.edu/academics/affairs/institutional-research
 - id: massachusetts-college-of-art-and-design
   name: Massachusetts College of Art and Design
   domain: massart.edu
   ipeds_id: '166674'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12449,20 +12475,21 @@ schools:
   name: Massachusetts Maritime Academy
   domain: maritime.edu
   ipeds_id: '166692'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:00Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.maritime.edu/institutional-research/facts-figures
 - id: massachusetts-school-of-law
   name: Massachusetts School of Law
   domain: mslaw.edu
   ipeds_id: '369002'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12473,7 +12500,7 @@ schools:
   ipeds_id: '173957'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12484,7 +12511,7 @@ schools:
   ipeds_id: '200226'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12495,7 +12522,7 @@ schools:
   ipeds_id: '146977'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12506,7 +12533,7 @@ schools:
   ipeds_id: '164270'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12517,7 +12544,7 @@ schools:
   ipeds_id: '147013'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12528,7 +12555,7 @@ schools:
   ipeds_id: '226587'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12539,7 +12566,7 @@ schools:
   ipeds_id: '159717'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12548,20 +12575,21 @@ schools:
   name: McPherson College
   domain: mcpherson.edu
   ipeds_id: '155511'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:02Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.mcpherson.edu/wp-content/uploads/2025/06/CDS-2024-2025-MC.pdf
 - id: mcphs-university
   name: MCPHS University
   domain: mcphs.edu
   ipeds_id: '166656'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12572,7 +12600,7 @@ schools:
   ipeds_id: '147031'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12583,7 +12611,7 @@ schools:
   ipeds_id: '490328'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12594,7 +12622,7 @@ schools:
   ipeds_id: '192925'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12605,7 +12633,7 @@ schools:
   ipeds_id: '239169'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12616,7 +12644,7 @@ schools:
   ipeds_id: '218335'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12627,7 +12655,7 @@ schools:
   ipeds_id: '220792'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12638,7 +12666,7 @@ schools:
   ipeds_id: '220871'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12649,7 +12677,7 @@ schools:
   ipeds_id: '118693'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12672,7 +12700,7 @@ schools:
   ipeds_id: '153977'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12683,7 +12711,7 @@ schools:
   ipeds_id: '203960'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12694,7 +12722,7 @@ schools:
   ipeds_id: '193016'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12705,7 +12733,7 @@ schools:
   ipeds_id: '213987'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12716,7 +12744,7 @@ schools:
   ipeds_id: '198950'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12739,7 +12767,7 @@ schools:
   ipeds_id: '193061'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12750,7 +12778,7 @@ schools:
   ipeds_id: '193052'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12761,7 +12789,7 @@ schools:
   ipeds_id: '193070'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12772,7 +12800,7 @@ schools:
   ipeds_id: '417752'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12795,7 +12823,7 @@ schools:
   ipeds_id: '147129'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12806,7 +12834,7 @@ schools:
   ipeds_id: '203997'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12817,7 +12845,7 @@ schools:
   ipeds_id: '198969'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12828,7 +12856,7 @@ schools:
   ipeds_id: '190114'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12839,7 +12867,7 @@ schools:
   ipeds_id: '174020'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12850,19 +12878,19 @@ schools:
   ipeds_id: '127565'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.msudenver.edu/wp-content/uploads/2023/07/CDS_2022-2023_MSU_DenverV2.pdf
+  discovery_seed_url: https://www.msudenver.edu/institutional-research/
 - id: mgh-institute-of-health-professions
   name: MGH Institute of Health Professions
   domain: mghihp.edu
   ipeds_id: '166869'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12923,7 +12951,7 @@ schools:
   ipeds_id: '169220'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12958,7 +12986,7 @@ schools:
   ipeds_id: '245953'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12969,7 +12997,7 @@ schools:
   ipeds_id: '151962'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12980,7 +13008,7 @@ schools:
   ipeds_id: '199458'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -12991,7 +13019,7 @@ schools:
   ipeds_id: '481225'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13002,7 +13030,7 @@ schools:
   ipeds_id: '155520'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13013,7 +13041,7 @@ schools:
   ipeds_id: '482158'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13024,7 +13052,7 @@ schools:
   ipeds_id: '220996'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13072,7 +13100,7 @@ schools:
   ipeds_id: '226806'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13083,7 +13111,7 @@ schools:
   ipeds_id: '181330'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13094,7 +13122,7 @@ schools:
   ipeds_id: '157377'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13105,7 +13133,7 @@ schools:
   ipeds_id: '178208'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13116,19 +13144,19 @@ schools:
   ipeds_id: '226833'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://msutexas.edu/institutional-effectiveness/_assets/files/institutional-reports1/common-data-set/cds-2021.pdf
+  discovery_seed_url: https://msutexas.edu/institutional-effectiveness/institutional-reports.php
 - id: midwestern-university-downers-grove
   name: Midwestern University-Downers Grove
   domain: midwestern.edu
   ipeds_id: '143853'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13139,7 +13167,7 @@ schools:
   ipeds_id: '423643'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13150,7 +13178,7 @@ schools:
   ipeds_id: '480985'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13161,7 +13189,7 @@ schools:
   ipeds_id: '101675'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13184,7 +13212,7 @@ schools:
   ipeds_id: '486901'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13195,7 +13223,7 @@ schools:
   ipeds_id: '147244'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13204,20 +13232,21 @@ schools:
   name: Millsaps College
   domain: millsaps.edu
   ipeds_id: '175980'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:13Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://millsaps.edu/admissions/office-of-records/
 - id: milwaukee-institute-of-art-and-design
   name: Milwaukee Institute of Art & Design
   domain: miad.edu
   ipeds_id: '239309'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13240,7 +13269,7 @@ schools:
   ipeds_id: '484844'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13251,7 +13280,7 @@ schools:
   ipeds_id: '174127'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13274,7 +13303,7 @@ schools:
   ipeds_id: '174358'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -13298,19 +13327,19 @@ schools:
   ipeds_id: '200253'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.minotstateu.edu/instplan/_documents/common_data_set/Common-Data-Set-21-22.pdf
+  discovery_seed_url: https://www.minotstateu.edu/instplan/common_data_set.shtml
 - id: miracosta-college
   name: MiraCosta College
   domain: miracosta.edu
   ipeds_id: '118912'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13321,7 +13350,7 @@ schools:
   ipeds_id: '193247'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13344,7 +13373,7 @@ schools:
   ipeds_id: '211130'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13355,7 +13384,7 @@ schools:
   ipeds_id: '176664'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13364,13 +13393,14 @@ schools:
   name: Mississippi College
   domain: mc.edu
   ipeds_id: '176053'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:17Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://alert.mc.edu/1-ultimate-guide-to-northwesterns-common-data-set
 - id: mississippi-state-university
   name: Mississippi State University
   domain: msstate.edu
@@ -13389,7 +13419,7 @@ schools:
   ipeds_id: '176035'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13400,7 +13430,7 @@ schools:
   ipeds_id: '176044'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13411,7 +13441,7 @@ schools:
   ipeds_id: '178244'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13422,12 +13452,12 @@ schools:
   ipeds_id: '178341'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.mssu.edu/academics/institutional-effectiveness/files/2021-2022-Common-Data-Set---Full-Report.pdf
+  discovery_seed_url: https://www.mssu.edu/academics/institutional-effectiveness/annual-reports.php
 - id: missouri-state-university-springfield
   name: Missouri State University-Springfield
   domain: missouristate.edu
@@ -13458,7 +13488,7 @@ schools:
   ipeds_id: '178369'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13481,7 +13511,7 @@ schools:
   ipeds_id: '129774'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13492,7 +13522,7 @@ schools:
   ipeds_id: '175281'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13503,7 +13533,7 @@ schools:
   ipeds_id: '118976'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13514,7 +13544,7 @@ schools:
   ipeds_id: '193292'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13525,7 +13555,7 @@ schools:
   ipeds_id: '147341'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13536,7 +13566,7 @@ schools:
   ipeds_id: '185572'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13547,7 +13577,7 @@ schools:
   ipeds_id: '262165'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13570,12 +13600,12 @@ schools:
   ipeds_id: '180179'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.msubillings.edu/ir/institutionalfacts/cds/2020-21/CDS_2020-2021%20G.pdf
+  discovery_seed_url: https://www.msubillings.edu/ir/institutionalfacts/CommonDataSet.htm
 - id: montana-state-university-northern
   name: Montana State University-Northern
   domain: msun.edu
@@ -13594,7 +13624,7 @@ schools:
   ipeds_id: '180416'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13617,7 +13647,7 @@ schools:
   ipeds_id: '199032'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13628,7 +13658,7 @@ schools:
   ipeds_id: '166911'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13639,19 +13669,19 @@ schools:
   ipeds_id: '147369'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://stage-data.moody.edu/globalassets/eda-portal-page/cds_2020-2021.pdf
+  discovery_seed_url: https://data.moody.edu/external-reports/
 - id: moore-college-of-art-and-design
   name: Moore College of Art and Design
   domain: moore.edu
   ipeds_id: '214148'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13698,7 +13728,7 @@ schools:
   ipeds_id: '140562'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13709,7 +13739,7 @@ schools:
   ipeds_id: '127617'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13720,7 +13750,7 @@ schools:
   ipeds_id: '163453'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13743,7 +13773,7 @@ schools:
   ipeds_id: '140571'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13754,7 +13784,7 @@ schools:
   ipeds_id: '218399'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13765,7 +13795,7 @@ schools:
   ipeds_id: '214166'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13776,7 +13806,7 @@ schools:
   ipeds_id: '209241'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13787,7 +13817,7 @@ schools:
   ipeds_id: '204176'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13810,31 +13840,31 @@ schools:
   ipeds_id: '219198'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.mountmarty.edu/globalassets/backend-reconstruction/about-us/academic-excellence/institutional-effectiveness/insteffective.archived/common-data-set-report-2022-2023.pdf
+  discovery_seed_url: https://www.mountmarty.edu/about-us/academic-excellence/institutional-effectiveness/
 - id: mount-mary-university
   name: Mount Mary University
   domain: mtmary.edu
   ipeds_id: '239390'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://mtmary.edu/_files/pdfs/about/cds_2022-2023.pdf
+  discovery_seed_url: https://mtmary.edu/about/fast-facts/index.html
 - id: mount-mercy-university
   name: Mount Mercy University
   domain: mtmercy.edu
   ipeds_id: '154013'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13845,7 +13875,7 @@ schools:
   ipeds_id: '193353'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13856,7 +13886,7 @@ schools:
   ipeds_id: '119173'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13867,7 +13897,7 @@ schools:
   ipeds_id: '189282'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13878,7 +13908,7 @@ schools:
   ipeds_id: '204200'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13889,7 +13919,7 @@ schools:
   ipeds_id: '163462'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -13901,7 +13931,7 @@ schools:
   ipeds_id: '204194'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -13913,7 +13943,7 @@ schools:
   ipeds_id: '209250'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13936,7 +13966,7 @@ schools:
   ipeds_id: '209287'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13946,13 +13976,14 @@ schools:
   domain: murraystate.edu
   ipeds_id: '157401'
   scrape_policy: active
+  discovery_seed_url: https://www.murraystate.edu/about/administration/Provost/institutional-effectiveness/OfficeOfInstitutionalResearch/CommonDataSet.aspx
 - id: muskingum-university
   name: Muskingum University
   domain: muskingum.edu
   ipeds_id: '204264'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13963,7 +13994,7 @@ schools:
   ipeds_id: '127653'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -13975,7 +14006,7 @@ schools:
   ipeds_id: '239424'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13986,7 +14017,7 @@ schools:
   ipeds_id: '147536'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -13997,7 +14028,7 @@ schools:
   ipeds_id: '119605'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14008,7 +14039,7 @@ schools:
   ipeds_id: '147590'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14019,7 +14050,7 @@ schools:
   ipeds_id: '209296'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14030,7 +14061,7 @@ schools:
   ipeds_id: '488721'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14041,7 +14072,7 @@ schools:
   ipeds_id: '187596'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14050,20 +14081,21 @@ schools:
   name: Naval Postgraduate School
   domain: nps.edu
   ipeds_id: '119678'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:29Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://faculty.nps.edu/ncrowe/oldstudents/jshaver_thesis.htm
 - id: navarro-college
   name: Navarro College
   domain: navarrocollege.edu
   ipeds_id: '227146'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14074,7 +14106,7 @@ schools:
   ipeds_id: '127714'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14085,7 +14117,7 @@ schools:
   ipeds_id: '178518'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14108,7 +14140,7 @@ schools:
   ipeds_id: '181419'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14119,7 +14151,7 @@ schools:
   ipeds_id: '181297'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14130,7 +14162,7 @@ schools:
   ipeds_id: '181446'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14141,7 +14173,7 @@ schools:
   ipeds_id: '163532'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14150,31 +14182,33 @@ schools:
   name: Neumann University
   domain: neumann.edu
   ipeds_id: '214272'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:31Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.neumann.edu/hubfs/CDS%202025-26%20Neumann%20University%20(3).pdf?hsLang=en
 - id: nevada-state-university
   name: Nevada State University
   domain: nsc.edu
   ipeds_id: '441900'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:31Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: http://archive.nsc.edu/institutional-research/links-and-resources.aspx
 - id: nevada-system-of-higher-education-system-office
   name: Nevada System of Higher Education-System Office
   domain: nshe.nevada.edu
   ipeds_id: '182519'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14185,7 +14219,7 @@ schools:
   ipeds_id: '185758'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14207,7 +14241,7 @@ schools:
   ipeds_id: '182980'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14218,7 +14252,7 @@ schools:
   ipeds_id: '167093'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14229,7 +14263,7 @@ schools:
   ipeds_id: '217305'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14240,7 +14274,7 @@ schools:
   ipeds_id: '167215'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14251,7 +14285,7 @@ schools:
   ipeds_id: '208725'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14262,7 +14296,7 @@ schools:
   ipeds_id: '185129'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14309,7 +14343,7 @@ schools:
   ipeds_id: '188030'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -14321,7 +14355,7 @@ schools:
   ipeds_id: '159948'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14332,7 +14366,7 @@ schools:
   ipeds_id: '440396'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14343,7 +14377,7 @@ schools:
   ipeds_id: '366368'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14354,7 +14388,7 @@ schools:
   ipeds_id: '418126'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14365,7 +14399,7 @@ schools:
   ipeds_id: '194073'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14376,7 +14410,7 @@ schools:
   ipeds_id: '439783'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14387,7 +14421,7 @@ schools:
   ipeds_id: '194091'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14398,7 +14432,7 @@ schools:
   ipeds_id: '193821'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14409,7 +14443,7 @@ schools:
   ipeds_id: '193830'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14420,7 +14454,7 @@ schools:
   ipeds_id: '194116'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14431,7 +14465,7 @@ schools:
   ipeds_id: '193894'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14442,7 +14476,7 @@ schools:
   ipeds_id: '218414'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14453,7 +14487,7 @@ schools:
   ipeds_id: '155335'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14464,7 +14498,7 @@ schools:
   ipeds_id: '496803'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14475,7 +14509,7 @@ schools:
   ipeds_id: '193973'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14498,7 +14532,7 @@ schools:
   ipeds_id: '167260'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -14510,7 +14544,7 @@ schools:
   ipeds_id: '232937'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14521,7 +14555,7 @@ schools:
   ipeds_id: '461795'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14532,12 +14566,12 @@ schools:
   ipeds_id: '199102'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ncat.edu/provost/ospie/cds_2023-2024_final.pdf
+  discovery_seed_url: https://www.ncat.edu/provost/ospie/common-data-set.php
 - id: north-carolina-central-university
   name: North Carolina Central University
   domain: nccu.edu
@@ -14568,7 +14602,7 @@ schools:
   ipeds_id: '199209'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14602,7 +14636,7 @@ schools:
   ipeds_id: '174437'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14613,19 +14647,19 @@ schools:
   ipeds_id: '200332'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ndsu.edu/fileadmin/oira/Common_Data_Set/CDS_2014-2015Updated.pdf
+  discovery_seed_url: https://www.ndsu.edu/data-services-strategic-analytics/institutional-reports/common-data-set
 - id: north-florida-college
   name: North Florida College
   domain: nfc.edu
   ipeds_id: '136145'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14636,7 +14670,7 @@ schools:
   ipeds_id: '218441'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14647,7 +14681,7 @@ schools:
   ipeds_id: '120023'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14658,7 +14692,7 @@ schools:
   ipeds_id: '147679'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14669,7 +14703,7 @@ schools:
   ipeds_id: '236072'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14680,7 +14714,7 @@ schools:
   ipeds_id: '444130'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14691,7 +14725,7 @@ schools:
   ipeds_id: '193751'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14702,7 +14736,7 @@ schools:
   ipeds_id: '204477'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14713,19 +14747,19 @@ schools:
   ipeds_id: '147776'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.neiu.edu/sites/default/files/inline_files/NEIU%20Common%20Data%20Set%20AY%202020-2021%20Tab%20G.pdf
+  discovery_seed_url: https://www.neiu.edu/about/institutional-research-and-assessment/data-digest/common-data-set
 - id: northeastern-seminary
   name: Northeastern Seminary
   domain: nes.edu
   ipeds_id: '439817'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14736,19 +14770,19 @@ schools:
   ipeds_id: '207263'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://offices.nsuok.edu/_resources/documents/CDS_2022-2023-3.pdf
+  discovery_seed_url: https://offices.nsuok.edu/InstitutionalEffectiveness/Reports.aspx
 - id: northeastern-university-oakland
   name: Northeastern University Oakland
   domain: oakland.northeastern.edu
   ipeds_id: '118888'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14784,7 +14818,7 @@ schools:
   ipeds_id: '147697'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14795,7 +14829,7 @@ schools:
   ipeds_id: '147703'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14830,7 +14864,7 @@ schools:
   ipeds_id: '188058'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14841,7 +14875,7 @@ schools:
   ipeds_id: '219259'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14852,7 +14886,7 @@ schools:
   ipeds_id: '230913'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14875,7 +14909,7 @@ schools:
   ipeds_id: '217606'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14886,7 +14920,7 @@ schools:
   ipeds_id: '240657'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14897,7 +14931,7 @@ schools:
   ipeds_id: '136233'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14908,7 +14942,7 @@ schools:
   ipeds_id: '380377'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14931,7 +14965,7 @@ schools:
   ipeds_id: '142461'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14942,12 +14976,12 @@ schools:
   ipeds_id: '236133'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.northwestu.edu/assets/documents/about/Common_Data_Set_Northwest_University_2022-2023.pdf
+  discovery_seed_url: https://www.northwestu.edu/about/consumer-information
 - id: northwest-university-center-for-online-and-extended
   name: Northwest University-Center for Online and Extended Education
   domain: northwestu.edu
@@ -14967,7 +15001,7 @@ schools:
   ipeds_id: '154101'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14978,7 +15012,7 @@ schools:
   ipeds_id: '174507'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -14989,7 +15023,7 @@ schools:
   ipeds_id: '171483'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15023,7 +15057,7 @@ schools:
   ipeds_id: '171492'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15046,7 +15080,7 @@ schools:
   ipeds_id: '204468'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15057,7 +15091,7 @@ schools:
   ipeds_id: '120184'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15068,7 +15102,7 @@ schools:
   ipeds_id: '163578'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15079,7 +15113,7 @@ schools:
   ipeds_id: '136215'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15090,7 +15124,7 @@ schools:
   ipeds_id: '200086'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15101,7 +15135,7 @@ schools:
   ipeds_id: '174525'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15112,7 +15146,7 @@ schools:
   ipeds_id: '149763'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15123,7 +15157,7 @@ schools:
   ipeds_id: '495059'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15132,20 +15166,21 @@ schools:
   name: Oakland City University
   domain: oak.edu
   ipeds_id: '152099'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:48Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.oak.edu/about/consumer-information/data-and-reports/
 - id: oakland-university
   name: Oakland University
   domain: oakland.edu
   ipeds_id: '171571'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -15157,7 +15192,7 @@ schools:
   ipeds_id: '101912'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15168,7 +15203,7 @@ schools:
   ipeds_id: '227289'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15191,7 +15226,7 @@ schools:
   ipeds_id: '227304'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15202,7 +15237,7 @@ schools:
   ipeds_id: '219277'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15225,7 +15260,7 @@ schools:
   ipeds_id: '201964'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15236,7 +15271,7 @@ schools:
   ipeds_id: '204617'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15259,7 +15294,7 @@ schools:
   ipeds_id: '204671'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15270,7 +15305,7 @@ schools:
   ipeds_id: '204680'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15281,7 +15316,7 @@ schools:
   ipeds_id: '204699'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15292,7 +15327,7 @@ schools:
   ipeds_id: '204705'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15342,7 +15377,7 @@ schools:
   ipeds_id: '204857'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -15393,7 +15428,7 @@ schools:
   ipeds_id: '194189'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15404,7 +15439,7 @@ schools:
   ipeds_id: '207403'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15415,7 +15450,7 @@ schools:
   ipeds_id: '207324'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15426,7 +15461,7 @@ schools:
   ipeds_id: '207458'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15437,7 +15472,7 @@ schools:
   ipeds_id: '207351'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15448,7 +15483,7 @@ schools:
   ipeds_id: '207315'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15459,12 +15494,12 @@ schools:
   ipeds_id: '207564'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://osuit.edu/about/institutional-research/files/cds-2024-ada-compliant.pdf
+  discovery_seed_url: https://osuit.edu/research/common-data-set.php
 - id: oklahoma-state-university-main-campus
   name: Oklahoma State University-Main Campus
   domain: okstate.edu
@@ -15483,7 +15518,7 @@ schools:
   ipeds_id: '207397'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15494,7 +15529,7 @@ schools:
   ipeds_id: '206835'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15517,7 +15552,7 @@ schools:
   ipeds_id: '147828'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15528,7 +15563,7 @@ schools:
   ipeds_id: '236188'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15539,7 +15574,7 @@ schools:
   ipeds_id: '461120'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15550,7 +15585,7 @@ schools:
   ipeds_id: '207582'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -15562,7 +15597,7 @@ schools:
   ipeds_id: '369659'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15595,23 +15630,24 @@ schools:
   name: Oregon State University
   domain: oregonstate.edu
   ipeds_id: '209542'
-  scrape_policy: unknown
+  scrape_policy: active
   notes: Re-added 2026-04-14 after discovering a bad hand-curated Reed College entry
     with the wrong IPEDS ID (209542) had been silently overlaying OSU's IPEDS row
     during build_school_list.py merge, deleting OSU from the corpus. Needs probe.
   probe_state:
-    last_probed_at: '2026-04-14T14:34:16Z'
-    last_result: not_found
-    last_method: pattern
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
+    last_method: brave
     patterns_tried: 105
     search_fallback_tried: false
+  discovery_seed_url: https://institutionalresearch.oregonstate.edu/common-data-set
 - id: oregon-state-university-cascades-campus
   name: Oregon State University-Cascades Campus
   domain: osucascades.edu
   ipeds_id: '440828'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15634,7 +15670,7 @@ schools:
   ipeds_id: '155636'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15645,7 +15681,7 @@ schools:
   ipeds_id: '428259'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15656,7 +15692,7 @@ schools:
   ipeds_id: '454582'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15667,7 +15703,7 @@ schools:
   ipeds_id: '155627'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15678,7 +15714,7 @@ schools:
   ipeds_id: '464226'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15689,7 +15725,7 @@ schools:
   ipeds_id: '204936'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15700,7 +15736,7 @@ schools:
   ipeds_id: '107512'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15711,7 +15747,7 @@ schools:
   ipeds_id: '227331'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15722,7 +15758,7 @@ schools:
   ipeds_id: '178679'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15733,7 +15769,7 @@ schools:
   ipeds_id: '177472'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15744,19 +15780,19 @@ schools:
   ipeds_id: '194310'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:20:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.pace.edu/sites/default/files/files/strategic-initiatives/pace-university-2016-2017-common-data-set.pdf
+  discovery_seed_url: https://www.pace.edu/opair/university-facts-and-figures
 - id: pacific-bible-college
   name: Pacific Bible College
   domain: pacificbible.edu
   ipeds_id: '407610'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15792,7 +15828,7 @@ schools:
   ipeds_id: '455406'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15803,7 +15839,7 @@ schools:
   ipeds_id: '120768'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15814,7 +15850,7 @@ schools:
   ipeds_id: '457484'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15825,7 +15861,7 @@ schools:
   ipeds_id: '120795'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15836,7 +15872,7 @@ schools:
   ipeds_id: '120838'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:20:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15870,7 +15906,7 @@ schools:
   ipeds_id: '140720'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15893,7 +15929,7 @@ schools:
   ipeds_id: '136358'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15904,7 +15940,7 @@ schools:
   ipeds_id: '154174'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15915,7 +15951,7 @@ schools:
   ipeds_id: '120698'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15926,7 +15962,7 @@ schools:
   ipeds_id: '364016'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15937,7 +15973,7 @@ schools:
   ipeds_id: '121628'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15948,7 +15984,7 @@ schools:
   ipeds_id: '178721'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15959,7 +15995,7 @@ schools:
   ipeds_id: '243823'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15970,7 +16006,7 @@ schools:
   ipeds_id: '136400'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15981,7 +16017,7 @@ schools:
   ipeds_id: '495916'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -15992,7 +16028,7 @@ schools:
   ipeds_id: '498243'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16003,7 +16039,7 @@ schools:
   ipeds_id: '451927'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16014,7 +16050,7 @@ schools:
   ipeds_id: '227429'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16025,7 +16061,7 @@ schools:
   ipeds_id: '194392'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16036,7 +16072,7 @@ schools:
   ipeds_id: '204990'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16047,7 +16083,7 @@ schools:
   ipeds_id: '214883'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16058,7 +16094,7 @@ schools:
   ipeds_id: '236258'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16069,7 +16105,7 @@ schools:
   ipeds_id: '214971'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16080,7 +16116,7 @@ schools:
   ipeds_id: '215053'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16089,20 +16125,21 @@ schools:
   name: Saint Joseph's University - Lancaster
   domain: sju.edu
   ipeds_id: '442356'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:04Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://sites.sju.edu/academicadmin/files/2017/01/SJU-Common-Data-Set-2015-2016-Part-One.pdf
 - id: pennsylvania-college-of-technology
   name: Pennsylvania College of Technology
   domain: pct.edu
   ipeds_id: '366252'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16113,7 +16150,7 @@ schools:
   ipeds_id: '214582'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16124,7 +16161,7 @@ schools:
   ipeds_id: '214661'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16135,7 +16172,7 @@ schools:
   ipeds_id: '214801'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16146,7 +16183,7 @@ schools:
   ipeds_id: '214689'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16157,7 +16194,7 @@ schools:
   ipeds_id: '214698'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16168,7 +16205,7 @@ schools:
   ipeds_id: '214704'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16179,7 +16216,7 @@ schools:
   ipeds_id: '214731'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16190,7 +16227,7 @@ schools:
   ipeds_id: '214740'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16201,7 +16238,7 @@ schools:
   ipeds_id: '214591'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16212,7 +16249,7 @@ schools:
   ipeds_id: '214759'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16223,7 +16260,7 @@ schools:
   ipeds_id: '214607'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16234,7 +16271,7 @@ schools:
   ipeds_id: '214786'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16245,7 +16282,7 @@ schools:
   ipeds_id: '214713'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16256,7 +16293,7 @@ schools:
   ipeds_id: '214768'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16267,7 +16304,7 @@ schools:
   ipeds_id: '214670'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16278,7 +16315,7 @@ schools:
   ipeds_id: '214795'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16289,7 +16326,7 @@ schools:
   ipeds_id: '214625'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16300,7 +16337,7 @@ schools:
   ipeds_id: '214810'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16311,7 +16348,7 @@ schools:
   ipeds_id: '214652'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16322,7 +16359,7 @@ schools:
   ipeds_id: '214634'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16333,7 +16370,7 @@ schools:
   ipeds_id: '214643'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16344,7 +16381,7 @@ schools:
   ipeds_id: '214829'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16355,7 +16392,7 @@ schools:
   ipeds_id: '479956'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16366,7 +16403,7 @@ schools:
   ipeds_id: '498571'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16377,7 +16414,7 @@ schools:
   ipeds_id: '136473'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16388,7 +16425,7 @@ schools:
   ipeds_id: '219842'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16423,7 +16460,7 @@ schools:
   ipeds_id: '199306'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16434,7 +16471,7 @@ schools:
   ipeds_id: '215123'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16445,7 +16482,7 @@ schools:
   ipeds_id: '107600'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16456,7 +16493,7 @@ schools:
   ipeds_id: '414966'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16467,7 +16504,7 @@ schools:
   ipeds_id: '381459'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16478,7 +16515,7 @@ schools:
   ipeds_id: '140818'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16489,7 +16526,7 @@ schools:
   ipeds_id: '235237'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16511,7 +16548,7 @@ schools:
   ipeds_id: '440794'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16534,7 +16571,7 @@ schools:
   ipeds_id: '215415'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16545,7 +16582,7 @@ schools:
   ipeds_id: '215424'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16568,12 +16605,12 @@ schools:
   ipeds_id: '183080'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
-    last_method: brave
+    last_method: pattern
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.plymouth.edu/sites/default/files/media/2023-01/common-data-set-2016-2017.pdf
+  discovery_seed_url: https://plymouth.edu/institutional-effectiveness/common-data-set/
 - id: point-loma-nazarene-university
   name: Point Loma Nazarene University
   domain: pointloma.edu
@@ -16604,7 +16641,7 @@ schools:
   ipeds_id: '138868'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16615,7 +16652,7 @@ schools:
   ipeds_id: '136516'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16660,7 +16697,7 @@ schools:
   ipeds_id: '498289'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16671,7 +16708,7 @@ schools:
   ipeds_id: '205027'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16683,7 +16720,7 @@ schools:
   ipeds_id: '131405'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16694,7 +16731,7 @@ schools:
   ipeds_id: '455813'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16705,7 +16742,7 @@ schools:
   ipeds_id: '167464'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16716,19 +16753,19 @@ schools:
   ipeds_id: '209807'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.pdx.edu/research-planning/sites/researchplanning.web.wdt.pdx.edu/files/2024-05/CDS_2023-2024%20(Updated%205-8-24%20AM).pdf
+  discovery_seed_url: https://www.pdx.edu/research-planning/common-data-set-archive
 - id: potomac-state-college-of-west-virginia-university
   name: Potomac State College of West Virginia University
   domain: potomacstatecollege.edu
   ipeds_id: '237701'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16751,19 +16788,19 @@ schools:
   ipeds_id: '194578'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.pratt.edu/wp-content/uploads/2023/05/CDS_2022-2023_Pratt.pdf
+  discovery_seed_url: https://www.pratt.edu/administrative-departments/office-of-the-provost/office-of-institutional-research-and-assessment/institute-and-ipeds-reports/
 - id: presbyterian-college
   name: Presbyterian College
   domain: presby.edu
   ipeds_id: '218539'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -16775,7 +16812,7 @@ schools:
   ipeds_id: '490045'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16786,7 +16823,7 @@ schools:
   ipeds_id: '105589'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16797,7 +16834,7 @@ schools:
   ipeds_id: '219295'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16808,7 +16845,7 @@ schools:
   ipeds_id: '486433'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16819,7 +16856,7 @@ schools:
   ipeds_id: '186122'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16828,20 +16865,21 @@ schools:
   name: Principia College
   domain: principiacollege.edu
   ipeds_id: '148016'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:17Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.principiacollege.edu/about/consumer-information/common-data-set
 - id: providence-christian-college
   name: Providence Christian College
   domain: providencecc.edu
   ipeds_id: '455770'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16862,20 +16900,21 @@ schools:
   name: Pueblo Community College
   domain: pueblocc.edu
   ipeds_id: '127884'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:18Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://pueblocc.edu/sites/default/files/2022-02/CDS-PCC-2020-2021.pdf
 - id: purdue-university-fort-wayne
   name: Purdue University Fort Wayne
   domain: pfw.edu
   ipeds_id: '151102'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -16887,7 +16926,7 @@ schools:
   ipeds_id: '489779'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16910,19 +16949,19 @@ schools:
   ipeds_id: '199412'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.queens.edu/president/wp-content/uploads/sites/18/2024/04/Fall-2023-CDSa.pdf
+  discovery_seed_url: https://www.queens.edu/president/visualizing-queens-data/
 - id: quincy-college
   name: Quincy College
   domain: quincycollege.edu
   ipeds_id: '167525'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16957,7 +16996,7 @@ schools:
   ipeds_id: '384421'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16968,7 +17007,7 @@ schools:
   ipeds_id: '194657'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16979,7 +17018,7 @@ schools:
   ipeds_id: '194693'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -16990,7 +17029,7 @@ schools:
   ipeds_id: '194666'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17001,7 +17040,7 @@ schools:
   ipeds_id: '186186'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17012,7 +17051,7 @@ schools:
   ipeds_id: '194736'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17023,7 +17062,7 @@ schools:
   ipeds_id: '405854'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17034,7 +17073,7 @@ schools:
   ipeds_id: '484871'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17045,7 +17084,7 @@ schools:
   ipeds_id: '205124'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17056,7 +17095,7 @@ schools:
   ipeds_id: '194718'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17067,7 +17106,7 @@ schools:
   ipeds_id: '194763'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17102,7 +17141,7 @@ schools:
   ipeds_id: '438665'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17113,7 +17152,7 @@ schools:
   ipeds_id: '207157'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17146,7 +17185,7 @@ schools:
   ipeds_id: '178891'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17157,7 +17196,7 @@ schools:
   ipeds_id: '497480'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17168,7 +17207,7 @@ schools:
   ipeds_id: '215619'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17191,7 +17230,7 @@ schools:
   ipeds_id: '497462'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17214,7 +17253,7 @@ schools:
   ipeds_id: '490230'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17225,7 +17264,7 @@ schools:
   ipeds_id: '231651'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -17237,7 +17276,7 @@ schools:
   ipeds_id: '167598'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17272,7 +17311,7 @@ schools:
   ipeds_id: '492209'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17283,7 +17322,7 @@ schools:
   ipeds_id: '475033'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17294,7 +17333,7 @@ schools:
   ipeds_id: '223463'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17305,7 +17344,7 @@ schools:
   ipeds_id: '497000'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17316,7 +17355,7 @@ schools:
   ipeds_id: '451866'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17327,7 +17366,7 @@ schools:
   ipeds_id: '129428'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17338,7 +17377,7 @@ schools:
   ipeds_id: '236382'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17361,7 +17400,7 @@ schools:
   ipeds_id: '217493'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17384,7 +17423,7 @@ schools:
   ipeds_id: '441104'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17395,7 +17434,7 @@ schools:
   ipeds_id: '186283'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17406,7 +17445,7 @@ schools:
   ipeds_id: '136774'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17417,7 +17456,7 @@ schools:
   ipeds_id: '121886'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17428,7 +17467,7 @@ schools:
   ipeds_id: '105668'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17439,7 +17478,7 @@ schools:
   ipeds_id: '239628'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17450,7 +17489,7 @@ schools:
   ipeds_id: '233408'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17461,7 +17500,7 @@ schools:
   ipeds_id: '183211'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17472,7 +17511,7 @@ schools:
   ipeds_id: '233426'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17483,7 +17522,7 @@ schools:
   ipeds_id: '215655'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17517,7 +17556,7 @@ schools:
   ipeds_id: '170967'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17528,7 +17567,7 @@ schools:
   ipeds_id: '148405'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17539,7 +17578,7 @@ schools:
   ipeds_id: '179043'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17562,7 +17601,7 @@ schools:
   ipeds_id: '217518'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17573,7 +17612,7 @@ schools:
   ipeds_id: '409616'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17608,7 +17647,7 @@ schools:
   ipeds_id: '148487'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17619,7 +17658,7 @@ schools:
   ipeds_id: '145558'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17642,7 +17681,7 @@ schools:
   ipeds_id: '445735'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17677,7 +17716,7 @@ schools:
   ipeds_id: '148511'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17688,7 +17727,7 @@ schools:
   ipeds_id: '195128'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17699,7 +17738,7 @@ schools:
   ipeds_id: '176318'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17710,7 +17749,7 @@ schools:
   ipeds_id: '186371'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17721,7 +17760,7 @@ schools:
   ipeds_id: '186399'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17732,7 +17771,7 @@ schools:
   ipeds_id: '172033'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17743,7 +17782,7 @@ schools:
   ipeds_id: '239637'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17754,7 +17793,7 @@ schools:
   ipeds_id: '130253'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17777,31 +17816,31 @@ schools:
   ipeds_id: '154235'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://sau.edu/media/content-assets/pdfs/consumer-information/SAU-Common-Data-Set-2023-24.pdf
+  discovery_seed_url: https://sau.edu/consumer-information/
 - id: saint-anselm-college
   name: Saint Anselm College
   domain: anselm.edu
   ipeds_id: '183239'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.anselm.edu/sites/default/files/Documents/Institutional%20Research/CDS_2020-2021-Complete.pdf
+  discovery_seed_url: https://www.anselm.edu/about/offices-centers-institutes/academic-affairs/institutional-research/common-data-set
 - id: saint-anthony-college-of-nursing
   name: Saint Anthony College of Nursing
   domain: sacn.edu
   ipeds_id: '149028'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17823,7 +17862,7 @@ schools:
   ipeds_id: '216047'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17846,7 +17885,7 @@ schools:
   ipeds_id: '227845'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17857,7 +17896,7 @@ schools:
   ipeds_id: '186618'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17868,7 +17907,7 @@ schools:
   ipeds_id: '148575'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17879,7 +17918,7 @@ schools:
   ipeds_id: '215743'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17890,7 +17929,7 @@ schools:
   ipeds_id: '167677'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17901,7 +17940,7 @@ schools:
   ipeds_id: '137281'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17923,7 +17962,7 @@ schools:
   ipeds_id: '160409'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17934,7 +17973,7 @@ schools:
   ipeds_id: '161518'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17945,7 +17984,7 @@ schools:
   ipeds_id: '215770'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -17957,7 +17996,7 @@ schools:
   ipeds_id: '137032'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -17968,7 +18007,7 @@ schools:
   ipeds_id: '179308'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18003,12 +18042,12 @@ schools:
   ipeds_id: '152390'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.saintmarys.edu/files/2024/04/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.saintmarys.edu/institutional-research/ir/common-data
 - id: saint-marys-college-of-california
   name: Saint Mary's College of California
   domain: stmarys-ca.edu
@@ -18027,7 +18066,7 @@ schools:
   ipeds_id: '174817'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -18039,7 +18078,7 @@ schools:
   ipeds_id: '152381'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18050,7 +18089,7 @@ schools:
   ipeds_id: '152451'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18061,12 +18100,12 @@ schools:
   ipeds_id: '231059'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.smcvt.edu/wp-content/uploads/2022/05/CDS_2021-2022_SMC-pub20220517.pdf
+  discovery_seed_url: https://www.smcvt.edu/offices-and-services/institutional-research/
 - id: saint-norbert-college
   name: Saint Norbert College
   domain: snc.edu
@@ -18085,7 +18124,7 @@ schools:
   ipeds_id: '179317'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18096,7 +18135,7 @@ schools:
   ipeds_id: '186432'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18119,7 +18158,7 @@ schools:
   ipeds_id: '136701'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18130,7 +18169,7 @@ schools:
   ipeds_id: '215813'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18141,7 +18180,7 @@ schools:
   ipeds_id: '195580'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18152,7 +18191,7 @@ schools:
   ipeds_id: '148627'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18163,7 +18202,7 @@ schools:
   ipeds_id: '199607'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18174,12 +18213,12 @@ schools:
   ipeds_id: '167729'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://records.salemstate.edu/sites/default/files/reports/2024-04/CDS_2023-2024.pdf
+  discovery_seed_url: https://records.salemstate.edu/reports/common-data-sets
 - id: salisbury-university
   name: Salisbury University
   domain: salisbury.edu
@@ -18198,7 +18237,7 @@ schools:
   ipeds_id: '180647'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18209,7 +18248,7 @@ schools:
   ipeds_id: '214564'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18220,7 +18259,7 @@ schools:
   ipeds_id: '217536'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18231,31 +18270,31 @@ schools:
   ipeds_id: '227881'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.shsu.edu/dept/institutional-research/documents/cds/CDS_2023_2024_FINAL-20240820.pdf
+  discovery_seed_url: https://www.shsu.edu/dept/data/publications.html
 - id: samford-university
   name: Samford University
   domain: samford.edu
   ipeds_id: '102049'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.samford.edu/departments/files/Institutional_Effectiveness/2022-2023/Section-C-First-Time-First-Year-Admission.pdf
+  discovery_seed_url: https://www.samford.edu/departments/institutional-effectiveness/facts-and-stats
 - id: samuel-merritt-university
   name: Samuel Merritt University
   domain: samuelmerritt.edu
   ipeds_id: '122296'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18266,7 +18305,7 @@ schools:
   ipeds_id: '227924'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18277,7 +18316,7 @@ schools:
   ipeds_id: '112084'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18288,7 +18327,7 @@ schools:
   ipeds_id: '122320'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18299,7 +18338,7 @@ schools:
   ipeds_id: '122375'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18322,7 +18361,7 @@ schools:
   ipeds_id: '120166'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18333,7 +18372,7 @@ schools:
   ipeds_id: '122506'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -18355,20 +18394,21 @@ schools:
   name: San Jacinto Community College
   domain: sanjac.edu
   ipeds_id: '227979'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:45Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.sanjac.edu/sites/default/files/inline-files/San%20Jacinto%20College%20CDS_2017-2018.pdf
 - id: san-joaquin-college-of-law
   name: San Joaquin College of Law
   domain: sjcl.edu
   ipeds_id: '122649'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18391,7 +18431,7 @@ schools:
   ipeds_id: '122782'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18402,7 +18442,7 @@ schools:
   ipeds_id: '481535'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18413,7 +18453,7 @@ schools:
   ipeds_id: '121619'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18436,7 +18476,7 @@ schools:
   ipeds_id: '137096'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18447,7 +18487,7 @@ schools:
   ipeds_id: '122977'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18470,7 +18510,7 @@ schools:
   ipeds_id: '494542'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18481,7 +18521,7 @@ schools:
   ipeds_id: '140951'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18490,20 +18530,21 @@ schools:
   name: Savannah State University
   domain: savannahstate.edu
   ipeds_id: '140960'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:47Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.savannahstate.edu/irp/consumer-information.shtml
 - id: saybrook-university
   name: Saybrook University
   domain: saybrook.edu
   ipeds_id: '123095'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18514,7 +18555,7 @@ schools:
   ipeds_id: '143048'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18525,7 +18566,7 @@ schools:
   ipeds_id: '172200'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18536,7 +18577,7 @@ schools:
   ipeds_id: '228042'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18559,7 +18600,7 @@ schools:
   ipeds_id: '236513'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18570,7 +18611,7 @@ schools:
   ipeds_id: '439914'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18581,12 +18622,12 @@ schools:
   ipeds_id: '236577'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://spu.edu/depts/idm/docs/2016-2017/CDS2016_2017F.pdf
+  discovery_seed_url: https://spu.edu/-/media/administration/office-of-institutional-effectiveness/docs/SPU-CDS-2024-2025-finalv2.ashx
 - id: seattle-university
   name: Seattle University
   domain: seattleu.edu
@@ -18605,7 +18646,7 @@ schools:
   ipeds_id: '102058'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18616,7 +18657,7 @@ schools:
   ipeds_id: '137209'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18627,7 +18668,7 @@ schools:
   ipeds_id: '232885'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18638,19 +18679,19 @@ schools:
   ipeds_id: '186584'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.shu.edu/documents/2004-05-20Common-20Data-20Set-20for-20Seton-20Hall-20University-20-FINAL.pdf
+  discovery_seed_url: https://www.shu.edu/institutional-research/reports.html
 - id: seton-hill-university
   name: Seton Hill University
   domain: setonhill.edu
   ipeds_id: '215947'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18661,7 +18702,7 @@ schools:
   ipeds_id: '195438'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18672,7 +18713,7 @@ schools:
   ipeds_id: '123280'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18683,7 +18724,7 @@ schools:
   ipeds_id: '123299'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18694,7 +18735,7 @@ schools:
   ipeds_id: '199643'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18705,7 +18746,7 @@ schools:
   ipeds_id: '205443'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18740,7 +18781,7 @@ schools:
   ipeds_id: '461485'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18751,7 +18792,7 @@ schools:
   ipeds_id: '218751'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18774,7 +18815,7 @@ schools:
   ipeds_id: '140988'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18785,19 +18826,19 @@ schools:
   ipeds_id: '195474'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.siena.edu/files/resources/siena_college_cds_2022-2023_final.pdf
+  discovery_seed_url: https://www.siena.edu/offices/oie/institutional-research/common-data-set/
 - id: siena-heights-university
   name: Siena Heights University
   domain: sienaheights.edu
   ipeds_id: '172264'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18808,7 +18849,7 @@ schools:
   ipeds_id: '461759'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18831,7 +18872,7 @@ schools:
   ipeds_id: '154350'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18842,19 +18883,19 @@ schools:
   ipeds_id: '123457'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://simpsonu.edu/wp-content/uploads/2024/04/Common-Data-Set-22-23-Read-Only.pdf
+  discovery_seed_url: https://simpsonu.edu/Pages/Academics/Institutional-Research/index.htm
 - id: sinclair-community-college
   name: Sinclair Community College
   domain: sinclair.edu
   ipeds_id: '205470'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18865,7 +18906,7 @@ schools:
   ipeds_id: '219374'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18876,7 +18917,7 @@ schools:
   ipeds_id: '219408'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18887,7 +18928,7 @@ schools:
   ipeds_id: '231068'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18898,7 +18939,7 @@ schools:
   ipeds_id: '200466'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18909,7 +18950,7 @@ schools:
   ipeds_id: '236638'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18932,7 +18973,7 @@ schools:
   ipeds_id: '123509'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18943,12 +18984,12 @@ schools:
   ipeds_id: '216038'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.sru.edu/documents/offices/analytics-decision-support/CDS_2021-2022.pdf
+  discovery_seed_url: https://www.sru.edu/offices/analytics-and-decision-support/reports
 - id: smith-college
   name: Smith College
   domain: smith.edu
@@ -18967,7 +19008,7 @@ schools:
   ipeds_id: '230597'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -18990,7 +19031,7 @@ schools:
   ipeds_id: '123563'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19013,7 +19054,7 @@ schools:
   ipeds_id: '420246'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19024,7 +19065,7 @@ schools:
   ipeds_id: '123633'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19047,7 +19088,7 @@ schools:
   ipeds_id: '219347'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19058,19 +19099,19 @@ schools:
   ipeds_id: '219356'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:21:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.sdstate.edu/sites/default/files/file-archive/2022-12/South%20Dakota%20State%20University%20-%20Common%20Data%20Set%20(2021-2022).pdf
+  discovery_seed_url: https://www.sdstate.edu/office-institutional-research-assessment/institutional-data
 - id: south-florida-bible-college-and-theological-seminary
   name: South Florida Bible College and Theological Seminary
   domain: sfbc.edu
   ipeds_id: '366003'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19081,7 +19122,7 @@ schools:
   ipeds_id: '137315'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19092,7 +19133,7 @@ schools:
   ipeds_id: '482699'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19103,7 +19144,7 @@ schools:
   ipeds_id: '236504'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19114,7 +19155,7 @@ schools:
   ipeds_id: '409315'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:21:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19125,7 +19166,7 @@ schools:
   ipeds_id: '228194'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19136,7 +19177,7 @@ schools:
   ipeds_id: '417734'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19147,19 +19188,19 @@ schools:
   ipeds_id: '179557'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://semo.edu/institutional-research/_pdfs/cds-2021-2022.pdf
+  discovery_seed_url: https://semo.edu/institutional-research/data-reports
 - id: southeastern-baptist-college
   name: Southeastern Baptist College
   domain: southeasternbaptist.edu
   ipeds_id: '176336'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19170,7 +19211,7 @@ schools:
   ipeds_id: '199759'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19181,7 +19222,7 @@ schools:
   ipeds_id: '233602'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19216,19 +19257,19 @@ schools:
   ipeds_id: '137564'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://sfnet.seu.edu/docs/research_retention/common_data_set_2008_2009.pdf
+  discovery_seed_url: https://seu.edu/about/information-management-digital-learning/data-analytics/
 - id: southern-adventist-university
   name: Southern Adventist University
   domain: southern.edu
   ipeds_id: '221661'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19239,7 +19280,7 @@ schools:
   ipeds_id: '107983'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19250,7 +19291,7 @@ schools:
   ipeds_id: '123952'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19261,7 +19302,7 @@ schools:
   ipeds_id: '117575'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19272,7 +19313,7 @@ schools:
   ipeds_id: '117672'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19283,7 +19324,7 @@ schools:
   ipeds_id: '221670'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19306,7 +19347,7 @@ schools:
   ipeds_id: '149222'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -19318,7 +19359,7 @@ schools:
   ipeds_id: '149231'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19329,7 +19370,7 @@ schools:
   ipeds_id: '149240'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19352,7 +19393,7 @@ schools:
   ipeds_id: '206862'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19363,7 +19404,7 @@ schools:
   ipeds_id: '183026'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19386,7 +19427,7 @@ schools:
   ipeds_id: '160621'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19397,7 +19438,7 @@ schools:
   ipeds_id: '160630'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19408,7 +19449,7 @@ schools:
   ipeds_id: '440916'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19419,7 +19460,7 @@ schools:
   ipeds_id: '160533'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19430,19 +19471,19 @@ schools:
   ipeds_id: '230603'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.suu.edu/ir/pdf/CDS9900.PDF
+  discovery_seed_url: https://www.suu.edu/ir/reports/cds.html
 - id: southern-virginia-university
   name: Southern Virginia University
   domain: svu.edu
   ipeds_id: '233611'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19465,7 +19506,7 @@ schools:
   ipeds_id: '179326'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19476,7 +19517,7 @@ schools:
   ipeds_id: '175078'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19487,7 +19528,7 @@ schools:
   ipeds_id: '228468'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19498,7 +19539,7 @@ schools:
   ipeds_id: '228325'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19509,7 +19550,7 @@ schools:
   ipeds_id: '228486'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19520,7 +19561,7 @@ schools:
   ipeds_id: '207856'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19531,7 +19572,7 @@ schools:
   ipeds_id: '155900'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19542,7 +19583,7 @@ schools:
   ipeds_id: '188207'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19553,7 +19594,7 @@ schools:
   ipeds_id: '123970'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19588,7 +19629,7 @@ schools:
   ipeds_id: '157757'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19599,7 +19640,7 @@ schools:
   ipeds_id: '218821'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19622,7 +19663,7 @@ schools:
   ipeds_id: '148982'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19633,7 +19674,7 @@ schools:
   ipeds_id: '236692'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19644,7 +19685,7 @@ schools:
   ipeds_id: '236708'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19667,7 +19708,7 @@ schools:
   ipeds_id: '102234'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19703,7 +19744,7 @@ schools:
   ipeds_id: '195155'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19714,7 +19755,7 @@ schools:
   ipeds_id: '195164'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19725,7 +19766,7 @@ schools:
   ipeds_id: '175005'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19748,7 +19789,7 @@ schools:
   ipeds_id: '154262'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19783,7 +19824,7 @@ schools:
   ipeds_id: '199698'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19794,7 +19835,7 @@ schools:
   ipeds_id: '148876'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19805,7 +19846,7 @@ schools:
   ipeds_id: '195173'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19828,7 +19869,7 @@ schools:
   ipeds_id: '137272'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19839,7 +19880,7 @@ schools:
   ipeds_id: '163976'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19850,7 +19891,7 @@ schools:
   ipeds_id: '245652'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19861,7 +19902,7 @@ schools:
   ipeds_id: '148593'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19872,19 +19913,19 @@ schools:
   ipeds_id: '195809'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.stjohns.edu/sites/default/files/2019-02/cds_2013-2014.pdf
+  discovery_seed_url: https://www.stjohns.edu/who-we-are/leadership-and-administration/administrative-offices/office-provost/institutional-research/tools-and-resources
 - id: st-josephs-university-new-york
   name: St. Joseph's University-New York
   domain: sjny.edu
   ipeds_id: '195544'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19943,7 +19984,7 @@ schools:
   ipeds_id: '123916'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -19952,13 +19993,14 @@ schools:
   name: State College of Florida-Manatee-Sarasota
   domain: scf.edu
   ipeds_id: '135391'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:14Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.scf.edu/administration/departments/institutional-effectiveness/institutional-effectiveness-research/
 - id: state-university-of-new-york-at-cortland
   name: State University of New York at Cortland
   domain: www2.cortland.edu
@@ -20013,7 +20055,7 @@ schools:
   ipeds_id: '179548'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20024,7 +20066,7 @@ schools:
   ipeds_id: '155937'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20035,7 +20077,7 @@ schools:
   ipeds_id: '231095'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20070,7 +20112,7 @@ schools:
   ipeds_id: '164173'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20081,7 +20123,7 @@ schools:
   ipeds_id: '102270'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20092,7 +20134,7 @@ schools:
   ipeds_id: '186876'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -20104,7 +20146,7 @@ schools:
   ipeds_id: '366340'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20139,7 +20181,7 @@ schools:
   ipeds_id: '228501'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20150,7 +20192,7 @@ schools:
   ipeds_id: '447953'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20161,7 +20203,7 @@ schools:
   ipeds_id: '181543'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20196,19 +20238,19 @@ schools:
   ipeds_id: '196121'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.brockport.edu/support/research_analysis/docs/research_pdfs/cds_2018_19.pdf
+  discovery_seed_url: https://www.brockport.edu/support/research-analysis/data-reports/common-set/
 - id: suny-buffalo-state-university
   name: SUNY Buffalo State University
   domain: suny.buffalostate.edu
   ipeds_id: '196130'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20243,43 +20285,43 @@ schools:
   ipeds_id: '196200'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.potsdam.edu/sites/default/files/inline-files/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.potsdam.edu/about/administrative-offices/office-institutional-effectiveness/campus-statistics/common-data-set-cds
 - id: suny-college-of-agriculture-and-technology-at-cobleskill
   name: SUNY College of Agriculture and Technology at Cobleskill
   domain: cobleskill.edu
   ipeds_id: '196033'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.cobleskill.edu/about/institutional-research/pdfs/Common%20Data%20Set%202021-2022.pdf
+  discovery_seed_url: https://cobleskill.edu/sitemap.xml
 - id: suny-college-of-environmental-science-and-forestry
   name: SUNY College of Environmental Science and Forestry
   domain: esf.edu
   ipeds_id: '196103'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.esf.edu/institutional-research/documents/ESFCDS-2017-18.pdf
+  discovery_seed_url: https://www.esf.edu/institutional-research/institutional-data.php
 - id: suny-college-of-optometry
   name: SUNY College of Optometry
   domain: sunyopt.edu
   ipeds_id: '196228'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20290,7 +20332,7 @@ schools:
   ipeds_id: '196006'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20301,19 +20343,19 @@ schools:
   ipeds_id: '196015'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.canton.edu/media/ir/CDS2018-2019.pdf
+  discovery_seed_url: https://www.canton.edu/research/cds.html
 - id: suny-college-of-technology-at-delhi
   name: SUNY College of Technology at Delhi
   domain: delhi.edu
   ipeds_id: '196024'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -20325,7 +20367,7 @@ schools:
   ipeds_id: '196255'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20336,7 +20378,7 @@ schools:
   ipeds_id: '196291'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20347,7 +20389,7 @@ schools:
   ipeds_id: '196051'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20358,7 +20400,7 @@ schools:
   ipeds_id: '196237'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20381,7 +20423,7 @@ schools:
   ipeds_id: '196112'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20392,7 +20434,7 @@ schools:
   ipeds_id: '195827'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20427,7 +20469,7 @@ schools:
   ipeds_id: '196413'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20449,7 +20491,7 @@ schools:
   ipeds_id: '236753'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20471,7 +20513,7 @@ schools:
   ipeds_id: '137759'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20482,7 +20524,7 @@ schools:
   ipeds_id: '137777'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20493,7 +20535,7 @@ schools:
   ipeds_id: '186900'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20504,7 +20546,7 @@ schools:
   ipeds_id: '196440'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20515,7 +20557,7 @@ schools:
   ipeds_id: '451404'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20526,7 +20568,7 @@ schools:
   ipeds_id: '196431'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20537,7 +20579,7 @@ schools:
   ipeds_id: '216311'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20560,7 +20602,7 @@ schools:
   ipeds_id: '152530'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -20572,7 +20614,7 @@ schools:
   ipeds_id: '196468'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20583,7 +20625,7 @@ schools:
   ipeds_id: '488800'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20594,7 +20636,7 @@ schools:
   ipeds_id: '149329'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20617,12 +20659,12 @@ schools:
   ipeds_id: '221847'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.tntech.edu/iare/pdf/institutional_research/CDS_22_23.pdf
+  discovery_seed_url: https://www.tntech.edu/iare/institutional_research/specialized_reports.php
 - id: tennessee-wesleyan-university
   name: Tennessee Wesleyan University
   domain: tnwesleyan.edu
@@ -20641,7 +20683,7 @@ schools:
   ipeds_id: '226152'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20664,31 +20706,31 @@ schools:
   ipeds_id: '224147'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.tamucc.edu/president/pir/cds_files/cds_2021-20221.pdf
+  discovery_seed_url: https://www.tamucc.edu/president/pir/common_data_set.php
 - id: texas-a-and-m-university-kingsville
   name: Texas A & M University-Kingsville
   domain: tamuk.edu
   ipeds_id: '228705'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.tamuk.edu/pes/_files_oir/CDS_reports/CDS_2022-2023.pdf
+  discovery_seed_url: https://www.tamuk.edu/pes/institutional-data/CDS-reporting.html
 - id: texas-a-and-m-university-system-office
   name: Texas A & M University-System Office
   domain: tamus.edu
   ipeds_id: '228732'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20734,7 +20776,7 @@ schools:
   ipeds_id: '228866'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20757,7 +20799,7 @@ schools:
   ipeds_id: '228884'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20766,20 +20808,21 @@ schools:
   name: Texas Lutheran University
   domain: tlu.edu
   ipeds_id: '228981'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:29Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://my.tlu.edu/ICS/icsfs/mm/cds_2019-2020.pdf?target=131fce79-e134-4490-af76-8300d47bef53
 - id: texas-southern-university
   name: Texas Southern University
   domain: tsu.edu
   ipeds_id: '229063'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20814,7 +20857,7 @@ schools:
   ipeds_id: '229337'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20825,7 +20868,7 @@ schools:
   ipeds_id: '492689'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20836,7 +20879,7 @@ schools:
   ipeds_id: '439154'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20883,7 +20926,7 @@ schools:
   ipeds_id: '455433'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20894,7 +20937,7 @@ schools:
   ipeds_id: '143978'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20905,7 +20948,7 @@ schools:
   ipeds_id: '492607'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20916,7 +20959,7 @@ schools:
   ipeds_id: '455664'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20927,7 +20970,7 @@ schools:
   ipeds_id: '491190'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20938,7 +20981,7 @@ schools:
   ipeds_id: '459745'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20949,7 +20992,7 @@ schools:
   ipeds_id: '487153'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20960,7 +21003,7 @@ schools:
   ipeds_id: '201821'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -20971,12 +21014,12 @@ schools:
   ipeds_id: '142294'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://collegeofidaho.edu/wp-content/uploads/2025/10/CDS_2023-2024.pdf
+  discovery_seed_url: https://www.collegeofidaho.edu/about/offices/institutional-research/data-colleges-have-common
 - id: the-college-of-new-jersey
   name: The College of New Jersey
   domain: tcnj.edu
@@ -20995,7 +21038,7 @@ schools:
   ipeds_id: '195234'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21017,7 +21060,7 @@ schools:
   ipeds_id: '133960'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21040,7 +21083,7 @@ schools:
   ipeds_id: '475228'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21051,7 +21094,7 @@ schools:
   ipeds_id: '125037'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21073,7 +21116,7 @@ schools:
   ipeds_id: '190372'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21096,7 +21139,7 @@ schools:
   ipeds_id: '192110'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21107,7 +21150,7 @@ schools:
   ipeds_id: '454184'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21118,7 +21161,7 @@ schools:
   ipeds_id: '439701'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21129,7 +21172,7 @@ schools:
   ipeds_id: '117751'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21140,7 +21183,7 @@ schools:
   ipeds_id: '167057'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21174,7 +21217,7 @@ schools:
   ipeds_id: '104665'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21185,7 +21228,7 @@ schools:
   ipeds_id: '441131'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21196,7 +21239,7 @@ schools:
   ipeds_id: '157748'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21207,7 +21250,7 @@ schools:
   ipeds_id: '494603'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21230,7 +21273,7 @@ schools:
   ipeds_id: '475237'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21241,7 +21284,7 @@ schools:
   ipeds_id: '202763'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21252,19 +21295,19 @@ schools:
   ipeds_id: '180489'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.umt.edu/institutional-research/documents/cds_2022-23-with-data.pdf
+  discovery_seed_url: https://www.umt.edu/institutional-research/documents/Common%20Data%20Set.php
 - id: the-university-of-montana-western
   name: The University of Montana-Western
   domain: umwestern.edu
   ipeds_id: '180692'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21275,7 +21318,7 @@ schools:
   ipeds_id: '171599'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21286,7 +21329,7 @@ schools:
   ipeds_id: '137847'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21297,7 +21340,7 @@ schools:
   ipeds_id: '487010'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21308,7 +21351,7 @@ schools:
   ipeds_id: '220701'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21319,7 +21362,7 @@ schools:
   ipeds_id: '492263'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21330,12 +21373,12 @@ schools:
   ipeds_id: '221740'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.utc.edu/sites/default/files/2023-02/CDS%202022-23.pdf
+  discovery_seed_url: https://www.utc.edu/media/76696
 - id: the-university-of-tennessee-knoxville
   name: The University of Tennessee-Knoxville
   domain: utk.edu
@@ -21359,7 +21402,7 @@ schools:
   ipeds_id: '228769'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21406,19 +21449,19 @@ schools:
   ipeds_id: '228802'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uttyler.edu/offices/information-analysis/files/cds-2023-2024.pdf
+  discovery_seed_url: https://www.uttyler.edu/offices/information-analysis/common-data-sets/
 - id: the-university-of-texas-health-science-center-at-houston
   name: The University of Texas Health Science Center at Houston
   domain: uth.edu
   ipeds_id: '229300'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21429,7 +21472,7 @@ schools:
   ipeds_id: '228644'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21440,7 +21483,7 @@ schools:
   ipeds_id: '416801'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21451,7 +21494,7 @@ schools:
   ipeds_id: '228653'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21474,7 +21517,7 @@ schools:
   ipeds_id: '227368'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -21498,19 +21541,19 @@ schools:
   ipeds_id: '221519'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://new.sewanee.edu/files/resources/sewanee-cds-2023-2024.pdf
+  discovery_seed_url: https://new.sewanee.edu/offices/university-offices/ir/common-data-set/
 - id: the-wright-institute
   name: The Wright Institute
   domain: wi.edu
   ipeds_id: '126012'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21521,7 +21564,7 @@ schools:
   ipeds_id: '216348'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21532,7 +21575,7 @@ schools:
   ipeds_id: '216357'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21543,7 +21586,7 @@ schools:
   ipeds_id: '124292'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21554,7 +21597,7 @@ schools:
   ipeds_id: '161563'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21565,7 +21608,7 @@ schools:
   ipeds_id: '187046'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21576,7 +21619,7 @@ schools:
   ipeds_id: '126049'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21599,7 +21642,7 @@ schools:
   ipeds_id: '172477'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21610,7 +21653,7 @@ schools:
   ipeds_id: '183275'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21621,7 +21664,7 @@ schools:
   ipeds_id: '157809'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21632,7 +21675,7 @@ schools:
   ipeds_id: '141167'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21643,19 +21686,19 @@ schools:
   ipeds_id: '206048'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.tiffin.edu/wp-content/uploads/2022/01/cds_2020-2021_final_3-5-2021_pdf_1.pdf
+  discovery_seed_url: https://www.tiffin.edu/about/tu-at-a-glance/institutional-research/
 - id: toccoa-falls-college
   name: Toccoa Falls College
   domain: tfc.edu
   ipeds_id: '141185'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21666,7 +21709,7 @@ schools:
   ipeds_id: '196583'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21700,7 +21743,7 @@ schools:
   ipeds_id: '459736'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21711,7 +21754,7 @@ schools:
   ipeds_id: '459824'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21722,7 +21765,7 @@ schools:
   ipeds_id: '459727'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21733,19 +21776,19 @@ schools:
   ipeds_id: '164076'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.towson.edu/ir/documents/cds1011.pdf
+  discovery_seed_url: https://www.towson.edu/ir/commondataset.html
 - id: toyota-technological-institute-at-chicago
   name: Toyota Technological Institute at Chicago
   domain: ttic.edu
   ipeds_id: '445054'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21756,7 +21799,7 @@ schools:
   ipeds_id: '157818'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21767,7 +21810,7 @@ schools:
   ipeds_id: '221892'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21778,7 +21821,7 @@ schools:
   ipeds_id: '206154'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21789,7 +21832,7 @@ schools:
   ipeds_id: '152567'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21800,7 +21843,7 @@ schools:
   ipeds_id: '414878'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21811,7 +21854,7 @@ schools:
   ipeds_id: '128258'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21822,7 +21865,7 @@ schools:
   ipeds_id: '137953'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21833,7 +21876,7 @@ schools:
   ipeds_id: '200484'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21868,7 +21911,7 @@ schools:
   ipeds_id: '137962'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21879,7 +21922,7 @@ schools:
   ipeds_id: '146755'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21890,7 +21933,7 @@ schools:
   ipeds_id: '216463'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21901,7 +21944,7 @@ schools:
   ipeds_id: '135610'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21912,7 +21955,7 @@ schools:
   ipeds_id: '149514'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21923,7 +21966,7 @@ schools:
   ipeds_id: '123448'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21934,7 +21977,7 @@ schools:
   ipeds_id: '229267'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:51Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21945,7 +21988,7 @@ schools:
   ipeds_id: '225308'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21956,7 +21999,7 @@ schools:
   ipeds_id: '131876'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21967,7 +22010,7 @@ schools:
   ipeds_id: '196653'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -21978,19 +22021,19 @@ schools:
   ipeds_id: '102368'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.troy.edu/_assets/irpe/_documents/cds-2021-2022.pdf
+  discovery_seed_url: https://www.troy.edu/about-us/offices-departments/institutional-research-planning-effectiveness/irpe-research/common-data-set.html
 - id: truckee-meadows-community-college
   name: Truckee Meadows Community College
   domain: tmcc.edu
   ipeds_id: '182500'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22001,7 +22044,7 @@ schools:
   ipeds_id: '141237'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22012,7 +22055,7 @@ schools:
   ipeds_id: '178615'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22035,7 +22078,7 @@ schools:
   ipeds_id: '200527'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22044,20 +22087,21 @@ schools:
   name: Tusculum University
   domain: tusculum.edu
   ipeds_id: '221953'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:53Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://web.tusculum.edu/oie/about-the-office/
 - id: tuskegee-university
   name: Tuskegee University
   domain: tuskegee.edu
   ipeds_id: '102377'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22068,19 +22112,19 @@ schools:
   ipeds_id: '229355'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.tjc.edu/download/downloads/id/347/common_data_set-current.pdf
+  discovery_seed_url: https://www.tjc.edu/downloads/download/50/common_data_set
 - id: union-adventist-university
   name: Union Adventist University
   domain: ucollege.edu
   ipeds_id: '181738'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22091,7 +22135,7 @@ schools:
   ipeds_id: '491525'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22100,13 +22144,14 @@ schools:
   name: Union College
   domain: unionky.edu
   ipeds_id: '157863'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
     last_probed_at: '2026-04-14T13:22:55Z'
-    last_result: not_found
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.union.edu/sites/default/files/institutional-research/202505/common-data-set-2024-2025-final-website-march-2025.pdf
 - id: union-college
   name: Union College
   domain: union.edu
@@ -22125,7 +22170,7 @@ schools:
   ipeds_id: '206279'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22136,7 +22181,7 @@ schools:
   ipeds_id: '233842'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22147,7 +22192,7 @@ schools:
   ipeds_id: '196884'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22158,7 +22203,7 @@ schools:
   ipeds_id: '221971'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22169,7 +22214,7 @@ schools:
   ipeds_id: '213631'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22192,7 +22237,7 @@ schools:
   ipeds_id: '130624'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22203,7 +22248,7 @@ schools:
   ipeds_id: '197027'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22238,7 +22283,7 @@ schools:
   ipeds_id: '102395'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22249,7 +22294,7 @@ schools:
   ipeds_id: '197018'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22260,7 +22305,7 @@ schools:
   ipeds_id: '206288'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22271,7 +22316,7 @@ schools:
   ipeds_id: '175139'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22282,7 +22327,7 @@ schools:
   ipeds_id: '200554'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22293,7 +22338,7 @@ schools:
   ipeds_id: '161572'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22328,12 +22373,12 @@ schools:
   ipeds_id: '200800'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:22:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uakron.edu/ir/docs/CDS/CDS%202022-2023%20University%20of%20Akron%20Main%20Campus.pdf
+  discovery_seed_url: https://www.uakron.edu/ir/common-data-set.dot
 - id: university-of-alabama-at-birmingham
   name: University of Alabama at Birmingham
   domain: uab.edu
@@ -22352,19 +22397,19 @@ schools:
   ipeds_id: '100706'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uah.edu/images/administrative/provost/oir/CDS/cds_2022-2023.pdf
+  discovery_seed_url: https://www.uah.edu/academic-affairs/offices/oirea/common-data-sets
 - id: university-of-alabama-system-office
   name: University of Alabama System Office
   domain: uasystem.edu
   ipeds_id: '100733'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:22:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22459,7 +22504,7 @@ schools:
   ipeds_id: '106485'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22470,7 +22515,7 @@ schools:
   ipeds_id: '106412'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22481,7 +22526,7 @@ schools:
   ipeds_id: '106263'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22492,7 +22537,7 @@ schools:
   ipeds_id: '442569'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22503,7 +22548,7 @@ schools:
   ipeds_id: '108056'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22536,7 +22581,7 @@ schools:
   ipeds_id: '128744'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22547,7 +22592,7 @@ schools:
   ipeds_id: '110398'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22582,7 +22627,7 @@ schools:
   ipeds_id: '110699'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22605,7 +22650,7 @@ schools:
   ipeds_id: '124557'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22616,7 +22661,7 @@ schools:
   ipeds_id: '106704'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22639,12 +22684,12 @@ schools:
   ipeds_id: '176965'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.ucmo.edu/offices/university-analytics-and-institutional-research/common-data-set/common-data-set-2022-2023.pdf
+  discovery_seed_url: https://www.ucmo.edu/offices/university-analytics-and-institutional-research/common-data-set/index.php
 - id: university-of-central-oklahoma
   name: University of Central Oklahoma
   domain: uco.edu
@@ -22663,7 +22708,7 @@ schools:
   ipeds_id: '237312'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22674,7 +22719,7 @@ schools:
   ipeds_id: '201955'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22685,7 +22730,7 @@ schools:
   ipeds_id: '201946'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22696,19 +22741,19 @@ schools:
   ipeds_id: '126580'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://data.uccs.edu/sites/default/files/inline-files/CDS%202022-2023.pdf
+  discovery_seed_url: https://data.uccs.edu/institutionaldata/common-data-set
 - id: university-of-colorado-denver-anschutz-medical-campus
   name: University of Colorado Denver/Anschutz Medical Campus
   domain: ucdenver.edu
   ipeds_id: '126562'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -22720,7 +22765,7 @@ schools:
   ipeds_id: '128300'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22743,7 +22788,7 @@ schools:
   ipeds_id: '436827'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22754,7 +22799,7 @@ schools:
   ipeds_id: '463056'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22765,7 +22810,7 @@ schools:
   ipeds_id: '436836'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22776,7 +22821,7 @@ schools:
   ipeds_id: '436818'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22787,12 +22832,12 @@ schools:
   ipeds_id: '224323'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://udallas.edu/offices-services/institutional-effectiveness/_documents/CDS_2022-2023%20DM.pdf
+  discovery_seed_url: https://udallas.edu/offices-services/institutional-effectiveness/facts-and-stats.php
 - id: university-of-dayton
   name: University of Dayton
   domain: udayton.edu
@@ -22823,19 +22868,19 @@ schools:
   ipeds_id: '169716'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.udmercy.edu/academics/academic-affairs/research/files/cds/2223_UDM_CDS.pdf
+  discovery_seed_url: https://www.udmercy.edu/academics/academic-affairs/research/data.php
 - id: university-of-dubuque
   name: University of Dubuque
   domain: dbq.edu
   ipeds_id: '153278'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22846,7 +22891,7 @@ schools:
   ipeds_id: '150534'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22857,7 +22902,7 @@ schools:
   ipeds_id: '484473'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22868,7 +22913,7 @@ schools:
   ipeds_id: '457402'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22879,7 +22924,7 @@ schools:
   ipeds_id: '129525'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22890,7 +22935,7 @@ schools:
   ipeds_id: '141565'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22901,19 +22946,19 @@ schools:
   ipeds_id: '141574'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://manoa.hawaii.edu/miro/wp-content/uploads/2023/11/AnalysisBrief_CommonDataSet_2023-2024_updated.pdf
+  discovery_seed_url: https://manoa.hawaii.edu/miro/e-book-chapter-3-common-data-set/
 - id: university-of-hawaii-maui-college
   name: University of Hawaii Maui College
   domain: maui.hawaii.edu
   ipeds_id: '141839'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22949,7 +22994,7 @@ schools:
   ipeds_id: '179265'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22960,7 +23005,7 @@ schools:
   ipeds_id: '160065'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -22995,12 +23040,12 @@ schools:
   ipeds_id: '225432'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uhd.edu/documents/provost/ie/institutional-research/common-data-set/cds-2020-2021.pdf
+  discovery_seed_url: https://www.uhd.edu/provost/ie/institutional-research/ir-common.aspx
 - id: university-of-houston-system-administration
   name: University of Houston-System Administration
   domain: uh.edu
@@ -23020,7 +23065,7 @@ schools:
   ipeds_id: '225502'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23055,12 +23100,12 @@ schools:
   ipeds_id: '148654'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uis.edu/sites/default/files/2022-10/CDS_2021-2022_0.pdf
+  discovery_seed_url: https://www.uis.edu/institutional-research/common-data-sets
 - id: university-of-illinois-system-offices
   name: University of Illinois System Offices
   domain: uillinois.edu
@@ -23119,7 +23164,7 @@ schools:
   ipeds_id: '200156'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23166,19 +23211,19 @@ schools:
   ipeds_id: '160658'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://getdata.louisiana.edu/sites/instres/files/UL_CDS_2021_2022.pdf
+  discovery_seed_url: https://getdata.louisiana.edu/data-sources
 - id: university-of-louisiana-at-monroe
   name: University of Louisiana at Monroe
   domain: ulm.edu
   ipeds_id: '159993'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23189,7 +23234,7 @@ schools:
   ipeds_id: '247083'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23212,7 +23257,7 @@ schools:
   ipeds_id: '232609'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23235,7 +23280,7 @@ schools:
   ipeds_id: '161217'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23246,7 +23291,7 @@ schools:
   ipeds_id: '161226'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23257,7 +23302,7 @@ schools:
   ipeds_id: '161235'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23294,7 +23339,7 @@ schools:
   ipeds_id: '200217'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23305,7 +23350,7 @@ schools:
   ipeds_id: '226471'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23328,7 +23373,7 @@ schools:
   ipeds_id: '163338'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23339,7 +23384,7 @@ schools:
   ipeds_id: '163204'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23350,7 +23395,7 @@ schools:
   ipeds_id: '163259'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23373,7 +23418,7 @@ schools:
   ipeds_id: '166708'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23384,7 +23429,7 @@ schools:
   ipeds_id: '262086'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23419,7 +23464,7 @@ schools:
   ipeds_id: '166665'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23442,7 +23487,7 @@ schools:
   ipeds_id: '220862'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -23490,12 +23535,12 @@ schools:
   ipeds_id: '174075'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://crk.umn.edu/sites/crk.umn.edu/files/2022-04/common-data-set-2021-2022.pdf
+  discovery_seed_url: https://crk.umn.edu/institutional-effectiveness/common-data-set-and-surveys
 - id: university-of-minnesota-duluth
   name: University of Minnesota-Duluth
   domain: d.umn.edu
@@ -23526,7 +23571,7 @@ schools:
   ipeds_id: '456959'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23559,13 +23604,14 @@ schools:
   name: University of Missouri-Kansas City
   domain: umkc.edu
   ipeds_id: '178402'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:22Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.umkc.edu/data/docs/cds_2024-2025.pdf
 - id: university-of-missouri-st-louis
   name: University of Missouri-St Louis
   domain: umsl.edu
@@ -23584,7 +23630,7 @@ schools:
   ipeds_id: '178439'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23606,7 +23652,7 @@ schools:
   ipeds_id: '101709'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23617,7 +23663,7 @@ schools:
   ipeds_id: '199069'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23628,7 +23674,7 @@ schools:
   ipeds_id: '193399'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23674,7 +23720,7 @@ schools:
   ipeds_id: '181428'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23685,7 +23731,7 @@ schools:
   ipeds_id: '181747'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23732,7 +23778,7 @@ schools:
   ipeds_id: '161457'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23743,7 +23789,7 @@ schools:
   ipeds_id: '183071'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23754,7 +23800,7 @@ schools:
   ipeds_id: '183257'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23765,7 +23811,7 @@ schools:
   ipeds_id: '182829'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23788,7 +23834,7 @@ schools:
   ipeds_id: '129941'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23799,19 +23845,19 @@ schools:
   ipeds_id: '187985'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://oia.unm.edu/facts-and-figures/cds-2021-22.pdf
+  discovery_seed_url: https://oia.unm.edu/facts-and-figures/common-data-set.html
 - id: university-of-new-orleans
   name: University of New Orleans
   domain: new.uno.edu
   ipeds_id: '159939'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23822,12 +23868,12 @@ schools:
   ipeds_id: '101879'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.una.edu/research/Institutional%20Data/university-of-north-alabama-cds-2022-2023.pdf
+  discovery_seed_url: https://www.una.edu/research/Institutional%20Data/common-data-set.html
 - id: university-of-north-carolina-asheville
   name: University of North Carolina Asheville
   domain: unca.edu
@@ -23882,7 +23928,7 @@ schools:
   ipeds_id: '199184'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -23894,7 +23940,7 @@ schools:
   ipeds_id: '199175'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23917,12 +23963,12 @@ schools:
   ipeds_id: '200280'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://und.edu/analytics-and-planning/_files/docs/common-data-set/cds-2020-2021.pdf
+  discovery_seed_url: https://und.edu/analytics-and-planning/data-and-reports/common-data-set.html
 - id: university-of-north-florida
   name: University of North Florida
   domain: unf.edu
@@ -23965,7 +24011,7 @@ schools:
   ipeds_id: '484905'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -23977,7 +24023,7 @@ schools:
   ipeds_id: '228909'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -23988,7 +24034,7 @@ schools:
   ipeds_id: '443711'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24023,7 +24069,7 @@ schools:
   ipeds_id: '204486'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24034,7 +24080,7 @@ schools:
   ipeds_id: '174491'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24057,7 +24103,7 @@ schools:
   ipeds_id: '207342'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24107,7 +24153,7 @@ schools:
   ipeds_id: '215266'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24118,7 +24164,7 @@ schools:
   ipeds_id: '215275'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24129,7 +24175,7 @@ schools:
   ipeds_id: '215284'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24152,7 +24198,7 @@ schools:
   ipeds_id: '180258'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24175,7 +24221,7 @@ schools:
   ipeds_id: '121691'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -24211,7 +24257,7 @@ schools:
   ipeds_id: '205203'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24234,7 +24280,7 @@ schools:
   ipeds_id: '152336'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24269,7 +24315,7 @@ schools:
   ipeds_id: '155812'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24280,7 +24326,7 @@ schools:
   ipeds_id: '148885'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24315,7 +24361,7 @@ schools:
   ipeds_id: '207722'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24338,7 +24384,7 @@ schools:
   ipeds_id: '497107'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24349,7 +24395,7 @@ schools:
   ipeds_id: '219383'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24360,12 +24406,12 @@ schools:
   ipeds_id: '102094'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.southalabama.edu/departments/institutionalresearch/resources/usa-cds-2023-2024.pdf
+  discovery_seed_url: https://www.southalabama.edu/departments/institutionalresearch/cds19-20/
 - id: university-of-south-carolina-aiken
   name: University of South Carolina Aiken
   domain: usca.edu
@@ -24384,7 +24430,7 @@ schools:
   ipeds_id: '218654'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24467,19 +24513,19 @@ schools:
   ipeds_id: '176372'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
-    last_method: brave
+    last_method: pattern
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.usm.edu/institutional-research/cds_2023_2024_final.pdf
+  discovery_seed_url: https://usm.edu/ir/cds/
 - id: university-of-st-francis
   name: University of St Francis
   domain: stfrancis.edu
   ipeds_id: '148584'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24488,13 +24534,14 @@ schools:
   name: University of St Thomas
   domain: stthomas.edu
   ipeds_id: '174914'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:46Z'
-    last_result: not_found
+    last_probed_at: '2026-04-14T13:23:47Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.stthom.edu/Public/getFile.asp?File_Content_ID=127511
 - id: university-of-st-thomas
   name: University of St Thomas
   domain: stthom.edu
@@ -24513,7 +24560,7 @@ schools:
   ipeds_id: '228635'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24524,7 +24571,7 @@ schools:
   ipeds_id: '215105'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24535,7 +24582,7 @@ schools:
   ipeds_id: '156541'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:48Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24546,7 +24593,7 @@ schools:
   ipeds_id: '131399'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:49Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24569,31 +24616,31 @@ schools:
   ipeds_id: '107558'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://ozarks.edu/wp-content/uploads/CDS_2020-2021.pdf
+  discovery_seed_url: https://ozarks.edu/about/institutional-research/
 - id: university-of-the-pacific
   name: University of the Pacific
   domain: pacific.edu
   ipeds_id: '120883'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:50Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.pacific.edu/sites/default/files/users/user777/2023_24_CDS__Instructional_Faculty_and_Class_Size.pdf
+  discovery_seed_url: https://www.pacific.edu/about-pacific/administrative-offices/institutional-research/common-data-set
 - id: university-of-the-people
   name: University of the People
   domain: uopeople.edu
   ipeds_id: '488846'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24604,7 +24651,7 @@ schools:
   ipeds_id: '188182'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24615,7 +24662,7 @@ schools:
   ipeds_id: '449870'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:52Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24626,19 +24673,19 @@ schools:
   ipeds_id: '206084'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.utoledo.edu/offices/institutional-research/report-library/common-data-set/docs/cds-2023-2024.pdf
+  discovery_seed_url: https://www.utoledo.edu/offices/institutional-research/home/university-facts.html
 - id: university-of-tulsa
   name: University of Tulsa
   domain: utulsa.edu
   ipeds_id: '207971'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:53Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24648,17 +24695,19 @@ schools:
   domain: utah.edu
   ipeds_id: '230764'
   scrape_policy: active
+  discovery_seed_url: https://data.utah.edu/data-dashboard/common-data-set/
 - id: university-of-valley-forge
   name: University of Valley Forge
   domain: valleyforge.edu
   ipeds_id: '216542'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:53Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://valleyforge.edu/careers-at-uvf/director-of-financial-services/
 - id: university-of-vermont
   name: University of Vermont
   domain: uvm.edu
@@ -24677,23 +24726,24 @@ schools:
   ipeds_id: '233897'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:54Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uvawise.edu/sites/default/files/attachments/pages/2025-01/cds_2021-2022.pdf
+  discovery_seed_url: https://www.uvawise.edu/about/leadership/institutional-research/common-data-set
 - id: university-of-washington-bothell-campus
   name: University of Washington-Bothell Campus
   domain: uwb.edu
   ipeds_id: '377555'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:54Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.uwb.edu/chancellor/institutional-research/data-resources-and-links/
 - id: university-of-washington-tacoma-campus
   name: University of Washington-Tacoma Campus
   domain: tacoma.uw.edu
@@ -24717,12 +24767,12 @@ schools:
   ipeds_id: '138354'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
-    last_method: brave
+    last_method: pattern
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://uwf.edu/media/university-of-west-florida/academic-affairs/departments/institutional-research/cds/2015-2016-Common-Data-Set.pdf
+  discovery_seed_url: https://uwf.edu/ir/cds/
 - id: university-of-west-georgia
   name: University of West Georgia
   domain: westga.edu
@@ -24741,7 +24791,7 @@ schools:
   ipeds_id: '210438'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24764,12 +24814,12 @@ schools:
   ipeds_id: '240277'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:55Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uwgb.edu/UWGBCMS/media/ise/files/CDS_2022-2023.pdf
+  discovery_seed_url: https://www.uwgb.edu/institutional-data/
 - id: university-of-wisconsin-la-crosse
   name: University of Wisconsin-La Crosse
   domain: uwlax.edu
@@ -24788,7 +24838,7 @@ schools:
   ipeds_id: '240453'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -24800,7 +24850,7 @@ schools:
   ipeds_id: '491288'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24823,19 +24873,19 @@ schools:
   ipeds_id: '240374'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://usaco.uwp.edu/explore/offices/institutional-research/upload/CDS_2019-2020_UW-Parkside_Final.pdf
+  discovery_seed_url: https://www.uwp.edu/live/offices/institutional-research/cds/
 - id: university-of-wisconsin-parkside-flex
   name: University of Wisconsin-Parkside Flex
   domain: flex.wisconsin.edu
   ipeds_id: '491297'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:56Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24846,7 +24896,7 @@ schools:
   ipeds_id: '240462'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24857,7 +24907,7 @@ schools:
   ipeds_id: '240471'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24868,19 +24918,19 @@ schools:
   ipeds_id: '240480'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www3.uwsp.edu/oire/Documents/CDS/CDS_UWSP-Main-AllCampuses/UWSP_CDS_ALLCAMPUSES-2023-2024_062624.pdf
+  discovery_seed_url: https://www3.uwsp.edu/oire/Pages/accountability-effectiveness.aspx
 - id: university-of-wisconsin-stout
   name: University of Wisconsin-Stout
   domain: uwstout.edu
   ipeds_id: '240417'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:57Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24903,7 +24953,7 @@ schools:
   ipeds_id: '240435'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24914,7 +24964,7 @@ schools:
   ipeds_id: '240189'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:23:58Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -24938,7 +24988,7 @@ schools:
   ipeds_id: '164146'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24949,7 +24999,7 @@ schools:
   ipeds_id: '404480'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:23:59Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24972,7 +25022,7 @@ schools:
   ipeds_id: '154493'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24983,7 +25033,7 @@ schools:
   ipeds_id: '196307'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -24994,7 +25044,7 @@ schools:
   ipeds_id: '456171'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:00Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25005,7 +25055,7 @@ schools:
   ipeds_id: '494685'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25016,7 +25066,7 @@ schools:
   ipeds_id: '455099'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25027,7 +25077,7 @@ schools:
   ipeds_id: '216524'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:01Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25050,7 +25100,7 @@ schools:
   ipeds_id: '446604'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25061,12 +25111,12 @@ schools:
   ipeds_id: '230728'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.usu.edu/oda/files/common-data-sets/CDS2022-23.pdf
+  discovery_seed_url: https://www.usu.edu/oda/analysis/common-data-set
 - id: utah-tech-university
   name: Utah Tech University
   domain: utahtech.edu
@@ -25085,24 +25135,24 @@ schools:
   ipeds_id: '230737'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:02Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.uvu.edu/birs/docs/info_about_uvu/common_data_set/cds2019-20.pdf
+  discovery_seed_url: https://www.uvu.edu/birs/info/college_department_major.html
 - id: utica-university
   name: Utica University
   domain: utica.edu
   ipeds_id: '197045'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:03Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.utica.edu/ir/CommonDataSets/Copy%20of%20CDS_2021-2022-1%2012212021.pdf
+  discovery_seed_url: https://www.utica.edu/ir/cds.cfm
 - id: valdosta-state-university
   name: Valdosta State University
   domain: valdosta.edu
@@ -25121,7 +25171,7 @@ schools:
   ipeds_id: '138187'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25132,7 +25182,7 @@ schools:
   ipeds_id: '200572'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25143,7 +25193,7 @@ schools:
   ipeds_id: '486257'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:04Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25166,7 +25216,7 @@ schools:
   ipeds_id: '149639'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25177,7 +25227,7 @@ schools:
   ipeds_id: '123651'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:05Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -25201,7 +25251,7 @@ schools:
   ipeds_id: '188340'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -25213,7 +25263,7 @@ schools:
   ipeds_id: '482228'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25224,7 +25274,7 @@ schools:
   ipeds_id: '455992'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25235,7 +25285,7 @@ schools:
   ipeds_id: '231147'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:06Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25246,7 +25296,7 @@ schools:
   ipeds_id: '231156'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25257,7 +25307,7 @@ schools:
   ipeds_id: '231165'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:07Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25291,7 +25341,7 @@ schools:
   ipeds_id: '152637'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25302,7 +25352,7 @@ schools:
   ipeds_id: '449834'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:08Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25347,20 +25397,21 @@ schools:
   name: Virginia State University
   domain: vsu.edu
   ipeds_id: '234155'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:09Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://www.vsu.edu/opie/assessment-day.php
 - id: virginia-union-university
   name: Virginia Union University
   domain: vuu.edu
   ipeds_id: '234164'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25371,7 +25422,7 @@ schools:
   ipeds_id: '490106'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:09Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25382,7 +25433,7 @@ schools:
   ipeds_id: '234137'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25393,7 +25444,7 @@ schools:
   ipeds_id: '234173'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25404,7 +25455,7 @@ schools:
   ipeds_id: '449764'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25427,7 +25478,7 @@ schools:
   ipeds_id: '218919'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:10Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25438,12 +25489,12 @@ schools:
   ipeds_id: '152673'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.wabash.edu/institutional_research/docs/cds_2021-20223.pdf
+  discovery_seed_url: https://www.wabash.edu/institutional_research/common
 - id: wagner-college
   name: Wagner College
   domain: wagner.edu
@@ -25462,7 +25513,7 @@ schools:
   ipeds_id: '236887'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:11Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25485,7 +25536,7 @@ schools:
   ipeds_id: '172608'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25496,7 +25547,7 @@ schools:
   ipeds_id: '206437'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25507,7 +25558,7 @@ schools:
   ipeds_id: '210304'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25518,7 +25569,7 @@ schools:
   ipeds_id: '480198'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25529,7 +25580,7 @@ schools:
   ipeds_id: '138275'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25540,7 +25591,7 @@ schools:
   ipeds_id: '199865'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:12Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25551,7 +25602,7 @@ schools:
   ipeds_id: '154527'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25562,7 +25613,7 @@ schools:
   ipeds_id: '154536'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25573,7 +25624,7 @@ schools:
   ipeds_id: '156082'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:13Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -25595,13 +25646,14 @@ schools:
   name: Washington Adventist University
   domain: wau.edu
   ipeds_id: '162210'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:14Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://our.wau.edu/eforms/library/Policies%20and%20Procedures/2011%20Policies%20and%20Procedures%20Manual/Institutional%20Research%20Manual/Data_Flows/CDS%20Data%20Flow.pdf
 - id: washington-college
   name: Washington College
   domain: washcoll.edu
@@ -25620,7 +25672,7 @@ schools:
   ipeds_id: '206446'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:14Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25667,7 +25719,7 @@ schools:
   ipeds_id: '229780'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25678,7 +25730,7 @@ schools:
   ipeds_id: '181783'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25701,7 +25753,7 @@ schools:
   ipeds_id: '216694'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25712,7 +25764,7 @@ schools:
   ipeds_id: '229799'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:15Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25723,7 +25775,7 @@ schools:
   ipeds_id: '197221'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25734,7 +25786,7 @@ schools:
   ipeds_id: '138293'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25745,19 +25797,19 @@ schools:
   ipeds_id: '230782'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:16Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.weber.edu/wsuimages/IR/Common%20Data%20Set_2020-21.pdf
+  discovery_seed_url: https://www.weber.edu/financialservices/reports_and_publications.html
 - id: webster-university
   name: Webster University
   domain: webster.edu
   ipeds_id: '179894'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25768,7 +25820,7 @@ schools:
   ipeds_id: '190424'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25779,7 +25831,7 @@ schools:
   ipeds_id: '220206'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25802,7 +25854,7 @@ schools:
   ipeds_id: '197230'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:17Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25813,7 +25865,7 @@ schools:
   ipeds_id: '236975'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25836,7 +25888,7 @@ schools:
   ipeds_id: '176451'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25847,7 +25899,7 @@ schools:
   ipeds_id: '131973'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25858,7 +25910,7 @@ schools:
   ipeds_id: '141325'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:18Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25881,12 +25933,12 @@ schools:
   ipeds_id: '216764'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.wcupa.edu/deputy-provost/institutionalResearch/documents/CDS_2023_2024_Final_05.06.24.pdf
+  discovery_seed_url: https://www.wcupa.edu/deputy-provost/institutionalResearch/dataSet.aspx
 - id: west-liberty-university
   name: West Liberty University
   domain: westliberty.edu
@@ -25905,7 +25957,7 @@ schools:
   ipeds_id: '125471'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:19Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25928,7 +25980,7 @@ schools:
   ipeds_id: '237880'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:20Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25962,7 +26014,7 @@ schools:
   ipeds_id: '237686'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25973,7 +26025,7 @@ schools:
   ipeds_id: '237950'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25984,7 +26036,7 @@ schools:
   ipeds_id: '237969'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:21Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -25995,23 +26047,24 @@ schools:
   ipeds_id: '200004'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.wcu.edu/_files/learn/provost/CDS-2023-2024.pdf
+  discovery_seed_url: https://www.wcu.edu/learn/office-of-the-provost/oipe/institutional-research/common-data-sets.aspx
 - id: western-colorado-university
   name: Western Colorado University
   domain: western.edu
   ipeds_id: '128391'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:22Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://western.edu/wp-content/uploads/CDS2008_2009.pdf
 - id: western-connecticut-state-university
   name: Western Connecticut State University
   domain: wcsu.edu
@@ -26030,7 +26083,7 @@ schools:
   ipeds_id: '433387'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:22Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26053,7 +26106,7 @@ schools:
   ipeds_id: '157951'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -26077,7 +26130,7 @@ schools:
   ipeds_id: '490373'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26088,7 +26141,7 @@ schools:
   ipeds_id: '182564'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26111,7 +26164,7 @@ schools:
   ipeds_id: '188304'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:23Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26134,7 +26187,7 @@ schools:
   ipeds_id: '210368'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26145,7 +26198,7 @@ schools:
   ipeds_id: '172705'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26156,7 +26209,7 @@ schools:
   ipeds_id: '112525'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26179,7 +26232,7 @@ schools:
   ipeds_id: '240693'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:24Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26200,10 +26253,10 @@ schools:
   name: Westminster College
   domain: wcmo.edu
   ipeds_id: '179946'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:25Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -26214,7 +26267,7 @@ schools:
   ipeds_id: '216807'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26225,7 +26278,7 @@ schools:
   ipeds_id: '216816'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:25Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26236,7 +26289,7 @@ schools:
   ipeds_id: '125718'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26259,19 +26312,19 @@ schools:
   ipeds_id: '125727'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.westmont.edu/sites/default/files/2025-02/CDS%202023-24%20FINAL.pdf
+  discovery_seed_url: https://www.westmont.edu/institutional-portfolio/institutional-data
 - id: whatcom-community-college
   name: Whatcom Community College
   domain: whatcom.edu
   ipeds_id: '237039'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26282,7 +26335,7 @@ schools:
   ipeds_id: '149781'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:26Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26305,7 +26358,7 @@ schools:
   ipeds_id: '238078'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26328,19 +26381,19 @@ schools:
   ipeds_id: '125763'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.whittier.edu/sites/default/files/media/63886174_cds_2021-2022.pdf
+  discovery_seed_url: https://www.whittier.edu/academics/ira/cds
 - id: whitworth-university
   name: Whitworth University
   domain: whitworth.edu
   ipeds_id: '237066'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26351,7 +26404,7 @@ schools:
   ipeds_id: '475200'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:27Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26362,12 +26415,12 @@ schools:
   ipeds_id: '156125'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.wichita.edu/services/planning_and_analysis/documents/WSU_CDS_2019-2020.pdf
+  discovery_seed_url: https://www.wichita.edu/services/planning_and_analysis/ERD_Explanation.php
 - id: widener-university
   name: Widener University
   domain: widener.edu
@@ -26386,7 +26439,7 @@ schools:
   ipeds_id: '206491'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26397,7 +26450,7 @@ schools:
   ipeds_id: '229887'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:28Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26444,7 +26497,7 @@ schools:
   ipeds_id: '176479'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26455,7 +26508,7 @@ schools:
   ipeds_id: '166717'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26466,7 +26519,7 @@ schools:
   ipeds_id: '122728'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:29Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26477,7 +26530,7 @@ schools:
   ipeds_id: '179955'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26500,7 +26553,7 @@ schools:
   ipeds_id: '199272'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26511,7 +26564,7 @@ schools:
   ipeds_id: '154590'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26522,7 +26575,7 @@ schools:
   ipeds_id: '179964'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:30Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26533,7 +26586,7 @@ schools:
   ipeds_id: '107877'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26556,7 +26609,7 @@ schools:
   ipeds_id: '443340'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26567,7 +26620,7 @@ schools:
   ipeds_id: '206507'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:31Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26578,8 +26631,8 @@ schools:
   ipeds_id: '131113'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:32Z'
-    last_result: found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
@@ -26590,7 +26643,7 @@ schools:
   ipeds_id: '217013'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26601,7 +26654,7 @@ schools:
   ipeds_id: '206516'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26612,7 +26665,7 @@ schools:
   ipeds_id: '199962'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:32Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26635,7 +26688,7 @@ schools:
   ipeds_id: '199999'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26646,19 +26699,19 @@ schools:
   ipeds_id: '218964'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.winthrop.edu/uploadedFiles/institutional-effectiveness/cds2023-24.pdf
+  discovery_seed_url: https://www.winthrop.edu/institutional-effectiveness/institutional-research/current-common-data-set.aspx
 - id: wisconsin-lutheran-college
   name: Wisconsin Lutheran College
   domain: wlc.edu
   ipeds_id: '240338'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26669,7 +26722,7 @@ schools:
   ipeds_id: '240213'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:33Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26692,7 +26745,7 @@ schools:
   ipeds_id: '218973'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26703,7 +26756,7 @@ schools:
   ipeds_id: '491631'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26714,7 +26767,7 @@ schools:
   ipeds_id: '442064'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26725,7 +26778,7 @@ schools:
   ipeds_id: '488907'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:34Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26734,13 +26787,14 @@ schools:
   name: Woodbury University
   domain: woodbury.edu
   ipeds_id: '125897'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:35Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://woodbury.edu/wp-content/uploads/2018/02/CDS2013_2014.pdf
 - id: worcester-polytechnic-institute
   name: Worcester Polytechnic Institute
   domain: wpi.edu
@@ -26771,7 +26825,7 @@ schools:
   ipeds_id: '401223'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26782,7 +26836,7 @@ schools:
   ipeds_id: '486460'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:35Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26793,7 +26847,7 @@ schools:
   ipeds_id: '206613'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26816,19 +26870,19 @@ schools:
   ipeds_id: '206622'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.xavier.edu/institutional-research/reports-and-documents/cds_2021-2022_final.pdf
+  discovery_seed_url: https://www.xavier.edu/institutional-research/reports-and-documents/commondataset
 - id: xavier-university-of-louisiana
   name: Xavier University of Louisiana
   domain: xula.edu
   ipeds_id: '160904'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -26840,7 +26894,7 @@ schools:
   ipeds_id: '237109'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:36Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26851,7 +26905,7 @@ schools:
   ipeds_id: '106148'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26862,7 +26916,7 @@ schools:
   ipeds_id: '490319'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26873,7 +26927,7 @@ schools:
   ipeds_id: '491622'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26884,7 +26938,7 @@ schools:
   ipeds_id: '434937'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:37Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26895,7 +26949,7 @@ schools:
   ipeds_id: '420325'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26906,7 +26960,7 @@ schools:
   ipeds_id: '197647'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26917,7 +26971,7 @@ schools:
   ipeds_id: '493716'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26928,7 +26982,7 @@ schools:
   ipeds_id: '491914'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:38Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26939,7 +26993,7 @@ schools:
   ipeds_id: '375230'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26950,7 +27004,7 @@ schools:
   ipeds_id: '491640'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26961,7 +27015,7 @@ schools:
   ipeds_id: '481410'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26972,7 +27026,7 @@ schools:
   ipeds_id: '491710'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26983,7 +27037,7 @@ schools:
   ipeds_id: '247773'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -26994,7 +27048,7 @@ schools:
   ipeds_id: '493707'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27005,7 +27059,7 @@ schools:
   ipeds_id: '488350'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:39Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27016,7 +27070,7 @@ schools:
   ipeds_id: '491613'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27027,7 +27081,7 @@ schools:
   ipeds_id: '476692'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27038,7 +27092,7 @@ schools:
   ipeds_id: '197601'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27049,7 +27103,7 @@ schools:
   ipeds_id: '491057'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27060,7 +27114,7 @@ schools:
   ipeds_id: '190752'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:40Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27071,7 +27125,7 @@ schools:
   ipeds_id: '498809'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27082,7 +27136,7 @@ schools:
   ipeds_id: '455257'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27093,7 +27147,7 @@ schools:
   ipeds_id: '197674'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27104,7 +27158,7 @@ schools:
   ipeds_id: '493594'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:41Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27115,7 +27169,7 @@ schools:
   ipeds_id: '431983'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27126,7 +27180,7 @@ schools:
   ipeds_id: '126076'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27137,7 +27191,7 @@ schools:
   ipeds_id: '490504'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27148,7 +27202,7 @@ schools:
   ipeds_id: '486017'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:42Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27159,7 +27213,7 @@ schools:
   ipeds_id: '490276'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27170,7 +27224,7 @@ schools:
   ipeds_id: '441609'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27181,7 +27235,7 @@ schools:
   ipeds_id: '486026'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27192,7 +27246,7 @@ schools:
   ipeds_id: '451398'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27215,7 +27269,7 @@ schools:
   ipeds_id: '494737'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27226,7 +27280,7 @@ schools:
   ipeds_id: '481438'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:43Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27237,7 +27291,7 @@ schools:
   ipeds_id: '487746'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27248,7 +27302,7 @@ schools:
   ipeds_id: '363712'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27259,7 +27313,7 @@ schools:
   ipeds_id: '451370'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27270,7 +27324,7 @@ schools:
   ipeds_id: '491765'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27281,7 +27335,7 @@ schools:
   ipeds_id: '405058'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:44Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27292,7 +27346,7 @@ schools:
   ipeds_id: '498906'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27303,7 +27357,7 @@ schools:
   ipeds_id: '493664'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27314,7 +27368,7 @@ schools:
   ipeds_id: '217040'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27325,7 +27379,7 @@ schools:
   ipeds_id: '197692'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:45Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27336,7 +27390,7 @@ schools:
   ipeds_id: '197735'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27347,7 +27401,7 @@ schools:
   ipeds_id: '197744'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27358,7 +27412,7 @@ schools:
   ipeds_id: '401250'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27369,7 +27423,7 @@ schools:
   ipeds_id: '217059'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27380,7 +27434,7 @@ schools:
   ipeds_id: '181853'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:46Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27391,7 +27445,7 @@ schools:
   ipeds_id: '126100'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0
@@ -27402,7 +27456,7 @@ schools:
   ipeds_id: '141361'
   scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: found
     last_method: brave
     patterns_tried: 0
@@ -27412,20 +27466,21 @@ schools:
   name: Youngstown State University
   domain: ysu.edu
   ipeds_id: '206695'
-  scrape_policy: unknown
+  scrape_policy: active
   probe_state:
-    last_probed_at: '2026-04-14T13:24:47Z'
-    last_result: not_found
+    last_probed_at: '2026-08-21T22:51:00Z'
+    last_result: found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
+  discovery_seed_url: https://ysu.edu/institutional-research-and-analytics
 - id: zane-state-college
   name: Zane State College
   domain: zanestate.edu
   ipeds_id: '204255'
   scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-04-14T13:24:47Z'
+    last_probed_at: '2026-08-21T22:51:00Z'
     last_result: not_found
     last_method: brave
     patterns_tried: 0

--- a/tools/finder/test_apply_probe_log.py
+++ b/tools/finder/test_apply_probe_log.py
@@ -1,0 +1,136 @@
+"""Tests for replaying finder probe logs onto schools.yaml."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.finder.apply_probe_log import (
+    apply_hit,
+    apply_logs,
+    parse_probe_log,
+)
+from tools.finder.merge_schools_yaml import merge_school_lists
+
+
+SAMPLE_LOG = """
+Probing 3 schools with 4 workers (rps=1.0 per worker)
+[    1/3] Albion College (albion.edu) ... [brave] FOUND: https://www.albion.edu/offices/registrar/institutional-data/
+[    2/3] Elms College (elms.edu) ... [brave] FOUND: https://search.elms.edu/=327/krespectf/stanford+common+data+set.pdf
+[    3/3] Agora University (agora.edu) ... not found
+"""
+
+YAML_FIXTURE = """\
+schools:
+- id: albion-college
+  name: Albion College
+  domain: albion.edu
+  scrape_policy: active
+  probe_state:
+    last_probed_at: '2026-04-14T13:16:34Z'
+    last_result: found
+    last_method: brave
+  discovery_seed_url: https://www.albion.edu/wp-content/uploads/cds-2023.pdf
+- id: elms-college
+  name: Elms College
+  domain: elms.edu
+  scrape_policy: active
+  probe_state:
+    last_probed_at: '2026-04-14T13:16:34Z'
+    last_result: found
+    last_method: brave
+  discovery_seed_url: https://www.elms.edu/old.pdf
+- id: agora-university
+  name: Agora University
+  domain: agora.edu
+  scrape_policy: unknown
+  probe_state:
+    last_probed_at: '2026-04-14T13:16:34Z'
+    last_result: not_found
+    last_method: brave
+"""
+
+
+class ParseLogTests(unittest.TestCase):
+    def test_parses_found_junk_and_miss(self) -> None:
+        hits = parse_probe_log(SAMPLE_LOG)
+        self.assertEqual(len(hits), 3)
+        self.assertEqual(hits[0].url, "https://www.albion.edu/offices/registrar/institutional-data/")
+        self.assertTrue(hits[1].found)
+        self.assertFalse(hits[2].found)
+
+
+class ApplyHitTests(unittest.TestCase):
+    def test_listing_replaces_pdf(self) -> None:
+        school = {
+            "id": "albion-college",
+            "discovery_seed_url": "https://www.albion.edu/old.pdf",
+            "scrape_policy": "active",
+        }
+        hit = parse_probe_log(SAMPLE_LOG)[0]
+        self.assertEqual(apply_hit(school, hit, "2026-08-21T22:51:00Z"), "replaced")
+        self.assertEqual(
+            school["discovery_seed_url"],
+            "https://www.albion.edu/offices/registrar/institutional-data/",
+        )
+
+    def test_search_junk_is_skipped(self) -> None:
+        school = {
+            "id": "elms-college",
+            "domain": "elms.edu",
+            "discovery_seed_url": "https://www.elms.edu/old.pdf",
+        }
+        hit = parse_probe_log(SAMPLE_LOG)[1]
+        self.assertEqual(apply_hit(school, hit, "2026-08-21T22:51:00Z"), "skipped_junk")
+        self.assertEqual(school["discovery_seed_url"], "https://www.elms.edu/old.pdf")
+
+
+class WriteYamlTests(unittest.TestCase):
+    def test_rewrites_seed_policy_and_probe_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schools.yaml"
+            path.write_text(YAML_FIXTURE)
+            log_path = Path(tmp) / "probe.log"
+            log_path.write_text(SAMPLE_LOG)
+            counts = apply_logs(
+                path,
+                [log_path],
+                probed_at="2026-08-21T22:51:00Z",
+            )
+            text = path.read_text()
+        self.assertEqual(counts["replaced"], 1)
+        self.assertEqual(counts["skipped_junk"], 1)
+        self.assertEqual(counts["not_found"], 1)
+        self.assertIn(
+            "https://www.albion.edu/offices/registrar/institutional-data/",
+            text,
+        )
+        self.assertIn("https://www.elms.edu/old.pdf", text)
+        self.assertIn("last_probed_at: '2026-08-21T22:51:00Z'", text)
+        self.assertIn("scrape_policy: unknown", text)
+
+
+class MergeListsTests(unittest.TestCase):
+    def test_overlays_only_schools_the_probe_changed(self) -> None:
+        base = [
+            {"id": "a", "discovery_seed_url": "https://a.edu/old.pdf", "scrape_policy": "active"},
+            {"id": "b", "discovery_seed_url": "https://b.edu/cds/", "scrape_policy": "active"},
+        ]
+        main = [
+            {"id": "a", "discovery_seed_url": "https://a.edu/old.pdf", "scrape_policy": "active", "notes": "keep"},
+            {"id": "b", "discovery_seed_url": "https://b.edu/iea/", "scrape_policy": "active"},
+        ]
+        probed = [
+            {"id": "a", "discovery_seed_url": "https://a.edu/ir/cds/", "scrape_policy": "active"},
+            {"id": "b", "discovery_seed_url": "https://b.edu/cds/", "scrape_policy": "active"},
+        ]
+        merged, changed = merge_school_lists(base, main, probed)
+        self.assertEqual(changed, ["a"])
+        self.assertEqual(merged[0]["discovery_seed_url"], "https://a.edu/ir/cds/")
+        self.assertEqual(merged[0]["notes"], "keep")
+        self.assertEqual(merged[1]["discovery_seed_url"], "https://b.edu/iea/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 
 from tools.finder.probe_urls import (
+    _save_yaml,
+    host_belongs_to_domain,
     is_cds_page,
+    looks_like_search_junk,
     select_brave_cds_url,
     should_replace_seed,
     should_skip,
     dedupe_identical_seeds,
+    write_probe_summary,
 )
 
 
@@ -64,6 +69,66 @@ class SelectBraveCdsUrlTests(unittest.TestCase):
             },
         ]
         self.assertIsNone(select_brave_cds_url(results))
+
+    def test_rejects_off_domain_and_search_junk_paths(self) -> None:
+        results = [
+            {
+                "url": "https://search.elms.edu/=327/krespectf/stanford+common+data+set.pdf",
+                "title": "Common Data Set",
+                "description": "Common Data Set",
+            },
+            {
+                "url": "https://other.edu/ir/common-data-set/",
+                "title": "Common Data Set",
+                "description": "Common Data Set",
+            },
+            {
+                "url": "https://www.elms.edu/ir/common-data-set/",
+                "title": "Common Data Set",
+                "description": "Common Data Set",
+            },
+        ]
+        self.assertEqual(
+            select_brave_cds_url(results, "elms.edu"),
+            "https://www.elms.edu/ir/common-data-set/",
+        )
+        self.assertTrue(looks_like_search_junk(results[0]["url"]))
+        self.assertTrue(host_belongs_to_domain(results[2]["url"], "elms.edu"))
+        self.assertFalse(host_belongs_to_domain(results[1]["url"], "elms.edu"))
+
+    def test_rejects_blog_slugs_that_are_not_cds_paths(self) -> None:
+        from tools.finder.probe_urls import looks_like_article_slug
+
+        self.assertTrue(
+            looks_like_article_slug(
+                "https://www.continents.us/does-harvard-accept-2-9-gpa/"
+            )
+        )
+        self.assertFalse(
+            looks_like_article_slug(
+                "https://www.albion.edu/offices/registrar/institutional-data/"
+            )
+        )
+
+    def test_rejects_news_pages_and_non_cds_pdfs(self) -> None:
+        from tools.finder.probe_urls import (
+            looks_like_news_or_blog,
+            looks_like_non_cds_document,
+        )
+
+        self.assertTrue(
+            looks_like_news_or_blog("https://www.widener.edu/news/noteworthy?page=2")
+        )
+        self.assertTrue(
+            looks_like_non_cds_document(
+                "https://www.csuci.edu/budget/documents/otp-budget-presentation-fy17-18.pdf"
+            )
+        )
+        self.assertFalse(
+            looks_like_non_cds_document(
+                "https://example.edu/ir/CDS_2023-2024.pdf"
+            )
+        )
 
 
 class IsCdsPageTests(unittest.TestCase):
@@ -120,6 +185,31 @@ class SkipAndDedupeTests(unittest.TestCase):
         self.assertNotIn("discovery_seed_url", schools[0])
         self.assertEqual(schools[0]["probe_state"]["last_result"], "shared_parent_seed")
         self.assertEqual(schools[1]["discovery_seed_url"], url)
+
+
+class CheckpointHelpersTests(unittest.TestCase):
+    def test_save_yaml_helper_still_exists(self) -> None:
+        self.assertTrue(callable(_save_yaml))
+
+    def test_write_probe_summary_does_not_touch_schools_yaml(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.json"
+            write_probe_summary(
+                path,
+                probed=12,
+                found=3,
+                replaced=2,
+                budget_remaining=17,
+                still_stuck=9,
+            )
+            payload = json.loads(path.read_text())
+        self.assertEqual(payload["probed"], 12)
+        self.assertEqual(payload["found"], 3)
+        self.assertEqual(payload["replaced"], 2)
+        self.assertEqual(payload["still_stuck"], 9)
 
 
 if __name__ == "__main__":

--- a/tools/finder/test_promote_landing_hints.py
+++ b/tools/finder/test_promote_landing_hints.py
@@ -1,0 +1,49 @@
+"""Tests for landing-hint Supabase credential resolution."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.finder.promote_landing_hints import supabase_credentials
+
+
+class SupabaseCredentialsTests(unittest.TestCase):
+    def test_process_env_works_without_dotenv_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / ".env"
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "SUPABASE_URL": "https://example.supabase.co",
+                    "SUPABASE_SERVICE_ROLE_KEY": "service-role",
+                },
+                clear=False,
+            ):
+                creds = supabase_credentials(missing)
+        self.assertEqual(creds["SUPABASE_URL"], "https://example.supabase.co")
+        self.assertEqual(creds["SUPABASE_SERVICE_ROLE_KEY"], "service-role")
+
+    def test_process_env_wins_over_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text(
+                "SUPABASE_URL=https://file.example\n"
+                "SUPABASE_SERVICE_ROLE_KEY=file-key\n"
+            )
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "SUPABASE_URL": "https://env.example",
+                    "SUPABASE_SERVICE_ROLE_KEY": "env-key",
+                },
+                clear=False,
+            ):
+                creds = supabase_credentials(env_path)
+        self.assertEqual(creds["SUPABASE_URL"], "https://env.example")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/enqueue_changed_seeds.py
+++ b/tools/ops/enqueue_changed_seeds.py
@@ -1,0 +1,104 @@
+"""Enqueue archive work for schools whose discovery seed just changed.
+
+Weekly archive otherwise waits out the 7-day success cooldown, so a PDF
+that we just rewrote to a listing would sit for a week. After 4 silent
+months, new listings should be fetched the same day they land on main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.ops.directory_enqueue_batches import (  # noqa: E402
+    OpsError,
+    SupabaseClient,
+    require_supabase_credentials,
+)
+
+
+def seed_of(school: dict) -> str:
+    return str(school.get("discovery_seed_url") or school.get("cds_url_hint") or "")
+
+
+def changed_seed_ids(before: list[dict], after: list[dict]) -> list[str]:
+    before_map = {str(row.get("id")): row for row in before if row.get("id")}
+    changed: list[str] = []
+    for row in after:
+        sid = str(row.get("id") or "")
+        if not sid:
+            continue
+        prev = before_map.get(sid)
+        if prev is None:
+            if seed_of(row) and row.get("scrape_policy") == "active":
+                changed.append(sid)
+            continue
+        if seed_of(row) and seed_of(row) != seed_of(prev):
+            changed.append(sid)
+        elif (
+            prev.get("scrape_policy") != "active"
+            and row.get("scrape_policy") == "active"
+            and seed_of(row)
+        ):
+            changed.append(sid)
+    return changed
+
+
+def load_schools(path: Path) -> list[dict]:
+    data = yaml.safe_load(path.read_text())
+    return data.get("schools") or []
+
+
+def chunked(ids: list[str], size: int = 80) -> list[list[str]]:
+    return [ids[i : i + size] for i in range(0, len(ids), size)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
+    ap.add_argument("--before", type=Path, required=True)
+    ap.add_argument("--after", type=Path, required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--env", type=Path, default=Path(".env"))
+    args = ap.parse_args()
+    ids = changed_seed_ids(load_schools(args.before), load_schools(args.after))
+    print(json.dumps({"changed": len(ids), "ids": ids}, indent=2))
+    if not ids:
+        print("No seed changes; skipping enqueue.", file=sys.stderr)
+        return 0
+    if not args.apply:
+        print("Dry-run. Pass --apply to enqueue.", file=sys.stderr)
+        return 0
+    url, key = require_supabase_credentials(args.env)
+    client = SupabaseClient(url, key)
+    enqueued = 0
+    run_id = str(uuid.uuid4())
+    for group in chunked(ids):
+        result = client.post_function(
+            "archive-enqueue",
+            {
+                "force_recheck": "true",
+                "school_ids": ",".join(group),
+                "run_id": run_id,
+            },
+        )
+        enqueued += int(result.get("enqueued") or 0)
+        print(json.dumps({"chunk": group, "result": result}))
+    print(json.dumps({"enqueued_total": enqueued}))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except OpsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/tools/ops/test_enqueue_changed_seeds.py
+++ b/tools/ops/test_enqueue_changed_seeds.py
@@ -1,0 +1,29 @@
+"""Tests for archive enqueue of changed finder seeds."""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.ops.enqueue_changed_seeds import changed_seed_ids, chunked
+
+
+class ChangedSeedIdsTests(unittest.TestCase):
+    def test_detects_url_change_and_unknown_to_active(self) -> None:
+        before = [
+            {"id": "a", "scrape_policy": "active", "discovery_seed_url": "https://a.edu/old.pdf"},
+            {"id": "b", "scrape_policy": "unknown"},
+            {"id": "c", "scrape_policy": "active", "discovery_seed_url": "https://c.edu/cds/"},
+        ]
+        after = [
+            {"id": "a", "scrape_policy": "active", "discovery_seed_url": "https://a.edu/ir/cds/"},
+            {"id": "b", "scrape_policy": "active", "discovery_seed_url": "https://b.edu/cds/"},
+            {"id": "c", "scrape_policy": "active", "discovery_seed_url": "https://c.edu/cds/"},
+        ]
+        self.assertEqual(changed_seed_ids(before, after), ["a", "b"])
+
+    def test_chunks_ids(self) -> None:
+        self.assertEqual(chunked(["a", "b", "c", "d"], 2), [["a", "b"], ["c", "d"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Friday's Brave probe (run [32521813065](https://github.com/bolewood/collegedata-fyi/actions/runs/32521813065)) found listings, then GitHub rejected the seed PR because `#135` had changed `ops-finder-probe.yml` while the 2h45m job still had the old workflow tree. The yaml never left the runner.
- The pipeline-board PR also ate `_save_yaml`, so the **next** monthly run would crash at the first checkpoint. Restored.
- Finder now artifacts `schools.yaml`, publishes the seed PR from current `main` (school-id overlay so Ohio's IEA seed is not reverted), and landing hints read `SUPABASE_*` from Actions env instead of a missing `.env`.
- Replay the Friday logs onto `schools.yaml`: **216 seed replacements** (listings over stuck PDFs, plus new unknowns), 40 junk URLs dropped (news pages, blog slugs, non-CDS PDFs). Probe_state timestamps updated so Sept 2 does not re-burn 1,500 Brave calls.

## Why this was red for four months
The schedule was restored in `#134`, but a successful Brave run still could not land seeds. A mid-run workflow edit looks like "create or update workflow" to the GitHub App, so the only copy of the rewrite died on the runner. Artifact + publish-from-main closes that hole.

## After merge (do not skip)
1. Deploy `archive-enqueue` so `school_ids` + `force_recheck` exist in production.
2. Dispatch [Ops archive seed catchup](../actions/workflows/ops-archive-seed-catchup.yml) to queue the 216 schools whose seed URL changed. Weekly success cooldown would otherwise wait 7 days.
3. Confirm `archive-process` is draining (every ~30s). New listings should start producing documents the same day.

## Test plan
- [x] `python -m unittest` finder + enqueue tests (checkpoint helper, junk filters, log replay, landing-hint env, school_ids)
- [x] Deno `archive-enqueue/schedule.test.ts`
- [x] `identity_guard.py` (0 errors) and `school_redirect_guard.py`
- [ ] Skim seed diff for satellite-campus copies (Amherst, UCSD, Albion, A-State `/books/common-data-set` are the intended shape; Widener's old PDF was kept)
- [ ] After merge: deploy `archive-enqueue`, run seed catchup, watch the process queue


Made with [Cursor](https://cursor.com)