### PR TITLE
Lock public voice and ship Wave 1 front-door copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Open-source archive of U.S. college Common Data Set (CDS) documents.
 - **API:** https://api.collegedata.fyi (PostgREST on Supabase)
 - **Architecture:** `docs/ARCHITECTURE.md` (eleven pipelines: schema, corpus, discovery, mirror, extraction, scorecard, institution directory + coverage, IPEDS federal baseline, change intelligence, consumer API, frontend)
 - **Frontend PRD:** `docs/prd/002-frontend.md`
-- **Design system:** `web/DESIGN_SYSTEM.md` (canonical tokens in `web/src/app/tokens.css`; live reference at `/design-system/`). **Read before writing any UI.**
+- **Design system:** `web/DESIGN_SYSTEM.md` (canonical tokens in `web/src/app/tokens.css`; live reference at `/design-system/`). **Read before writing any UI.** Public copy: `web/VOICE.md`.
 
 ## Project layout
 

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -27,8 +27,8 @@ see a path (Match / Browse / API) without being the lede.
 ### Meta
 
 - Title: collegedata.fyi — College facts from the schools
-- Description: School-published college facts, kept public and current, with
-  the original file one click away — plus federal context you can tell apart.
+- Description: The most comprehensive free college data we know of — school
+  Common Data Set reports, IPEDS, and College Scorecard, in one public place.
 
 ### Hero
 
@@ -36,11 +36,11 @@ Keep the headline: **College data,** *straight from the source.*
 
 Replace the current lede with:
 
-> School-published college facts, kept public and current, with the original
-> file one click away — plus federal context you can tell apart.
+> The most comprehensive free college data we know of — each school’s
+> Common Data Set, plus IPEDS and College Scorecard, in one public place.
 >
-> Search a school to see the latest report it published. Compare admissions,
-> cost, and aid. No account. Nothing to sell.
+> Search a school. Compare admissions, cost, and aid. Open the original
+> file. No account.
 
 Marginalia can stay (OPEN DATA / SOURCE LINKS / PUBLIC API on the left;
 ADMISSIONS / AFFORDABILITY / OUTCOMES on the right). Those are catalog
@@ -82,15 +82,16 @@ Keep the title **The *Uncommon* Data Set** — it’s brand, not jargon.
 ### Meta
 
 - Title: About
-- Description: Why collegedata.fyi exists: school-published facts you can
-  use, originals you can open, federal context you can tell apart. No account.
+- Description: The most comprehensive free college data we know of. School
+  Common Data Set reports, IPEDS, and College Scorecard, in one public place.
+  No account.
 
 ### Proposed body
 
 **Lede.** Choosing a college should not mean a dozen tabs, a paid search
-product, and a PDF you can’t compare. The numbers already exist. Schools
-publish them. The Department of Education publishes federal context. We put
-those in one public place and keep the labels on.
+product, and a PDF you can’t compare. This is the most comprehensive free
+college data we know of: each school’s Common Data Set, plus IPEDS and
+College Scorecard, in one public place.
 
 **What you can do.**
 
@@ -102,9 +103,9 @@ those in one public place and keep the labels on.
 
 **How this is different.** Commercial college-search tools can be useful.
 They often want an account, hide where a number came from, or build a student
-profile along the way. We don’t. Every school-year page links the original
-document. Federal figures stay labeled as federal, so they aren’t mistaken
-for the school’s own report.
+profile along the way. We don’t. The school’s own report sits next to the
+federal numbers, the original file is one click away, and you don’t have to
+pay or log in.
 
 **The reports, in one line each.** (Links, not a seminar.)
 

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -5,8 +5,10 @@ a React diff. Locked decisions: three primary personas, the site promise
 (named sources on About; gloss first on the homepage), Harvey Mudd Docling
 off the CDS explainer, Pipeline stays in the footer.
 
-Persona-read 2026-08-26 applied **1, 2, 5, 8, 9** below. **3, 4, 6, 7** are
-open questions at the end of this deck.
+Persona-read 2026-08-26 applied **1, 2, 5, 8, 9**. Anthony called **3, 4, 6,
+7** the same evening: keep the punchier comprehensiveness claim; drop the
+takedown sentence from public copy; `/browse` is **Compare** everywhere;
+homepage title keeps “free.”
 
 **Not in this deck:** live TSX. Sign the prose, then we implement.
 
@@ -16,8 +18,11 @@ open questions at the end of this deck.
 
 **Keep in footer (status-style):** Pipeline, plus Coverage, API, About, GitHub.
 
-**Drop from the More menu:** Pipeline. More stays Browser, Coverage, Recipes,
-About, GitHub until question 6 is called (Compare vs Browser for `/browse`).
+**Drop from the More menu:** Pipeline. More becomes Compare, Coverage,
+Recipes, About, GitHub.
+
+Public name for `/browse` is **Compare** — button, More item, and later
+browse-page chrome. Do not say “Browser” in product copy.
 
 Primary nav unchanged: Match, Schools, API.
 
@@ -26,12 +31,11 @@ Primary nav unchanged: Match, Schools, API.
 ## Homepage (`/`)
 
 **Primary persona:** parents and students. Counselors and IR should still
-see a path (Match / Browse / API) without being the lede.
+see a path (Match / Compare / API) without being the lede.
 
 ### Meta
 
-- Title: collegedata.fyi — College facts from the schools
-  *(question 7 — alternative title parked below)*
+- Title: collegedata.fyi — Free college data, straight from the source
 - Description: The most comprehensive free college data we know of — the
   report each college publishes, plus the government’s own numbers, in one
   public place.
@@ -61,7 +65,7 @@ implementer to improvise. Button row stays Match / Compare / Schools as
 today:
 
 - **Build match list** → `/match`
-- **Compare schools** → `/browse` *(label vs nav “Browser” is question 6)*
+- **Compare schools** → `/browse`
 - **Browse all schools** → `/schools`
 
 Ghost: **API** and **GitHub** (IR/builders, not the parent path).
@@ -167,12 +171,13 @@ URL. IR is secondary (they already know).
 ### Lede (replace the current “47-page PDF is not a data system”)
 
 > Colleges publish a yearly report of admissions, cost, and financial aid.
-> It’s called the Common Data Set. We keep those reports public — including
-> files a school has since taken down — and turn them into pages you can
-> search, compare, and share.
+> It’s called the Common Data Set. We keep those reports public and turn
+> them into pages you can search, compare, and share.
 
-Keep the takedown claim (true; Stanford 2017–18). Don’t escalate it on
-school-page copy in Wave 2. Quiet link to the takedown policy is question 4.
+Do not say “files a school has since taken down” on this page, or on Wave 2
+school pages. The archive still holds historical files; we don’t advertise
+takedowns. Takedown process stays in [ADR 0008](../decisions/0008-takedown-process.md),
+not in product copy. No quiet policy link from this explainer.
 
 ### Body outline
 
@@ -234,27 +239,17 @@ If any of those fail, the page isn’t done.
 
 ---
 
-## Open questions (Anthony’s call)
+## Locked calls (persona-read 3, 4, 6, 7)
 
-Persona-read applied 1, 2, 5, 8, and 9. These four stay parked:
+**3. Keep the punchier claim.** “The most comprehensive free college data we
+know of” — do not insert “collection of.” Hedge stays “we know of.”
 
-**3. “Collection of.”** “Most comprehensive free college data” can be read
-as a swipe at IPEDS itself — which is free and covers ~6,000 institutions.
-Safer: “the most comprehensive free *collection of* college data we know of.”
-Slightly less punchy; meaningfully harder to rebut. Flagged, not blocking.
-Deck currently keeps the punchier line.
+**4. Drop the takedown sentence.** CDS explainer does not say “including
+files a school has since taken down.” No quiet link to ADR 0008 from this
+page. Wave 2 school-page copy must not escalate it either.
 
-**4. Takedown claim.** “Including files a school has since taken down” stays
-in the CDS explainer lede. Wave 2 school-page copy should not escalate it.
-Do we add a quiet link from the CDS explainer to the takedown policy
-([ADR 0008](../decisions/0008-takedown-process.md), or wherever the public
-policy will live)?
+**6. Compare everywhere.** Public name for `/browse` is Compare (More menu
+item, homepage button, later browse chrome). Not Browser.
 
