### PR TITLE
fix: stop the next finder run from losing seeds the Friday way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Audit retired school redirects
         run: python tools/finder/school_redirect_guard.py
       - name: Run finder identity tests
-        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls tools.finder.test_stuck_pdf_seeds tools.finder.test_apply_probe_log tools.finder.test_promote_landing_hints
+        run: python -m unittest tools.finder.test_identity_guard tools.finder.test_school_redirect_guard tools.finder.test_probe_urls tools.finder.test_stuck_pdf_seeds tools.finder.test_apply_probe_log tools.finder.test_promote_landing_hints tools.finder.test_finder_workflows
       - name: Run scorecard loader tests
         run: python -m unittest tools.scorecard.test_load_directory
       - name: Run IPEDS loader tests

--- a/.github/workflows/ops-archive-seed-catchup.yml
+++ b/.github/workflows/ops-archive-seed-catchup.yml
@@ -1,12 +1,17 @@
 name: Ops archive seed catchup
 
 # After finder seeds land on main, weekly archive would otherwise wait out
-# the 7-day success cooldown. Dispatch this once the updated archive-enqueue
-# (school_ids + force_recheck) is deployed. Do not auto-fire on push until
-# that function is in production — a missing school_ids filter plus
-# force_recheck would re-queue the whole corpus.
+# the 7-day success cooldown. Push-to-main is safe only because
+# archive-enqueue filters on school_ids and this job canaries that echo
+# before sending force_recheck. A missing filter plus force_recheck would
+# re-queue the whole corpus — the canary refuses to continue in that case.
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - tools/finder/schools.yaml
   workflow_dispatch:
     inputs:
       before_ref:
@@ -24,6 +29,7 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      BEFORE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.before_ref || 'HEAD^' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -40,7 +46,7 @@ jobs:
 
       - name: Enqueue schools whose discovery seed changed
         run: |
-          git show "${{ inputs.before_ref }}:tools/finder/schools.yaml" > /tmp/schools-before.yaml
+          git show "${BEFORE_REF}:tools/finder/schools.yaml" > /tmp/schools-before.yaml
           python tools/ops/enqueue_changed_seeds.py \
             --before /tmp/schools-before.yaml \
             --after tools/finder/schools.yaml \

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -174,7 +174,7 @@ jobs:
             --run-url "${PIPELINE_RUN_URL}"
 
       - name: Heartbeat finder_brave start
