### PR TITLE
fix: ignore unknown CDS years when picking latest coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project uses four-part semantic versioning.
 ### Fixed
 
 - Rank Jump-to-school exact slugs and nicknames (MIT, Penn) ahead of accidental name substrings, and prefer schools that already have a CDS year.
+- Ignore sentinel CDS years such as `unknown` when choosing a school's latest coverage year, so search no longer labels a current extract (Michigan 2025-26) as "Older CDS available".
 - Point Oklahoma's archive seed at the IRR listing (`/irr/other-reports`) instead of a single 2023-24 DAM PDF, and prefer Brave HTML listings over year-specific PDFs so sibling years are not frozen out.
 - Stop copying Ohio University's main-campus CDS URL onto the five regional UNITIDs that share ohio.edu.
 - Mark coverage `cds_available_stale` when the latest extracted year is older than the finder freshness floor, even if weekly archive re-verified the same file.

--- a/supabase/migrations/20260823220000_coverage_ignore_unknown_years.sql
+++ b/supabase/migrations/20260823220000_coverage_ignore_unknown_years.sql
@@ -1,0 +1,219 @@
+-- Ignore sentinel CDS years like 'unknown' when picking latest coverage.
+--
+-- cds_documents.cds_year is text. DISTINCT ON (... ORDER BY cds_year DESC)
+-- therefore treats 'unknown' as newer than '2025-26' ('u' > '2'). Search
+-- then shows "CDS unknown" / "Older CDS available" for schools that already
+-- hold a current extracted year (Michigan 2025-26 is the reported case).
+--
+-- A weekly archive_queue miss (transient / no_pdfs_found) also used to
+-- force cds_available_stale even when the extracted year meets the
+-- freshness floor. Promote those back to current.
+
+begin;
+
+create or replace function public.refresh_institution_cds_coverage()
+returns table (rows_written int, duration_ms int)
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  started timestamptz := clock_timestamp();
+  written int;
+begin
+  truncate table public.institution_cds_coverage;
+
+  with
+    cds_extracted as (
+      select distinct on (school_id)
+        school_id,
+        cds_year             as latest_extracted_year,
+        id                   as latest_document_id,
+        source_url           as latest_extracted_source_url
+      from public.cds_documents
+      where extraction_status = 'extracted'
+        and cds_year ~ '^[0-9]{4}-[0-9]{2}$'
+      order by school_id, cds_year desc
+    ),
+    cds_found as (
+      select distinct on (school_id)
+        school_id,
+        cds_year             as latest_found_year,
+        extraction_status    as latest_found_extraction_status
+      from public.cds_documents
+      where source_url is not null
+        and cds_year ~ '^[0-9]{4}-[0-9]{2}$'
+      order by school_id, cds_year desc
+    ),
+    queue_latest as (
+      select distinct on (school_id)
+        school_id,
+        last_outcome,
+        processed_at
+      from public.archive_queue
+      where status in ('done', 'failed_permanent')
+        and last_outcome is not null
+        and processed_at is not null
+      order by school_id, processed_at desc
+    ),
+    crosswalk_aliases as (
+      select
+        ipeds_id,
+        array_agg(distinct alias) filter (where source <> 'redirect') as aliases
+      from public.institution_slug_crosswalk
+      group by ipeds_id
+    ),
+    resolved_raw as (
+      select
+        d.ipeds_id,
+        d.school_id,
+        d.school_name,
+        d.city,
+        d.state,
+        d.website_url,
+        d.undergraduate_enrollment,
+        d.scorecard_data_year,
+        coalesce(ca.aliases, '{}'::text[])              as aliases,
+        ce.latest_extracted_year,
+        ce.latest_document_id,
+        ce.latest_extracted_source_url,
+        cf.latest_found_year,
+        cf.latest_found_extraction_status,
+        q.last_outcome,
+        q.processed_at                                    as last_checked_at,
+        o.public_note                                     as override_note,
+        coalesce(
+          o.status,
+          public.derive_coverage_status(
+            d.in_scope,
+            ce.latest_extracted_year,
+            cf.latest_found_year,
+            cf.latest_found_extraction_status,
+            q.last_outcome
+          )
+        )                                                 as derived_status
+      from public.institution_directory d
+      left join cds_extracted ce on ce.school_id = d.school_id
+      left join cds_found cf on cf.school_id = d.school_id
+      left join queue_latest q on q.school_id = d.school_id
+      left join crosswalk_aliases ca on ca.ipeds_id = d.ipeds_id
+      left join public.institution_cds_coverage_overrides o on o.ipeds_id = d.ipeds_id
+    ),
+    resolved as (
+      select
+        ipeds_id,
+        school_id,
+        school_name,
+        city,
+        state,
+        website_url,
+        undergraduate_enrollment,
+        scorecard_data_year,
+        aliases,
+        latest_extracted_year,
+        latest_document_id,
+        latest_extracted_source_url,
+        latest_found_year,
+        latest_found_extraction_status,
+        last_outcome,
+        last_checked_at,
+        override_note,
+        case
+          when derived_status = 'cds_available_current'
+               and latest_extracted_year is not null
+               and latest_extracted_year < public.cds_freshness_floor()
+            then 'cds_available_stale'::public.coverage_status_t
+          when derived_status = 'cds_available_stale'
+               and latest_extracted_year is not null
+               and latest_extracted_year >= public.cds_freshness_floor()
+            then 'cds_available_current'::public.coverage_status_t
+          else derived_status
+        end as coverage_status
+      from resolved_raw
+    )
+  insert into public.institution_cds_coverage (
+    ipeds_id,
+    school_id,
+    school_name,
+    aliases,
+    city,
+    state,
+    website_url,
+    undergraduate_enrollment,
+    scorecard_data_year,
+    coverage_status,
+    coverage_label,
+    coverage_summary,
+    latest_available_cds_year,
+    latest_found_cds_year,
+    latest_attempted_year,
+    latest_document_id,
+    latest_public_source_url,
+    latest_field_count,
+    last_checked_at,
+    can_submit_source,
+    search_text,
+    updated_at
+  )
+  select
+    ipeds_id,
+    school_id,
+    school_name,
+    aliases,
+    city,
+    state,
+    website_url,
+    undergraduate_enrollment,
+    scorecard_data_year,
+    coverage_status,
+    public.coverage_status_label(coverage_status),
+    public.coverage_status_summary(
+      school_name,
+      coverage_status,
+      latest_extracted_year,
+      latest_found_year,
+      last_outcome,
+      override_note
+    ),
+    latest_extracted_year                                          as latest_available_cds_year,
+    latest_found_year                                              as latest_found_cds_year,
+    latest_found_year                                              as latest_attempted_year,
+    latest_document_id,
+    case
+      when coverage_status = 'cds_available_current'
+        then latest_extracted_source_url
+      else null
+    end                                                            as latest_public_source_url,
+    null::integer                                                  as latest_field_count,
+    last_checked_at,
+    coverage_status in (
+      'no_public_cds_found',
+      'source_not_automatically_accessible',
+      'not_checked'
+    )                                                              as can_submit_source,
+    lower(
+      school_name
+      || ' ' || coalesce(array_to_string(aliases, ' '), '')
+      || ' ' || coalesce(city, '')
+      || ' ' || coalesce(state, '')
+    )                                                              as search_text,
+    now()                                                          as updated_at
+  from resolved;
+
+  get diagnostics written = row_count;
+
+  return query select
+    written,
+    extract(milliseconds from clock_timestamp() - started)::int;
+end;
+$$;
+
+revoke all on function public.refresh_institution_cds_coverage() from public;
+revoke all on function public.refresh_institution_cds_coverage() from anon, authenticated;
+grant execute on function public.refresh_institution_cds_coverage() to service_role;
+
+-- Replacing the function does not rewrite institution_cds_coverage.
+-- Rebuild now so search stops treating 'unknown' as the latest year.
+select * from public.refresh_institution_cds_coverage();
+
+commit;