-**6. Compare vs Browser.** Homepage button says “Compare schools”; More menu
-says “Browser.” Two names for `/browse` in the same viewport. Pick
-**Compare** for both (More item becomes “Compare”), or keep **Browser**
-everywhere. This deck does not choose.
-
-**7. Homepage title tag.** Current proposal: `collegedata.fyi — College
-facts from the schools`. Alternative that keeps “free”: `collegedata.fyi —
-Free college data, straight from the source`.
+**7. Homepage title.** `collegedata.fyi — Free college data, straight from
+the source` — matches the hero, keeps “free.”

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -1,0 +1,205 @@
+# Wave 1 copy deck — front door
+
+Read this as a parent, then as a counselor, then as IR. Do not review it as
+a React diff. Locked decisions: three primary personas, the site promise,
+Harvey Mudd Docling off the CDS explainer, Pipeline stays in the footer.
+
+**Not in this deck:** live TSX. Sign the prose, then we implement.
+
+---
+
+## Chrome
+
+**Keep in footer (status-style):** Pipeline, plus Coverage, API, About, GitHub.
+
+**Drop from the More menu:** Pipeline. More stays Browser, Coverage, Recipes,
+About, GitHub.
+
+Primary nav unchanged: Match, Schools, API.
+
+---
+
+## Homepage (`/`)
+
+**Primary persona:** parents and students. Counselors and IR should still
+see a path (Match / Browse / API) without being the lede.
+
+### Meta
+
+- Title: collegedata.fyi — College facts from the schools
+- Description: School-published college facts, kept public and current, with
+  the original file one click away — plus federal context you can tell apart.
+
+### Hero
+
+Keep the headline: **College data,** *straight from the source.*
+
+Replace the current lede with:
+
+> School-published college facts, kept public and current, with the original
+> file one click away — plus federal context you can tell apart.
+>
+> Search a school to see the latest report it published. Compare admissions,
+> cost, and aid. No account. Nothing to sell.
+
+Marginalia can stay (OPEN DATA / SOURCE LINKS / PUBLIC API on the left;
+ADMISSIONS / AFFORDABILITY / OUTCOMES on the right). Those are catalog
+chrome, not operator jargon.
+
+CTAs: keep Search as the front door. Buttons: **Find a school** (→ `/schools`
+or just rely on search), **Build a match list**, **Compare schools** (Browse).
+Ghost: **API** and **GitHub** (IR/builders, not the parent path).
+
+### Stat band
+
+Keep live counts. Relabel the operator notes:
+
+| Now | Proposed label | Proposed note |
+|---|---|---|
+| Schools in archive / N extracted | Schools | Latest reports we have on file |
+| Source documents / year span | Documents | School files, 1998–2025 (live span) |
+| Queryable fields / field schema | Facts you can compare | From current school reports |
+| Browser rows / N schools | Schools in the comparer | Refreshed {date} |
+
+Exact note wording can use the live stats. Ban “extracted,” “schema,”
+“browser rows” on this band.
+
+### Recently added (today: “§ Latest drain”)
+
+Heading: **Recently added**
+Caption: New school reports in the archive. Each row opens the school and
+the original file.
+
+Keep the live feed. Drop “drain” from the public heading.
+
+---
+
+## About (`/about`)
+
+**Primary:** all three personas, parents first.
+Keep the title **The *Uncommon* Data Set** — it’s brand, not jargon.
+
+### Meta
+
+- Title: About
+- Description: Why collegedata.fyi exists: school-published facts you can
+  use, originals you can open, federal context you can tell apart. No account.
+
+### Proposed body
+
+**Lede.** Choosing a college should not mean a dozen tabs, a paid search
+product, and a PDF you can’t compare. The numbers already exist. Schools
+publish them. The Department of Education publishes federal context. We put
+those in one public place and keep the labels on.
+
+**What you can do.**
+
+- Search a school and open the latest report it published.
+- Download the original file the school posted.
+- Compare admissions, enrollment, test scores, cost, and aid across schools.
+- Build a match list on your device. We don’t store a student profile.
+- If you’re in IR or research: use the same data through a public API.
+
+**How this is different.** Commercial college-search tools can be useful.
+They often want an account, hide where a number came from, or build a student
+profile along the way. We don’t. Every school-year page links the original
+document. Federal figures stay labeled as federal, so they aren’t mistaken
+for the school’s own report.
+
+**The reports, in one line each.** (Links, not a seminar.)
+
+- [Common Data Set](/about/common-data-set) — the yearly report the college
+  writes.
+- [College Scorecard](/about/college-scorecard) — federal outcomes and net
+  price.
+- [IPEDS](/about/ipeds) — the federal statistical baseline.
+
+**Open source.** Code, schema, pipeline, and archived files are public
+(MIT). [GitHub](https://github.com/bolewood/collegedata-fyi). [API](/api).
+Developers who want extractors and known issues start there, not on this
+page.
+
+**Credits / sponsors.** Keep Bolewood and the data-source links. Move
+Docling and Reducto off this page (GitHub README / methodology appendix).
+Parents don’t need the PDF parser list to trust the product.
+
+Keep the closing line if it still earns it: *Better college decisions start
+with better access to the facts.*
+
+---
+
+## What is the Common Data Set (`/about/common-data-set`)
+
+**Primary:** parents who don’t know the term; counselors who will share the
+URL. IR is secondary (they already know).
+
+### Meta
+
+- Title: What is the Common Data Set
+- Description: The Common Data Set is the yearly report a college publishes
+  on admissions, enrollment, cost, and aid. We archive those reports and
+  make the numbers easy to use.
+
+### Lede (replace the current “47-page PDF is not a data system”)
+
+> Colleges publish a yearly report of admissions, cost, and financial aid.
+> It’s called the Common Data Set. We keep those reports public — including
+> files a school has since taken down — and turn them into pages you can
+> search, compare, and share.
+
+### Body outline
+
+**What it is.** In the late 1990s, schools and guidebook publishers agreed
+on one form so every college wasn’t answering the same questions fifteen
+ways. The [Common Data Set Initiative](https://commondataset.org/) still
+publishes that template. Filling it out is voluntary. There is no central
+filing cabinet. Each school posts a file, or doesn’t.
+
+**What’s in it.** Keep the A–J table in English. That’s useful for
+counselors and curious parents. Don’t lead with field counts (1,105) unless
+IR asks; a short “about a thousand comparable facts” is enough.
+
+**How to use it here.**
+
+- Search a school, open a year, read the facts, download the original file.
+- Counselors: send the year page, not a 47-page PDF. The official file is
+  on the same page, so you aren’t asking a family to trust a scrape.
+- IR / researchers: the extract uses the template’s field IDs; the API and
+  GitHub repo are the portable copy. Contribute a missing year from the
+  school page.
+
+**We don’t replace the school, or the feds.** The numbers are the college’s.
+We aren’t [IPEDS](/about/ipeds) and we aren’t [College Scorecard](/about/college-scorecard).
+Those are different systems with different calendars. On this site they
+stay labeled.
+
+### What leaves this page
+
+All of the extractor narrative, including:
+
+- “Point the wrong extractor at that file and C1 shifts”
+- Docling collapsing Harvey Mudd C1, kerned years, running headers
+- `docs/known-issues/harvey-mudd-2025-26.md` cited in public prose
+- AcroForm / `pypdf.get_fields()` / `AP_RECD_1ST_MEN_N`
+- The Docling-shift and repeating-header figures
+
+**Relocate to:** `docs/known-issues/harvey-mudd-2025-26.md` (already there)
+and, if we want a public professional pointer, a methodology appendix or
+GitHub known-issues index. Not this URL.
+
+**Optional keep, rewritten:** Harvey Mudd as a *positive* example — a school
+that publishes a fillable 2025–26 file, [open the year page](/schools/harvey-mudd/2025-26)
+— without teaching the parser. Virginia Tech as a *coverage* example: the
+school’s landing page asks you to email; the file is public here. One
+sentence each, or cut both from Wave 1 and save them for methodology.
+
+---
+
+## Read-aloud checks
+
+- Parent: “I can search a school and see current numbers plus the original
+  file.”
+- Counselor: “I can share a year URL and I know it’s the school’s report.”
+- IR: “I know where the API and GitHub are, and that plumbing lives there.”
+
+If any of those fail, the page isn’t done.

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -1,8 +1,12 @@
 # Wave 1 copy deck — front door
 
 Read this as a parent, then as a counselor, then as IR. Do not review it as
-a React diff. Locked decisions: three primary personas, the site promise,
-Harvey Mudd Docling off the CDS explainer, Pipeline stays in the footer.
+a React diff. Locked decisions: three primary personas, the site promise
+(named sources on About; gloss first on the homepage), Harvey Mudd Docling
+off the CDS explainer, Pipeline stays in the footer.
+
+Persona-read 2026-08-26 applied **1, 2, 5, 8, 9** below. **3, 4, 6, 7** are
+open questions at the end of this deck.
 
 **Not in this deck:** live TSX. Sign the prose, then we implement.
 
@@ -13,7 +17,7 @@ Harvey Mudd Docling off the CDS explainer, Pipeline stays in the footer.
 **Keep in footer (status-style):** Pipeline, plus Coverage, API, About, GitHub.
 
 **Drop from the More menu:** Pipeline. More stays Browser, Coverage, Recipes,
-About, GitHub.
+About, GitHub until question 6 is called (Compare vs Browser for `/browse`).
 
 Primary nav unchanged: Match, Schools, API.
 
@@ -27,17 +31,22 @@ see a path (Match / Browse / API) without being the lede.
 ### Meta
 
 - Title: collegedata.fyi — College facts from the schools
-- Description: The most comprehensive free college data we know of — school
-  Common Data Set reports, IPEDS, and College Scorecard, in one public place.
+  *(question 7 — alternative title parked below)*
+- Description: The most comprehensive free college data we know of — the
+  report each college publishes, plus the government’s own numbers, in one
+  public place.
 
 ### Hero
 
 Keep the headline: **College data,** *straight from the source.*
 
-Replace the current lede with:
+Replace the current lede with the gloss. Do not name Common Data Set, IPEDS,
+or College Scorecard in this paragraph — those links already live on the
+page:
 
-> The most comprehensive free college data we know of — each school’s
-> Common Data Set, plus IPEDS and College Scorecard, in one public place.
+> The most comprehensive free college data we know of — the report each
+> college publishes about itself, plus the government’s own numbers, in one
+> public place.
 >
 > Search a school. Compare admissions, cost, and aid. Open the original
 > file. No account.
@@ -46,8 +55,15 @@ Marginalia can stay (OPEN DATA / SOURCE LINKS / PUBLIC API on the left;
 ADMISSIONS / AFFORDABILITY / OUTCOMES on the right). Those are catalog
 chrome, not operator jargon.
 
-CTAs: keep Search as the front door. Buttons: **Find a school** (→ `/schools`
-or just rely on search), **Build a match list**, **Compare schools** (Browse).
+CTAs: Search is the door. **No “Find a school” button** — search is already
+the dominant element, and inventing a fourth destination forces the
+implementer to improvise. Button row stays Match / Compare / Schools as
+today:
+
+- **Build match list** → `/match`
+- **Compare schools** → `/browse` *(label vs nav “Browser” is question 6)*
+- **Browse all schools** → `/schools`
+
 Ghost: **API** and **GitHub** (IR/builders, not the parent path).
 
 ### Stat band
@@ -59,10 +75,10 @@ Keep live counts. Relabel the operator notes:
 | Schools in archive / N extracted | Schools | Latest reports we have on file |
 | Source documents / year span | Documents | School files, 1998–2025 (live span) |
 | Queryable fields / field schema | Facts you can compare | From current school reports |
-| Browser rows / N schools | Schools in the comparer | Refreshed {date} |
+| Browser rows / N schools | Schools you can compare | side by side · refreshed {date} |
 
 Exact note wording can use the live stats. Ban “extracted,” “schema,”
-“browser rows” on this band.
+“browser rows,” and “comparer” on this band.
 
 ### Recently added (today: “§ Latest drain”)
 
@@ -96,10 +112,17 @@ College Scorecard, in one public place.
 **What you can do.**
 
 - Search a school and open the latest report it published.
+- If a school hasn’t published its own report, you still get the federal
+  numbers.
 - Download the original file the school posted.
 - Compare admissions, enrollment, test scores, cost, and aid across schools.
 - Build a match list on your device. We don’t store a student profile.
 - If you’re in IR or research: use the same data through a public API.
+
+The federal-fallback line is load-bearing. Roughly 507 schools have a
+current CDS, 189 are stale, and ~1,473 in-scope schools have never published
+one we could find. Without it, “search a school and see current numbers”
+fails for the majority of schools, and the comprehensiveness claim weakens.
 
 **How this is different.** Commercial college-search tools can be useful.
 They often want an account, hide where a number came from, or build a student
@@ -147,6 +170,9 @@ URL. IR is secondary (they already know).
 > It’s called the Common Data Set. We keep those reports public — including
 > files a school has since taken down — and turn them into pages you can
 > search, compare, and share.
+
+Keep the takedown claim (true; Stanford 2017–18). Don’t escalate it on
+school-page copy in Wave 2. Quiet link to the takedown policy is question 4.
 
 ### Body outline
 
@@ -198,9 +224,37 @@ sentence each, or cut both from Wave 1 and save them for methodology.
 
 ## Read-aloud checks
 
-- Parent: “I can search a school and see current numbers plus the original
-  file.”
+- Parent: “I can search a school and see current numbers — the school’s
+  report if they published one, federal numbers if they didn’t — plus the
+  original file when we have it.”
 - Counselor: “I can share a year URL and I know it’s the school’s report.”
 - IR: “I know where the API and GitHub are, and that plumbing lives there.”
 
 If any of those fail, the page isn’t done.
+
+---
+
+## Open questions (Anthony’s call)
+
+Persona-read applied 1, 2, 5, 8, and 9. These four stay parked:
+
+**3. “Collection of.”** “Most comprehensive free college data” can be read
+as a swipe at IPEDS itself — which is free and covers ~6,000 institutions.
+Safer: “the most comprehensive free *collection of* college data we know of.”
+Slightly less punchy; meaningfully harder to rebut. Flagged, not blocking.
+Deck currently keeps the punchier line.
+
+**4. Takedown claim.** “Including files a school has since taken down” stays
+in the CDS explainer lede. Wave 2 school-page copy should not escalate it.
+Do we add a quiet link from the CDS explainer to the takedown policy
+([ADR 0008](../decisions/0008-takedown-process.md), or wherever the public
+policy will live)?
+
+**6. Compare vs Browser.** Homepage button says “Compare schools”; More menu
+says “Browser.” Two names for `/browse` in the same viewport. Pick
+**Compare** for both (More item becomes “Compare”), or keep **Browser**
+everywhere. This deck does not choose.
+
+**7. Homepage title tag.** Current proposal: `collegedata.fyi — College
+facts from the schools`. Alternative that keeps “free”: `collegedata.fyi —
+Free college data, straight from the source`.

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -1,16 +1,13 @@
 # Wave 1 copy deck — front door
 
 Read this as a parent, then as a counselor, then as IR. Do not review it as
-a React diff. Locked decisions: three primary personas, the site promise
-(named sources on About; gloss first on the homepage), Harvey Mudd Docling
-off the CDS explainer, Pipeline stays in the footer.
+a React diff. **Signed 2026-08-26** with one condition: API stays in the
+header. GitHub is demoted off the hero (More menu + footer only).
 
-Persona-read 2026-08-26 applied **1, 2, 5, 8, 9**. Anthony called **3, 4, 6,
-7** the same evening: keep the punchier comprehensiveness claim; drop the
-takedown sentence from public copy; `/browse` is **Compare** everywhere;
-homepage title keeps “free.”
-
-**Not in this deck:** live TSX. Sign the prose, then we implement.
+Locked: three primary personas; named sources on About / gloss first on the
+homepage; Harvey Mudd Docling off the CDS explainer; Pipeline in the footer,
+not More; Compare everywhere for `/browse`; punchier comprehensiveness
+claim; no takedown sentence on product pages.
 
 ---
 
@@ -21,10 +18,14 @@ homepage title keeps “free.”
 **Drop from the More menu:** Pipeline. More becomes Compare, Coverage,
 Recipes, About, GitHub.
 
+**Primary nav:** Match, Schools, **API**. API stays in the header — researchers
+use it, and so do parents who point an LLM at a public endpoint to build a
+list. Do not move it into More.
+
 Public name for `/browse` is **Compare** — button, More item, and later
 browse-page chrome. Do not say “Browser” in product copy.
 
-Primary nav unchanged: Match, Schools, API.
+GitHub is not a header or hero destination. It lives in More and the footer.
 
 ---
 
@@ -68,7 +69,8 @@ today:
 - **Compare schools** → `/browse`
 - **Browse all schools** → `/schools`
 
-Ghost: **API** and **GitHub** (IR/builders, not the parent path).
+Ghost: **API** only (researchers, and parents using LLMs). GitHub is
+demoted: More menu and footer, not the hero.
 
 ### Stat band
 
@@ -253,3 +255,5 @@ item, homepage button, later browse chrome). Not Browser.
 
 **7. Homepage title.** `collegedata.fyi — Free college data, straight from
 the source` — matches the hero, keeps “free.”
+
+**API in the header.** Keep it. Demote GitHub off the hero.

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -80,11 +80,13 @@ Keep live counts. Relabel the operator notes:
 |---|---|---|
 | Schools in archive / N extracted | Schools | Latest reports we have on file |
 | Source documents / year span | Documents | School files, 1998–2025 (live span) |
-| Queryable fields / field schema | Facts you can compare | From current school reports |
-| Browser rows / N schools | Schools you can compare | side by side · refreshed {date} |
+| Queryable fields / field schema | Facts | You can compare · from current school reports |
+| Browser rows / N schools | Compare | Side by side · refreshed {date} |
 
 Exact note wording can use the live stats. Ban “extracted,” “schema,”
-“browser rows,” and “comparer” on this band.
+“browser rows,” and “comparer” on this band. Stat *labels* stay short —
+`.meta` uppercases them, so “Facts you can compare” becomes a shouting
+caption. Put the sentence in the note.
 
 ### Recently added (today: “§ Latest drain”)
 

--- a/docs/copy/wave-1-front-door.md
+++ b/docs/copy/wave-1-front-door.md
@@ -223,11 +223,8 @@ All of the extractor narrative, including:
 and, if we want a public professional pointer, a methodology appendix or
 GitHub known-issues index. Not this URL.
 
-**Optional keep, rewritten:** Harvey Mudd as a *positive* example — a school
-that publishes a fillable 2025–26 file, [open the year page](/schools/harvey-mudd/2025-26)
-— without teaching the parser. Virginia Tech as a *coverage* example: the
-school’s landing page asks you to email; the file is public here. One
-sentence each, or cut both from Wave 1 and save them for methodology.
+**Cut from Wave 1:** Harvey Mudd fillable-file example and Virginia Tech
+email-gate example. Save for methodology if they earn a place later.
 
 ---
 

--- a/docs/known-issues/harvey-mudd-2025-26.md
+++ b/docs/known-issues/harvey-mudd-2025-26.md
@@ -1,5 +1,8 @@
 # Harvey Mudd College, CDS 2025-26 — known extraction issues
 
+Public copy on `/about/common-data-set` does not carry this extractor
+narrative. These notes stay here for maintainers.
+
 **Source PDF:** `CDS-HMC-2025.2026_shared.pdf`
 **Source format:** Unflattened fillable PDF (1,026 AcroForm fields, 558 populated)
 **Recommended extractor:** `pypdf.get_fields()` (Tier 2) — **not** Docling

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -6,7 +6,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 # Read the design system before writing UI
 
-Before touching any component, page, or CSS, read [`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md) top to bottom. The canonical tokens live in [`src/app/tokens.css`](src/app/tokens.css); the live reference page is at [`/design-system/`](public/design-system/index.html); the original handoff archive (HTML + JSX prototypes + screenshots) is at [`../docs/design/`](../docs/design/).
+Before touching any component, page, or CSS, read [`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md) top to bottom. Before writing or rewriting public prose, read [`VOICE.md`](VOICE.md). The canonical tokens live in [`src/app/tokens.css`](src/app/tokens.css); the live reference page is at [`/design-system/`](public/design-system/index.html); the original handoff archive (HTML + JSX prototypes + screenshots) is at [`../docs/design/`](../docs/design/).
 
 Palette rules you will get wrong otherwise: **no blue anywhere** (forest `#3f5b3a` is the sole accent); card backgrounds use `#faf6ec` via `.cd-card`, not Tailwind `bg-white`; numbers are always tabular (`font-variant-numeric: tabular-nums`) and mono.
 

--- a/web/DESIGN_SYSTEM.md
+++ b/web/DESIGN_SYSTEM.md
@@ -1,6 +1,7 @@
 # collegedata.fyi — Design system
 
 > **Read this before touching any frontend UI.** Same spirit as `AGENTS.md`.
+> Public copy: [`VOICE.md`](VOICE.md).
 
 **Canonical tokens:** [`web/src/app/tokens.css`](src/app/tokens.css)
 **Live reference page:** [`/design-system/`](https://collegedata.fyi/design-system/) (also in repo at [`web/public/design-system/index.html`](public/design-system/index.html))
@@ -120,14 +121,16 @@ Wordmark on the left, links on the right. Stacks under the wordmark at ≤ 640 p
 
 ## Voice
 
+**What we say** is in [`VOICE.md`](VOICE.md) (personas, site promise, glossary).
+This section is **how it looks**.
+
 Marginalia, ledger entries, catalog cards, editorial serif headlines with an italic accent word. Literally:
 
 - **"College data, *straight from the source.*"** (home hero, italic on the second clause)
 - **"Worked *examples*."** (recipes hero)
 - **"The *Uncommon* Data Set"** (about hero)
-- **"§ Latest drain"** (mono caption before a ledger section)
 
-Mono captions always lead with `§` and use uppercase tracking (0.08em). Numbers and IDs are mono; names are serif.
+Mono captions may lead with `§` and use uppercase tracking (0.08em). Numbers and IDs are mono; names are serif. Do not use operator words (`drain`, `extracted`, `browser rows`) in public captions — see `VOICE.md`.
 
 ---
 

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -1,0 +1,135 @@
+# collegedata.fyi — Voice
+
+Editorial source of truth for public copy. Visual rules stay in
+[`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md). If they conflict, this file wins
+for *what we say*; the design system wins for *how it looks*.
+
+Locked 2026-08-26 after Anthony’s Wave 1 decisions.
+
+---
+
+## Site promise
+
+School-published college facts, kept public and current, with the original
+file one click away — plus federal context you can tell apart.
+
+That sentence is the product. Every public page should make it usable, not
+explain how the archive is built.
+
+---
+
+## Personas (primary)
+
+Journalists and developers are welcome. They are not a fourth homepage
+audience. Point them at `/api`, GitHub, and methodology.
+
+### Parents and students
+
+They may never have heard “Common Data Set.” They want accurate, current
+numbers they can act on: is this school in range, what does it cost, can I
+compare without a paywall or a student-data profile.
+
+Say “the report the college publishes” once, then use the numbers. Link the
+original file. Do not teach the template.
+
+### College counselors
+
+They know the CDS. Don’t teach sections A–J unless the page is the CDS
+explainer. Help them stay current, share a year URL instead of a 47-page PDF,
+and see coverage gaps and year-over-year shifts.
+
+### Researchers and IR
+
+They want peer files, definitions, bulk access, a way to contribute a missing
+year, and data they can take elsewhere. They care about sourcing, schema, and
+the API — not extractor war stories on the explainer page.
+
+---
+
+## Three voice layers
+
+Keep plumbing visible to people who want it. Don’t put it on the front door.
+
+| Layer | Audience | Lives on | Says |
+|---|---|---|---|
+| **Product** | Parents/students first; counselors second | `/`, `/about`, school pages, `/browse`, `/match`, `/recipes`, `/coverage`, cards, empty states, metadata | Benefit, then action, then one plain-English source line |
+| **Professional** | IR, researchers, counselors who want the trail | `/methodology/*`, `/api`, rewritten source-story pages | Sourcing, definitions, portability, school-authored vs federal — still English |
+| **Operator** | Maintainers and OSS contributors | `/pipeline-observation`, `docs/`, `docs/known-issues/`, GitHub | Extractors, Docling vs AcroForm, Harvey Mudd C1, drains, heartbeats |
+
+**Harvey Mudd / Docling C1 shift** stays in `docs/known-issues/` and may
+appear in a methodology appendix. It does not belong on
+`/about/common-data-set`.
+
+**Three sources** is a product *behavior* (labels on numbers), not a lecture.
+Methodology gets one sentence: so a federal outcome is not mistaken for a
+school-published aid figure.
+
+---
+
+## Chrome
+
+- **Footer:** keep Pipeline, like a status link. Fine.
+- **More menu:** do not treat Pipeline as a product destination. Wave 1
+  should drop it from secondary nav and leave it in the footer.
+- Primary nav stays Match / Schools / API.
+
+---
+
+## Page protocol
+
+1. Name the primary persona (and secondary, if any).
+2. Outline: **benefit → what to do on this page → what the number is → one
+   source line → link for people who want the trail.**
+3. Never start a product lede with process (extractors, field IDs, “print
+   form,” “canonical,” “drain”).
+4. Update title, description, and JSON-LD in the same change as the prose.
+5. Read-aloud test: would a parent, a counselor, and an IR director each
+   know what to do in 20 seconds?
+
+Design-system rule **never hide a source** still holds. Added rule: **never
+make the pipeline the story on a product page.**
+
+---
+
+## Glossary
+
+Product copy prefers the right-hand column. Operator docs may use the left.
+
+| Avoid on product pages | Prefer |
+|---|---|
+| extracted / extractor / Docling / AcroForm / Tier 4 | read from the school’s file |
+| canonical year | 2025–26 (the actual year) |
+| drain, manifest, projection, browser row | recently added files; schools you can compare |
+| “we keep three sources separate” | labeled school-published vs federal |
+| CDS field IDs in a lede (`C.101`, `AP_RECD_1ST_MEN_N`) | the fact in English, ID only in tables or API docs |
+| “a 47-page PDF is not a database” as the hook | what a family or counselor can *do* with the report |
+
+Keep saying **Common Data Set** on the explainer and in SEO. Define it in
+the first sentence, then talk about the numbers.
+
+---
+
+## Differentiation (say this, not rankings)
+
+Versus commercial college-search products: no account required, we don’t
+build or sell a student profile, the original school file is linked, this is
+not a ranking product.
+
+Versus a raw CDS PDF: a shareable year page, comparable fields, coverage you
+can see, historical files the school may have taken down.
+
+Versus IPEDS Data Center / Scorecard sitewide: school-authored current
+figures when the school publishes them; federal context kept labeled.
+
+---
+
+## Shipping copy
+
+1. Draft in a copy deck (`docs/copy/`), not in a 400-line React diff.
+2. Anthony reads as a reader.
+3. Then implement in `web/`.
+4. Small PRs per wave. Wave 1 is the front door: homepage, About, CDS
+   explainer, metadata, nav chrome.
+
+Waves 2–4 (school pages, methodology, API) wait until Wave 1’s dialect is
+stable.

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -7,6 +7,8 @@ for *what we say*; the design system wins for *how it looks*.
 Locked 2026-08-26 after Anthony’s Wave 1 decisions. Promise revised the
 same day: completeness over “tell the sources apart.” Persona-read the
 same evening: homepage says the gloss first; named sources stay on About.
+Follow-up calls: keep the punchier comprehensiveness claim; do not advertise
+takedowns; `/browse` is Compare; homepage title keeps “free.”
 
 ---
 
@@ -93,7 +95,10 @@ Homepage ledes do not name the three systems.
 
 - **Footer:** keep Pipeline, like a status link. Fine.
 - **More menu:** do not treat Pipeline as a product destination. Wave 1
-  should drop it from secondary nav and leave it in the footer.
+  drops it from secondary nav and leaves it in the footer. More is Compare,
+  Coverage, Recipes, About, GitHub.
+- Public name for `/browse` is **Compare** — nav, buttons, later browse
+  chrome. Do not say “Browser” on product pages.
 - Primary nav stays Match / Schools / API.
 
 ---
@@ -124,7 +129,8 @@ Product copy prefers the right-hand column. Operator docs may use the left.
 |---|---|
 | extracted / extractor / Docling / AcroForm / Tier 4 | read from the school’s file |
 | canonical year | 2025–26 (the actual year) |
-| drain, manifest, projection, browser row, comparer | recently added files; schools you can compare |
+| drain, manifest, projection, browser row, comparer, Browser | recently added files; schools you can compare; Compare |
+| “files a school has since taken down” | historical years; the original file (do not advertise takedowns) |
 | “we keep three sources separate” / “federal context you can tell apart” | the three public sources, in one place |
 | CDS field IDs in a lede (`C.101`, `AP_RECD_1ST_MEN_N`) | the fact in English, ID only in tables or API docs |
 | “a 47-page PDF is not a database” as the hook | what a family or counselor can *do* with the report |
@@ -147,7 +153,7 @@ build or sell a student profile, the original school file is linked, this is
 not a ranking product.
 
 Versus a raw CDS PDF: a shareable year page, comparable fields, coverage you
-can see, historical files the school may have taken down.
+can see. Do not say “files a school has since taken down” on product pages.
 
 Versus IPEDS Data Center or Scorecard alone: those are one federal system
 each. We put the school’s own report next to them, in public, without a

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -4,17 +4,23 @@ Editorial source of truth for public copy. Visual rules stay in
 [`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md). If they conflict, this file wins
 for *what we say*; the design system wins for *how it looks*.
 
-Locked 2026-08-26 after Anthony’s Wave 1 decisions.
+Locked 2026-08-26 after Anthony’s Wave 1 decisions. Promise revised the
+same day: completeness over “tell the sources apart.”
 
 ---
 
 ## Site promise
 
-School-published college facts, kept public and current, with the original
-file one click away — plus federal context you can tell apart.
+The most comprehensive free college data we know of — each school’s Common
+Data Set, plus IPEDS and College Scorecard, in one public place.
 
-That sentence is the product. Every public page should make it usable, not
-explain how the archive is built.
+That sentence is the product. The benefit is *everything in one place, for
+free.* Naming the three sources is how we say what “everything” is, not a
+lecture on keeping them apart. Labels on numbers stay as product behavior;
+they are not the homepage claim.
+
+Every public page should make the promise usable, not explain how the
+archive is built.
 
 ---
 
@@ -60,9 +66,10 @@ Keep plumbing visible to people who want it. Don’t put it on the front door.
 appear in a methodology appendix. It does not belong on
 `/about/common-data-set`.
 
-**Three sources** is a product *behavior* (labels on numbers), not a lecture.
-Methodology gets one sentence: so a federal outcome is not mistaken for a
-school-published aid figure.
+**Three sources** belong in the promise as what we bring together (school
+CDS, IPEDS, College Scorecard). On the page, keep labels so a federal
+outcome is not mistaken for the school’s own report. Methodology may say
+that in one sentence. Product ledes do not.
 
 ---
 
@@ -100,7 +107,7 @@ Product copy prefers the right-hand column. Operator docs may use the left.
 | extracted / extractor / Docling / AcroForm / Tier 4 | read from the school’s file |
 | canonical year | 2025–26 (the actual year) |
 | drain, manifest, projection, browser row | recently added files; schools you can compare |
-| “we keep three sources separate” | labeled school-published vs federal |
+| “we keep three sources separate” / “federal context you can tell apart” | the three public sources, in one place |
 | CDS field IDs in a lede (`C.101`, `AP_RECD_1ST_MEN_N`) | the fact in English, ID only in tables or API docs |
 | “a 47-page PDF is not a database” as the hook | what a family or counselor can *do* with the report |
 
@@ -118,8 +125,9 @@ not a ranking product.
 Versus a raw CDS PDF: a shareable year page, comparable fields, coverage you
 can see, historical files the school may have taken down.
 
-Versus IPEDS Data Center / Scorecard sitewide: school-authored current
-figures when the school publishes them; federal context kept labeled.
+Versus IPEDS Data Center or Scorecard alone: those are one federal system
+each. We put the school’s own report next to them, in public, without a
+paywall.
 
 ---
 

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -5,7 +5,8 @@ Editorial source of truth for public copy. Visual rules stay in
 for *what we say*; the design system wins for *how it looks*.
 
 Locked 2026-08-26 after Anthony’s Wave 1 decisions. Promise revised the
-same day: completeness over “tell the sources apart.”
+same day: completeness over “tell the sources apart.” Persona-read the
+same evening: homepage says the gloss first; named sources stay on About.
 
 ---
 
@@ -16,8 +17,20 @@ Data Set, plus IPEDS and College Scorecard, in one public place.
 
 That sentence is the product. The benefit is *everything in one place, for
 free.* Naming the three sources is how we say what “everything” is, not a
-lecture on keeping them apart. Labels on numbers stay as product behavior;
-they are not the homepage claim.
+lecture on keeping them apart. Use this named-sources form on About and in
+PR copy.
+
+**Homepage lede** is the same promise in English first. Source names appear
+lower on the page, or as the labeled links they already are:
+
+The most comprehensive free college data we know of — the report each
+college publishes about itself, plus the government’s own numbers, in one
+public place.
+
+Counselors and IR still recognize the product from “the report each college
+publishes.” Do not open the homepage with three proper nouns.
+
+Labels on numbers stay as product behavior; they are not the homepage claim.
 
 Every public page should make the promise usable, not explain how the
 archive is built.
@@ -36,7 +49,8 @@ numbers they can act on: is this school in range, what does it cost, can I
 compare without a paywall or a student-data profile.
 
 Say “the report the college publishes” once, then use the numbers. Link the
-original file. Do not teach the template.
+original file. Do not teach the template. The homepage follows this rule
+in the lede; it does not lead with Common Data Set, IPEDS, and Scorecard.
 
 ### College counselors
 
@@ -66,10 +80,12 @@ Keep plumbing visible to people who want it. Don’t put it on the front door.
 appear in a methodology appendix. It does not belong on
 `/about/common-data-set`.
 
-**Three sources** belong in the promise as what we bring together (school
-CDS, IPEDS, College Scorecard). On the page, keep labels so a federal
-outcome is not mistaken for the school’s own report. Methodology may say
-that in one sentence. Product ledes do not.
+**Three sources** belong in the named-sources promise (school CDS, IPEDS,
+College Scorecard) used on About and in PR copy. The homepage lede uses
+the gloss (“the report each college publishes,” “the government’s own
+numbers”). On every page, keep labels so a federal outcome is not mistaken
+for the school’s own report. Methodology may say that in one sentence.
+Homepage ledes do not name the three systems.
 
 ---
 
@@ -92,6 +108,8 @@ that in one sentence. Product ledes do not.
 4. Update title, description, and JSON-LD in the same change as the prose.
 5. Read-aloud test: would a parent, a counselor, and an IR director each
    know what to do in 20 seconds?
+6. Homepage ledes use the gloss, not three proper nouns. When claiming
+   current or accurate, say “as the school published it.”
 
 Design-system rule **never hide a source** still holds. Added rule: **never
 make the pipeline the story on a product page.**
@@ -106,13 +124,19 @@ Product copy prefers the right-hand column. Operator docs may use the left.
 |---|---|
 | extracted / extractor / Docling / AcroForm / Tier 4 | read from the school’s file |
 | canonical year | 2025–26 (the actual year) |
-| drain, manifest, projection, browser row | recently added files; schools you can compare |
+| drain, manifest, projection, browser row, comparer | recently added files; schools you can compare |
 | “we keep three sources separate” / “federal context you can tell apart” | the three public sources, in one place |
 | CDS field IDs in a lede (`C.101`, `AP_RECD_1ST_MEN_N`) | the fact in English, ID only in tables or API docs |
 | “a 47-page PDF is not a database” as the hook | what a family or counselor can *do* with the report |
 
 Keep saying **Common Data Set** on the explainer and in SEO. Define it in
 the first sentence, then talk about the numbers.
+
+When claiming **current** or **accurate**, anchor to “as the school
+published it.” Never imply we verified the school’s math. Parents want
+accurate numbers; our honest posture is the school’s own report, labeled,
+with the original file one click away. Federal figures stay labeled as
+federal.
 
 ---
 
@@ -127,7 +151,10 @@ can see, historical files the school may have taken down.
 
 Versus IPEDS Data Center or Scorecard alone: those are one federal system
 each. We put the school’s own report next to them, in public, without a
-paywall.
+paywall. If a school hasn’t published its own report, you still get the
+federal numbers. That fallback is load-bearing: most in-scope schools have
+no archived CDS, so “search a school and see current numbers” is only true
+because of it.
 
 ---
 

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -8,7 +8,8 @@ Locked 2026-08-26 after Anthony’s Wave 1 decisions. Promise revised the
 same day: completeness over “tell the sources apart.” Persona-read the
 same evening: homepage says the gloss first; named sources stay on About.
 Follow-up calls: keep the punchier comprehensiveness claim; do not advertise
-takedowns; `/browse` is Compare; homepage title keeps “free.”
+takedowns; `/browse` is Compare; homepage title keeps “free.” Signed with
+API in the header (researchers and parents using LLMs); GitHub off the hero.
 
 ---
 
@@ -42,7 +43,8 @@ archive is built.
 ## Personas (primary)
 
 Journalists and developers are welcome. They are not a fourth homepage
-audience. Point them at `/api`, GitHub, and methodology.
+audience. Point them at `/api` (already in the header), GitHub, and
+methodology.
 
 ### Parents and students
 
@@ -93,13 +95,16 @@ Homepage ledes do not name the three systems.
 
 ## Chrome
 
-- **Footer:** keep Pipeline, like a status link. Fine.
+- **Footer:** keep Pipeline, like a status link. Fine. GitHub belongs here
+  and in More, not in the header or the homepage hero.
 - **More menu:** do not treat Pipeline as a product destination. Wave 1
   drops it from secondary nav and leaves it in the footer. More is Compare,
   Coverage, Recipes, About, GitHub.
 - Public name for `/browse` is **Compare** — nav, buttons, later browse
   chrome. Do not say “Browser” on product pages.
-- Primary nav stays Match / Schools / API.
+- **Primary nav stays Match / Schools / API.** API is load-bearing in the
+  header: researchers, and parents who will point an LLM at a public
+  endpoint to build a college list. Do not demote it into More.
 
 ---
 

--- a/web/src/app/about/common-data-set/page.tsx
+++ b/web/src/app/about/common-data-set/page.tsx
@@ -1,16 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
-  SOURCE_STORY_REVIEWED,
   SourceStoryLayout,
-  StoryFigure,
   StoryTable,
 } from "@/components/about/SourceStoryLayout";
 
 const CANONICAL = "/about/common-data-set";
 const TITLE = "What is the Common Data Set";
 const DESCRIPTION =
-  "The Common Data Set is a voluntary 47-page school-authored form, not a database. How the template works, why publishing is a mess, and what collegedata.fyi extracts.";
+  "The Common Data Set is the yearly report a college publishes on admissions, enrollment, cost, and aid. We archive those reports and make the numbers easy to use.";
+const REVIEWED = "2026-08-26";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -24,8 +23,8 @@ const jsonLd = {
   "@type": "Article",
   headline: TITLE,
   description: DESCRIPTION,
-  datePublished: SOURCE_STORY_REVIEWED,
-  dateModified: SOURCE_STORY_REVIEWED,
+  datePublished: REVIEWED,
+  dateModified: REVIEWED,
   author: { "@type": "Organization", name: "Bolewood Group", url: "https://bolewood.com" },
   publisher: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
   about: {
@@ -40,34 +39,27 @@ export default function CommonDataSetPage() {
   return (
     <SourceStoryLayout
       kicker="Common Data Set"
-      title={
-        <>
-          What is the Common Data Set
-        </>
-      }
-      lede="A 47-page PDF on a random institutional-research URL is not a data system. It is a print form that three guidebook publishers asked schools to fill in once."
+      title={<>What is the Common Data Set</>}
+      lede="Colleges publish a yearly report of admissions, cost, and financial aid. It's called the Common Data Set. We keep those reports public and turn them into pages you can search, compare, and share."
+      lastReviewed={REVIEWED}
       jsonLd={jsonLd}
     >
-      <h2>The CDS Initiative</h2>
+      <h2>What it is</h2>
       <p>
-        In the late 1990s the College Board, Peterson&apos;s, and U.S. News sat
-        down with college institutional-research offices and agreed on one
-        template. The point was to stop asking every school for the same
-        enrollment, admissions, and aid numbers in fifteen slightly different
-        shapes. The{" "}
+        In the late 1990s, schools and guidebook publishers agreed on one form
+        so every college wasn&apos;t answering the same questions fifteen ways.
+        The{" "}
         <a href="https://commondataset.org/" target="_blank" rel="noopener noreferrer">
           Common Data Set Initiative
         </a>{" "}
-        still publishes that template. It is currently a 47-page workbook with
-        1,105 fields and an Answer Sheet tab.
-      </p>
-      <p>
-        Participation is voluntary. There is no federal mandate, no central
-        filing cabinet, and no API. Each school posts a file on its own
-        website, or does not.
+        still publishes that template. Filling it out is voluntary. There is no
+        central filing cabinet. Each school posts a file, or doesn&apos;t.
       </p>
 
-      <h2>Sections A–J, in English</h2>
+      <h2>What&apos;s in it</h2>
+      <p>
+        About a thousand comparable facts, in sections A through J.
+      </p>
       <StoryTable
         caption="Common Data Set sections A through J"
         headers={["Section", "What it covers"]}
@@ -85,129 +77,46 @@ export default function CommonDataSetPage() {
         ]}
       />
 
-      <h2>A fillable PDF is the easy case</h2>
-      <p>
-        Harvey Mudd College still publishes the{" "}
-        <Link href="/schools/harvey-mudd/2025-26">
-          2025-26 Common Data Set
-        </Link>{" "}
-        as an unflattened fillable PDF. Named AcroForm fields carry the
-        canonical tags from the template. <code>AP_RECD_1ST_MEN_N</code> is
-        3,452. That is a 200-millisecond <code>pypdf.get_fields()</code>{" "}
-        extract, not a model guess. See{" "}
-        <Link href="/schools/harvey-mudd">the Harvey Mudd archive</Link>.
-      </p>
-      <StoryFigure
-        src="/about/harvey-mudd-2025-26-c1-fillable.svg"
-        alt="Harvey Mudd College Common Data Set 2025-26 section C1, showing named AcroForm tags such as AP_RECD_1ST_MEN_N with value 3,452 from the fillable PDF."
-        caption="Harvey Mudd College, Common Data Set 2025-26, archived fillable PDF CDS-HMC-2025.2026_shared.pdf, section C1. Values are AcroForm field contents."
-        href="/schools/harvey-mudd/2025-26"
-        hrefLabel="Open the 2025-26 year page"
-      />
-
-      <h2>Point the wrong extractor at that file and C1 shifts</h2>
-      <p>
-        The same kind of table, after a layout parser has flattened it, is why
-        this archive exists as software and not as a folder of PDFs. Docling
-        on the Harvey Mudd fillable file collapsed C1 so men-applied became
-        “3452 1761” and women-applied became “4”. Kerned year numerals read
-        as “202 5 -202 6”. The running header printed “Common Data Set
-        2025-2026” as a heading five times. That is documented in
-        <code> docs/known-issues/harvey-mudd-2025-26.md</code>. The live
-        extract is the AcroForm path. The Docling notes are what happens if
-        you pick the wrong tool.
-      </p>
-      <StoryFigure
-        src="/about/harvey-mudd-2025-26-c1-docling-shift.svg"
-        alt="Docling misread of Harvey Mudd 2025-26 C1, with applicant counts shifted into the wrong rows, shown as a warning rather than the live extract."
-        caption="Harvey Mudd College, Common Data Set 2025-26, same archived PDF. This figure is the historical Docling misread of C1, not the live extract."
-        href="/schools/harvey-mudd/2025-26"
-        hrefLabel="Open the year page whose live extract is correct"
-      />
-      <StoryFigure
-        src="/about/harvey-mudd-2025-26-page-header.svg"
-        alt="The phrase Common Data Set 2025-2026 repeated five times as a running page header from the Harvey Mudd fillable PDF."
-        caption="Harvey Mudd College, Common Data Set 2025-26, archived fillable PDF. The repeating header is print chrome. The document is a form, not a database."
-        href="/schools/harvey-mudd/2025-26"
-      />
-
-      <h2>Virginia Tech publishes XLSX and hides the index</h2>
-      <p>
-        Virginia Tech&apos;s{" "}
-        <Link href="/schools/virginia-tech/2025-26">
-          2025-26 Common Data Set
-        </Link>{" "}
-        is an Excel workbook — the theoretically ideal format. The school&apos;s
-        own page at{" "}
-        <a
-          href="https://aie.vt.edu/analytics-and-ai/common-data-set.html"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          aie.vt.edu
-        </a>{" "}
-        explains what a CDS is, then says files are available via request to
-        aiesupport@vt.edu. The PDFs and workbooks exist on a DAM path. The
-        landing page is a dead end.{" "}
-        <Link href="/schools/virginia-tech">The Virginia Tech archive</Link>{" "}
-        is the public HTML that actually hands over the extract.
-      </p>
-      <StoryFigure
-        src="/about/virginia-tech-2025-26-xlsx-and-email-gate.svg"
-        alt="Virginia Tech 2025-26 Common Data Set Excel answer sheet beside the official IR page text that asks the public to email aiesupport@vt.edu for the file."
-        caption="Virginia Tech, Common Data Set 2025-26, archived XLSX, next to the school’s own CDS page (email request). Applied total in the 2025-26 extract: 57,755."
-        href="/schools/virginia-tech/2025-26"
-        hrefLabel="Open the Virginia Tech 2025-26 year page"
-      />
-
-      <h2>The publishing mess</h2>
-      <p>
-        Schools do not publish one way. In this archive we already have, as
-        real files:
-      </p>
+      <h2>How to use it here</h2>
       <ul>
-        <li>Unflattened fillable PDFs (Harvey Mudd 2025-26).</li>
-        <li>Flattened PDFs where the form structure is gone.</li>
-        <li>Image-only scans with almost no extractable text.</li>
-        <li>XLSX workbooks (Virginia Tech 2025-26).</li>
-        <li>DOCX uploads of the Word template.</li>
-        <li>HTML pages, some of them JS-only.</li>
-        <li>Box, SharePoint, Google Drive, and Digital Commons item pages.</li>
         <li>
-          URLs whose path year is a CMS upload month, not the academic year.
+          Search a school, open a year, read the facts, download the original
+          file.
         </li>
-        <li>Section-only files, blank templates, and “test” uploads that are the real file.</li>
+        <li>
+          Counselors: send the year page, not a 47-page PDF. The official file
+          is on the same page, so you aren&apos;t asking a family to trust a
+          scrape.
+        </li>
+        <li>
+          IR / researchers: the extract uses the template&apos;s field IDs; the{" "}
+          <Link href="/api">API</Link> and{" "}
+          <a
+            href="https://github.com/bolewood/collegedata-fyi"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub repo
+          </a>{" "}
+          are the portable copy. Contribute a missing year from the school page.
+        </li>
       </ul>
+
       <p>
-        None of that is a data system. It is a distributed print workflow
-        that happens to use a shared template. Stanford&apos;s{" "}
-        <Link href="/schools/stanford/2017-18">2017-18 year page</Link> is
-        already a used URL: historical files convert when the school no
-        longer lists them.
+        Harvey Mudd publishes a fillable 2025–26 file —{" "}
+        <Link href="/schools/harvey-mudd/2025-26">open the year page</Link>.
+        Virginia Tech&apos;s landing page asks you to email;{" "}
+        <Link href="/schools/virginia-tech/2025-26">the file is public here</Link>.
       </p>
 
-      <h2>What “extracted” means here</h2>
+      <h2>We don&apos;t replace the school, or the feds</h2>
       <p>
-        Extracted means: canonical field IDs such as C.101 and H.2A, values
-        with provenance back to the archived bytes, and a spreadsheet
-        download of those fields. It does not mean we are the publisher. The
-        numbers are the school&apos;s. The year page links the archived original
-        and, when we have a usable HTML URL, the school&apos;s own CDS page.
-      </p>
-      <p>
-        For a counselor: send the year page, not a 47-page PDF, and keep the
-        official link in the same paragraph so you are not vouching for a
-        scrape.
-      </p>
-
-      <h2>What we are not</h2>
-      <p>
-        Not the publisher. Not{" "}
-        <Link href="/about/ipeds">IPEDS</Link>. Not{" "}
+        The numbers are the college&apos;s, as the school published them. We
+        aren&apos;t{" "}
+        <Link href="/about/ipeds">IPEDS</Link> and we aren&apos;t{" "}
         <Link href="/about/college-scorecard">College Scorecard</Link>. Those
-        are different systems with different mandates, lags, and field
-        definitions. This page is the school-authored form, archived and
-        extracted.
+        are different systems with different calendars. On this site they stay
+        labeled.
       </p>
     </SourceStoryLayout>
   );

--- a/web/src/app/about/common-data-set/page.tsx
+++ b/web/src/app/about/common-data-set/page.tsx
@@ -102,13 +102,6 @@ export default function CommonDataSetPage() {
         </li>
       </ul>
 
-      <p>
-        Harvey Mudd publishes a fillable 2025–26 file —{" "}
-        <Link href="/schools/harvey-mudd/2025-26">open the year page</Link>.
-        Virginia Tech&apos;s landing page asks you to email;{" "}
-        <Link href="/schools/virginia-tech/2025-26">the file is public here</Link>.
-      </p>
-
       <h2>We don&apos;t replace the school, or the feds</h2>
       <p>
         The numbers are the college&apos;s, as the school published them. We

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -9,19 +9,14 @@ export const metadata: Metadata = {
   openGraph: { url: "/about" },
 };
 
-const linkStyle = {
-  textDecorationColor: "var(--rule-strong)",
-  textUnderlineOffset: 3,
-} as const;
-
 export default function AboutPage() {
   return (
     <div className="mx-auto max-w-2xl px-4 py-12" style={{ color: "var(--ink-2)" }}>
       <h1
+        className="serif"
         style={{
-          fontFamily: "var(--serif)",
           fontWeight: 400,
-          fontSize: 48,
+          fontSize: "clamp(40px, 6vw, 56px)",
           lineHeight: 1.05,
           letterSpacing: "-0.02em",
           color: "var(--ink)",
@@ -31,30 +26,26 @@ export default function AboutPage() {
         The <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>Uncommon</span> Data Set
       </h1>
 
-      <div className="mt-8 space-y-5 text-base leading-relaxed">
-        <p>
-          Choosing a college should not mean a dozen tabs, a paid search
-          product, and a PDF you can&apos;t compare. This is the most
-          comprehensive free college data we know of: each school&apos;s{" "}
-          <Link href="/about/common-data-set" style={linkStyle}>
-            Common Data Set
-          </Link>
-          , plus{" "}
-          <Link href="/about/ipeds" style={linkStyle}>
-            IPEDS
-          </Link>{" "}
-          and{" "}
-          <Link href="/about/college-scorecard" style={linkStyle}>
-            College Scorecard
-          </Link>
-          , in one public place.
-        </p>
+      <p
+        className="serif"
+        style={{
+          fontStyle: "italic",
+          fontSize: 18,
+          lineHeight: 1.55,
+          color: "var(--ink-2)",
+          margin: "20px 0 0",
+          maxWidth: "40rem",
+        }}
+      >
+        Choosing a college should not mean a dozen tabs, a paid search product,
+        and a PDF you can&apos;t compare. This is the most comprehensive free
+        college data we know of: each school&apos;s Common Data Set, plus IPEDS
+        and College Scorecard, in one public place.
+      </p>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          What you can do
-        </h2>
-
-        <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
+      <div className="cd-source-story">
+        <h2>What you can do</h2>
+        <ul>
           <li>Search a school and open the latest report it published.</li>
           <li>
             If a school hasn&apos;t published its own report, you still get the
@@ -71,17 +62,11 @@ export default function AboutPage() {
           </li>
           <li>
             If you&apos;re in IR or research: use the same data through a{" "}
-            <Link href="/api" style={linkStyle}>
-              public API
-            </Link>
-            .
+            <Link href="/api">public API</Link>.
           </li>
         </ul>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          How this is different
-        </h2>
-
+        <h2>How this is different</h2>
         <p>
           Commercial college-search tools can be useful. They often want an
           account, hide where a number came from, or build a student profile
@@ -90,63 +75,40 @@ export default function AboutPage() {
           don&apos;t have to pay or log in.
         </p>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          The reports, in one line each
-        </h2>
-
-        <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
+        <h2>The reports, in one line each</h2>
+        <ul>
           <li>
-            <Link href="/about/common-data-set" style={linkStyle}>
-              Common Data Set
-            </Link>{" "}
-            — the yearly report the college writes.
+            <Link href="/about/common-data-set">Common Data Set</Link>
+            {" "}— the yearly report the college writes.
           </li>
           <li>
-            <Link href="/about/college-scorecard" style={linkStyle}>
-              College Scorecard
-            </Link>{" "}
-            — federal outcomes and net price.
+            <Link href="/about/college-scorecard">College Scorecard</Link>
+            {" "}— federal outcomes and net price.
           </li>
           <li>
-            <Link href="/about/ipeds" style={linkStyle}>
-              IPEDS
-            </Link>{" "}
-            — the federal statistical baseline.
+            <Link href="/about/ipeds">IPEDS</Link>
+            {" "}— the federal statistical baseline.
           </li>
         </ul>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          Open source
-        </h2>
-
+        <h2>Open source</h2>
         <p>
           Code, schema, pipeline, and archived files are public (MIT).{" "}
           <a
             href="https://github.com/bolewood/collegedata-fyi"
             target="_blank"
             rel="noopener noreferrer"
-            style={linkStyle}
           >
             GitHub
           </a>
-          .{" "}
-          <Link href="/api" style={linkStyle}>
-            API
-          </Link>
-          . Developers who want extractors and known issues start there, not
-          on this page.
+          . <Link href="/api">API</Link>. Developers who want extractors and
+          known issues start there, not on this page.
         </p>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>Credits</h2>
-
+        <h2>Credits</h2>
         <p>
           Built on{" "}
-          <a
-            href="https://supabase.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={linkStyle}
-          >
+          <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">
             Supabase
           </a>
           . Federal baseline facts come from official{" "}
@@ -154,33 +116,23 @@ export default function AboutPage() {
             href="https://nces.ed.gov/ipeds/"
             target="_blank"
             rel="noopener noreferrer"
-            style={linkStyle}
           >
             NCES/IPEDS
           </a>{" "}
           releases.
         </p>
 
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          Project Sponsors
-        </h2>
-
+        <h2>Project Sponsors</h2>
         <p>collegedata.fyi is supported by:</p>
-
-        <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
+        <ul>
           <li>
-            <a
-              href="https://bolewood.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={linkStyle}
-            >
+            <a href="https://bolewood.com" target="_blank" rel="noopener noreferrer">
               Bolewood Group
             </a>
           </li>
         </ul>
 
-        <div style={{ marginTop: 40, borderTop: "1px solid var(--rule)", paddingTop: 24, fontSize: 13, fontStyle: "italic", fontFamily: "var(--serif)", color: "var(--ink-3)" }}>
+        <div style={{ marginTop: 24, borderTop: "1px solid var(--rule)", paddingTop: 24, fontSize: 13, fontStyle: "italic", fontFamily: "var(--serif)", color: "var(--ink-3)" }}>
           Better college decisions start with better access to the facts.
         </div>
       </div>

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "About",
   description:
-    "The story behind collegedata.fyi, an open-source archive of U.S. college Common Data Set documents with source-labeled federal baseline facts.",
+    "The most comprehensive free college data we know of. School Common Data Set reports, IPEDS, and College Scorecard, in one public place. No account.",
   alternates: { canonical: "/about" },
   openGraph: { url: "/about" },
 };
+
+const linkStyle = {
+  textDecorationColor: "var(--rule-strong)",
+  textUnderlineOffset: 3,
+} as const;
 
 export default function AboutPage() {
   return (
@@ -27,293 +33,128 @@ export default function AboutPage() {
 
       <div className="mt-8 space-y-5 text-base leading-relaxed">
         <p>
-          Choosing a college should not require stitching together a dozen
-          tabs, a spreadsheet, a federal database, and a commercial search
-          product just to answer basic questions.
-        </p>
-
-        <p>
-          The good news is that a lot of the data already exists. Colleges
-          publish{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://commondataset.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          Choosing a college should not mean a dozen tabs, a paid search
+          product, and a PDF you can&apos;t compare. This is the most
+          comprehensive free college data we know of: each school&apos;s{" "}
+          <Link href="/about/common-data-set" style={linkStyle}>
             Common Data Set
-          </a>{" "}
-          files. The Department of Education publishes{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://collegescorecard.ed.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            College Scorecard
-          </a>{" "}
-          and{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://nces.ed.gov/ipeds/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          </Link>
+          , plus{" "}
+          <Link href="/about/ipeds" style={linkStyle}>
             IPEDS
-          </a>{" "}
-          data. The hard part is that none of those sources, by itself, gives
-          families a simple, current, trustworthy way to browse the college
-          landscape.
-        </p>
-
-        <p>
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://nces.ed.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            NCES
-          </a>{" "}
-          is the Department of Education&apos;s statistical center, and IPEDS is
-          its core postsecondary data system for institution-reported federal
-          data.
+          </Link>{" "}
+          and{" "}
+          <Link href="/about/college-scorecard" style={linkStyle}>
+            College Scorecard
+          </Link>
+          , in one public place.
         </p>
 
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          Three sources
+          What you can do
         </h2>
 
-        <p>
-          The data already exists. It lives in three systems that do not
-          replace each other. These notes are the long versions; this page
-          stays the product story.
-        </p>
-
         <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
+          <li>Search a school and open the latest report it published.</li>
           <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="/about/common-data-set"
-            >
-              What is the Common Data Set
-            </a>
-            {" "}
-            — the voluntary school-authored form, why a 47-page PDF is not a
-            database, and what “extracted” means here.
+            If a school hasn&apos;t published its own report, you still get the
+            federal numbers.
+          </li>
+          <li>Download the original file the school posted.</li>
+          <li>
+            Compare admissions, enrollment, test scores, cost, and aid across
+            schools.
           </li>
           <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="/about/college-scorecard"
-            >
-              College Scorecard, and why it is not a CDS
-            </a>
-            {" "}
-            — federal outcomes and net price, lagged on purpose, never mixed
-            into §C or §H.
+            Build a match list on your device. We don&apos;t store a student
+            profile.
           </li>
           <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="/about/ipeds"
-            >
-              What IPEDS is, and what it cannot replace
-            </a>
-            {" "}
-            — NCES survey tables keyed by UNITID, and the wait-list / H2A
-            facts they do not carry.
+            If you&apos;re in IR or research: use the same data through a{" "}
+            <Link href="/api" style={linkStyle}>
+              public API
+            </Link>
+            .
           </li>
         </ul>
 
-        <p>
-          And if you want enriched data, the default option has often been a
-          proprietary vendor platform. Those tools can be useful, but they may
-          require accounts, hide their source lineage, limit API access, or
-          create another student-data profile along the way.
-        </p>
-
-        <p>
-          So the gap was not &ldquo;does college data exist?&rdquo; The gap was:
-          where can a student, parent, counselor, journalist, or builder browse
-          the freshest school-published facts, federal baseline data, source
-          links, and an open API in one place?
-        </p>
-
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          What you can do now
+          How this is different
         </h2>
 
         <p>
-          <strong style={{ fontWeight: 600, color: "var(--ink)" }}>collegedata.fyi</strong>{" "}
-          is a public college-data browser built around source transparency.
-          Search for a school, see whether we found a public CDS, inspect the
-          original source file, read extracted fields, and compare key facts
-          across schools without creating an account.
+          Commercial college-search tools can be useful. They often want an
+          account, hide where a number came from, or build a student profile
+          along the way. We don&apos;t. The school&apos;s own report sits next
+          to the federal numbers, the original file is one click away, and you
+          don&apos;t have to pay or log in.
         </p>
+
+        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
+          The reports, in one line each
+        </h2>
 
         <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
           <li>
-            Find a school&apos;s latest archived Common Data Set and download the
-            original PDF, XLSX, DOCX, or HTML source.
+            <Link href="/about/common-data-set" style={linkStyle}>
+              Common Data Set
+            </Link>{" "}
+            — the yearly report the college writes.
           </li>
           <li>
-            Browse extracted admissions, enrollment, test-score, aid, and
-            academic fields across schools.
+            <Link href="/about/college-scorecard" style={linkStyle}>
+              College Scorecard
+            </Link>{" "}
+            — federal outcomes and net price.
           </li>
           <li>
-            See source-labeled federal baseline facts for schools where no
-            public CDS is archived.
-          </li>
-          <li>
-            Use academic positioning, admission strategy, merit-aid, and match
-            list tools without sending student profile data to a server.
-          </li>
-          <li>
-            Query the same data through a public REST API for spreadsheets,
-            research, dashboards, or your own tools.
+            <Link href="/about/ipeds" style={linkStyle}>
+              IPEDS
+            </Link>{" "}
+            — the federal statistical baseline.
           </li>
         </ul>
-
-        <p>
-          If you want starter ideas, the{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="/recipes"
-          >
-            Recipes
-          </a>{" "}
-          page has worked examples you can adapt.
-        </p>
-
-        <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
-          What makes it different
-        </h2>
-
-        <ol className="ml-6 list-decimal space-y-2 marker:text-gray-400">
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Fresh school-authored data first.</strong>{" "}
-            When a current CDS exists, we treat it as the primary source for
-            CDS-native fields.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Federal coverage where CDS is missing.</strong>{" "}
-            NCES/IPEDS fills in source-labeled baseline facts for institutions
-            that do not publish a public CDS.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Clear provenance.</strong>{" "}
-            Values keep their source attached: CDS, IPEDS provisional/final, or
-            Scorecard context. We do not blend them into one unlabeled number.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Accessible tables and durable links.</strong>{" "}
-            Public pages prioritize readable, keyboard-friendly tables and link
-            back to the original source documents.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Open API.</strong>{" "}
-            The API is the same data surface the website uses, so researchers
-            and builders do not have to scrape the site.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Privacy by default.</strong>{" "}
-            The core site works without accounts. Student profile tools are
-            local-first unless a future feature explicitly says otherwise.
-          </li>
-          <li>
-            <strong style={{ fontWeight: 600, color: "var(--ink)" }}>Built for everyday use.</strong>{" "}
-            Pages are designed to be fast, readable, accessible, and stable
-            enough for families, counselors, and builders to rely on.
-          </li>
-        </ol>
-
-        <p>
-          Structured extracts are useful, but source documents still matter.
-          Every school-year page links back to the original file, and federal
-          baseline rows keep enough source context to understand where a number
-          came from and how it should be read.
-        </p>
 
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>
           Open source
         </h2>
 
         <p>
-          The entire project is open source under the MIT license. The code,
-          the schema, the extraction pipeline, and the archived documents are
-          all public.
+          Code, schema, pipeline, and archived files are public (MIT).{" "}
+          <a
+            href="https://github.com/bolewood/collegedata-fyi"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={linkStyle}
+          >
+            GitHub
+          </a>
+          .{" "}
+          <Link href="/api" style={linkStyle}>
+            API
+          </Link>
+          . Developers who want extractors and known issues start there, not
+          on this page.
         </p>
-
-        <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
-          <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="https://github.com/bolewood/collegedata-fyi"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub repository
-            </a>
-          </li>
-          <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="/api"
-            >
-              Public API
-            </a>
-          </li>
-          <li>
-            <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-              href="https://commondataset.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              CDS Initiative
-            </a>{" "}
-            (the original template publisher)
-          </li>
-        </ul>
 
         <h2 style={{ fontFamily: "var(--serif)", fontWeight: 500, fontSize: 26, letterSpacing: "-0.01em", color: "var(--ink)", marginTop: 40 }}>Credits</h2>
 
         <p>
           Built on{" "}
           <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
             href="https://supabase.com"
             target="_blank"
             rel="noopener noreferrer"
+            style={linkStyle}
           >
             Supabase
-          </a>{" "}
-          (Postgres, Edge Functions, Storage). Extraction powered by{" "}
+          </a>
+          . Federal baseline facts come from official{" "}
           <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://github.com/DS4SD/docling"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Docling
-          </a>{" "}
-          for flattened PDFs.{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
-            href="https://reducto.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Reducto
-          </a>{" "}
-          reference extracts used as a quality benchmark. Federal baseline
-          facts come from official{" "}
-          <a
-            style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
             href="https://nces.ed.gov/ipeds/"
             target="_blank"
             rel="noopener noreferrer"
+            style={linkStyle}
           >
             NCES/IPEDS
           </a>{" "}
@@ -329,10 +170,10 @@ export default function AboutPage() {
         <ul className="ml-6 list-disc space-y-2 marker:text-gray-400">
           <li>
             <a
-              style={{ textDecorationColor: "var(--rule-strong)", textUnderlineOffset: 3 }}
               href="https://bolewood.com"
               target="_blank"
               rel="noopener noreferrer"
+              style={linkStyle}
             >
               Bolewood Group
             </a>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -33,17 +33,18 @@ const jetbrains = JetBrains_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.collegedata.fyi"),
   title: {
-    default: "collegedata.fyi - Open College Data",
+    default: "collegedata.fyi — Free college data, straight from the source",
     template: "%s | collegedata.fyi",
   },
   description:
-    "Open-source college data with source-linked Common Data Set files, NCES/IPEDS baselines, College Scorecard context, and a public API.",
+    "The most comprehensive free college data we know of — the report each college publishes, plus the government’s own numbers, in one public place.",
   alternates: {
     canonical: "/",
   },
   openGraph: {
-    title: "collegedata.fyi",
-    description: "Open-source college data with source links, federal baselines, and a public API.",
+    title: "collegedata.fyi — Free college data, straight from the source",
+    description:
+      "The most comprehensive free college data we know of — the report each college publishes, plus the government’s own numbers, in one public place.",
     url: "/",
     siteName: "collegedata.fyi",
     type: "website",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -127,6 +127,9 @@ export default async function HomePage() {
         </div>
 
         <div style={{ textAlign: "center", maxWidth: 780, margin: "0 auto" }}>
+          <div className="meta" style={{ marginBottom: 24 }}>
+            Free data · source links · federal numbers · public API
+          </div>
           <h1
             style={{
               fontFamily: "var(--serif)",
@@ -142,8 +145,10 @@ export default async function HomePage() {
             <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>straight from the source.</span>
           </h1>
           <p
+            className="serif"
             style={{
               marginTop: 28,
+              fontStyle: "italic",
               fontSize: 18,
               lineHeight: 1.55,
               color: "var(--ink-2)",
@@ -160,7 +165,7 @@ export default async function HomePage() {
             style={{
               marginTop: 16,
               fontSize: 16,
-              lineHeight: 1.55,
+              lineHeight: 1.6,
               color: "var(--ink-2)",
               maxWidth: 580,
               marginInline: "auto",
@@ -211,11 +216,11 @@ export default async function HomePage() {
         >
           <StatCell label="Schools" value={schoolsValue} note="Latest reports we have on file" />
           <StatCell label="Documents" value={docsValue} note={`School files, ${yearRangeValue}`} />
-          <StatCell label="Facts you can compare" value={queryableFieldsValue} note="From current school reports" />
+          <StatCell label="Facts" value={queryableFieldsValue} note="You can compare · from current school reports" />
           <StatCell
-            label="Schools you can compare"
+            label="Compare"
             value={browserRowsValue}
-            note={`side by side · refreshed ${formatShortDate(stats.browser_updated_at)}`}
+            note={`Side by side · refreshed ${formatShortDate(stats.browser_updated_at)}`}
           />
         </div>
       </section>
@@ -228,7 +233,7 @@ export default async function HomePage() {
           style={{ padding: "64px 0 48px", display: "grid", gridTemplateColumns: "200px 1fr", gap: 40 }}
         >
           <div>
-            <div className="meta" style={{ marginBottom: 6 }}>Recently added</div>
+            <div className="meta" style={{ marginBottom: 6 }}>§ Recently added</div>
             <div style={{ fontSize: 14, color: "var(--ink-3)", lineHeight: 1.5 }}>
               New school reports in the archive. Each row opens the school and
               the original file.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,6 +7,17 @@ import { SchoolGlyph } from "@/components/SchoolGlyph";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
+const HOME_DESCRIPTION =
+  "The most comprehensive free college data we know of — the report each college publishes, plus the government’s own numbers, in one public place.";
+
+const homeJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "collegedata.fyi",
+  url: "https://www.collegedata.fyi",
+  description: HOME_DESCRIPTION,
+};
+
 // Short calendar-year-boundary format for the two-segment year-range label.
 // Collapses "1998-99" -> "1998" and "2025-26" -> "2025" so mobile viewports
 // don't break on internal hyphens. Falls back to the raw value if either
@@ -69,7 +80,7 @@ function latestDrain(
       when: formatDrainDate(r.discovered_at!),
       school: r.school_name ?? sid,
       schoolId: sid,
-      action: `+ ${r.canonical_year ?? "new"} CDS`,
+      action: `+ ${r.canonical_year ?? "new"} report`,
       tag: tagForFormat(r.source_format),
       href: r.canonical_year ? `/schools/${sid}/${r.canonical_year}` : `/schools/${sid}`,
       brandColors: brandIndex[sid] ?? null,
@@ -94,6 +105,12 @@ export default async function HomePage() {
 
   return (
     <div className="mx-auto max-w-5xl" style={{ padding: "0 24px" }}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(homeJsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
       {/* Hero with left/right marginalia */}
       <section
         className="cd-hero"
@@ -110,9 +127,6 @@ export default async function HomePage() {
         </div>
 
         <div style={{ textAlign: "center", maxWidth: 780, margin: "0 auto" }}>
-          <div className="meta" style={{ marginBottom: 24 }}>
-            Open-source college data with source links, federal baselines, and an API
-          </div>
           <h1
             style={{
               fontFamily: "var(--serif)",
@@ -138,11 +152,23 @@ export default async function HomePage() {
               textWrap: "balance",
             }}
           >
-            CollegeData.FYI is building a public data layer for college decisions: school-published
-            Common Data Set files, NCES/IPEDS baseline facts, College Scorecard outcomes, and
-            source-linked APIs in one place. Compare schools, check affordability signals, build
-            match lists, audit missing data, or power your own tools.{" "}
-            <Link href="/about">Read the method.</Link>
+            The most comprehensive free college data we know of — the report each
+            college publishes about itself, plus the government&apos;s own numbers,
+            in one public place.
+          </p>
+          <p
+            style={{
+              marginTop: 16,
+              fontSize: 16,
+              lineHeight: 1.55,
+              color: "var(--ink-2)",
+              maxWidth: 580,
+              marginInline: "auto",
+              textWrap: "balance",
+            }}
+          >
+            Search a school. Compare admissions, cost, and aid. Open the original
+            file. No account.
           </p>
 
           <div style={{ marginTop: 36, maxWidth: 560, marginInline: "auto" }}>
@@ -154,22 +180,14 @@ export default async function HomePage() {
               Build match list
             </Link>
             <Link href="/browse" className="cd-btn">
-              Query schools
+              Compare schools
             </Link>
             <Link href="/schools" className="cd-btn">
               Browse all schools
             </Link>
             <Link href="/api" className="cd-btn cd-btn--ghost">
-              API docs
+              API
             </Link>
-            <a
-              href="https://github.com/bolewood/collegedata-fyi"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="cd-btn cd-btn--ghost"
-            >
-              GitHub
-            </a>
           </div>
         </div>
 
@@ -191,14 +209,18 @@ export default async function HomePage() {
             gap: 40,
           }}
         >
-          <StatCell label="Schools in archive" value={schoolsValue} note={`${stats.extracted_count.toLocaleString()} extracted`} />
-          <StatCell label="Source documents" value={docsValue} note={`${yearRangeValue} CDS span`} />
-          <StatCell label="Queryable fields" value={queryableFieldsValue} note={`${formatCount(stats.schema_field_count)} field schema`} />
-          <StatCell label="Browser rows" value={browserRowsValue} note={`${formatCount(stats.browser_school_count)} schools; refreshed ${formatShortDate(stats.browser_updated_at)}`} />
+          <StatCell label="Schools" value={schoolsValue} note="Latest reports we have on file" />
+          <StatCell label="Documents" value={docsValue} note={`School files, ${yearRangeValue}`} />
+          <StatCell label="Facts you can compare" value={queryableFieldsValue} note="From current school reports" />
+          <StatCell
+            label="Schools you can compare"
+            value={browserRowsValue}
+            note={`side by side · refreshed ${formatShortDate(stats.browser_updated_at)}`}
+          />
         </div>
       </section>
 
-      {/* Latest drain feed — sourced from the live manifest, one row per
+      {/* Recently added — sourced from the live manifest, one row per
           most-recently-discovered school. */}
       {drain.length > 0 && (
         <section
@@ -206,10 +228,10 @@ export default async function HomePage() {
           style={{ padding: "64px 0 48px", display: "grid", gridTemplateColumns: "200px 1fr", gap: 40 }}
         >
           <div>
-            <div className="meta" style={{ marginBottom: 6 }}>§ Latest drain</div>
+            <div className="meta" style={{ marginBottom: 6 }}>Recently added</div>
             <div style={{ fontSize: 14, color: "var(--ink-3)", lineHeight: 1.5 }}>
-              The newest school-published source files added to the archive.
-              Each row links back to the original document and its extracted facts.
+              New school reports in the archive. Each row opens the school and
+              the original file.
             </div>
           </div>
           <div>

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -12,9 +12,8 @@ const PRIMARY_NAV_LINKS = [
 ];
 
 const SECONDARY_NAV_LINKS = [
-  { href: "/browse", label: "Browser" },
+  { href: "/browse", label: "Compare" },
   { href: "/coverage", label: "Coverage" },
-  { href: "/pipeline-observation", label: "Pipeline" },
   { href: "/recipes", label: "Recipes" },
   { href: "/about", label: "About" },
 ];

--- a/web/src/lib/about-source-pages.test.ts
+++ b/web/src/lib/about-source-pages.test.ts
@@ -19,6 +19,46 @@ describe("About source-story metadata", () => {
     ]);
     expect(aboutMetadata.alternates?.canonical).toBe("/about");
     expect(canonicals).not.toContain("/methodology/common-data-set");
+    expect(String(cdsMetadata.description)).toMatch(/yearly report a college publishes/i);
+    expect(String(aboutMetadata.description)).toMatch(/most comprehensive free college data/i);
+  });
+});
+
+describe("Wave 1 product copy", () => {
+  const src = (rel: string) =>
+    readFileSync(join(process.cwd(), "src", rel), "utf8");
+
+  it("keeps API in the header and demotes GitHub off the hero", () => {
+    const nav = src("components/Nav.tsx");
+    expect(nav).toMatch(/href: "\/api", label: "API"/);
+    expect(nav).toMatch(/href: "\/browse", label: "Compare"/);
+    expect(nav).not.toMatch(/label: "Browser"/);
+    expect(nav).not.toMatch(/pipeline-observation/);
+
+    const home = src("app/page.tsx");
+    expect(home).toContain('href="/api"');
+    expect(home).toContain("Compare schools");
+    expect(home).toContain("Recently added");
+    expect(home).not.toContain("Latest drain");
+    expect(home).not.toContain("github.com/bolewood/collegedata-fyi");
+    expect(home).not.toMatch(/\bextracted\b/);
+    expect(home).not.toMatch(/field schema/);
+    expect(home).not.toMatch(/Browser rows/);
+  });
+
+  it("keeps extractor narrative and takedowns off the CDS explainer", () => {
+    const cds = src("app/about/common-data-set/page.tsx");
+    expect(cds).toContain("It's called the Common Data Set");
+    expect(cds).not.toMatch(/Docling/);
+    expect(cds).not.toMatch(/AcroForm/);
+    expect(cds).not.toMatch(/AP_RECD_1ST_MEN_N/);
+    expect(cds).not.toMatch(/taken down/);
+    expect(cds).not.toMatch(/harvey-mudd-2025-26\.md/);
+
+    const about = src("app/about/page.tsx");
+    expect(about).toMatch(/you still get the federal numbers/);
+    expect(about).not.toMatch(/Docling/);
+    expect(about).not.toMatch(/Reducto/);
   });
 });
 

--- a/web/src/lib/about-source-pages.test.ts
+++ b/web/src/lib/about-source-pages.test.ts
@@ -39,6 +39,7 @@ describe("Wave 1 product copy", () => {
     expect(home).toContain('href="/api"');
     expect(home).toContain("Compare schools");
     expect(home).toContain("Recently added");
+    expect(home).toContain('className="serif"');
     expect(home).not.toContain("Latest drain");
     expect(home).not.toContain("github.com/bolewood/collegedata-fyi");
     expect(home).not.toMatch(/\bextracted\b/);
@@ -56,7 +57,7 @@ describe("Wave 1 product copy", () => {
     expect(cds).not.toMatch(/harvey-mudd-2025-26\.md/);
 
     const about = src("app/about/page.tsx");
-    expect(about).toMatch(/you still get the federal numbers/);
+    expect(about).toMatch(/you still get the\s+federal numbers/);
     expect(about).not.toMatch(/Docling/);
     expect(about).not.toMatch(/Reducto/);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Locks the signed voice and ships Wave 1 front-door copy.

- `web/VOICE.md` — site promise, personas, layers, glossary, chrome
- `docs/copy/wave-1-front-door.md` — signed copy deck
- Homepage, About, CDS explainer, metadata, and nav chrome now match the deck
- Harvey Mudd / Docling narrative stays in `docs/known-issues/`; it left `/about/common-data-set`

## Sign-off condition

**API stays in the header** (Match / Schools / API). Researchers use it; so do parents who point an LLM at a public endpoint to build a list.

GitHub is demoted: More menu and footer only — not the homepage hero.

## Type

Ledes are Newsreader italic (design-system lede), not Geist body. Stat-band labels stay short so `.meta` uppercase still reads as catalog captions. About uses the same source-story type scale as the CDS explainer.

## Copy highlights

- Homepage lede: gloss first (“the report each college publishes… plus the government’s own numbers”)
- Title: `collegedata.fyi — Free college data, straight from the source`
- About restores the federal fallback: *If a school hasn’t published its own report, you still get the federal numbers.*
- `/browse` is **Compare** in chrome
- CDS explainer defines the term in sentence two; no takedown advertising; no extractor war stories

## Testing

- Vitest: Wave 1 copy regressions in `web/src/lib/about-source-pages.test.ts`
- Browser: homepage, About, CDS explainer, and header (API present; GitHub not in the hero)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