-        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown'
+        if: ${{ always() && !cancelled() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown') }}
         run: |
           python tools/ops/record_heartbeat.py \
             --station finder_brave \
@@ -184,7 +184,7 @@ jobs:
 
       - id: probe_unknown
         name: Probe unknown schools
-        if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown'
+        if: ${{ always() && !cancelled() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown') }}
         run: |
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
             --brave-fallback \
@@ -219,7 +219,7 @@ jobs:
             --run-url "${PIPELINE_RUN_URL}"
 
       - name: Heartbeat finder_landing_hints start
-        if: env.INPUT_APPLY_LANDING_HINTS == 'true'
+        if: ${{ always() && !cancelled() && env.INPUT_APPLY_LANDING_HINTS == 'true' }}
         run: |
           python tools/ops/record_heartbeat.py \
             --station finder_landing_hints \
@@ -229,7 +229,7 @@ jobs:
 
       - id: promote_landing_hints
         name: Promote high-confidence landing hints
-        if: env.INPUT_APPLY_LANDING_HINTS == 'true'
+        if: ${{ always() && !cancelled() && env.INPUT_APPLY_LANDING_HINTS == 'true' }}
         run: |
           python tools/finder/promote_landing_hints.py \
             --min-confidence medium \
@@ -344,7 +344,11 @@ jobs:
   publish-seeds:
     name: Open seed PR from latest main
     needs: probe
-    if: success() && needs.probe.outputs.create_pr == 'true'
+    # Probe can go red after Brave already checkpointed schools.yaml
+    # (landing-hints, coverage issue, a later heartbeat). Friday lost a
+    # 2h45m run because the seed push lived in the failing job. Publish
+    # from the artifact whenever the probe job actually ran.
+    if: ${{ always() && !cancelled() && needs.probe.outputs.create_pr == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -371,6 +375,8 @@ jobs:
 
       - name: Overlay probed seeds onto current main
         run: |
+          test -s finder-probe/schools-base.yaml
+          test -s finder-probe/schools.yaml
           python tools/finder/merge_schools_yaml.py \
             --base finder-probe/schools-base.yaml \
             --main tools/finder/schools.yaml \
@@ -381,10 +387,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add tools/finder/schools.yaml
-          if git diff --cached --quiet; then
+          git add -- tools/finder/schools.yaml
+          staged="$(git diff --cached --name-only)"
+          if [[ -z "$staged" ]]; then
             echo "No schools.yaml changes against origin/main."
             exit 0
+          fi
+          if [[ "$staged" != "tools/finder/schools.yaml" ]]; then
+            echo "::error::publish-seeds may only commit tools/finder/schools.yaml"
+            printf '%s\n' "$staged"
+            exit 1
           fi
           branch="chore/finder-probe-${GITHUB_RUN_ID}"
           git checkout -B "$branch"
@@ -405,6 +417,6 @@ jobs:
 
           ## Test plan
           - [ ] Skim the PR diff for accidental satellite-campus seed copies
-          - [ ] After merge, \`ops-archive-seed-catchup\` enqueues schools whose seed URL changed
+          - [ ] Merging this PR auto-enqueues changed seeds via \`ops-archive-seed-catchup\`
           EOF
           )"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project uses four-part semantic versioning.
 - Restore finder checkpoint saves (`_save_yaml`) that the pipeline-board heartbeat patch accidentally deleted.
 - Let landing-hint promotion read `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` from the Actions environment instead of requiring a `.env` file on the runner.
 - Recover 216 listing/seed replacements from the 2026-08-21 Brave run logs (the seed PR never left the runner) and skip search-junk URLs so news pages and non-CDS PDFs do not become seeds.
+- Publish finder seed PRs even when a later probe step fails, keep a mid-run listing fix on `main` when the probe only stamped `probe_state`, and auto-enqueue changed seeds on merge after a `school_ids` canary so a rolled-back filter cannot re-queue the corpus.
 
 ## [0.5.1.0] - 2026-08-10
 

--- a/supabase/functions/archive-enqueue/index.ts
+++ b/supabase/functions/archive-enqueue/index.ts
@@ -44,6 +44,7 @@ import {
   parseCooldownDaysOverride,
   parseSchoolIdsOverride,
   restrictSchoolsToIds,
+  schoolIdsFilterMeta,
 } from "./schedule.ts";
 import { recordPipelineHeartbeat } from "../_shared/pipeline_heartbeat.ts";
 
@@ -138,6 +139,7 @@ Deno.serve(async (req: Request) => {
       before,
     });
   }
+  const idsMeta = schoolIdsFilterMeta(schoolIdsFilter, allSchools.length);
 
   if (skippedInvalid > 0) {
     // Not fatal — validation filters out malformed rows so the good ones
@@ -157,6 +159,7 @@ Deno.serve(async (req: Request) => {
       run_id: runId,
       enqueued: 0,
       note: "schools.yaml has no archivable schools",
+      ...idsMeta,
     });
   }
 
@@ -349,6 +352,7 @@ Deno.serve(async (req: Request) => {
       skipped_invalid_yaml: skippedInvalid,
       total_archivable: allSchools.length,
       note: "all archivable schools were in cooldown",
+      ...idsMeta,
     });
   }
 
@@ -372,6 +376,7 @@ Deno.serve(async (req: Request) => {
       error: `enqueue failed: ${error.message}`,
       run_id: runId,
       intended_count: rows.length,
+      ...idsMeta,
     }, 500);
   }
 
@@ -396,6 +401,7 @@ Deno.serve(async (req: Request) => {
     skipped_cooldown: inCooldown.size,
     skipped_invalid_yaml: skippedInvalid,
     total_archivable: allSchools.length,
+    ...idsMeta,
   });
 });
 

--- a/supabase/functions/archive-enqueue/schedule.test.ts
+++ b/supabase/functions/archive-enqueue/schedule.test.ts
@@ -7,6 +7,7 @@ import {
   parseCooldownDaysOverride,
   parseSchoolIdsOverride,
   restrictSchoolsToIds,
+  schoolIdsFilterMeta,
 } from "./schedule.ts";
 
 Deno.test("archiveEnqueueRunKey uses daily attempt buckets year-round", () => {
@@ -150,4 +151,19 @@ Deno.test("restrictSchoolsToIds keeps only requested ids", () => {
   const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
   assertEquals(restrictSchoolsToIds(rows, null), rows);
   assertEquals(restrictSchoolsToIds(rows, ["c", "a"]), [{ id: "a" }, { id: "c" }]);
+});
+
+Deno.test("schoolIdsFilterMeta is a positive assertion that the filter ran", () => {
+  assertEquals(schoolIdsFilterMeta(null, 2000), {
+    school_ids_requested: null,
+    school_ids_matched: null,
+  });
+  assertEquals(schoolIdsFilterMeta(["__canary__"], 0), {
+    school_ids_requested: 1,
+    school_ids_matched: 0,
+  });
+  assertEquals(schoolIdsFilterMeta(["a", "b"], 2), {
+    school_ids_requested: 2,
+    school_ids_matched: 2,
+  });
 });

--- a/supabase/functions/archive-enqueue/schedule.ts
+++ b/supabase/functions/archive-enqueue/schedule.ts
@@ -48,6 +48,22 @@ export function restrictSchoolsToIds<T extends { id: string }>(
   return schools.filter((school) => allow.has(school.id));
 }
 
+export function schoolIdsFilterMeta(
+  filter: string[] | null,
+  matchedCount: number,
+): {
+  school_ids_requested: number | null;
+  school_ids_matched: number | null;
+} {
+  if (filter === null) {
+    return { school_ids_requested: null, school_ids_matched: null };
+  }
+  return {
+    school_ids_requested: filter.length,
+    school_ids_matched: matchedCount,
+  };
+}
+
 export function archiveEnqueueRunKey(now: Date): string {
   const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
   const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");

--- a/tools/finder/merge_schools_yaml.py
+++ b/tools/finder/merge_schools_yaml.py
@@ -32,17 +32,29 @@ def by_id(schools: list[dict]) -> dict[str, dict]:
     return {str(school.get("id")): school for school in schools if school.get("id")}
 
 
-def seed_signature(school: dict | None) -> tuple:
+def seed_url(school: dict | None) -> str | None:
+    if not school:
+        return None
+    return school.get("discovery_seed_url") or school.get("cds_url_hint")
+
+
+def seed_policy(school: dict | None):
+    if not school:
+        return None
+    return school.get("scrape_policy")
+
+
+def probe_state_signature(school: dict | None) -> tuple:
     if not school:
         return ()
     ps = school.get("probe_state") or {}
-    return (
-        school.get("discovery_seed_url") or school.get("cds_url_hint"),
-        school.get("scrape_policy"),
-        ps.get("last_result"),
-        ps.get("last_probed_at"),
-        ps.get("last_method"),
-    )
+    return (ps.get("last_result"), ps.get("last_probed_at"), ps.get("last_method"))
+
+
+def seed_signature(school: dict | None) -> tuple:
+    if not school:
+        return ()
+    return (seed_url(school), seed_policy(school), *probe_state_signature(school))
 
 
 def overlay_seed_fields(target: dict, source: dict) -> dict:
@@ -53,6 +65,13 @@ def overlay_seed_fields(target: dict, source: dict) -> dict:
         elif field in merged and field not in source:
             if field == "cds_url_hint":
                 continue
+    return merged
+
+
+def overlay_probe_state(target: dict, source: dict) -> dict:
+    merged = dict(target)
+    if "probe_state" in source:
+        merged["probe_state"] = source["probe_state"]
     return merged
 
 
@@ -70,10 +89,26 @@ def merge_school_lists(
         sid = str(school.get("id") or "")
         seen.add(sid)
         probed_school = probed_map.get(sid)
-        if probed_school is not None and seed_signature(probed_school) != seed_signature(
-            base_map.get(sid)
-        ):
+        if probed_school is None:
+            out.append(school)
+            continue
+        started = base_map.get(sid)
+        url_or_policy_changed = seed_url(probed_school) != seed_url(
+            started
+        ) or seed_policy(probed_school) != seed_policy(started)
+        state_changed = probe_state_signature(probed_school) != probe_state_signature(
+            started
+        )
+        if url_or_policy_changed:
+            # Probe actually rewrote the seed. That find wins even if main
+            # also moved the same school during the run.
             out.append(overlay_seed_fields(school, probed_school))
+            changed_ids.append(sid)
+        elif state_changed:
+            # Cooldown / not_found stamps must land, but must not revert a
+            # listing that merged to main while the probe still held the
+            # start-of-run PDF.
+            out.append(overlay_probe_state(school, probed_school))
             changed_ids.append(sid)
         else:
             out.append(school)

--- a/tools/finder/promote_landing_hints.py
+++ b/tools/finder/promote_landing_hints.py
@@ -80,6 +80,14 @@ def supabase_credentials(env_path: Path) -> dict[str, str]:
     return {"SUPABASE_URL": url, "SUPABASE_SERVICE_ROLE_KEY": key}
 
 
+def init_supabase_client(env_path: Path):
+    """Fail closed: a missing client used to look like '0 proposals'."""
+    if create_client is None:
+        raise RuntimeError("supabase package is not installed")
+    creds = supabase_credentials(env_path)
+    return create_client(creds["SUPABASE_URL"], creds["SUPABASE_SERVICE_ROLE_KEY"])
+
+
 DOCUMENT_EXT_RE = re.compile(r"\.(pdf|xlsx|docx)(\?|#|$)", re.I)
 
 # Box / Google Drive share URLs look like direct docs but aren't — skip
@@ -483,14 +491,14 @@ def main() -> int:
     print(f"manual_urls.yaml entries: {len(manual)}", file=sys.stderr)
 
     sb = None
-    if not args.skip_db and create_client is not None:
+    if not args.skip_db:
         try:
-            creds = supabase_credentials(args.env)
-            sb = create_client(creds["SUPABASE_URL"], creds["SUPABASE_SERVICE_ROLE_KEY"])
+            sb = init_supabase_client(args.env)
             print("Supabase client: ready", file=sys.stderr)
         except Exception as e:
-            print(f"warn: Supabase client init failed ({e}); continuing with manual_urls only",
-                  file=sys.stderr)
+            print(f"error: Supabase client init failed ({e})", file=sys.stderr)
+            write_landing_summary(args.summary_json, proposals=0, promoted=0)
+            return 2
 
     proposals = build_proposals(schools, manual, sb)
     print(f"Proposals (pre-verify): {len(proposals)}", file=sys.stderr)
@@ -552,6 +560,13 @@ def main() -> int:
         if rank.get(p.get("confidence") or "low", 0) >= min_rank
     ]
     if args.ids_file:
+        if not args.ids_file.exists():
+            print(
+                f"warn: ids-file {args.ids_file} missing; skipping promotions",
+                file=sys.stderr,
+            )
+            write_landing_summary(args.summary_json, proposals=0, promoted=0)
+            return 0
         allow = {
             line.strip()
             for line in args.ids_file.read_text().splitlines()

--- a/tools/finder/test_apply_probe_log.py
+++ b/tools/finder/test_apply_probe_log.py
@@ -131,6 +131,44 @@ class MergeListsTests(unittest.TestCase):
         self.assertEqual(merged[0]["notes"], "keep")
         self.assertEqual(merged[1]["discovery_seed_url"], "https://b.edu/iea/")
 
+    def test_probe_state_only_does_not_revert_main_listing(self) -> None:
+        base = [
+            {
+                "id": "ohio-university-main-campus",
+                "discovery_seed_url": "https://www.ohio.edu/instres/commondataset.pdf",
+                "scrape_policy": "active",
+                "probe_state": {"last_result": "found", "last_probed_at": "2026-04-14T00:00:00Z"},
+            }
+        ]
+        main = [
+            {
+                "id": "ohio-university-main-campus",
+                "discovery_seed_url": "https://www.ohio.edu/iea/university-data",
+                "scrape_policy": "active",
+                "probe_state": {"last_result": "found", "last_probed_at": "2026-04-14T00:00:00Z"},
+            }
+        ]
+        probed = [
+            {
+                "id": "ohio-university-main-campus",
+                "discovery_seed_url": "https://www.ohio.edu/instres/commondataset.pdf",
+                "scrape_policy": "active",
+                "probe_state": {
+                    "last_result": "not_found",
+                    "last_probed_at": "2026-09-02T14:18:00Z",
+                    "last_method": "brave",
+                },
+            }
+        ]
+        merged, changed = merge_school_lists(base, main, probed)
+        self.assertEqual(changed, ["ohio-university-main-campus"])
+        self.assertEqual(
+            merged[0]["discovery_seed_url"],
+            "https://www.ohio.edu/iea/university-data",
+        )
+        self.assertEqual(merged[0]["probe_state"]["last_result"], "not_found")
+        self.assertEqual(merged[0]["probe_state"]["last_probed_at"], "2026-09-02T14:18:00Z")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/finder/test_finder_workflows.py
+++ b/tools/finder/test_finder_workflows.py
@@ -1,0 +1,47 @@
+"""Workflow contracts so the next finder run cannot lose seeds the Friday way."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FINDER = (ROOT / ".github/workflows/ops-finder-probe.yml").read_text()
+CATCHUP = (ROOT / ".github/workflows/ops-archive-seed-catchup.yml").read_text()
+
+
+class FinderProbeWorkflowTests(unittest.TestCase):
+    def test_publish_job_does_not_require_probe_success(self) -> None:
+        _, publish = FINDER.split("publish-seeds:", 1)
+        job_header = publish.split("steps:", 1)[0]
+        self.assertIn("always()", job_header)
+        self.assertNotIn("if: success()", job_header)
+
+    def test_publish_checks_out_current_main(self) -> None:
+        _, publish = FINDER.split("publish-seeds:", 1)
+        self.assertIn("ref: main", publish)
+
+    def test_publish_may_only_add_schools_yaml(self) -> None:
+        self.assertIn("git add -- tools/finder/schools.yaml", FINDER)
+        self.assertNotIn("git add -A", FINDER)
+        self.assertNotIn("git add .", FINDER)
+        self.assertIn(
+            'publish-seeds may only commit tools/finder/schools.yaml',
+            FINDER,
+        )
+
+    def test_probe_always_snapshots_yaml_into_the_artifact(self) -> None:
+        self.assertIn("cp tools/finder/schools.yaml finder-probe/schools.yaml", FINDER)
+        self.assertIn("cp tools/finder/schools.yaml finder-probe/schools-base.yaml", FINDER)
+
+
+class ArchiveSeedCatchupWorkflowTests(unittest.TestCase):
+    def test_runs_on_schools_yaml_push_to_main(self) -> None:
+        self.assertIn("push:", CATCHUP)
+        self.assertIn("tools/finder/schools.yaml", CATCHUP)
+        self.assertIn("HEAD^", CATCHUP)
+        self.assertIn("--apply", CATCHUP)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -211,6 +211,21 @@ class CheckpointHelpersTests(unittest.TestCase):
         self.assertEqual(payload["replaced"], 2)
         self.assertEqual(payload["still_stuck"], 9)
 
+    def test_save_yaml_writes_checkpoint(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest import mock
+
+        import tools.finder.probe_urls as probe_urls
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schools.yaml"
+            with mock.patch.object(probe_urls, "SCHOOLS_YAML", path):
+                probe_urls._save_yaml({"schools": [{"id": "x", "name": "Xavier"}]})
+            text = path.read_text()
+        self.assertIn("id: x", text)
+        self.assertIn("Xavier", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/finder/test_promote_landing_hints.py
+++ b/tools/finder/test_promote_landing_hints.py
@@ -44,6 +44,14 @@ class SupabaseCredentialsTests(unittest.TestCase):
                 creds = supabase_credentials(env_path)
         self.assertEqual(creds["SUPABASE_URL"], "https://env.example")
 
+    def test_missing_package_fails_closed(self) -> None:
+        from tools.finder.promote_landing_hints import init_supabase_client
+
+        with mock.patch("tools.finder.promote_landing_hints.create_client", None):
+            with self.assertRaises(RuntimeError) as ctx:
+                init_supabase_client(Path(".env"))
+        self.assertIn("not installed", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ops/enqueue_changed_seeds.py
+++ b/tools/ops/enqueue_changed_seeds.py
@@ -25,6 +25,8 @@ from tools.ops.directory_enqueue_batches import (  # noqa: E402
     require_supabase_credentials,
 )
 
+CANARY_SCHOOL_ID = "__finder_seed_catchup_canary__"
+
 
 def seed_of(school: dict) -> str:
     return str(school.get("discovery_seed_url") or school.get("cds_url_hint") or "")
@@ -62,12 +64,70 @@ def chunked(ids: list[str], size: int = 80) -> list[list[str]]:
     return [ids[i : i + size] for i in range(0, len(ids), size)]
 
 
+def canary_filter_error(result: dict) -> str | None:
+    """Catch a rolled-back archive-enqueue that ignores school_ids.
+
+    A missing filter plus force_recheck would re-queue the whole corpus.
+    The canary itself never sends force_recheck; it refuses to continue
+    unless the function echoes that it applied a 1-id filter and matched
+    nothing.
+    """
+    requested = result.get("school_ids_requested")
+    matched = result.get("school_ids_matched")
+    enqueued = int(result.get("enqueued") or 0)
+    if requested != 1:
+        return (
+            f"school_ids_requested={requested!r}, expected 1 "
+            "(archive-enqueue school_ids filter is not live)"
+        )
+    if int(matched or 0) != 0:
+        return f"school_ids_matched={matched!r}, expected 0"
+    if enqueued != 0:
+        return f"enqueued={enqueued}, expected 0"
+    return None
+
+
+def chunk_filter_error(result: dict, group: list[str]) -> str | None:
+    requested = result.get("school_ids_requested")
+    matched = result.get("school_ids_matched")
+    enqueued = int(result.get("enqueued") or 0)
+    if requested != len(group):
+        return (
+            f"school_ids_requested={requested!r}, expected {len(group)} "
+            "(filter did not echo this chunk)"
+        )
+    if matched is None or int(matched) > len(group):
+        return f"school_ids_matched={matched!r} exceeds chunk of {len(group)}"
+    if enqueued > len(group):
+        return f"enqueued={enqueued} exceeds chunk of {len(group)}"
+    return None
+
+
+def assert_school_ids_filter(client: SupabaseClient) -> dict:
+    result = client.post_function(
+        "archive-enqueue",
+        {
+            "school_ids": CANARY_SCHOOL_ID,
+            "run_id": str(uuid.uuid4()),
+        },
+    )
+    error = canary_filter_error(result)
+    if error:
+        raise OpsError(error)
+    return result
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.strip().split("\n\n")[0])
     ap.add_argument("--before", type=Path, required=True)
     ap.add_argument("--after", type=Path, required=True)
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--env", type=Path, default=Path(".env"))
+    ap.add_argument(
+        "--skip-canary",
+        action="store_true",
+        help="Do not ping archive-enqueue with a fake school_id first.",
+    )
     args = ap.parse_args()
     ids = changed_seed_ids(load_schools(args.before), load_schools(args.after))
     print(json.dumps({"changed": len(ids), "ids": ids}, indent=2))
@@ -79,6 +139,9 @@ def main() -> int:
         return 0
     url, key = require_supabase_credentials(args.env)
     client = SupabaseClient(url, key)
+    if not args.skip_canary:
+        canary = assert_school_ids_filter(client)
+        print(json.dumps({"canary": canary}))
     enqueued = 0
     run_id = str(uuid.uuid4())
     for group in chunked(ids):
@@ -90,6 +153,9 @@ def main() -> int:
                 "run_id": run_id,
             },
         )
+        error = chunk_filter_error(result, group)
+        if error:
+            raise OpsError(error)
         enqueued += int(result.get("enqueued") or 0)
         print(json.dumps({"chunk": group, "result": result}))
     print(json.dumps({"enqueued_total": enqueued}))

--- a/tools/ops/test_enqueue_changed_seeds.py
+++ b/tools/ops/test_enqueue_changed_seeds.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import unittest
 
-from tools.ops.enqueue_changed_seeds import changed_seed_ids, chunked
+from tools.ops.enqueue_changed_seeds import (
+    CANARY_SCHOOL_ID,
+    canary_filter_error,
+    changed_seed_ids,
+    chunk_filter_error,
+    chunked,
+)
 
 
 class ChangedSeedIdsTests(unittest.TestCase):
@@ -23,6 +29,65 @@ class ChangedSeedIdsTests(unittest.TestCase):
 
     def test_chunks_ids(self) -> None:
         self.assertEqual(chunked(["a", "b", "c", "d"], 2), [["a", "b"], ["c", "d"]])
+
+
+class SchoolIdsCanaryTests(unittest.TestCase):
+    def test_accepts_live_filter_echo(self) -> None:
+        self.assertIsNone(
+            canary_filter_error(
+                {
+                    "enqueued": 0,
+                    "school_ids_requested": 1,
+                    "school_ids_matched": 0,
+                    "note": "schools.yaml has no archivable schools",
+                }
+            )
+        )
+
+    def test_rejects_missing_filter_echo(self) -> None:
+        # Pre-#139 function, or a rollback: extra query params are ignored.
+        self.assertIn(
+            "not live",
+            canary_filter_error(
+                {"enqueued": 0, "note": "schools.yaml has no archivable schools"}
+            )
+            or "",
+        )
+
+    def test_rejects_corpus_match(self) -> None:
+        self.assertIsNotNone(
+            canary_filter_error(
+                {
+                    "enqueued": 0,
+                    "school_ids_requested": 1,
+                    "school_ids_matched": 1800,
+                }
+            )
+        )
+
+    def test_chunk_rejects_oversize_enqueue(self) -> None:
+        group = ["a", "b"]
+        self.assertIsNotNone(
+            chunk_filter_error(
+                {
+                    "enqueued": 50,
+                    "school_ids_requested": 2,
+                    "school_ids_matched": 2,
+                },
+                group,
+            )
+        )
+        self.assertIsNone(
+            chunk_filter_error(
+                {
+                    "enqueued": 2,
+                    "school_ids_requested": 2,
+                    "school_ids_matched": 2,
+                },
+                group,
+            )
+        )
+        self.assertEqual(CANARY_SCHOOL_ID, "__finder_seed_catchup_canary__")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Friday's class of failure was not fully closed after #139: a red later probe step still skipped the seed PR, catchup was still a manual dispatch, and a probe-state-only overlay could revert a listing that landed on `main` mid-run (Ohio IEA vs the start-of-run PDF).
- `publish-seeds` now runs from the artifact unless the workflow was cancelled, and refuses to commit anything except `tools/finder/schools.yaml`.
- Changed seeds auto-enqueue on push of `schools.yaml` to `main`, but only after a live `school_ids` canary. A rolled-back filter cannot `force_recheck` the corpus.
- Landing-hints fail closed when Supabase is missing (no more silent `0 proposals`). `archive-enqueue` is already deployed with the filter echo.

## Test plan
- [x] Unit tests for merge (Ohio probe-state-only), workflow contracts, canary, `_save_yaml` write, landing-hints fail-closed
- [x] Live canary: fake school id → `school_ids_requested=1`, `matched=0`, `enqueued=0`
- [x] Landing-hints with process env and no `.env` → `Supabase client: ready`
- [ ] CI green
- [ ] After merge, confirm `ops-archive-seed-catchup` does **not** fire (this PR does not touch `schools.yaml`)


Made with [Cursor](https://cursor.com)