### PR TITLE
feat: theme school records with derived two-plate brand inks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses four-part semantic versioning.
 
 ### Added
 
+- Theme school records with a two-plate riso ink pair derived from each school's brand hexes, seeded for the 19 brief schools that exist in the Scorecard directory, and keep house forest/ochre when no usable colour is on file.
 - Show a data-generated Common Data Set archive lead on school hubs and year pages, including an official IR link when we have a usable HTML URL, and gated-request copy only for schools we have actually read (Virginia Tech).
 - Publish three source-literacy pages under `/about` (Common Data Set, College Scorecard, IPEDS) and link them from About, the footer, and `/llms.txt`.
 - Record the August 2026 Search Console CDS-query export next to PRD 028, including URL inspection of the Virginia Tech and Harvey Mudd canaries.

--- a/supabase/migrations/20260823200000_institution_brand_colors.sql
+++ b/supabase/migrations/20260823200000_institution_brand_colors.sql
@@ -1,0 +1,41 @@
+-- Source brand hexes for school-page two-plate inks.
+-- Store what the school publishes, not the derived A/B plates.
+-- The Scorecard directory upsert does not send these columns, so
+-- scouted values survive a directory refresh.
+
+alter table public.institution_directory
+  add column if not exists brand_colors text[],
+  add column if not exists brand_colors_source text,
+  add column if not exists brand_colors_checked_at date,
+  add column if not exists brand_colors_confidence text,
+  add column if not exists brand_colors_notes text;
+
+alter table public.institution_directory
+  drop constraint if exists institution_directory_brand_colors_len,
+  drop constraint if exists institution_directory_brand_colors_confidence;
+
+alter table public.institution_directory
+  add constraint institution_directory_brand_colors_len
+    check (
+      brand_colors is null
+      or (
+        cardinality(brand_colors) between 1 and 3
+        and brand_colors_source is not null
+      )
+    ),
+  add constraint institution_directory_brand_colors_confidence
+    check (
+      brand_colors_confidence is null
+      or brand_colors_confidence in ('high', 'medium', 'low')
+    );
+
+comment on column public.institution_directory.brand_colors is
+  '1–3 official brand hexes, primary first. Null means house inks. Never store derived plates.';
+comment on column public.institution_directory.brand_colors_source is
+  'URL of the brand guide or page the hexes were read from.';
+comment on column public.institution_directory.brand_colors_checked_at is
+  'Date the source was last read.';
+comment on column public.institution_directory.brand_colors_confidence is
+  'high = official hexes; medium = official names plus on-domain hex; low = secondary index.';
+comment on column public.institution_directory.brand_colors_notes is
+  'Scout notes: athletics vs academic conflict, system-shared brand, search that found nothing.';

--- a/supabase/migrations/20260823210000_seed_handoff_brand_colors.sql
+++ b/supabase/migrations/20260823210000_seed_handoff_brand_colors.sql
@@ -1,0 +1,140 @@
+-- First-ship brand hexes from the riso school-inks design handoff
+-- (ink-lab.html). Plates are still derived at render; this stores source
+-- hexes only.
+--
+-- 19 of the 20 brief school palettes. Deep Springs College is not in
+-- institution_directory (Scorecard does not list it), and its grey-only
+-- palette would house-fallthrough anyway. The synthetic "Pale primary ·
+-- test" row is not a school.
+
+with seed (
+  school_id,
+  brand_colors,
+  brand_colors_source,
+  brand_colors_notes
+) as (
+  values
+    (
+      'umich',
+      array['#00274C', '#FFCB05']::text[],
+      'https://brand.umich.edu/design-resources/colors/',
+      'First-ship palette from the riso school-inks design handoff. Michigan Blue + Maize.'
+    ),
+    (
+      'stanford',
+      array['#8C1515', '#E98300']::text[],
+      'https://identity.stanford.edu/design-elements/color/',
+      'First-ship palette from the riso school-inks design handoff. Cardinal + accent gold.'
+    ),
+    (
+      'uc-berkeley',
+      array['#003262', '#FDB515']::text[],
+      'https://brand.berkeley.edu/visual-identity/color/',
+      'First-ship palette from the riso school-inks design handoff. Berkeley Blue + California Gold.'
+    ),
+    (
+      'howard-university',
+      array['#003A63', '#E51937']::text[],
+      'https://www2.howard.edu/brand',
+      'First-ship palette from the riso school-inks design handoff. Navy + Howard red. B-on-A type stays cream.'
+    ),
+    (
+      'ut-austin',
+      array['#BF5700']::text[],
+      'https://brand.utexas.edu/visual-identity/colors/',
+      'First-ship palette from the riso school-inks design handoff. Burnt orange only; A falls back to charcoal.'
+    ),
+    (
+      'mit',
+      array['#750014', '#8A8B8C']::text[],
+      'https://web.mit.edu/graphicidentity/colors.html',
+      'First-ship palette from the riso school-inks design handoff. MIT Maroon; grey second colour is rejected.'
+    ),
+    (
+      'wellesley-college',
+      array['#0142A2', '#C9D9EE']::text[],
+      'https://www.wellesley.edu/communications',
+      'First-ship palette from the riso school-inks design handoff. Wellesley blue + pale second.'
+    ),
+    (
+      'grinnell-college',
+      array['#B01F24', '#F0B323']::text[],
+      'https://www.grinnell.edu/about/offices-services/communications/brand',
+      'First-ship palette from the riso school-inks design handoff.'
+    ),
+    (
+      'spelman-college',
+      array['#00457C', '#7A9A01']::text[],
+      'https://www.spelman.edu/about-us',
+      'First-ship palette from the riso school-inks design handoff.'
+    ),
+    (
+      'reed-college',
+      array['#A70E13', '#4F5858']::text[],
+      'https://www.reed.edu/communications/visual-identity/',
+      'First-ship palette from the riso school-inks design handoff. Reed red; grey second colour is rejected.'
+    ),
+    (
+      'bethel-university',
+      array['#10306B', '#F0B323']::text[],
+      'https://www.bethel.edu/university-communications/brand',
+      'First-ship palette from the riso school-inks design handoff. Bethel University (MN, UNITID 173160), not IN/TN namesakes.'
+    ),
+    (
+      'oberlin',
+      array['#C00000', '#FFC72C']::text[],
+      'https://www.oberlin.edu/communications',
+      'First-ship palette from the riso school-inks design handoff.'
+    ),
+    (
+      'morehouse-college',
+      array['#8A1C1C', '#B79A5B']::text[],
+      'https://morehouse.edu/about/brand',
+      'First-ship palette from the riso school-inks design handoff.'
+    ),
+    (
+      'smith-college',
+      array['#F5C400', '#002B45']::text[],
+      'https://www.smith.edu/about-smith/college-relations',
+      'First-ship palette from the riso school-inks design handoff. Gold + navy; order as published in the brief.'
+    ),
+    (
+      'rice',
+      array['#00205B', '#7C7E7F']::text[],
+      'https://brand.rice.edu/',
+      'First-ship palette from the riso school-inks design handoff. Rice Blue; grey second colour is rejected.'
+    ),
+    (
+      'tulane-university-of-louisiana',
+      array['#006747', '#418FDE']::text[],
+      'https://brand.tulane.edu/',
+      'First-ship palette from the riso school-inks design handoff. Olive + Tulane blue.'
+    ),
+    (
+      'colorado-college',
+      array['#FFC72C', '#1E1E1E']::text[],
+      'https://www.coloradocollege.edu/offices/communications/',
+      'First-ship palette from the riso school-inks design handoff. Gold + black.'
+    ),
+    (
+      'amherst',
+      array['#4F2683', '#B7A57A']::text[],
+      'https://www.amherst.edu/news/communications',
+      'First-ship palette from the riso school-inks design handoff. Purple + gold.'
+    ),
+    (
+      'hampton-university',
+      array['#00447C', '#005EB8']::text[],
+      'https://www.hamptonu.edu/',
+      'First-ship palette from the riso school-inks design handoff. Two close blues; B is pushed brighter to separate.'
+    )
+)
+update public.institution_directory as d
+set
+  brand_colors = s.brand_colors,
+  brand_colors_source = s.brand_colors_source,
+  brand_colors_checked_at = date '2026-08-23',
+  brand_colors_confidence = 'medium',
+  brand_colors_notes = s.brand_colors_notes
+from seed s
+where d.school_id = s.school_id;

