### PR TITLE
feat: show two-dot school glyphs beside names off the school page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses four-part semantic versioning.
 ### Added
 
 - Theme school records with a two-plate riso ink pair derived from each school's brand hexes, seeded for the 19 brief schools that exist in the Scorecard directory, and keep house forest/ochre when no usable colour is on file.
+- Show a two-dot school glyph beside school names in search, directory, coverage, browse, match, breadcrumbs, and the latest-drain feed, using grey plus a hollow B when colours are not on file.
 - Show a data-generated Common Data Set archive lead on school hubs and year pages, including an official IR link when we have a usable HTML URL, and gated-request copy only for schools we have actually read (Virginia Tech).
 - Publish three source-literacy pages under `/about` (Common Data Set, College Scorecard, IPEDS) and link them from About, the footer, and `/llms.txt`.
 - Record the August 2026 Search Console CDS-query export next to PRD 028, including URL inspection of the Virginia Tech and Harvey Mudd canaries.

--- a/supabase/migrations/20260824120000_search_institutions_brand_colors.sql
+++ b/supabase/migrations/20260824120000_search_institutions_brand_colors.sql
@@ -1,0 +1,110 @@
+-- Include scouted brand_colors on search so Jump-to-school can render
+-- the two-dot glyph without a second round-trip. Null means the unknown
+-- (grey + hollow) glyph, not house forest/ochre.
+
+begin;
+
+drop function if exists public.search_institutions(text, int);
+
+create function public.search_institutions(
+  p_query text,
+  p_limit int default 10
+)
+returns table (
+  school_id                  text,
+  school_name                text,
+  city                       text,
+  state                      text,
+  coverage_status            public.coverage_status_t,
+  coverage_label             text,
+  latest_available_cds_year  text,
+  brand_colors               text[]
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with q as (
+    select
+      lower(trim(coalesce(p_query, ''))) as qstr,
+      regexp_replace(
+        lower(trim(coalesce(p_query, ''))),
+        '[^a-z0-9]',
+        '',
+        'g'
+      ) as qcompact,
+      regexp_replace(
+        lower(trim(coalesce(p_query, ''))),
+        '([\\.^$|?*+(){}\[\]-])',
+        '\\\1',
+        'g'
+      ) as qescaped
+  )
+  select
+    c.school_id,
+    c.school_name,
+    c.city,
+    c.state,
+    c.coverage_status,
+    c.coverage_label,
+    c.latest_available_cds_year,
+    d.brand_colors
+  from public.institution_cds_coverage c
+  left join public.institution_directory d on d.school_id = c.school_id
+  cross join q
+  where c.coverage_status <> 'out_of_scope'
+    and length(q.qstr) > 0
+    and length(q.qcompact) > 0
+    and (
+      regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+      or exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g')
+          like q.qcompact || '%'
+      )
+      or (
+        length(q.qescaped) > 0
+        and lower(c.school_name) ~ ('\y' || q.qescaped)
+      )
+      or (
+        length(q.qstr) > 4
+        and c.search_text like '%' || q.qstr || '%'
+      )
+    )
+  order by
+    case
+      when regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') = q.qcompact
+        then 0
+      when exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g') = q.qcompact
+      ) then 0
+      when regexp_replace(c.school_id, '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+        then 1
+      when exists (
+        select 1
+        from unnest(coalesce(c.aliases, '{}'::text[])) as alias
+        where regexp_replace(lower(alias), '[^a-z0-9]', '', 'g') like q.qcompact || '%'
+      ) then 1
+      when length(q.qescaped) > 0
+        and lower(c.school_name) ~ ('\y' || q.qescaped)
+        then 2
+      when lower(c.school_name) like '%' || q.qstr || '%'
+        then 3
+      else 4
+    end,
+    case when c.latest_available_cds_year is not null then 0 else 1 end,
+    c.undergraduate_enrollment desc nulls last,
+    c.school_name
+  limit greatest(p_limit, 1);
+$$;
+
+comment on function public.search_institutions(text, int) is
+  'Public autocomplete over institution_cds_coverage. Rank: exact school_id/alias, id/alias prefix, name token-prefix, name substring, other search_text. CDS year then enrollment as tie-breaks. Includes scouted brand_colors for the school glyph. SECURITY INVOKER so RLS hides out_of_scope rows.';
+
+grant execute on function public.search_institutions(text, int) to anon, authenticated;
+
+commit;

--- a/web/src/app/browse/page.tsx
+++ b/web/src/app/browse/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { SchoolBrowser } from "@/components/SchoolBrowser";
-import { fetchSiteStats } from "@/lib/queries";
+import { fetchSiteStats, fetchBrandColorIndex } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
 
 export const metadata: Metadata = {
@@ -14,7 +14,10 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function BrowsePage() {
-  const stats = await fetchSiteStats();
+  const [stats, brandColors] = await Promise.all([
+    fetchSiteStats(),
+    fetchBrandColorIndex(),
+  ]);
 
   return (
     <div className="mx-auto max-w-6xl" style={{ padding: "52px 24px 72px" }}>
@@ -77,7 +80,7 @@ export default async function BrowsePage() {
         </div>
       </section>
 
-      <SchoolBrowser />
+      <SchoolBrowser brandColors={brandColors} />
 
       <style>{`
         @media (max-width: 760px) {

--- a/web/src/app/coverage/page.tsx
+++ b/web/src/app/coverage/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
-import { fetchCoverageRows } from "@/lib/queries";
+import { fetchCoverageRows, fetchBrandColorIndex } from "@/lib/queries";
 import { CoverageDashboard } from "@/components/CoverageDashboard";
 
 export const revalidate = 900; // ISR: 15 minutes, matches the refresh-coverage cron
@@ -14,7 +14,14 @@ export const metadata: Metadata = {
 };
 
 export default async function CoveragePage() {
-  const rows = await fetchCoverageRows();
+  const [rows, brandIndex] = await Promise.all([
+    fetchCoverageRows(),
+    fetchBrandColorIndex(),
+  ]);
+  const coloredRows = rows.map((row) => ({
+    ...row,
+    brand_colors: brandIndex[row.school_id] ?? null,
+  }));
 
   return (
     <div className="mx-auto max-w-6xl px-4 sm:px-6 py-8">
@@ -55,7 +62,7 @@ export default async function CoveragePage() {
           search params via useSearchParams; without it, Next.js bails
           out of static generation for /coverage. */}
       <Suspense fallback={<div className="mono" style={{ padding: "32px 0", color: "var(--ink-3)" }}>LOADING COVERAGE DATA…</div>}>
-        <CoverageDashboard rows={rows} />
+        <CoverageDashboard rows={coloredRows} />
       </Suspense>
 
       <section style={{ marginTop: 64, maxWidth: 760 }}>

--- a/web/src/app/match/page.tsx
+++ b/web/src/app/match/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { MatchListBuilder } from "@/components/MatchListBuilder";
-import { fetchMatchBuilderSchools } from "@/lib/queries";
+import { fetchMatchBuilderSchools, fetchBrandColorIndex } from "@/lib/queries";
 
 export const revalidate = 3600;
 
@@ -16,7 +16,11 @@ export default async function MatchPage({
 }: {
   searchParams: Promise<{ code?: string }>;
 }) {
-  const [{ code }, schools] = await Promise.all([searchParams, fetchMatchBuilderSchools()]);
+  const [{ code }, schools, brandColors] = await Promise.all([
+    searchParams,
+    fetchMatchBuilderSchools(),
+    fetchBrandColorIndex(),
+  ]);
 
   return (
     <div className="mx-auto max-w-6xl px-4 sm:px-6 py-8 match-page">
@@ -29,7 +33,7 @@ export default async function MatchPage({
         </p>
       </header>
 
-      <MatchListBuilder schools={schools} initialCode={code} />
+      <MatchListBuilder schools={schools} initialCode={code} brandColors={brandColors} />
     </div>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import { fetchManifest, fetchSiteStats } from "@/lib/queries";
+import { fetchManifest, fetchSiteStats, fetchBrandColorIndex } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
 import type { ManifestRow } from "@/lib/types";
 import { SchoolSearch } from "@/components/SchoolSearch";
+import { SchoolGlyph } from "@/components/SchoolGlyph";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -40,12 +41,17 @@ function formatDrainDate(iso: string): string {
 type DrainEntry = {
   when: string;
   school: string;
+  schoolId: string;
   action: string;
   tag: string;
   href: string;
+  brandColors: string[] | null;
 };
 
-function latestDrain(rows: ManifestRow[]): DrainEntry[] {
+function latestDrain(
+  rows: ManifestRow[],
+  brandIndex: Record<string, string[]>,
+): DrainEntry[] {
   const sorted = rows
     .filter((r) => r.discovered_at && r.school_name && r.school_id)
     .slice()
@@ -62,17 +68,23 @@ function latestDrain(rows: ManifestRow[]): DrainEntry[] {
     out.push({
       when: formatDrainDate(r.discovered_at!),
       school: r.school_name ?? sid,
+      schoolId: sid,
       action: `+ ${r.canonical_year ?? "new"} CDS`,
       tag: tagForFormat(r.source_format),
       href: r.canonical_year ? `/schools/${sid}/${r.canonical_year}` : `/schools/${sid}`,
+      brandColors: brandIndex[sid] ?? null,
     });
   }
   return out;
 }
 
 export default async function HomePage() {
-  const [manifest, stats] = await Promise.all([fetchManifest(), fetchSiteStats()]);
-  const drain = latestDrain(manifest);
+  const [manifest, stats, brandIndex] = await Promise.all([
+    fetchManifest(),
+    fetchSiteStats(),
+    fetchBrandColorIndex(),
+  ]);
+  const drain = latestDrain(manifest, brandIndex);
 
   const schoolsValue = stats.total_schools.toLocaleString();
   const docsValue = stats.total_documents.toLocaleString();
@@ -210,7 +222,7 @@ export default async function HomePage() {
                   display: "grid",
                   gridTemplateColumns: "96px 1fr auto auto",
                   gap: 16,
-                  alignItems: "baseline",
+                  alignItems: "center",
                   padding: "10px 0",
                   fontSize: 14,
                   color: "inherit",
@@ -218,7 +230,10 @@ export default async function HomePage() {
                 }}
               >
                 <span className="mono" style={{ color: "var(--ink-3)", fontSize: 12 }}>{r.when}</span>
-                <span style={{ fontFamily: "var(--serif)", fontSize: 18 }}>{r.school}</span>
+                <span className="cd-drain-row__school">
+                  <SchoolGlyph brandColors={r.brandColors} />
+                  {r.school}
+                </span>
                 <span className="mono" style={{ fontSize: 12, color: "var(--ink-2)" }}>{r.action}</span>
                 <span className="cd-chip">{r.tag}</span>
               </Link>
@@ -228,14 +243,22 @@ export default async function HomePage() {
       )}
 
       <style>{`
-        .cd-drain-row:hover span:nth-child(2) { color: var(--forest-ink); text-decoration: underline; text-underline-offset: 3px; }
+        .cd-drain-row__school {
+          display: inline-flex;
+          min-width: 0;
+          align-items: center;
+          gap: 14px;
+          font-family: var(--serif);
+          font-size: 18px;
+        }
+        .cd-drain-row:hover .cd-drain-row__school { color: var(--forest-ink); text-decoration: underline; text-underline-offset: 3px; }
         @media (max-width: 860px) {
           .cd-hero { grid-template-columns: 1fr !important; padding-top: 48px !important; }
           .cd-marginalia-left, .cd-marginalia-right { display: none !important; }
           .cd-stat-grid { grid-template-columns: repeat(2, 1fr) !important; gap: 24px !important; }
           .cd-drain { grid-template-columns: 1fr !important; gap: 16px !important; }
           .cd-drain-row { grid-template-columns: 88px 1fr auto !important; gap: 10px 12px !important; }
-          .cd-drain-row span:nth-child(2) { grid-column: 1 / -1; grid-row: 2; }
+          .cd-drain-row__school { grid-column: 1 / -1; grid-row: 2; }
         }
       `}</style>
     </div>

--- a/web/src/app/school-alias-pages.test.tsx
+++ b/web/src/app/school-alias-pages.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   fetchMeritProfileBySchoolId: vi.fn(),
   fetchChangeEventsBySchoolId: vi.fn(),
   fetchSchoolFederalFacts: vi.fn(),
+  fetchSchoolBrandColors: vi.fn(),
   permanentRedirect: vi.fn(),
   notFound: vi.fn(),
   imageResponse: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock("@/lib/queries", () => ({
   fetchMeritProfileBySchoolId: mocks.fetchMeritProfileBySchoolId,
   fetchChangeEventsBySchoolId: mocks.fetchChangeEventsBySchoolId,
   fetchSchoolFederalFacts: mocks.fetchSchoolFederalFacts,
+  fetchSchoolBrandColors: mocks.fetchSchoolBrandColors,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -59,6 +61,7 @@ describe("retired alias pages and Open Graph images", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.fetchCanonicalSchoolId.mockResolvedValue("tufts");
+    mocks.fetchSchoolBrandColors.mockResolvedValue(null);
     mocks.permanentRedirect.mockImplementation(() => {
       throw redirectSentinel;
     });

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchExtract,
   fetchScorecardByIpedsId,
   fetchCanonicalSchoolId,
+  fetchSchoolBrandColors,
 } from "@/lib/queries";
 import type { FieldValue, ArtifactNotes } from "@/lib/types";
 import { storageUrl, formatBadgeLabel, sourceDownloadLabel } from "@/lib/format";
@@ -20,6 +21,7 @@ import { AdmissionStrategyCard } from "@/components/AdmissionStrategyCard";
 import { SpreadsheetDownloadLinks } from "@/components/SpreadsheetDownloadLinks";
 import { ArchiveLead } from "@/components/ArchiveLead";
 import { yearArchiveLead } from "@/lib/archive-lead";
+import { SchoolGlyph } from "@/components/SchoolGlyph";
 
 export const revalidate = 3600;
 
@@ -72,7 +74,10 @@ export default async function SchoolYearPage({ params }: {
   // Scorecard is per-school, not per-year — pull once at the page level
   // and render under KeyStats in each document variant.
   const ipedsId = docs.find((d) => d.ipeds_id)?.ipeds_id ?? null;
-  const scorecard = await fetchScorecardByIpedsId(ipedsId);
+  const [scorecard, brandColors] = await Promise.all([
+    fetchScorecardByIpedsId(ipedsId),
+    fetchSchoolBrandColors(school_id),
+  ]);
 
   const schoolName = docs[0].school_name ?? "Unknown school";
   const yearLead = yearArchiveLead({
@@ -131,7 +136,10 @@ export default async function SchoolYearPage({ params }: {
           <nav className="mono" style={{ fontSize: 11, letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: 12 }}>
             <Link href="/schools">Schools</Link>
             {" / "}
-            <Link href={`/schools/${school_id}`}>{schoolName}</Link>
+            <span className="school-crumb-with-glyph">
+              <SchoolGlyph size="lg" brandColors={brandColors} />
+              <Link href={`/schools/${school_id}`}>{schoolName}</Link>
+            </span>
             {" / "}
             <span>{year}</span>
           </nav>

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -12,6 +12,7 @@ import {
   fetchChangeEventsBySchoolId,
   fetchSchoolFederalFacts,
   fetchCanonicalSchoolId,
+  fetchSchoolBrandColors,
 } from "@/lib/queries";
 import { OutcomesSection } from "@/components/OutcomesSection";
 import { PositioningCard } from "@/components/PositioningCard";
@@ -27,6 +28,7 @@ import { FederalBaselineTable } from "@/components/FederalBaselineTable";
 import { isCanonicalCdsYear, storageUrl, yearRange } from "@/lib/format";
 import { archiveLead } from "@/lib/archive-lead";
 import { ArchiveLead } from "@/components/ArchiveLead";
+import { SchoolGlyph } from "@/components/SchoolGlyph";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
 
 export const revalidate = 3600;
@@ -173,6 +175,7 @@ export default async function SchoolDetailPage({ params }: {
     changeEvents,
     coverage,
     federalFacts,
+    brandColors,
   ] = await Promise.all([
     fetchScorecardByIpedsId(ipedsId),
     fetchBrowserRowBySchoolId(school_id),
@@ -182,6 +185,7 @@ export default async function SchoolDetailPage({ params }: {
     fetchChangeEventsBySchoolId(school_id),
     fetchInstitutionCoverage(school_id),
     fetchSchoolFederalFacts(school_id),
+    fetchSchoolBrandColors(school_id),
   ]);
   const positioningSchool = browserRow
     ? { ...browserRow, ...gpaProfile }
@@ -321,7 +325,11 @@ export default async function SchoolDetailPage({ params }: {
             <Link href="/schools" style={{ textDecoration: "none" }}>
               SCHOOLS
             </Link>{" "}
-            / <span>{name.toUpperCase()}</span>
+            /{" "}
+            <span className="school-crumb-with-glyph">
+              <SchoolGlyph size="lg" brandColors={brandColors} />
+              <span>{name.toUpperCase()}</span>
+            </span>
           </div>
           <h1
             className="serif"

--- a/web/src/app/schools/page.tsx
+++ b/web/src/app/schools/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { fetchManifest, aggregateSchools } from "@/lib/queries";
+import { fetchManifest, aggregateSchools, fetchBrandColorIndex } from "@/lib/queries";
 import { SchoolTable } from "@/components/SchoolTable";
 
 export const metadata: Metadata = {
@@ -13,8 +13,14 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function SchoolsPage() {
-  const manifest = await fetchManifest();
-  const schools = aggregateSchools(manifest);
+  const [manifest, brandIndex] = await Promise.all([
+    fetchManifest(),
+    fetchBrandColorIndex(),
+  ]);
+  const schools = aggregateSchools(manifest).map((school) => ({
+    ...school,
+    brand_colors: brandIndex[school.school_id] ?? null,
+  }));
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">

--- a/web/src/app/tokens.css
+++ b/web/src/app/tokens.css
@@ -256,8 +256,8 @@
 }
 .cd-header-search__result {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
+  grid-template-columns: 17px minmax(0, 1fr) auto;
+  column-gap: 14px;
   align-items: center;
   padding: 10px 12px;
   cursor: pointer;
@@ -2832,4 +2832,44 @@
 }
 .school-record .admission-strategy-wait-stage--admitted .admission-strategy-wait-stage__track i {
   background: var(--ink-b);
+}
+
+/* Two-dot school glyph. Decorative; always sits next to the name. */
+.school-glyph {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 3px;
+}
+.school-glyph i {
+  display: block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.school-glyph i.school-glyph__dot--hollow {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px currentColor;
+}
+.school-glyph--sm i {
+  width: 6px;
+  height: 6px;
+}
+.school-glyph--lg i {
+  width: 8px;
+  height: 8px;
+}
+.school-name-with-glyph {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 14px;
+}
+.school-name-with-glyph--lg {
+  gap: 9px;
+}
+.school-crumb-with-glyph {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
 }

--- a/web/src/components/CoverageDashboard.tsx
+++ b/web/src/components/CoverageDashboard.tsx
@@ -22,6 +22,7 @@ import Link from "next/link";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { CoverageStatus, InstitutionCoverage } from "@/lib/types";
 import { CoverageBadge } from "./CoverageBadge";
+import { SchoolGlyph } from "./SchoolGlyph";
 
 // Display order for both the histogram and the status filter chips.
 // Mirrors PRD line 309 (most-positive → least-positive → never-checked).
@@ -433,6 +434,7 @@ export function CoverageDashboard({ rows }: { rows: InstitutionCoverage[] }) {
                   >
                     <Link
                       href={`/schools/${r.school_id}`}
+                      className="school-name-with-glyph"
                       style={{
                         fontFamily: "var(--serif)",
                         fontSize: 16,
@@ -441,6 +443,7 @@ export function CoverageDashboard({ rows }: { rows: InstitutionCoverage[] }) {
                         textDecoration: "none",
                       }}
                     >
+                      <SchoolGlyph size="sm" brandColors={r.brand_colors} />
                       {r.school_name}
                     </Link>
                     <span className="mono" style={{ fontSize: 12, color: "var(--ink-2)" }}>

--- a/web/src/components/HeaderSchoolSearch.tsx
+++ b/web/src/components/HeaderSchoolSearch.tsx
@@ -6,13 +6,17 @@ import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
 import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
+import { SchoolGlyph } from "./SchoolGlyph";
+import { withGlyph, type GlyphInks } from "@/lib/derive-inks";
 import { isCanonicalCdsYear } from "@/lib/format";
 
 const DEBOUNCE_MS = 180;
 
+type SearchHit = InstitutionSearchResult & { glyph: GlyphInks };
+
 export function HeaderSchoolSearch() {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<InstitutionSearchResult[]>([]);
+  const [results, setResults] = useState<SearchHit[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -50,7 +54,7 @@ export function HeaderSchoolSearch() {
         setResults([]);
         return;
       }
-      setResults(data ?? []);
+      setResults((data ?? []).map(withGlyph));
       setSelectedIndex(0);
     }, DEBOUNCE_MS);
 
@@ -123,6 +127,7 @@ export function HeaderSchoolSearch() {
               data-active={index === selectedIndex ? "true" : "false"}
               onMouseDown={() => handleSelect(result.school_id, "mouse")}
             >
+              <SchoolGlyph inks={result.glyph} />
               <span className="cd-header-search__school">
                 <span className="cd-header-search__name">{result.school_name}</span>
                 <span className="cd-header-search__meta">

--- a/web/src/components/MatchListBuilder.tsx
+++ b/web/src/components/MatchListBuilder.tsx
@@ -73,9 +73,11 @@ function downloadCsv(filename: string, contents: string) {
 export function MatchListBuilder({
   schools,
   initialCode,
+  brandColors,
 }: {
   schools: MatchBuilderSchool[];
   initialCode?: string;
+  brandColors?: Record<string, string[]>;
 }) {
   const [profile, setProfile] = useState<MatchProfile | null>(null);
   const [filters, setFilters] = useState<MatchFilters>(DEFAULT_MATCH_FILTERS);
@@ -376,7 +378,11 @@ export function MatchListBuilder({
                   </div>
                   <div className="match-tier-group__rows">
                     {rows.map((school) => (
-                      <SchoolListItem key={school.documentId} school={school} />
+                      <SchoolListItem
+                        key={school.documentId}
+                        school={school}
+                        brandColors={brandColors?.[school.schoolId]}
+                      />
                     ))}
                   </div>
                 </section>

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/browser-search";
 import { trackDownload, trackEvent, trackSourceOpened } from "@/lib/analytics";
 import { formatBadgeLabel, formatCurrency, formatPercent } from "@/lib/format";
+import { SchoolGlyph } from "./SchoolGlyph";
 
 type FilterState = {
   undergradMin: string;
@@ -160,7 +161,11 @@ function downloadCsv(rows: BrowserRow[]) {
   URL.revokeObjectURL(url);
 }
 
-export function SchoolBrowser() {
+export function SchoolBrowser({
+  brandColors,
+}: {
+  brandColors?: Record<string, string[]>;
+}) {
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [sortIndex, setSortIndex] = useState(1);
   const [page, setPage] = useState(1);
@@ -372,7 +377,7 @@ export function SchoolBrowser() {
 
       <div className="browser-mobile-results" style={{ opacity: loading ? 0.62 : 1 }}>
         {rows.map((row) => (
-          <BrowserResultCard key={row.document_id} row={row} />
+          <BrowserResultCard key={row.document_id} row={row} brandColors={brandColors?.[row.school_id]} />
         ))}
       </div>
 
@@ -398,6 +403,7 @@ export function SchoolBrowser() {
                 <td style={{ padding: "12px 10px 12px 0" }}>
                   <Link
                     href={`/schools/${row.school_id}`}
+                    className="school-name-with-glyph"
                     style={{ fontFamily: "var(--serif)", fontSize: 18 }}
                     onClick={() =>
                       trackEvent("browser_school_opened", {
@@ -407,6 +413,7 @@ export function SchoolBrowser() {
                       })
                     }
                   >
+                    <SchoolGlyph size="sm" brandColors={brandColors?.[row.school_id]} />
                     {row.school_name}
                   </Link>
                   {row.sub_institutional && (
@@ -543,13 +550,20 @@ export function SchoolBrowser() {
   );
 }
 
-function BrowserResultCard({ row }: { row: BrowserRow }) {
+function BrowserResultCard({
+  row,
+  brandColors,
+}: {
+  row: BrowserRow;
+  brandColors?: string[] | null;
+}) {
   return (
     <article className="cd-card" style={{ padding: 14 }}>
       <div style={{ display: "flex", gap: 10, alignItems: "flex-start", justifyContent: "space-between" }}>
         <div style={{ minWidth: 0 }}>
           <Link
             href={`/schools/${row.school_id}`}
+            className="school-name-with-glyph"
             style={{ fontFamily: "var(--serif)", fontSize: 19, lineHeight: 1.15 }}
             onClick={() =>
               trackEvent("browser_school_opened", {
@@ -559,6 +573,7 @@ function BrowserResultCard({ row }: { row: BrowserRow }) {
               })
             }
           >
+            <SchoolGlyph brandColors={brandColors} />
             {row.school_name}
           </Link>
           {row.sub_institutional && (

--- a/web/src/components/SchoolGlyph.tsx
+++ b/web/src/components/SchoolGlyph.tsx
@@ -1,0 +1,31 @@
+import { glyphInks, type GlyphInks } from "@/lib/derive-inks";
+
+export type SchoolGlyphSize = "sm" | "md" | "lg";
+
+export function SchoolGlyph({
+  brandColors,
+  inks: inksProp,
+  size = "md",
+}: {
+  brandColors?: string[] | string | null;
+  inks?: GlyphInks;
+  size?: SchoolGlyphSize;
+}) {
+  const inks = inksProp ?? glyphInks(brandColors);
+  const className =
+    size === "md" ? "school-glyph" : `school-glyph school-glyph--${size}`;
+
+  return (
+    <span
+      className={className}
+      title={inks.unknown ? "Colours not on file" : `${inks.a} · ${inks.b}`}
+      aria-hidden="true"
+    >
+      <i style={{ background: inks.a }} />
+      <i
+        className={inks.hollowB ? "school-glyph__dot--hollow" : undefined}
+        style={inks.hollowB ? { color: inks.b } : { background: inks.b }}
+      />
+    </span>
+  );
+}

--- a/web/src/components/SchoolListItem.tsx
+++ b/web/src/components/SchoolListItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { SchoolGlyph } from "./SchoolGlyph";
 import { trackEvent, trackSourceOpened } from "@/lib/analytics";
 import { academicFitLabel, admissionsOutlookLabel, type Caveat } from "@/lib/positioning";
 import type { RankedMatchSchool } from "@/lib/list-builder";
@@ -38,7 +39,13 @@ function caveatLabel(caveat: Caveat): string {
   }
 }
 
-export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
+export function SchoolListItem({
+  school,
+  brandColors,
+}: {
+  school: RankedMatchSchool;
+  brandColors?: string[] | null;
+}) {
   const caveats = school.result.caveats
     .filter((caveat) =>
       ["low_sat_submit_rate", "stale_cds", "sub_15_admit_rate_suppression", "data_incomplete", "no_admit_rate"].includes(caveat),
@@ -51,6 +58,7 @@ export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
         <div className="match-school-row__name">
           <Link
             href={school.schoolUrl}
+            className="school-name-with-glyph"
             onClick={() =>
               trackEvent("match_school_opened", {
                 school_id: school.schoolId,
@@ -60,6 +68,7 @@ export function SchoolListItem({ school }: { school: RankedMatchSchool }) {
               })
             }
           >
+            <SchoolGlyph brandColors={brandColors} />
             {school.schoolName}
           </Link>
         </div>

--- a/web/src/components/SchoolSearch.tsx
+++ b/web/src/components/SchoolSearch.tsx
@@ -6,7 +6,11 @@ import { supabase } from "@/lib/supabase";
 import type { InstitutionSearchResult } from "@/lib/types";
 import { trackSchoolSearchSelected } from "@/lib/analytics";
 import { CoverageBadge } from "./CoverageBadge";
+import { SchoolGlyph } from "./SchoolGlyph";
+import { withGlyph, type GlyphInks } from "@/lib/derive-inks";
 import { isCanonicalCdsYear } from "@/lib/format";
+
+type SearchHit = InstitutionSearchResult & { glyph: GlyphInks };
 
 // PRD 015 M4 — server-backed autocomplete over institution_cds_coverage.
 // Calls the search_institutions RPC with a debounced query so missing-
@@ -21,7 +25,7 @@ const DEBOUNCE_MS = 220;
 
 export function SchoolSearch() {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<InstitutionSearchResult[]>([]);
+  const [results, setResults] = useState<SearchHit[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -65,7 +69,7 @@ export function SchoolSearch() {
         setResults([]);
         return;
       }
-      setResults(data ?? []);
+      setResults((data ?? []).map(withGlyph));
       setSelectedIndex(0);
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
@@ -162,15 +166,16 @@ export function SchoolSearch() {
               onMouseDown={() => handleSelect(r.school_id, "mouse")}
               style={{
                 display: "grid",
-                gridTemplateColumns: "1fr auto",
-                gap: 12,
-                alignItems: "baseline",
+                gridTemplateColumns: "17px minmax(0, 1fr) auto",
+                columnGap: 14,
+                alignItems: "center",
                 padding: "10px 14px",
                 cursor: "pointer",
                 background: i === selectedIndex ? "var(--paper-2)" : "transparent",
                 borderTop: i === 0 ? "none" : "1px solid var(--rule)",
               }}
             >
+              <SchoolGlyph inks={r.glyph} />
               <div style={{ minWidth: 0 }}>
                 <div
                   style={{

--- a/web/src/components/SchoolTable.tsx
+++ b/web/src/components/SchoolTable.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import type { SchoolSummary } from "@/lib/types";
 import { Badge } from "./Badge";
+import { SchoolGlyph } from "./SchoolGlyph";
 import { formatBadgeLabel, formatColor } from "@/lib/format";
 
 type SortKey = "name" | "docs" | "year";
@@ -89,8 +90,9 @@ export function SchoolTable({ schools }: { schools: SchoolSummary[] }) {
                 <td className="py-2.5 pr-4">
                   <Link
                     href={`/schools/${school.school_id}`}
-                    className="text-blue-600 hover:text-blue-800 font-medium"
+                    className="school-name-with-glyph text-blue-600 hover:text-blue-800 font-medium"
                   >
+                    <SchoolGlyph size="sm" brandColors={school.brand_colors} />
                     {school.school_name}
                   </Link>
                 </td>

--- a/web/src/lib/derive-inks.test.ts
+++ b/web/src/lib/derive-inks.test.ts
@@ -8,8 +8,12 @@ import {
   PAPER,
   TARGET_A,
   TARGET_ON_B,
+  UNKNOWN_GLYPH_A,
+  UNKNOWN_GLYPH_B,
   contrast,
   deriveInks,
+  glyphInks,
+  glyphSearchFields,
 } from "./derive-inks";
 
 describe("deriveInks", () => {
@@ -72,5 +76,68 @@ describe("deriveInks", () => {
     expect(contrast(HOUSE_A, PAPER)).toBeLessThan(TARGET_A);
     expect(contrast("#ffcb05", PAPER)).toBeGreaterThanOrEqual(MIN_B_ON_CREAM);
     expect(contrast("#ffcb05", PAPER)).toBeLessThan(1.3);
+  });
+});
+
+describe("glyphInks", () => {
+  it("returns grey plus a hollow B when no colours are on file", () => {
+    expect(glyphInks(null)).toEqual({
+      a: UNKNOWN_GLYPH_A,
+      b: UNKNOWN_GLYPH_B,
+      hollowB: true,
+      unknown: true,
+    });
+    expect(glyphInks([])).toEqual(glyphInks(null));
+  });
+
+  it("does not use house forest and ochre for an unknown school", () => {
+    const inks = glyphInks(null);
+    expect(inks.a).not.toBe(HOUSE_A);
+    expect(inks.b).not.toBe(HOUSE_B);
+  });
+
+  it("keeps Michigan maize as the B dot", () => {
+    const inks = glyphInks(["#00274C", "#FFCB05"]);
+    expect(inks.unknown).toBe(false);
+    expect(inks.hollowB).toBe(false);
+    expect(inks.a).toBe("#00274c");
+    expect(inks.b).toBe("#ffcb05");
+  });
+
+  it("treats a lone dark as A and derives a bright B", () => {
+    const inks = glyphInks(["#18453B"]);
+    expect(inks.unknown).toBe(false);
+    expect(inks.a).toBe("#18453b");
+    expect(inks.b).toBe("#159c84");
+  });
+
+  it("rejects black as a plate and keeps the gold", () => {
+    const inks = glyphInks(["#000000", "#FFCC00"]);
+    expect(inks.unknown).toBe(false);
+    expect(inks.a).toBe("#333f48");
+    expect(inks.b).toBe("#ffcc00");
+  });
+
+  it("ships a, b, and hollow_b for the search payload", () => {
+    expect(glyphSearchFields(null)).toEqual({
+      a: UNKNOWN_GLYPH_A,
+      b: UNKNOWN_GLYPH_B,
+      hollow_b: true,
+    });
+    expect(glyphSearchFields(["#00274C", "#FFCB05"])).toEqual({
+      a: "#00274c",
+      b: "#ffcb05",
+      hollow_b: false,
+    });
+  });
+
+  it("keeps scouted Michigan A plates as given", () => {
+    expect(glyphInks(["#6C4023", "#B5A167"]).a).toBe("#6c4023");
+    expect(glyphInks(["#6A0032"]).a).toBe("#6a0032");
+    expect(glyphInks(["#005841", "#FFB600"])).toMatchObject({
+      a: "#005841",
+      b: "#ffb600",
+      unknown: false,
+    });
   });
 });

--- a/web/src/lib/derive-inks.ts
+++ b/web/src/lib/derive-inks.ts
@@ -276,6 +276,47 @@ export function deriveInks(brand: string | string[] | null | undefined): Derived
   return finish(a, bright.hex, "ideal pair — both plates used as given");
 }
 
+// Glyph-only neutrals. A school with no colours on file still prints house
+// inks on its own page (the site's voice). Beside the school's name in a
+// list, forest + ochre would claim those are the school's colours.
+export const UNKNOWN_GLYPH_A = "#8a8779";
+export const UNKNOWN_GLYPH_B = "#a8a59a";
+
+export type GlyphInks = {
+  a: string;
+  b: string;
+  hollowB: boolean;
+  unknown: boolean;
+};
+
+export function glyphInks(
+  brand: string | string[] | null | undefined,
+): GlyphInks {
+  const plates = deriveInks(brand);
+  if (plates.house) {
+    return {
+      a: UNKNOWN_GLYPH_A,
+      b: UNKNOWN_GLYPH_B,
+      hollowB: true,
+      unknown: true,
+    };
+  }
+  return { a: plates.a, b: plates.b, hollowB: false, unknown: false };
+}
+
+export function glyphSearchFields(
+  brand: string | string[] | null | undefined,
+): { a: string; b: string; hollow_b: boolean } {
+  const inks = glyphInks(brand);
+  return { a: inks.a, b: inks.b, hollow_b: inks.hollowB };
+}
+
+export function withGlyph<T extends { brand_colors?: string[] | null }>(
+  row: T,
+): T & { glyph: GlyphInks } {
+  return { ...row, glyph: glyphInks(row.brand_colors) };
+}
+
 export function inkStyle(inks: DerivedInks): Record<string, string> {
   return {
     "--ink-a": inks.a,

--- a/web/src/lib/public-data.ts
+++ b/web/src/lib/public-data.ts
@@ -1,10 +1,12 @@
 import { supabase, STORAGE_BASE_URL } from "./supabase";
 import {
   fetchInstitutionCoverage,
+  fetchSchoolBrandColors,
   fetchSchoolDocuments,
   fetchSchoolFederalFacts,
   fetchScorecardByIpedsId,
 } from "./queries";
+import { glyphSearchFields } from "./derive-inks";
 import type { InstitutionCoverage, ManifestRow, SchoolFactUnifiedRow } from "./types";
 import {
   federalCategory,
@@ -796,6 +798,7 @@ export async function searchSchools(query: string, limit = 10) {
     state: string | null;
     coverage_status: string;
     latest_available_cds_year: string | null;
+    brand_colors?: string[] | null;
   }>;
 
   const rpcResults = await Promise.all(
@@ -812,6 +815,7 @@ export async function searchSchools(query: string, limit = 10) {
         has_cds: row.latest_available_cds_year != null,
         has_federal_baseline: facts.length > 0,
         school_url: `${SITE_URL}/schools/${row.school_id}`,
+        ...glyphSearchFields(row.brand_colors),
       };
     }),
   );
@@ -829,6 +833,7 @@ export async function searchSchools(query: string, limit = 10) {
             has_cds: exactCoverage.latest_available_cds_year != null,
             has_federal_baseline: (await fetchSchoolFederalFacts(exactCoverage.school_id)).length > 0,
             school_url: `${SITE_URL}/schools/${exactCoverage.school_id}`,
+            ...glyphSearchFields(await fetchSchoolBrandColors(exactCoverage.school_id)),
           },
         ]
       : [];

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -800,6 +800,41 @@ export const fetchSchoolBrandColors = cache(
   },
 );
 
+export const fetchBrandColorIndex = cache(
+  async function fetchBrandColorIndex(): Promise<Record<string, string[]>> {
+    const PAGE = 1000;
+    const out: Record<string, string[]> = {};
+    try {
+      for (let start = 0; start < 50_000; start += PAGE) {
+        const { data, error } = await (supabase as unknown as UntypedSupabase)
+          .from("institution_directory")
+          .select("school_id, brand_colors")
+          .not("brand_colors", "is", null)
+          .range(start, start + PAGE - 1);
+        if (error) break;
+        const page = (data as Array<{ school_id: string | null; brand_colors: string[] | null }>) ?? [];
+        for (const row of page) {
+          if (row.school_id && Array.isArray(row.brand_colors) && row.brand_colors.length > 0) {
+            out[row.school_id] = row.brand_colors;
+          }
+        }
+        if (page.length < PAGE) break;
+      }
+    } catch {
+      return out;
+    }
+    return out;
+  },
+);
+
+export function brandColorsFor(
+  index: Record<string, string[]>,
+  schoolId: string | null | undefined,
+): string[] | null {
+  if (!schoolId) return null;
+  return index[schoolId] ?? null;
+}
+
 // Resolve reviewed retired slugs from the checked-in manifest first, then use
 // the public crosswalk for other aliases. A primary alias wins over demoted
 // aliases; ambiguous rows return null so callers render normally instead of

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -166,6 +166,7 @@ export interface SchoolSummary {
   latest_year: string | null;
   formats: string[];
   has_extracted: boolean;
+  brand_colors?: string[] | null;
 }
 
 // PRD 015 M3 — coverage_status_t enum from
@@ -194,6 +195,7 @@ export interface InstitutionSearchResult {
   coverage_status: CoverageStatus;
   coverage_label: string;
   latest_available_cds_year: string | null;
+  brand_colors?: string[] | null;
 }
 
 // fetchInstitutionCoverage() return shape — a single row from
@@ -213,6 +215,7 @@ export interface InstitutionCoverage {
   latest_available_cds_year: string | null;
   last_checked_at: string | null;
   can_submit_source: boolean;
+  brand_colors?: string[] | null;
 }
 
 export type FederalFactQuality =


### PR DESCRIPTION
## Summary
- Add a 17px two-dot school glyph beside names in search, directory, coverage, browse, match, breadcrumbs, and the latest-drain feed.
- Use `glyphInks()` off the school page so missing colours render grey plus a hollow B instead of house forest/ochre.
- Include `brand_colors` on `search_institutions` and ship `a` / `b` / `hollow_b` on the public search API so the dropdown does not re-derive plates on each render.

## Test plan
- [ ] `cd web && npx vitest run && npx tsc --noEmit`
- [ ] Search `mich`: Michigan maize, MSU derived B, Tech charcoal+gold, unknown schools grey+hollow
- [ ] Directory, coverage, browse, match, drain, and school breadcrumbs show the glyph without theming the row
- [ ] After merge, apply `20260824120000_search_institutions_brand_colors.sql` from the primary checkout (`supabase db push --linked --yes`); until then search glyphs stay unknown
- [ ] Screen reader announces name/location/badge only (`aria-hidden` on the glyph)


Made with [Cursor](https://cursor.com)