### PR TITLE
chore: set up Cloud Agent dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Project overview, layout, and operational conventions live in [`CLAUDE.md`](CLAUDE.md)
+and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Contributor setup basics are in
+[`CONTRIBUTING.md`](CONTRIBUTING.md); frontend specifics in [`web/README.md`](web/README.md).
+
+## Cursor Cloud specific instructions
+
+The environment update script already installs dependencies on boot
+(`npm --prefix web ci`, a repo-root `.venv`, and `tools/ci-requirements.txt`).
+Toolchains not covered by the update script (Node 22, Python 3.12, Deno 2.x, the
+`python3.12-venv` and `unzip` apt packages) are baked into the environment
+snapshot. Notes below are the non-obvious bits for running/testing here.
+
+### Services
+
+- **Next.js frontend + friendly JSON API** (`web/`, the primary product) — the only
+  long-running service you normally start. It talks to the **hosted production
+  Supabase** backend (PostgREST + Edge Functions at `https://api.collegedata.fyi`),
+  so there is **no local database to run**. Everything else in the repo
+  (`tools/*` Python pipelines, `supabase/functions/*` Deno functions) is offline
+  batch tooling or serverless code exercised only through its test suites.
+
+### Running the web app
+
+- Requires `web/.env.local` with `NEXT_PUBLIC_SUPABASE_URL` and
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY`. This file is gitignored and NOT recreated by the
+  update script. The anon key is public (RLS-scoped) and is the same one committed in
+  the `web` job of [`.github/workflows/ci.yml`](.github/workflows/ci.yml); copy the
+  `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` values from there. Without
+  this file the dev server boots but all data-backed pages/APIs return empty results.
+- Start it with `npm run dev` in `web/` (serves `http://localhost:3000`, including the
+  `/api/*` friendly API). Standard scripts (`dev`, `build`, `typecheck`, `test`,
+  `test:smoke`) are in `web/package.json`.
+
+### Tests / lint / build
+
+- Canonical commands per surface live in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+  (web build/typecheck/test, Python unit suites, Deno function tests, migration hygiene).
+- Python tools: run with the repo-root venv, e.g. `.venv/bin/python -m pytest tools/discovery -q`
+  or the `unittest` invocations from CI. All CI Python jobs run against
+  `tools/ci-requirements.txt` alone (the heavier `tools/*/requirements.txt` files are only
+  needed to actually run those pipelines, not their unit tests).
+- Deno function tests need `deno` on `PATH` (`~/.deno/bin`, already added to `~/.bashrc`);
+  run with `--allow-env --allow-read` as in CI.
+- Playwright smoke tests (`web/npm run test:smoke`) hit the live hosted API and require a
+  one-time `npx playwright install --with-deps chromium`; they are optional for most work.
+
+### Gotchas
+
+- This is Next.js 16 with breaking changes from older versions — read
+  `web/node_modules/next/dist/docs/` before writing frontend code (see
+  [`web/AGENTS.md`](web/AGENTS.md)).
+- Do NOT run database migrations from this environment. Per [`CLAUDE.md`](CLAUDE.md),
+  migrations are applied to production only from a fresh `main` checkout after a PR merges,
+  never from a feature branch.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the collegedata.fyi monorepo and captures durable, non-obvious startup notes for future agents. The only code/content change is a new root `AGENTS.md`; all dependency installation is handled by the environment update script (not committed here).

The primary product — the **Next.js 16 web app + friendly JSON API** in `web/` — runs against the **hosted production Supabase** backend, so no local database is required. Supporting Python pipelines (`tools/*`) and Deno Edge Functions (`supabase/functions/*`) are exercised via their test suites.

## What was set up

- **Web** (`web/`): `npm ci` (Node 22 already present); created gitignored `web/.env.local` with the public `NEXT_PUBLIC_SUPABASE_*` values (same anon key used in CI).
- **Python** (`tools/`): repo-root `.venv` + `pip install -r tools/ci-requirements.txt` (Python 3.12; installed `python3.12-venv` apt package).
- **Deno**: installed Deno 2.x for Edge Function tests (added to `PATH` via `~/.bashrc`; installed `unzip`).

## Verification

| Surface | Command | Result |
| --- | --- | --- |
| Web typecheck | `npm run typecheck` (web/) | pass |
| Web unit tests | `npm test` (web/) | 375 passed (41 files) |
| Web build | `npm run build` (web/) | success |
| Web dev + API | `npm run dev` + `curl /api/schools/search` | home 200, live Harvard JSON |
| Python | `pytest tools/discovery`, browser projection, tier4 cleaner, change intelligence, identity guard | all pass |
| Deno | `deno test` on `_shared` + `browser-search` | 168 passed |

### Hello-world E2E

Searched "Harvard" on the running dev site and navigated to the Harvard University detail page, which rendered live CDS + IPEDS data from the hosted backend.

[collegedata_search_harvard_school_page_demo.mp4](https://cursor.com/agents/bc-d0372283-4a22-4f12-a22e-d892506fdb58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcollegedata_search_harvard_school_page_demo.mp4)

[Harvard University school detail page](https://cursor.com/agents/bc-d0372283-4a22-4f12-a22e-d892506fdb58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fharvard_school_page.webp)

## Update script (registered separately)

```
npm --prefix web ci
python3 -m venv .venv
.venv/bin/python -m pip install -r tools/ci-requirements.txt
```

## Notes

`web/.env.local` is gitignored and not recreated by the update script; future agents should copy the public `NEXT_PUBLIC_SUPABASE_*` values from `.github/workflows/ci.yml`. Details are in the new `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0372283-4a22-4f12-a22e-d892506fdb58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0372283-4a22-4f12-a22e-d892506fdb58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