--- a/web/src/app/schools/[school_id]/opengraph-image.tsx
+++ b/web/src/app/schools/[school_id]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 import { fetchCanonicalSchoolId, fetchSchoolDocuments } from "@/lib/queries";
-import { yearRange } from "@/lib/format";
+import { isCanonicalCdsYear, yearRange } from "@/lib/format";
 import { cachedSchoolInks, schoolOgColors } from "@/lib/school-inks";
 
 export const alt = "School Common Data Set archive";
@@ -43,7 +43,7 @@ export default async function Image({
   const name = docs[0].school_name ?? resolvedSchoolId;
   const years = docs
     .map((d) => d.canonical_year)
-    .filter((y): y is string => y != null)
+    .filter(isCanonicalCdsYear)
     .sort();
 
   return new ImageResponse(

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -24,7 +24,7 @@ import { Sparkline } from "@/components/Sparkline";
 import { CoverageBadge } from "@/components/CoverageBadge";
 import { SubmissionForm } from "@/components/SubmissionForm";
 import { FederalBaselineTable } from "@/components/FederalBaselineTable";
-import { storageUrl, yearRange } from "@/lib/format";
+import { isCanonicalCdsYear, storageUrl, yearRange } from "@/lib/format";
 import { archiveLead } from "@/lib/archive-lead";
 import { ArchiveLead } from "@/components/ArchiveLead";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
@@ -66,7 +66,7 @@ export async function generateMetadata({
   const location = formatLocation(coverage);
   const years = docs
     .map((d) => d.canonical_year)
-    .filter((y): y is string => y != null)
+    .filter(isCanonicalCdsYear)
     .sort();
   const path = `/schools/${resolvedSchoolId}`;
   const archiveCount = `${docs.length} CDS document${docs.length !== 1 ? "s" : ""}`;
@@ -129,7 +129,7 @@ function formatLocation(
 function archiveHistory(docs: ManifestRow[]): number[] {
   const years = docs
     .map((d) => d.canonical_year)
-    .filter((y): y is string => y != null)
+    .filter(isCanonicalCdsYear)
     .sort();
   if (years.length === 0) return [];
   const series: number[] = [];
@@ -192,7 +192,7 @@ export default async function SchoolDetailPage({ params }: {
   const location = formatLocation(coverage);
   const years = docs
     .map((d) => d.canonical_year)
-    .filter((y): y is string => y != null)
+    .filter(isCanonicalCdsYear)
     .sort();
 
   const hasSubs = docs.some((d) => d.sub_institutional != null);

--- a/web/src/components/HeaderSchoolSearch.tsx
+++ b/web/src/components/HeaderSchoolSearch.tsx
@@ -6,6 +6,7 @@ import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
 import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
+import { isCanonicalCdsYear } from "@/lib/format";
 
 const DEBOUNCE_MS = 180;
 
@@ -126,7 +127,9 @@ export function HeaderSchoolSearch() {
                 <span className="cd-header-search__name">{result.school_name}</span>
                 <span className="cd-header-search__meta">
                   {[result.city, result.state].filter(Boolean).join(", ") || "Institution profile"}
-                  {result.latest_available_cds_year ? ` - CDS ${result.latest_available_cds_year}` : ""}
+                  {isCanonicalCdsYear(result.latest_available_cds_year)
+                    ? ` - CDS ${result.latest_available_cds_year}`
+                    : ""}
                 </span>
               </span>
               <CoverageBadge

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -6,6 +6,7 @@ import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
 import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
+import { isCanonicalCdsYear } from "@/lib/format";
 
 // PRD 015 M4 — server-backed autocomplete over institution_cds_coverage.
 // Calls the search_institutions RPC with a debounced query so missing-
@@ -194,7 +195,7 @@ export function SchoolSearch() {
                     }}
                   >
                     <span>{[r.city, r.state].filter(Boolean).join(", ")}</span>
-                    {r.latest_available_cds_year && (
+                    {isCanonicalCdsYear(r.latest_available_cds_year) && (
                       <span>
                         CDS {r.latest_available_cds_year}
                       </span>

--- a/web/src/lib/archive-lead.test.ts
+++ b/web/src/lib/archive-lead.test.ts
@@ -93,6 +93,34 @@ describe("archiveLead", () => {
     expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
   });
 
+  it("ignores sentinel CDS years when naming the archive range", () => {
+    const lead = archiveLead({
+      schoolId: "umich",
+      schoolName: "University of Michigan",
+      documents: [
+        {
+          canonical_year: "unknown",
+          source_format: "pdf_flat",
+          extraction_status: "extracted",
+        },
+        {
+          canonical_year: "2025-26",
+          source_format: "xlsx",
+          extraction_status: "extracted",
+        },
+        {
+          canonical_year: "2000-01",
+          source_format: "pdf_flat",
+          extraction_status: "extracted",
+        },
+      ],
+    });
+    const text = leadPlainText(lead);
+    expect(text).toContain("2000–2025");
+    expect(text).toContain("Latest extracted year is 2025-26");
+    expect(text).not.toContain("unknown");
+  });
+
   it("states when a year-page date is only this archive's discovery", () => {
     const lead = yearArchiveLead({
       schoolId: "thin-college",

--- a/web/src/lib/archive-lead.ts
+++ b/web/src/lib/archive-lead.ts
@@ -1,4 +1,4 @@
-import { yearRange } from "./format";
+import { isCanonicalCdsYear, yearRange } from "./format";
 import {
   getOfficialCdsPage,
   type OfficialCdsPage,
@@ -82,7 +82,7 @@ function uniqueYears(documents: ArchiveDocumentFacts[]): string[] {
     new Set(
       documents
         .map((doc) => doc.canonical_year)
-        .filter((year): year is string => Boolean(year)),
+        .filter(isCanonicalCdsYear),
     ),
   ).sort();
 }

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRecipeShare, sourceDownloadLabel } from "./format";
+import { formatRecipeShare, isCanonicalCdsYear, sourceDownloadLabel } from "./format";
 
 describe("formatRecipeShare", () => {
   it("uses whole percents at 10% and above", () => {
@@ -17,6 +17,16 @@ describe("formatRecipeShare", () => {
   it("lets draw-rate figures keep a tenth even above 10%", () => {
     expect(formatRecipeShare(0.048, 1)).toBe("4.8%");
     expect(formatRecipeShare(0.151, 1)).toBe("15.1%");
+  });
+});
+
+describe("isCanonicalCdsYear", () => {
+  it("accepts YYYY-YY cycles and rejects sentinels", () => {
+    expect(isCanonicalCdsYear("2025-26")).toBe(true);
+    expect(isCanonicalCdsYear("2000-01")).toBe(true);
+    expect(isCanonicalCdsYear("unknown")).toBe(false);
+    expect(isCanonicalCdsYear(null)).toBe(false);
+    expect(isCanonicalCdsYear("2025")).toBe(false);
   });
 });
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -135,6 +135,13 @@ export function formatRecipeShare(
   return `${pct.toFixed(places)}%`;
 }
 
+// Canonical CDS cycle like 2025-26. Sentinels such as "unknown" sort
+// after real years in text ORDER BY cds_year DESC and must not be treated
+// as the latest available year.
+export function isCanonicalCdsYear(year: string | null | undefined): year is string {
+  return typeof year === "string" && /^\d{4}-\d{2}$/.test(year);
+}
+
 export function yearRange(
   earliest: string | null,
   latest: string | null

--- a/web/src/lib/freshness.test.ts
+++ b/web/src/lib/freshness.test.ts
@@ -52,6 +52,17 @@ describe("pickFreshnessSignal", () => {
     ]);
     expect(signal?.kind).toBe("http_last_modified");
   });
+
+  it("ignores sentinel years when picking the latest document", () => {
+    const signal = latestDocumentFreshness([
+      { canonical_year: "unknown", discovered_at: "2026-08-01T00:00:00Z" },
+      {
+        canonical_year: "2025-26",
+        source_http_last_modified: "2026-07-01T00:00:00Z",
+      },
+    ]);
+    expect(signal?.kind).toBe("http_last_modified");
+  });
 });
 
 describe("buildSchoolRss", () => {

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -1,4 +1,4 @@
-import { formatShortDate } from "./format";
+import { formatShortDate, isCanonicalCdsYear } from "./format";
 
 export type FreshnessFacts = {
   source_modification_date?: string | null;
@@ -64,8 +64,10 @@ export function freshnessSentence(signal: FreshnessSignal | null): string | null
 export function latestDocumentFreshness<T extends FreshnessFacts & { canonical_year?: string | null }>(
   documents: T[],
 ): FreshnessSignal | null {
+  const yearKey = (year: string | null | undefined) =>
+    isCanonicalCdsYear(year) ? year : "";
   const sorted = [...documents].sort((a, b) =>
-    (b.canonical_year ?? "").localeCompare(a.canonical_year ?? ""),
+    yearKey(b.canonical_year).localeCompare(yearKey(a.canonical_year)),
   );
   for (const doc of sorted) {
     const signal = pickFreshnessSignal(doc);

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -35,6 +35,7 @@ import {
   type SchoolAliasRow,
 } from "./school-alias";
 import retiredSchoolAliases from "../data/school-redirects.json";
+import { isCanonicalCdsYear } from "./format";
 
 // Documents with these participation_status values are excluded from every
 // public-facing manifest query. 'withdrawn' = takedown per ADR 0008.
@@ -603,14 +604,16 @@ export function aggregateSchools(rows: ManifestRow[]): SchoolSummary[] {
         school_id: sid,
         school_name: sname,
         doc_count: 1,
-        latest_year: row.canonical_year,
+        latest_year: isCanonicalCdsYear(row.canonical_year)
+          ? row.canonical_year
+          : null,
         formats: row.source_format ? [row.source_format] : [],
         has_extracted: row.extraction_status === "extracted",
       });
     } else {
       existing.doc_count += 1;
       if (
-        row.canonical_year &&
+        isCanonicalCdsYear(row.canonical_year) &&
         (!existing.latest_year || row.canonical_year > existing.latest_year)
       ) {
         existing.latest_year = row.canonical_year;
@@ -633,7 +636,7 @@ export function computeStats(rows: ManifestRow[]): CorpusStats {
   const schoolIds = new Set(rows.map((r) => r.school_id).filter(Boolean));
   const years = rows
     .map((r) => r.canonical_year)
-    .filter((y): y is string => y != null && y !== "unknown" && /^\d{4}/.test(y))
+    .filter(isCanonicalCdsYear)
     .sort();
   const extracted = rows.filter(
     (r) => r.extraction_status === "extracted"


### PR DESCRIPTION
## Summary
- Search coverage used text `ORDER BY cds_year DESC`, so a leftover `unknown` year sorted newer than `2025-26` and Michigan showed **CDS unknown** / **Older CDS available**.
- Coverage refresh now ignores non-`YYYY-YY` years, and a stale row whose extracted year meets the freshness floor is promoted back to current (a weekly queue miss should not label a fresh year older).
- School pages, archive lead, search chips, and OG year ranges also skip sentinel years.

## Test plan
- [ ] After this lands, apply the migration from the primary checkout (`supabase db push --linked --yes`). The migration rebuilds `institution_cds_coverage`.
- [ ] Search `mich` and confirm University of Michigan shows **CDS 2025-26** and **CDS available**, not **CDS unknown** / **Older CDS available**.
- [ ] Open `/schools/umich` and confirm the archive lead year range ends in 2025, not `unknown`.


Made with [Cursor](https://cursor.com)