--- a/web/src/app/ink-lab/page.tsx
+++ b/web/src/app/ink-lab/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import {
+  INK_LAB_PRESETS,
+  deriveInks,
+  HOUSE_A,
+  HOUSE_B,
+} from "@/lib/derive-inks";
+
+export const metadata: Metadata = {
+  title: "Ink lab",
+  robots: { index: false, follow: false },
+};
+
+export default function InkLabPage() {
+  const house = deriveInks([]);
+  const rows = [
+    ["House inks (no brand colours)", ""] as [string, string],
+    ...INK_LAB_PRESETS,
+  ];
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-10">
+      <p className="meta">§ Internal · not indexed</p>
+      <h1 className="serif" style={{ fontSize: 42, fontWeight: 400, margin: "8px 0 0" }}>
+        Ink lab
+      </h1>
+      <p style={{ maxWidth: "62ch", color: "var(--ink-2)", marginTop: 12 }}>
+        Regression grid for the two-plate school inks. House A/B must stay{" "}
+        <code>{HOUSE_A}</code> / <code>{HOUSE_B}</code>. Michigan maize must stay
+        maize. A failed B-on-A gate means the name stays cream on the hero band.
+      </p>
+      <p className="meta" style={{ marginTop: 10 }}>
+        House aOnCream {house.contrast.aOnCream}:1 (site forest, not forced to 7:1)
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: 14,
+          marginTop: 28,
+        }}
+      >
+        {rows.map(([name, hexes]) => {
+          const inks = deriveInks(hexes);
+          return (
+            <article
+              key={name}
+              style={{
+                border: "1px solid var(--rule-strong)",
+                background: "var(--paper)",
+              }}
+            >
+              <div style={{ display: "flex", height: 54 }}>
+                <i style={{ flex: 1, background: inks.a }} />
+                <i style={{ flex: 0.62, background: inks.b }} />
+              </div>
+              <div style={{ padding: "10px 12px 12px" }}>
+                <div className="serif" style={{ fontSize: 16 }}>
+                  {name}
+                </div>
+                <p
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    letterSpacing: "0.04em",
+                    textTransform: "uppercase",
+                    color: "var(--ink-3)",
+                    margin: "6px 0 0",
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {inks.rule}
+                </p>
+                <p
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    margin: "8px 0 0",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: 8,
+                  }}
+                >
+                  <span>A {inks.contrast.aOnCream}:1</span>
+                  <span>onB {inks.contrast.textOnB}:1</span>
+                  <span>B {inks.contrast.bOnCream}:1</span>
+                  <span style={{ color: inks.bTypeOnA ? "var(--forest)" : "var(--ochre)" }}>
+                    B/A {inks.contrast.bOnA}:1
+                  </span>
+                </p>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -4,7 +4,7 @@ const SITE_URL = "https://www.collegedata.fyi";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: { userAgent: "*", allow: "/" },
+    rules: { userAgent: "*", allow: "/", disallow: "/ink-lab" },
     sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/web/src/app/schools/[school_id]/[year]/opengraph-image.tsx
+++ b/web/src/app/schools/[school_id]/[year]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import {
   fetchExtract,
 } from "@/lib/queries";
 import type { FieldValue } from "@/lib/types";
+import { cachedSchoolInks, schoolOgColors } from "@/lib/school-inks";
 
 export const alt = "Common Data Set year detail";
 export const size = { width: 1200, height: 630 };
@@ -48,19 +49,20 @@ export default async function Image({
   const { school_id, year } = await params;
   const resolvedSchoolId = (await fetchCanonicalSchoolId(school_id)) ?? school_id;
   const docs = await fetchDocumentsBySchoolAndYear(resolvedSchoolId, year);
+  const og = schoolOgColors(await cachedSchoolInks(resolvedSchoolId));
 
   if (docs.length === 0) {
     return new ImageResponse(
       (
         <div
           style={{
-            background: "#1e3a5f",
+            background: og.ground,
             width: "100%",
             height: "100%",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            color: "#ffffff",
+            color: og.type,
             fontSize: 48,
           }}
         >
@@ -114,7 +116,7 @@ export default async function Image({
     (
       <div
         style={{
-          background: "linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)",
+          background: og.ground,
           width: "100%",
           height: "100%",
           display: "flex",
@@ -128,7 +130,7 @@ export default async function Image({
           style={{
             display: "flex",
             fontSize: 20,
-            color: "#60a5fa",
+            color: og.accent,
             marginBottom: 16,
             letterSpacing: 1,
           }}
@@ -142,7 +144,7 @@ export default async function Image({
             display: "flex",
             fontSize: schoolName.length > 40 ? 40 : 52,
             fontWeight: 700,
-            color: "#ffffff",
+            color: og.type,
             lineHeight: 1.2,
           }}
         >
@@ -154,7 +156,7 @@ export default async function Image({
           style={{
             display: "flex",
             fontSize: 28,
-            color: "#94a3b8",
+            color: og.type,
             marginTop: 8,
             marginBottom: 32,
           }}
@@ -166,7 +168,7 @@ export default async function Image({
         {stats.length > 0 ? (
           <div style={{ display: "flex", gap: 32 }}>
             {stats.slice(0, 4).map((s) => (
-              <StatPill key={s.label} label={s.label} value={s.value} />
+              <StatPill key={s.label} label={s.label} value={s.value} type={og.type} />
             ))}
           </div>
         ) : null}
@@ -176,22 +178,30 @@ export default async function Image({
   );
 }
 
-function StatPill({ label, value }: { label: string; value: string }) {
+function StatPill({
+  label,
+  value,
+  type,
+}: {
+  label: string;
+  value: string;
+  type: string;
+}) {
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        background: "rgba(255,255,255,0.1)",
-        borderRadius: 16,
+        background: "rgba(241,236,225,0.12)",
+        borderRadius: 2,
         padding: "16px 32px",
       }}
     >
-      <div style={{ fontSize: 32, fontWeight: 700, color: "#ffffff" }}>
+      <div style={{ fontSize: 32, fontWeight: 700, color: type }}>
         {value}
       </div>
-      <div style={{ fontSize: 14, color: "#94a3b8", marginTop: 4 }}>
+      <div style={{ fontSize: 14, color: type, opacity: 0.72, marginTop: 4 }}>
         {label}
       </div>
     </div>

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -125,25 +125,33 @@ export default async function SchoolYearPage({ params }: {
           __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
         }}
       />
-      {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500 mb-4">
-        <Link href="/schools" className="hover:text-gray-700">
-          Schools
-        </Link>
-        {" / "}
-        <Link
-          href={`/schools/${school_id}`}
-          className="hover:text-gray-700"
-        >
-          {schoolName}
-        </Link>
-        {" / "}
-        <span className="text-gray-900">{year}</span>
-      </nav>
-
-      {/* Header */}
-      <h1 className="text-3xl font-bold text-gray-900">{schoolName}</h1>
-      <h2 className="text-xl text-gray-600 mt-1">{yearLead.heading}</h2>
+      {/* Breadcrumb + year identity share the school plates with the overview. */}
+      <header className="cd-school-header">
+        <div>
+          <nav className="mono" style={{ fontSize: 11, letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: 12 }}>
+            <Link href="/schools">Schools</Link>
+            {" / "}
+            <Link href={`/schools/${school_id}`}>{schoolName}</Link>
+            {" / "}
+            <span>{year}</span>
+          </nav>
+          <h1
+            className="serif"
+            style={{
+              fontWeight: 400,
+              fontSize: "clamp(36px, 5vw, 52px)",
+              margin: 0,
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+            }}
+          >
+            {schoolName}
+          </h1>
+          <h2 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "10px 0 0" }}>
+            {yearLead.heading}
+          </h2>
+        </div>
+      </header>
       <ArchiveLead lead={yearLead} showHeading={false} />
 
       {/* Render each document variant. The spreadsheet download covers all
@@ -192,16 +200,14 @@ async function DocumentVariant({
     : null;
 
   return (
-    <div className="mt-8">
-      {/* Sub-institutional label */}
+    <div style={{ marginTop: 32 }}>
       {doc.sub_institutional && (
-        <h2 className="text-lg font-semibold text-gray-800 mb-2">
+        <h2 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "0 0 8px" }}>
           {doc.sub_institutional}
         </h2>
       )}
 
-      {/* Meta */}
-      <div className="flex items-center gap-3 flex-wrap">
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         {doc.source_format && (
           <Badge
             label={formatBadgeLabel(doc.source_format)}
@@ -213,7 +219,8 @@ async function DocumentVariant({
             href={sourceDownloadUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-blue-600 hover:text-blue-800"
+            className="mono"
+            style={{ fontSize: 13 }}
           >
             {sourceDownloadLabel(doc.source_format, doc.source_storage_path)}
           </a>
@@ -226,9 +233,8 @@ async function DocumentVariant({
         )}
       </div>
 
-      {/* Key stats */}
       {hasValues && (
-        <div className="mt-4">
+        <div style={{ marginTop: 16 }}>
           <KeyStats schemaVersion={schemaVersion ?? doc.cds_year ?? undefined} values={values} />
         </div>
       )}
@@ -244,22 +250,22 @@ async function DocumentVariant({
           document variant; for schools with sub-institutional variants, the
           Scorecard data is IPEDS-level and identical across them. */}
       {scorecard && !doc.sub_institutional && (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-900">
+        <div style={{ marginTop: 24 }}>
+          <div className="meta">§ Federal outcomes</div>
+          <h2 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "6px 0 0" }}>
             Federal outcomes
           </h2>
-          <div className="mt-1"><ScorecardVintageNote scorecard={scorecard} /></div>
-          <div className="mt-3">
+          <div style={{ marginTop: 4 }}><ScorecardVintageNote scorecard={scorecard} /></div>
+          <div style={{ marginTop: 12 }}>
             <OutcomesBand scorecard={scorecard} />
           </div>
         </div>
       )}
 
-      {/* Full fields */}
       {hasValues ? (
-        <div className="mt-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
-            All Extracted Fields
+        <div style={{ marginTop: 24 }}>
+          <h3 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "0 0 16px" }}>
+            All extracted fields
           </h3>
           <FieldsView
             schemaVersion={schemaVersion ?? doc.cds_year}
@@ -268,11 +274,11 @@ async function DocumentVariant({
           />
         </div>
       ) : isExtracted ? (
-        <div className="mt-4 rounded-lg border border-gray-200 p-6 text-center text-gray-500">
+        <div className="cd-card" style={{ marginTop: 16, padding: "24px 28px" }}>
           <p>No structured field values available for this document yet.</p>
         </div>
       ) : (
-        <div className="mt-4 rounded-lg border border-yellow-200 bg-yellow-50 p-6 text-center text-yellow-800">
+        <div className="cd-card" style={{ marginTop: 16, padding: "24px 28px" }}>
           <p>
             Structured data coming soon. The source document is available for
             download above.

--- a/web/src/app/schools/[school_id]/layout.tsx
+++ b/web/src/app/schools/[school_id]/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { cachedSchoolInks, schoolInkWrapperProps } from "@/lib/school-inks";
+
+export default async function SchoolRecordLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ school_id: string }>;
+}) {
+  const { school_id } = await params;
+  const inks = await cachedSchoolInks(school_id);
+  return <div {...schoolInkWrapperProps(inks)}>{children}</div>;
+}

--- a/web/src/app/schools/[school_id]/opengraph-image.tsx
+++ b/web/src/app/schools/[school_id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { fetchCanonicalSchoolId, fetchSchoolDocuments } from "@/lib/queries";
 import { yearRange } from "@/lib/format";
+import { cachedSchoolInks, schoolOgColors } from "@/lib/school-inks";
 
 export const alt = "School Common Data Set archive";
 export const size = { width: 1200, height: 630 };
@@ -15,19 +16,20 @@ export default async function Image({
   const { school_id } = await params;
   const resolvedSchoolId = (await fetchCanonicalSchoolId(school_id)) ?? school_id;
   const docs = await fetchSchoolDocuments(resolvedSchoolId);
+  const og = schoolOgColors(await cachedSchoolInks(resolvedSchoolId));
 
   if (docs.length === 0) {
     return new ImageResponse(
       (
         <div
           style={{
-            background: "#1e3a5f",
+            background: og.ground,
             width: "100%",
             height: "100%",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            color: "#ffffff",
+            color: og.type,
             fontSize: 48,
           }}
         >
@@ -48,7 +50,7 @@ export default async function Image({
     (
       <div
         style={{
-          background: "linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)",
+          background: og.ground,
           width: "100%",
           height: "100%",
           display: "flex",
@@ -62,7 +64,7 @@ export default async function Image({
           style={{
             display: "flex",
             fontSize: 20,
-            color: "#60a5fa",
+            color: og.accent,
             marginBottom: 16,
             letterSpacing: 1,
           }}
@@ -76,7 +78,7 @@ export default async function Image({
             display: "flex",
             fontSize: name.length > 40 ? 44 : 56,
             fontWeight: 700,
-            color: "#ffffff",
+            color: og.type,
             lineHeight: 1.2,
             marginBottom: 24,
           }}
@@ -89,16 +91,19 @@ export default async function Image({
           <StatPill
             label="Documents"
             value={docs.length.toString()}
+            type={og.type}
           />
           {years.length > 0 ? (
             <StatPill
               label="Years"
               value={yearRange(years[0], years[years.length - 1])}
+              type={og.type}
             />
           ) : null}
           <StatPill
             label="Extracted"
             value={docs.filter((d) => d.extraction_status === "extracted").length.toString()}
+            type={og.type}
           />
         </div>
       </div>
@@ -107,22 +112,30 @@ export default async function Image({
   );
 }
 
-function StatPill({ label, value }: { label: string; value: string }) {
+function StatPill({
+  label,
+  value,
+  type,
+}: {
+  label: string;
+  value: string;
+  type: string;
+}) {
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        background: "rgba(255,255,255,0.1)",
-        borderRadius: 16,
+        background: "rgba(241,236,225,0.12)",
+        borderRadius: 2,
         padding: "20px 36px",
       }}
     >
-      <div style={{ fontSize: 36, fontWeight: 700, color: "#ffffff" }}>
+      <div style={{ fontSize: 36, fontWeight: 700, color: type }}>
         {value}
       </div>
-      <div style={{ fontSize: 16, color: "#94a3b8", marginTop: 4 }}>
+      <div style={{ fontSize: 16, color: type, opacity: 0.72, marginTop: 4 }}>
         {label}
       </div>
     </div>

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -307,31 +307,21 @@ export default async function SchoolDetailPage({ params }: {
       />
 
       {/* Header */}
-      <header
-        className="cd-school-header"
-        style={{ paddingTop: 24, paddingBottom: 8 }}
-      >
+      <header className="cd-school-header">
         <div>
           <div
             className="mono"
             style={{
               fontSize: 11,
-              color: "var(--ink-3)",
               letterSpacing: "0.08em",
               marginBottom: 12,
               textTransform: "uppercase",
             }}
           >
-            <Link
-              href="/schools"
-              style={{
-                color: "var(--ink-3)",
-                textDecoration: "none",
-              }}
-            >
+            <Link href="/schools" style={{ textDecoration: "none" }}>
               SCHOOLS
             </Link>{" "}
-            / <span style={{ color: "var(--ink)" }}>{name.toUpperCase()}</span>
+            / <span>{name.toUpperCase()}</span>
           </div>
           <h1
             className="serif"
@@ -359,7 +349,6 @@ export default async function SchoolDetailPage({ params }: {
               gap: 22,
               marginTop: 16,
               alignItems: "baseline",
-              color: "var(--ink-2)",
               fontSize: 14,
             }}
           >
@@ -368,7 +357,6 @@ export default async function SchoolDetailPage({ params }: {
                 className="mono"
                 style={{
                   fontSize: 11.5,
-                  color: "var(--ink)",
                   letterSpacing: "0.05em",
                 }}
               >
@@ -380,7 +368,6 @@ export default async function SchoolDetailPage({ params }: {
                 className="mono"
                 style={{
                   fontSize: 11.5,
-                  color: "var(--ink-3)",
                   letterSpacing: "0.05em",
                 }}
               >
@@ -393,7 +380,6 @@ export default async function SchoolDetailPage({ params }: {
                 title="Federal College Scorecard Carnegie basic classification code"
                 style={{
                   fontSize: 11.5,
-                  color: "var(--ink-3)",
                   letterSpacing: "0.05em",
                 }}
               >
@@ -416,7 +402,7 @@ export default async function SchoolDetailPage({ params }: {
             )}
           </div>
           {history.length > 1 && (
-            <Sparkline data={history} w={120} h={26} color="var(--forest)" />
+            <Sparkline data={history} w={120} h={26} color="currentColor" />
           )}
         </div>
       </header>
@@ -522,13 +508,14 @@ async function DirectoryOnlySchoolPage({
         }}
       />
 
-      <header style={{ paddingTop: 48, paddingBottom: 32 }}>
+      <header className="cd-school-header">
+        <div>
         <div className="meta" style={{ marginBottom: 16 }}>
           § Institution directory
         </div>
         <h1
+          className="serif"
           style={{
-            fontFamily: "var(--serif)",
             fontWeight: 400,
             fontSize: "clamp(36px, 5.5vw, 56px)",
             lineHeight: 1.05,
@@ -540,14 +527,14 @@ async function DirectoryOnlySchoolPage({
           {tail && (
             <>
               {" "}
-              <span style={{ fontStyle: "italic", color: "var(--ink-2)" }}>{tail}</span>
+              <span style={{ fontStyle: "italic" }}>{tail}</span>
             </>
           )}
         </h1>
         {location && (
           <div
             className="mono"
-            style={{ marginTop: 12, fontSize: 13, color: "var(--ink-3)" }}
+            style={{ marginTop: 12, fontSize: 13 }}
           >
             {location}
             {coverage.undergraduate_enrollment != null && (
@@ -557,6 +544,7 @@ async function DirectoryOnlySchoolPage({
             )}
           </div>
         )}
+        </div>
       </header>
 
       <section

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -2721,3 +2721,115 @@
     gap: 9px;
   }
 }
+
+/* School record inks. Wrapper sets --ink-a / --ink-b / --onb. Nav stays house. */
+.school-record {
+  --ink-a: var(--forest);
+  --ink-b: var(--ochre);
+  --onb: var(--paper);
+}
+.school-record .cd-school-header {
+  background: var(--ink-a);
+  color: var(--paper);
+  padding: 26px 28px 28px;
+  margin: 0 0 12px;
+}
+.school-record .cd-school-header a {
+  color: var(--paper);
+  text-decoration-color: color-mix(in srgb, var(--paper) 40%, transparent);
+}
+.school-record .cd-school-header h1 {
+  color: var(--paper);
+}
+.school-record .cd-school-header h1 span {
+  color: inherit;
+}
+.school-record[data-ink-b-on-a="true"] .cd-school-header h1 span {
+  color: var(--ink-b);
+}
+.school-record .cd-school-header .meta,
+.school-record .cd-school-header .mono,
+.school-record .cd-school-header__count,
+.school-record .cd-school-header__glyph,
+.school-record .cd-school-header__aside {
+  color: var(--paper);
+}
+.school-record .cd-school-header__years::before {
+  color: color-mix(in srgb, var(--paper) 55%, var(--ink-a));
+}
+.school-record .cd-school-header :focus-visible {
+  outline-color: var(--paper);
+}
+.school-record .cd-school-header a:hover {
+  color: var(--paper);
+  text-decoration-color: var(--paper);
+}
+.school-record .cd-school-header h2,
+.school-record .cd-school-header .cd-archive-lead__heading,
+.school-record .cd-school-header .cd-archive-lead p {
+  color: color-mix(in srgb, var(--paper) 88%, var(--ink-a));
+}
+.school-record .school-documents-ledger__head .meta {
+  color: var(--ink-a);
+}
+.school-record .positioning-range__track,
+.school-record .positioning-range__track::before,
+.school-record .positioning-range__track span {
+  border-color: var(--ink-a);
+}
+.school-record .positioning-range__track::before {
+  border-top-color: var(--ink-a);
+}
+.school-record .merit-profile-stat {
+  border-top-color: var(--ink-a);
+}
+.school-record .merit-profile-stat--muted {
+  border-top-color: var(--rule-strong);
+}
+.school-record .merit-profile-stat strong,
+.school-record .merit-profile-context strong,
+.school-record .outcomes-band .stat-num {
+  color: var(--ink-a);
+}
+.school-record .outcomes-band > div {
+  border-top: 4px solid var(--ink-a);
+  padding-top: 11px;
+}
+.school-record .outcomes-band > div:nth-child(2),
+.school-record .outcomes-band > div:nth-child(4) {
+  border-top-color: var(--ink-b);
+}
+.school-record .admission-strategy-seatbar__ed {
+  background: var(--ink-b);
+  color: var(--onb);
+}
+.school-record .admission-strategy-seatbar__regular {
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in srgb, var(--ink-a) 14%, var(--paper)),
+    color-mix(in srgb, var(--ink-a) 14%, var(--paper)) 8px,
+    var(--paper) 8px,
+    var(--paper) 16px
+  );
+}
+.school-record .admission-strategy-flow-cell__bar--ed {
+  background: var(--ink-b);
+}
+.school-record .admission-strategy-flow-cell__bar--other {
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in srgb, var(--ink-a) 18%, var(--paper)),
+    color-mix(in srgb, var(--ink-a) 18%, var(--paper)) 6px,
+    var(--paper) 6px,
+    var(--paper) 12px
+  );
+}
+.school-record .admission-strategy-flow-cell__bar--single {
+  background: var(--ink-a);
+}
+.school-record .admission-strategy-wait-stage__track i {
+  background: var(--ink-a);
+}
+.school-record .admission-strategy-wait-stage--admitted .admission-strategy-wait-stage__track i {
+  background: var(--ink-b);
+}

--- a/web/src/components/AdmissionStrategyCard.tsx
+++ b/web/src/components/AdmissionStrategyCard.tsx
@@ -214,13 +214,21 @@ function WaitListStage({
   label,
   value,
   width,
+  admitted = false,
 }: {
   label: string;
   value: number | null;
   width: number;
+  admitted?: boolean;
 }) {
   return (
-    <div className="admission-strategy-wait-stage">
+    <div
+      className={
+        admitted
+          ? "admission-strategy-wait-stage admission-strategy-wait-stage--admitted"
+          : "admission-strategy-wait-stage"
+      }
+    >
       <div>
         <span>{label}</span>
         <strong>{maybeCount(value)}</strong>
@@ -280,6 +288,7 @@ function WaitListView({
               label="Admitted from wait list"
               value={admitted}
               width={shareOf(admitted, max)}
+              admitted
             />
           </div>
           <p>

--- a/web/src/components/NetPriceByIncome.tsx
+++ b/web/src/components/NetPriceByIncome.tsx
@@ -58,7 +58,7 @@ export function NetPriceByIncome({
           </h3>
         </div>
         <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
-          CDS H2A · {scorecard.scorecard_data_year}
+          Scorecard · {scorecard.scorecard_data_year}
         </div>
       </div>
 
@@ -98,7 +98,7 @@ export function NetPriceByIncome({
                     inset: 0,
                     right: "auto",
                     width: `${widthPct}%`,
-                    background: r.isModal ? "var(--forest)" : "var(--ink)",
+                    background: r.isModal ? "var(--ink-b, var(--forest))" : "var(--ink-a, var(--ink))",
                   }}
                 />
               </div>
@@ -107,7 +107,7 @@ export function NetPriceByIncome({
                 aria-hidden={!r.isModal}
                 style={{
                   fontSize: 10.5,
-                  color: "var(--forest)",
+                  color: "var(--ink-a, var(--forest))",
                   letterSpacing: "0.05em",
                   whiteSpace: "nowrap",
                   visibility: r.isModal ? "visible" : "hidden",

--- a/web/src/lib/derive-inks.test.ts
+++ b/web/src/lib/derive-inks.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOUSE_A,
+  HOUSE_B,
+  INK_LAB_PRESETS,
+  MIN_B_ON_A,
+  MIN_B_ON_CREAM,
+  PAPER,
+  TARGET_A,
+  TARGET_ON_B,
+  contrast,
+  deriveInks,
+} from "./derive-inks";
+
+describe("deriveInks", () => {
+  it("returns production forest and ochre unchanged when no brand colours exist", () => {
+    const inks = deriveInks([]);
+    expect(inks.house).toBe(true);
+    expect(inks.a).toBe(HOUSE_A);
+    expect(inks.b).toBe(HOUSE_B);
+    expect(inks.a).toBe("#3f5b3a");
+    expect(inks.b).toBe("#8a6a2b");
+    expect(inks.bTypeOnA).toBe(false);
+  });
+
+  it("treats a grey-only palette as house inks instead of inventing a hue", () => {
+    const inks = deriveInks(["#3B3B3B"]);
+    expect(inks.house).toBe(true);
+    expect(inks.a).toBe(HOUSE_A);
+    expect(inks.b).toBe(HOUSE_B);
+  });
+
+  it("leaves Michigan maize untouched on production paper", () => {
+    const inks = deriveInks(["#00274C", "#FFCB05"]);
+    expect(inks.house).toBe(false);
+    expect(inks.b).toBe("#ffcb05");
+    expect(inks.contrast.bOnCream).toBeGreaterThanOrEqual(MIN_B_ON_CREAM);
+    expect(inks.bTypeOnA).toBe(true);
+    expect(inks.rule.startsWith("ideal pair")).toBe(true);
+  });
+
+  it("does not walk B to pass the type-on-A gate", () => {
+    const inks = deriveInks(["#003A63", "#E51937"]);
+    expect(inks.bTypeOnA).toBe(false);
+    expect(inks.contrast.bOnA).toBeLessThan(MIN_B_ON_A);
+    expect(inks.rule).toMatch(/type on A stays cream/);
+  });
+
+  it("pulls a near-paper yellow down so the plate is still an area colour", () => {
+    const inks = deriveInks(["#FFF9C4"]);
+    expect(inks.b).not.toBe("#fff9c4");
+    expect(inks.contrast.bOnCream).toBeGreaterThanOrEqual(MIN_B_ON_CREAM);
+    expect(inks.rule).toMatch(/pulled down/);
+  });
+
+  it("clears reading gates for every lab preset without raising the cream floor", () => {
+    for (const [name, hexes] of INK_LAB_PRESETS) {
+      const inks = deriveInks(hexes);
+      expect(inks.contrast.textOnB, name).toBeGreaterThanOrEqual(TARGET_ON_B);
+      expect(inks.contrast.bOnCream, name).toBeGreaterThanOrEqual(MIN_B_ON_CREAM);
+      if (inks.house) {
+        expect(inks.a, name).toBe(HOUSE_A);
+        expect(inks.b, name).toBe(HOUSE_B);
+      } else {
+        expect(inks.contrast.aOnCream, name).toBeGreaterThanOrEqual(TARGET_A);
+      }
+    }
+  });
+
+  it("keeps production paper as the cream the gates are measured against", () => {
+    expect(PAPER).toBe("#f1ece1");
+    expect(contrast(HOUSE_A, PAPER)).toBeLessThan(TARGET_A);
+    expect(contrast("#ffcb05", PAPER)).toBeGreaterThanOrEqual(MIN_B_ON_CREAM);
+    expect(contrast("#ffcb05", PAPER)).toBeLessThan(1.3);
+  });
+});

--- a/web/src/lib/derive-inks.ts
+++ b/web/src/lib/derive-inks.ts
@@ -1,0 +1,309 @@
+// Two-plate school inks. Brand hexes in, A/B plates out.
+//   A  = dark plate. Hero ground, display numbers, non-highlight fills.
+//        Scouted darks are forced to >= 7:1 on production paper.
+//   B  = bright plate. Highlight area only. Never small type on paper.
+//   onB = ink or cream, whichever reads on B at >= 4.5:1.
+// House path (no usable brand colour) returns production forest + ochre
+// unchanged — those are the site inks, not a derived pair.
+
+export const PAPER = "#f1ece1";
+export const INK = "#1c1e1b";
+export const CREAM_ON_B = "#fdf6ea";
+export const CHARCOAL = "#333f48";
+export const HOUSE_A = "#3f5b3a";
+export const HOUSE_B = "#8a6a2b";
+
+export const TARGET_A = 7;
+export const TARGET_ON_B = 4.5;
+export const MIN_B_ON_CREAM = 1.25;
+export const MIN_B_ON_A = 3;
+export const MIN_B_L = 0.58;
+export const NEUTRAL_C = 0.035;
+export const HUE_SEP = 22;
+
+export type InkContrast = {
+  aOnCream: number;
+  textOnB: number;
+  bOnCream: number;
+  bOnA: number;
+};
+
+export type DerivedInks = {
+  a: string;
+  b: string;
+  onB: string;
+  rule: string;
+  house: boolean;
+  bTypeOnA: boolean;
+  paper: string;
+  contrast: InkContrast;
+};
+
+type Lch = { L: number; C: number; h: number };
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+
+function hexToRgb(h: string): [number, number, number] {
+  let hex = h.trim().replace(/^#/, "");
+  if (hex.length === 3) hex = hex.split("").map((c) => c + c).join("");
+  const n = parseInt(hex, 16);
+  return [(n >> 16 & 255) / 255, (n >> 8 & 255) / 255, (n & 255) / 255];
+}
+
+const rgbToHex = (rgb: number[]) =>
+  "#" + rgb.map((c) => Math.round(clamp01(c) * 255).toString(16).padStart(2, "0")).join("");
+
+const toLin = (c: number) =>
+  c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+const toSrgb = (c: number) =>
+  c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+
+function rgbToOklab([r, g, b]: [number, number, number]): [number, number, number] {
+  r = toLin(r);
+  g = toLin(g);
+  b = toLin(b);
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return [
+    0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s,
+  ];
+}
+
+function oklabToRgb([L, a, b]: [number, number, number]): [number, number, number] {
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.2914855480 * b) ** 3;
+  return [
+    toSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    toSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    toSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s),
+  ];
+}
+
+const inGamut = (rgb: number[]) => rgb.every((c) => c >= -0.001 && c <= 1.001);
+
+function hexToLch(hex: string): Lch {
+  const [L, a, b] = rgbToOklab(hexToRgb(hex));
+  return { L, C: Math.hypot(a, b), h: (Math.atan2(b, a) * 180 / Math.PI + 360) % 360 };
+}
+
+function lchToHex({ L, C, h }: Lch): string {
+  const rad = h * Math.PI / 180;
+  for (let c = C; c >= 0; c -= 0.004) {
+    const rgb = oklabToRgb([clamp01(L), Math.cos(rad) * c, Math.sin(rad) * c]);
+    if (inGamut(rgb)) return rgbToHex(rgb);
+  }
+  return rgbToHex(oklabToRgb([clamp01(L), 0, 0]));
+}
+
+const relLum = (hex: string) => {
+  const [r, g, b] = hexToRgb(hex).map(toLin);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+export function contrast(x: string, y: string): number {
+  const a = relLum(x);
+  const b = relLum(y);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+function forceDark(hex: string): string {
+  let lch = hexToLch(hex);
+  let out = hex;
+  for (let i = 0; i < 90 && contrast(out, PAPER) < TARGET_A; i++) {
+    lch = { ...lch, L: Math.max(0, lch.L - 0.01) };
+    out = lchToHex(lch);
+  }
+  return out;
+}
+
+function forceBright(hex: string, floor = MIN_B_L): string {
+  const lch = hexToLch(hex);
+  if (lch.C < NEUTRAL_C) return lchToHex({ L: Math.max(lch.L, floor), C: 0, h: 0 });
+  if (lch.L >= floor) return hex;
+  return lchToHex({ L: floor, C: Math.max(lch.C * 1.35, 0.16), h: lch.h });
+}
+
+const hueGap = (a: number, b: number) => {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+};
+
+function separateFromPaper(hex: string): { hex: string; moved: boolean } {
+  if (contrast(hex, PAPER) >= MIN_B_ON_CREAM) return { hex, moved: false };
+  const lch = hexToLch(hex);
+  let out = hex;
+  let L = lch.L;
+  for (let i = 0; i < 90 && contrast(out, PAPER) < MIN_B_ON_CREAM; i++) {
+    L = Math.max(0, L - 0.01);
+    out = lchToHex({ ...lch, L });
+  }
+  return { hex: out, moved: true };
+}
+
+const bestOn = (b: string) =>
+  contrast(INK, b) >= contrast(CREAM_ON_B, b) ? INK : CREAM_ON_B;
+
+function walk(hex: string, dir: number): { hex: string; on: string; steps: number } {
+  const lch = hexToLch(hex);
+  const on = dir > 0 ? INK : CREAM_ON_B;
+  let out = hex;
+  let L = lch.L;
+  for (let i = 1; i <= 80; i++) {
+    L = clamp01(L + dir * 0.01);
+    out = lchToHex({ ...lch, L });
+    if (contrast(on, out) >= TARGET_ON_B) return { hex: out, on, steps: i };
+    if (L === 0 || L === 1) break;
+  }
+  return { hex: out, on, steps: Infinity };
+}
+
+function fitOnB(hex: string): { hex: string; onB: string; moved: boolean } {
+  const on = bestOn(hex);
+  if (contrast(on, hex) >= TARGET_ON_B) return { hex, onB: on, moved: false };
+  const up = walk(hex, +1);
+  const down = walk(hex, -1);
+  const win = down.steps <= up.steps ? down : up;
+  return { hex: win.hex, onB: bestOn(win.hex), moved: win.steps !== Infinity };
+}
+
+function round2(n: number): number {
+  return +n.toFixed(2);
+}
+
+function pack(a: string, b: string, onB: string, rule: string, house: boolean): DerivedInks {
+  const bOnA = contrast(b, a);
+  const bTypeOnA = bOnA >= MIN_B_ON_A;
+  if (!bTypeOnA) rule += " · type on A stays cream";
+  return {
+    a,
+    b,
+    onB,
+    rule,
+    house,
+    bTypeOnA,
+    paper: PAPER,
+    contrast: {
+      aOnCream: round2(contrast(a, PAPER)),
+      textOnB: round2(contrast(onB, b)),
+      bOnCream: round2(contrast(b, PAPER)),
+      bOnA: round2(bOnA),
+    },
+  };
+}
+
+function houseResult(rule: string): DerivedInks {
+  return pack(HOUSE_A, HOUSE_B, bestOn(HOUSE_B), rule, true);
+}
+
+function finish(a: string, b: string, rule: string, house = false): DerivedInks {
+  if (house) return houseResult(rule);
+  a = forceDark(a);
+  const sep = separateFromPaper(b);
+  if (sep.moved) rule += " · B pulled down to separate from the stock";
+  const fit = fitOnB(sep.hex);
+  if (fit.moved) rule += " · B nudged so its label clears 4.5:1";
+  return pack(a, fit.hex, fit.onB, rule, false);
+}
+
+export function parseBrandHexes(brand: string | string[] | null | undefined): string[] {
+  if (brand == null) return [];
+  const parts = Array.isArray(brand) ? brand : String(brand).split(/[,\s]+/);
+  return parts
+    .map((h) => h.trim())
+    .filter(Boolean)
+    .map((h) => (h.startsWith("#") ? h : `#${h}`).toLowerCase());
+}
+
+export function deriveInks(brand: string | string[] | null | undefined): DerivedInks {
+  const hexes = parseBrandHexes(brand);
+  if (!hexes.length) {
+    return finish(HOUSE_A, HOUSE_B, "no brand colours on file — house inks", true);
+  }
+
+  const cols = hexes.map((hex) => ({ hex, ...hexToLch(hex) }));
+  const inks = cols.filter((c) => c.C >= NEUTRAL_C);
+  const greys = cols.length - inks.length;
+  const greyNote = greys ? " (neutral second colour rejected)" : "";
+
+  if (inks.length === 0) {
+    return finish(
+      HOUSE_A,
+      HOUSE_B,
+      "brand colours are neutral — house inks, no hue invented",
+      true,
+    );
+  }
+  if (inks.length === 1) {
+    const only = inks[0];
+    if (only.L < 0.55) {
+      return finish(
+        forceDark(only.hex),
+        forceBright(only.hex, 0.62),
+        `single ink — A is the brand colour, B a brightened tint${greyNote}`,
+      );
+    }
+    return finish(
+      CHARCOAL,
+      only.hex,
+      `single bright ink — A falls back to charcoal${greyNote}`,
+    );
+  }
+
+  const dark = inks.reduce((m, c) => (c.L < m.L ? c : m));
+  const rest = inks.filter((c) => c !== dark);
+  const bright = rest.reduce((m, c) =>
+    c.L * (0.5 + c.C) > m.L * (0.5 + m.C) ? c : m,
+  );
+
+  const a = forceDark(dark.hex);
+  const separated =
+    hueGap(dark.h, bright.h) >= HUE_SEP || bright.L - dark.L >= 0.22;
+
+  if (!separated) {
+    return finish(
+      a,
+      forceBright(bright.hex, 0.66),
+      "second ink too close to A — B pushed brighter to separate",
+    );
+  }
+  if (bright.L < 0.5) {
+    return finish(a, forceBright(bright.hex), "two darks — B brightened to carry as an area colour");
+  }
+  return finish(a, bright.hex, "ideal pair — both plates used as given");
+}
+
+export function inkStyle(inks: DerivedInks): Record<string, string> {
+  return {
+    "--ink-a": inks.a,
+    "--ink-b": inks.b,
+    "--onb": inks.onB,
+  };
+}
+
+export const INK_LAB_PRESETS: Array<[string, string]> = [
+  ["University of Michigan", "#00274C, #FFCB05"],
+  ["Stanford", "#8C1515, #E98300"],
+  ["Berkeley", "#003262, #FDB515"],
+  ["Howard", "#003A63, #E51937"],
+  ["UT Austin", "#BF5700"],
+  ["MIT", "#750014, #8A8B8C"],
+  ["Wellesley", "#0142A2, #C9D9EE"],
+  ["Grinnell", "#B01F24, #F0B323"],
+  ["Spelman", "#00457C, #7A9A01"],
+  ["Reed", "#A70E13, #4F5858"],
+  ["Bethel", "#10306B, #F0B323"],
+  ["Oberlin", "#C00000, #FFC72C"],
+  ["Morehouse", "#8A1C1C, #B79A5B"],
+  ["Smith", "#F5C400, #002B45"],
+  ["Rice", "#00205B, #7C7E7F"],
+  ["Tulane", "#006747, #418FDE"],
+  ["Colorado College", "#FFC72C, #1E1E1E"],
+  ["Deep Springs", "#3B3B3B"],
+  ["Pale primary · test", "#FFF9C4"],
+  ["Amherst", "#4F2683, #B7A57A"],
+  ["Hampton", "#00447C, #005EB8"],
+];

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -776,6 +776,27 @@ export const fetchInstitutionCoverage = cache(
   },
 );
 
+// Brand hexes are source values only. Plates are derived at render.
+// Missing columns (pre-migration) or a null row both mean house inks.
+export const fetchSchoolBrandColors = cache(
+  async function fetchSchoolBrandColors(
+    schoolId: string,
+  ): Promise<string[] | null> {
+    try {
+      const { data, error } = await (supabase as unknown as UntypedSupabase)
+        .from("institution_directory")
+        .select("brand_colors")
+        .eq("school_id", schoolId)
+        .maybeSingle();
+      if (error || !data) return null;
+      const colors = (data as { brand_colors: string[] | null }).brand_colors;
+      return Array.isArray(colors) && colors.length > 0 ? colors : null;
+    } catch {
+      return null;
+    }
+  },
+);
+
 // Resolve reviewed retired slugs from the checked-in manifest first, then use
 // the public crosswalk for other aliases. A primary alias wins over demoted
 // aliases; ambiguous rows return null so callers render normally instead of

--- a/web/src/lib/school-inks.ts
+++ b/web/src/lib/school-inks.ts
@@ -1,0 +1,47 @@
+import { cache } from "react";
+import {
+  PAPER,
+  deriveInks,
+  inkStyle,
+  type DerivedInks,
+} from "./derive-inks";
+import {
+  fetchCanonicalSchoolId,
+  fetchSchoolBrandColors,
+} from "./queries";
+
+export async function loadSchoolInks(schoolId: string): Promise<DerivedInks> {
+  const canonical = (await fetchCanonicalSchoolId(schoolId)) ?? schoolId;
+  const hexes = await fetchSchoolBrandColors(canonical);
+  return deriveInks(hexes);
+}
+
+export const cachedSchoolInks = cache(loadSchoolInks);
+
+export function schoolOgColors(inks: DerivedInks): {
+  ground: string;
+  accent: string;
+  type: string;
+} {
+  return {
+    ground: inks.a,
+    type: PAPER,
+    accent: inks.bTypeOnA ? inks.b : PAPER,
+  };
+}
+
+export function schoolInkWrapperProps(inks: DerivedInks): {
+  className: string;
+  style: Record<string, string>;
+  "data-ink-rule": string;
+  "data-ink-house": string;
+  "data-ink-b-on-a": string;
+} {
+  return {
+    className: "school-record",
+    style: inkStyle(inks),
+    "data-ink-rule": inks.rule,
+    "data-ink-house": inks.house ? "true" : "false",
+    "data-ink-b-on-a": inks.bTypeOnA ? "true" : "false",
+  };
+}


### PR DESCRIPTION
## Summary
- Derive each school record’s A/B plates from stored brand hexes at render (overview, year pages, and OG). Nav stays house. Michigan maize is not pulled to fit our cream.
- Add `brand_colors` on `institution_directory` and seed the 19 brief palettes that exist in the Scorecard directory. Deep Springs is not in the directory (and a grey-only palette would house-fallthrough anyway).
- Unlisted schools keep production forest/ochre exactly. `/ink-lab` is noindex and disallowed in robots.

## Test plan
- [ ] After merge, apply migrations from `main` (`supabase db push --linked`). Do not apply from this branch.
- [ ] Open `/schools/umich` — hero band is Michigan Blue, last-word suffix is maize, nav is still house forest.
- [ ] Open `/schools/umich/2024-2025` (or latest year) and confirm the same plates.
- [ ] Open `/schools/howard-university` — name stays cream on navy (B-on-A gate fails; B is not walked).
- [ ] Open a school with no `brand_colors` — house forest/ochre only.
- [ ] Confirm `/ink-lab` renders the 21-palette grid and is not in the sitemap/nav.

Made with [Cursor](https://cursor.com)