### PR TITLE
Ship Wave 2 product-surface copy

### DIFF
--- a/docs/copy/wave-2-fable-review.md
+++ b/docs/copy/wave-2-fable-review.md
@@ -2,6 +2,13 @@
 
 Verdict: **ship with patches**
 
+Patches applied to `wave-2-product-surfaces.md` 2026-08-27 (must-fixes 1–6
+and should-fixes 1–8, with one honesty tweak on #4: “no Scorecard row”
+is not the same as “no federal numbers” — IPEDS baseline can still
+render. The deck now splits on any federal data vs neither). Nits left
+for Anthony except the Compare error shout and “side by side” on the
+sub-kicker.
+
 The deck's direction is right on every surface — the ban lists are the correct
 bans, the locks are respected, and the worst live copy dies ("Queryable school
 browser," "archive and extract," "filter the corpus," "the resolver has not

--- a/docs/copy/wave-2-fable-review.md
+++ b/docs/copy/wave-2-fable-review.md
@@ -1,0 +1,309 @@
+# Wave 2 Fable review
+
+Verdict: **ship with patches**
+
+The deck's direction is right on every surface — the ban lists are the correct
+bans, the locks are respected, and the worst live copy dies ("Queryable school
+browser," "archive and extract," "filter the corpus," "the resolver has not
+scanned it"). But six lines fail a persona read-aloud, contradict the deck
+itself, or promise something some pages cannot deliver. All six are patchable
+without reopening anything.
+
+## Must-fix
+
+### 1. Compare — the "Rows" stat mislabels its own number
+
+> | Primary rows | Rows | Latest year per school |
+
+The number behind this stat counts **every** primary row from 2024-25 on —
+including two rows for a school that has both 2024-25 and 2025-26 on file
+(`site_stats`: `count(*) filter (where sub_institutional is null)` over
+`school_browser_rows`, `year_start >= 2024`). "Latest year per school"
+describes the table's default view, not this count. IR reads "Schools: 700"
+next to "Rows: 900 — latest year per school," sees that the caption and the
+arithmetic can't both be true, and stops trusting the band. It's the caption.
+
+Replacement:
+
+> | Primary rows | Reports | 2024-25 and newer |
+
+### 2. Schools directory — hides the common case and dead-ends the parent
+
+> Lede (italic serif): Every school we have a report for. Search by name.
+
+Accurate, and useless to the majority. Most in-scope schools have no archived
+CDS — that is the product's central fact, not an edge. A parent hunting one of
+those ~1,473 names types it into the on-page search and gets the live table's
+dead end ("No schools found matching …") with no exit. The load-bearing
+federal fallback is unreachable from this page. The lede needs the pointer,
+and the empty state needs to carry it too — the on-page search only filters
+this table; the header search is the one that finds every school.
+
+Replacement lede:
+
+> Every school we have a report from. Don't see yours? Check
+> [Coverage](/coverage) — schools without a report still get a page with the
+> federal numbers.
+
+Replacement empty state (table, no matches):
+
+> No reports on file match "{query}." Try the site search — schools without a
+> report still have a page with the federal numbers.
+
+### 3. School page — "This is the {name} Common Data Set" claims to be the document
+
+> This is the {name} Common Data Set — the yearly report the college
+> publishes. {n} reports, {range}.
+
+Two failures in eleven words. First, the page is not the Common Data Set; it
+is our copy of {n} of them next to the federal numbers. The deck's own
+publisher line ("The school's own page is the publisher") corrects this — but
+that line only renders when we know the school's page. When we don't, the
+claim stands uncorrected, and a counselor forwarding the URL has just told a
+family this page *is* the school's document. That is the school-authored /
+our-copy blur the locks exist to prevent. Second, "This is the [singular]"
+collides with "{n} reports" in the next breath.
+
+Replacement (keeps `{name} Common Data Set` in sentence one — lock intact):
+
+> The {name} Common Data Set is the yearly report the college publishes about
+> itself. {n} reports on file, {range}; the latest is {year}. Downloads
+> include {formats}.
+
+### 4. Directory-only page — garden-path grammar and a promise some pages break
+
+> We don't have a Common Data Set this school published. You still get the
+> federal numbers.
+
+Read sentence one aloud as a parent: the relative clause arrives with no
+warning and the sentence parses on the second try. And sentence two is false
+on some of these pages: when a school has no Scorecard row, the live page
+renders "FEDERAL OUTCOMES DATA NOT AVAILABLE FOR THIS INSTITUTION" directly
+under the promise. The common-case page cannot ship copy its own body
+contradicts.
+
+Replacement, two states:
+
+With federal data:
+
+> We haven't found a Common Data Set from this school. The federal numbers
+> are below.
+
+Without:
+
+> We haven't found a Common Data Set from this school, and federal outcome
+> data isn't available for it either.
+
+### 5. Year page — title collides with the site template
+
+> Title: `{name} Common Data Set {year} | collegedata.fyi`
+
+The layout template is `%s | collegedata.fyi` (`web/src/app/layout.tsx`). Set
+the title to this literal string and every year page renders "…Common Data
+Set 2024-2025 | collegedata.fyi | collegedata.fyi." The deck knows this: the
+school-page section writes its title bare with a "(template → …)" note, and
+the Coverage section drops "— collegedata.fyi" for exactly this reason. The
+year-page section forgot its own rule.
+
+Replacement:
+
+> Title: `{name} Common Data Set {year}`
+> (template appends `| collegedata.fyi`)
+
+### 6. Coverage — "Title-IV" in the lede, to a parent
+
+> Every undergraduate Title-IV school, with whether we have a public report
+> on file.
+
+The deck names "parents who searched a missing school" as an audience for
+this page, then opens with a federal statute citation. No parent knows what
+Title-IV is, and the ones who land here just failed to find their kid's
+school. Say it in English; keep Title-IV in Methodology, where IR reads.
+
+Replacement:
+
+> Every U.S. college that takes federal student aid, and whether we have a
+> public report on file. Publishing is voluntary. Some schools post the file,
+> some bury it, some don't publish one we could find.
+
+## Should-fix
+
+### 1. Compare description overclaims "latest published"
+
+> Each row is the latest report the school published that we can put side by
+> side.
+
+"The latest report the school published" asserts our discovery is complete.
+It isn't — a school can post 2025-26 tomorrow and this sentence is wrong
+until we find it. The deck's own lede has the honest form eight lines later
+("the latest school report we can compare"). Use it; it's shorter too.
+
+Replacement description:
+
+> Compare admissions, cost, and aid across schools. Each row is the latest
+> school report we can compare, as the school published it. The original file
+> is one click away.
+
+### 2. Compare — "From current reports" claims currency the rows don't have
+
+> | Queryable fields | Facts | From current reports |
+
+A 2024-25 row read in 2026 is not "current"; it is the latest on file. The
+lock says current/accurate claims anchor to "as the school published it" —
+the lede carries that anchor, this note doesn't, and the note is the one
+sitting next to a number. (This is the Compare band, not the signed Wave 1
+homepage band. The homepage stays.)
+
+Replacement note: `From the latest reports`
+
+### 3. Compare — the second stat band is unwritten and the caption points at nothing
+
+The live dashboard has its own band the deck never touches: "Schools in scope
+/ Matching filters / With required fields / Missing fields," plus "Fields
+needed for the current filters: …". The deck bans "queryable" and "primary
+row" but gives the implementer nothing for this chrome — they will improvise,
+which is how "Browser rows" happened the first time. And the proposed
+in-table caption says missing schools "are counted separately" — separately
+*where*? The reader can't find the count from that word.
+
+Replacement band labels: `Schools` / `Match your filters` / `Have every
+number` / `Missing a number`
+
+Replacement caption:
+
+> Latest reports, 2024-25+. Schools missing a number your filters need are
+> counted above. Building a list? Use Match.
+
+### 4. Schools directory description drops "Common Data Set" from the whole surface
+
+> Description: Find a college and open the reports it published.
+
+The live description carries "Common Data Set"; the proposal removes the
+phrase from `/schools` entirely — title, description, H1, lede, caption. The
+lock keeps the query in SEO, and this is the page Google would surface for
+"college common data set list." One mention, no stuffing. Also "Find a
+college" promises any college; the table only holds the ones with reports.
+
+Replacement:
+
+> Every college with a Common Data Set on file. Open the reports each school
+> published.
+
+### 5. Coverage description — "which we've never found" and "stale"
+
+> Which schools have a current report, which are stale, and which we've never
+> found. Filter by state and size.
+
+"Which we've never found" reads as schools we never found — the object went
+missing mid-sentence. "Stale" is our pipeline word for the middle state; a
+counselor guesses right, a parent doesn't. And this surface also loses
+"Common Data Set" (the live description has it).
+
+Replacement:
+
+> Which schools have a current Common Data Set, which have only older years,
+> and which have none we could find. Filter by state and size.
+
+### 6. Match lede — "profile" does double duty and trips the parent
+
+> Enter a profile on this device. … We don't store a student profile.
+
+Sentence one tells the parent to enter a profile; sentence four says no
+profile is stored. That is the exact shape of a contradiction, aimed at the
+reader we most need to reassure — and the anxiety word is ours, twice. Say
+what they actually enter; save the claim word for the claim.
+
+Replacement:
+
+> Enter scores and GPA — they stay on this device. Filter by fit and admit
+> rate. Export a list with the year and the original file. We don't store a
+> student profile.
+
+### 7. Year page — lead and empty state assume the file link rendered
+
+> [Download the original file](url). — and — The original file is above.
+
+`source_storage_path` is nullable and the live lead renders the download link
+conditionally. When there is no stored file, the deck's empty card opens with
+a claim about a file that isn't on the page. One deck note fixes it:
+
+> Empty state, no downloadable file: "The numbers from this report aren't on
+> the page yet."
+
+(One line replacing both live empty variants — "No structured field values
+available" and "Structured data coming soon" both die — is right. Keep that.)
+
+### 8. Year page — "the school's own page" is ambiguous as a bare link
+
+> See the [school's own page](url).
+
+On the school page this phrase has the publisher sentence around it. Here it
+is naked, and a parent reads it as the school's homepage. Say what the link
+is without re-saying CDS.
+
+Replacement: `See the [school's page for these reports](url).`
+
+## Nit
+
+1. **Compare — "side by side" three times.** H1 ("Compare schools, side by
+   side."), sub kicker ("2024-25+ · side by side"), description ("put side by
+   side"). Should-fix 1 removes it from the description; cut it from the sub
+   too: `§ Compare / 2024-25+`. The H1 earns it once.
+2. **Dash drift.** The deck writes "2024–25+" (en dash) in Compare chrome and
+   "2024-25+" (hyphen) elsewhere; the data layer prints hyphens. Pick the
+   hyphen and stop.
+3. **Fact-list order drifts by surface.** School page: "admissions, cost, and
+   aid." Year page: "admissions, cost, aid, and enrollment." Compare:
+   "admissions, enrollment, cost, and aid." Pick one order (Wave 1's hero is
+   "admissions, cost, and aid") and reuse it.
+4. **JSON-LD cleanup stops one string early.** The deck kills "extracted by,"
+   but the live DataCatalog description still says "keyed to the canonical
+   1,105-field schema" — "canonical" is glossary-banned and it's a
+   field-count lecture in a string Google can show. Replacement: "Every
+   Common Data Set year we have for {name}, as the school published it."
+5. **Kicker chrome is inconsistent across the deck.** Compare gets
+   "§ Compare," Match gets bare "Match," school pages get a bare "Common Data
+   Set" kicker, directory-only keeps "§ Institution directory." Pick the §
+   convention for all top-level kickers and say so, or the implementer
+   decides per page.
+6. **Compare error shouts.** "Couldn't load these schools." replaces a `.meta`
+   label, so it uppercases to a full shouted sentence, and it gives no
+   action. Keep the label short and put the sentence in the body: label
+   `Couldn't load`, body "Try again in a moment."
+7. **"(CDS)" leaves the school-page title with no counterweight.** Dropping
+   it from the title is right — it isn't the query. But counselors genuinely
+   search "{name} CDS." Cheap insurance: let the description carry the
+   abbreviation once ("…the yearly report (CDS) the college publishes…") if
+   it fits. Not worth more than that.
+
+## What holds
+
+- The ban lists are the right lists, and the worst live copy dies with them.
+- The Compare caption killing "Looking for fit ranking?" — we don't rank; the
+  live link copy implied we do. "Use Match" survives without the claim.
+- "The numbers, as published" as the fields heading is the best line in the
+  deck.
+- Coverage catching the doubled "— collegedata.fyi" title, replacing "the
+  resolver has not scanned it," and cutting the tell-the-sources-apart
+  lecture to one line.
+- "don't publish one we could find" fixing the live lede's "don't publish at
+  all" overclaim.
+- The email-gate line: "The original is here." Four words, does the whole job.
+- Match description staccato: "On this device. No account. No student profile
+  stored."
+
+## Do not reopen
+
+Survived this pass, intact in the deck:
+
+- Compare is the public name everywhere; "Browser" appears only in ban lists.
+- School and year titles and first sentences keep `{name} Common Data Set`;
+  H1 stays the school name; year titles keep the year query.
+- Directory-only pages keep the school-page title and tell the truth
+  (Must-fix 4 patches the wording, not the truth).
+- No takedown language anywhere in the deck.
+- "As the school published it" anchors the Compare lede and year-page lead.
+- Federal fallback stated on directory-only, and reachable from `/schools`
+  once Must-fix 2 lands.
+- API in the header, GitHub off the hero — untouched.
+- No TSX. The deck is prose.

--- a/docs/copy/wave-2-product-surfaces.md
+++ b/docs/copy/wave-2-product-surfaces.md
@@ -24,6 +24,10 @@ name. The lead then talks like a parent.
 - `VOICE.md` already allows this: Common Data Set on the explainer
   **and in SEO**.
 
+Fable review 2026-08-27: **ship with patches.** Must-fixes and the
+should-fixes that survived a code check are applied below. Full write-up:
+[`wave-2-fable-review.md`](wave-2-fable-review.md).
+
 **Not in this deck:** live TSX. Sign the prose, then we implement.
 
 ---
@@ -50,36 +54,50 @@ secondary (CSV / filters).
 
 - Title: Compare schools
 - Description: Compare admissions, cost, and aid across schools. Each row is
-  the latest report the school published that we can put side by side. The
+  the latest school report we can compare, as the school published it. The
   original file is one click away.
 
 **Chrome**
 
 - Kicker: § Compare
-- Sub: 2024–25+ · side by side
+- Sub: 2024-25+
 
 **H1:** Compare schools, *side by side.*
 
 **Lede** (Newsreader italic, 18 / 1.55):
 
-> Filter admissions, enrollment, cost, and aid. Each row is the latest
-> school report we can compare, as the school published it. Open the
-> original file from the same row.
+> Filter admissions, cost, and aid. Each row is the latest school report
+> we can compare, as the school published it. Open the original file from
+> the same row.
 
-**Stats** (short labels — `.meta` uppercases them):
+**Hero stats** (short labels — `.meta` uppercases them):
+
+The “Rows” count is every primary row from 2024-25 on, not latest-year-
+per-school (`site_stats.browser_primary_row_count`). Label it as what it
+is.
 
 | Now | Label | Note |
 |---|---|---|
 | Schools in scope | Schools | In this table |
-| Primary rows | Rows | Latest year per school |
-| Queryable fields | Facts | From current reports |
+| Primary rows | Reports | 2024-25 and newer |
+| Queryable fields | Facts | From the latest reports |
 | Data refreshed | Refreshed | {date} |
 
-**In-table caption:** Latest reports, 2024–25+. Schools missing a number
-needed for your filters are counted separately. Looking for a match list?
-Use Match.
+**Filter-band stats** (the live dashboard under the filters — write it so
+the implementer does not invent “Browser rows” again):
 
-**Error:** Couldn’t load these schools.
+| Now | Label |
+|---|---|
+| Schools in scope | Schools |
+| Matching filters | Match your filters |
+| With required fields | Have every number |
+| Missing fields | Missing a number |
+
+**In-table caption:** Latest reports, 2024-25+. Schools missing a number
+your filters need are counted above. Building a list? Use Match.
+
+**Error:** label `Couldn’t load` (`.meta` will shout a full sentence).
+Body: Try again in a moment.
 
 Ban on this page: browser, browser rows, primary row, queryable.
 
@@ -98,10 +116,21 @@ Ban on this page: browser, browser rows, primary row, queryable.
 ### Proposed
 
 - Title: Schools
-- Description: Find a college and open the reports it published.
+- Description: Every college with a Common Data Set on file. Open the
+  reports each school published.
 - H1 (serif, display): Schools
-- Lede (italic serif): Every school we have a report for. Search by name.
+- Lede (italic serif): Every school we have a report from. Don’t see
+  yours? Check [Coverage](/coverage) — schools without a report still get
+  a page with the federal numbers.
 - Caption: {n} schools
+- Empty (on-page search, no matches): No reports on file match “{query}.”
+  Try the site search — schools without a report still have a page with
+  the federal numbers.
+
+This table is only schools with a CDS on file. The header search and
+Coverage are how a parent reaches the common case (no CDS, federal
+numbers). Write the empty state; the live copy dead-ends (“No schools
+found matching…”).
 
 Keep the table. Restyle onto paper/ink/serif in the same change as the
 prose — the gray heading is the design-system debt on this page.
@@ -141,11 +170,14 @@ twice without stuffing the headline.
 
 ### Proposed archive lead
 
-Name the term once, then use “report” and the numbers:
+Name the term once, then use “report” and the numbers. Do not say the
+page *is* the Common Data Set — it is our copy of {n} of them, next to
+the federal numbers. The publisher line only renders when we know the
+school’s page, so the lead has to stand on its own.
 
-> This is the {name} Common Data Set — the yearly report the college
-> publishes. {n} reports, {range}. Latest year is {year}. Downloads
-> include {formats}.
+> The {name} Common Data Set is the yearly report the college publishes
+> about itself. {n} reports on file, {range}; the latest is {year}.
+> Downloads include {formats}.
 
 If the school’s own page is public:
 
@@ -166,17 +198,29 @@ took a file down.
 ### Directory-only (no CDS on file)
 
 Keep the stub. Title still `{name} Common Data Set` — that’s the query
-that got them here. Then tell the truth:
+that got them here. Then tell the truth. Do not promise federal numbers
+on pages that have neither Scorecard nor an IPEDS baseline table
+(live copy: “FEDERAL OUTCOMES DATA NOT AVAILABLE FOR THIS INSTITUTION”).
 
-> We don’t have a Common Data Set this school published. You still get
-> the federal numbers.
+With any federal data on the page:
+
+> We haven’t found a Common Data Set from this school. The federal
+> numbers are below.
+
+With neither:
+
+> We haven’t found a Common Data Set from this school, and we don’t have
+> federal numbers for it either.
 
 Contribute remains on this page (IR path).
 
 ### JSON-LD
 
-Same facts, no “extracted by.” Dataset description: admissions, enrollment,
-cost, and aid as the school published them.
+Same facts, no “extracted by.” Kill “keyed to the canonical 1,105-field
+schema” too — “canonical” is glossary-banned.
+
+Dataset description: Every Common Data Set year we have for {name}, as
+the school published it.
 
 ---
 
@@ -194,20 +238,24 @@ cost, and aid as the school published them.
 
 ### Proposed meta
 
-- Title: `{name} Common Data Set {year} | collegedata.fyi`
-  (keep the query in the title — “Virginia Tech Common Data Set
-  2024-2025” is a real search. Don’t add “Archive.”)
+- Title: `{name} Common Data Set {year}`
+  (template appends `| collegedata.fyi` — do not write the suffix into
+  the title or it doubles. Keep the query; “Virginia Tech Common Data
+  Set 2024-2025” is a real search. Don’t add “Archive.”)
 - Description: `{name} {year}: the school’s Common Data Set —
-  admissions, cost, aid, and enrollment — plus the original file
-  to download.` (keep “Common Data Set” once; drop “extracted”)
+  admissions, cost, and aid — plus the original file to download.`
+  (keep “Common Data Set” once; drop “extracted”)
 
 ### Proposed lead
 
-Name Common Data Set once, then “this year’s report”:
+Name Common Data Set once, then “this year’s report.” The download link
+is conditional (`source_storage_path` can be null). The publisher link
+is the school’s reports page, not its homepage.
 
-> The {year} Common Data Set for {name} — admissions, cost, aid, and
-> enrollment, as the school published them. [Download the original
-> file](url). See the [school’s own page](url). Subscribe via [RSS](feed).
+> The {year} Common Data Set for {name} — admissions, cost, and aid, as
+> the school published them. [Download the original file](url) (omit if
+> none). See the [school’s page for these reports](url). Subscribe via
+> [RSS](feed).
 
 After that sentence, “the numbers” and “this year’s report” are
 enough. Don’t keep saying Common Data Set.
@@ -221,8 +269,12 @@ Empty (file on disk, numbers not on the page yet):
 > The original file is above. The numbers from this report aren’t on the
 > page yet.
 
-Ban: extracted field tables, structured data coming soon (too product-y
-without saying what to do).
+Empty, no downloadable file:
+
+> The numbers from this report aren’t on the page yet.
+
+Ban: extracted field tables, structured data coming soon, “No structured
+field values available.”
 
 ---
 
@@ -250,9 +302,9 @@ without saying what to do).
 
 **Lede** (italic serif):
 
-> Enter a profile on this device. Filter by scores, fit, and admit rate.
-> Export a list with the year and the original file. We don’t store a
-> student profile.
+> Enter scores and GPA — they stay on this device. Filter by fit and
+> admit rate. Export a list with the year and the original file. We
+> don’t store a student profile.
 
 “Corpus” and “source-backed” leave the page. The file link stays — that’s
 the counselor proof.
@@ -268,13 +320,15 @@ The H1 already works: What we have, *and what we don’t.*
 ### Tighten
 
 - Title: Coverage (drop “— collegedata.fyi”; the template adds it)
-- Description: Which schools have a current report, which are stale, and
-  which we’ve never found. Filter by state and size.
-- Lede can stay, minus “resolver”:
+- Description: Which schools have a current Common Data Set, which have
+  only older years, and which have none we could find. Filter by state
+  and size.
+- Lede, minus “resolver” and minus “Title-IV” (parents land here after a
+  failed school search; keep the statute in Methodology):
 
-> Every undergraduate Title-IV school, with whether we have a public
-> report on file. Publishing is voluntary. Some schools post the file,
-> some bury it, some don’t publish one we could find.
+> Every U.S. college that takes federal student aid, and whether we have
+> a public report on file. Publishing is voluntary. Some schools post
+> the file, some bury it, some don’t publish one we could find.
 
 **Methodology** (on this page, still English):
 

--- a/docs/copy/wave-2-product-surfaces.md
+++ b/docs/copy/wave-2-product-surfaces.md
@@ -10,6 +10,20 @@ About; `/browse` is **Compare**; API in the header; GitHub off the hero; no
 takedown advertising; when claiming current or accurate, say “as the school
 published it.”
 
+**School pages are a Google door.** People search “Virginia Tech Common Data
+Set.” Title and first sentence keep those words. The H1 can stay the school
+name. The lead then talks like a parent.
+
+- **H1 vs title.** Title and description carry the search query
+  (`{name} Common Data Set`). H1 is the school name — that’s what
+  the human is looking at. A `.meta` kicker can say Common Data Set
+  once so the page isn’t a mystery. After the first sentence, say
+  “report” and “the numbers,” not CDS every paragraph.
+- **Year pages** keep `{name} Common Data Set {year}` in the title —
+  that’s the long-tail (“Virginia Tech Common Data Set 2024-2025”).
+- `VOICE.md` already allows this: Common Data Set on the explainer
+  **and in SEO**.
+
 **Not in this deck:** live TSX. Sign the prose, then we implement.
 
 ---
@@ -110,18 +124,28 @@ contribute.
 - Directory-only stub exists (good) but does not say you still get federal
   numbers
 
-### Proposed meta
+### Proposed meta (SEO + readable)
 
-- Title: `{name}`
-- Description: `{name} — the report the college publishes, plus federal
-  numbers, in one place. Open the original file.`
+People type `{name} Common Data Set`. Match that. Drop “Archive” and the
+parenthetical “(CDS)” — both are extra syllables that aren’t the query.
+
+- Title: `{name} Common Data Set`
+  (template → `Virginia Tech Common Data Set | collegedata.fyi`)
+- Description: `{name} Common Data Set — the yearly report the college
+  publishes on admissions, cost, and aid, plus federal numbers. Years on
+  file: {range}. Download the original file.`
+
+H1 stays the school name (serif, institutional suffix italic). A `.meta`
+kicker above it can read `Common Data Set` so the phrase is on the page
+twice without stuffing the headline.
 
 ### Proposed archive lead
 
-Heading can stay the school name (already the H1). Body:
+Name the term once, then use “report” and the numbers:
 
-> This page has {n} reports from {range}. Latest year is {year}.
-> Downloads include {formats}.
+> This is the {name} Common Data Set — the yearly report the college
+> publishes. {n} reports, {range}. Latest year is {year}. Downloads
+> include {formats}.
 
 If the school’s own page is public:
 
@@ -141,10 +165,11 @@ took a file down.
 
 ### Directory-only (no CDS on file)
 
-Keep the stub. Add the Wave 1 fallback in product voice:
+Keep the stub. Title still `{name} Common Data Set` — that’s the query
+that got them here. Then tell the truth:
 
-> We don’t have a report this school published. You still get the federal
-> numbers.
+> We don’t have a Common Data Set this school published. You still get
+> the federal numbers.
 
 Contribute remains on this page (IR path).
 
@@ -161,6 +186,7 @@ cost, and aid as the school published them.
 
 ### Now
 
+- Title: `{name} Common Data Set {year}` (keep this — it’s the query)
 - Description: “official source download plus extracted admissions…”
 - Lead: “archived source file … plus the extracted field tables”
 - Heading: “All extracted fields”
@@ -168,15 +194,23 @@ cost, and aid as the school published them.
 
 ### Proposed meta
 
-- Title: `{name}, {year}`
-- Description: `{name} {year} — the report the college published, as it
-  published it. Download the original file.`
+- Title: `{name} Common Data Set {year} | collegedata.fyi`
+  (keep the query in the title — “Virginia Tech Common Data Set
+  2024-2025” is a real search. Don’t add “Archive.”)
+- Description: `{name} {year}: the school’s Common Data Set —
+  admissions, cost, aid, and enrollment — plus the original file
+  to download.` (keep “Common Data Set” once; drop “extracted”)
 
 ### Proposed lead
 
-> This is {name}’s {year} report, as the school published it.
-> [Download the original file](url). See the [school’s own page](url).
-> Subscribe via [RSS](feed).
+Name Common Data Set once, then “this year’s report”:
+
+> The {year} Common Data Set for {name} — admissions, cost, aid, and
+> enrollment, as the school published them. [Download the original
+> file](url). See the [school’s own page](url). Subscribe via [RSS](feed).
+
+After that sentence, “the numbers” and “this year’s report” are
+enough. Don’t keep saying Common Data Set.
 
 ### Fields heading
 

--- a/docs/copy/wave-2-product-surfaces.md
+++ b/docs/copy/wave-2-product-surfaces.md
@@ -1,0 +1,276 @@
+# Wave 2 copy deck — product surfaces
+
+Read this as a parent, then as a counselor, then as IR. Do not review it as
+a React diff. Wave 1 is on `main`. This wave is the pages that still talk
+like the pipeline: Compare, the schools directory, school and year pages,
+Match, and Coverage.
+
+Locked from Wave 1 (do not reopen): gloss-first homepage; named sources on
+About; `/browse` is **Compare**; API in the header; GitHub off the hero; no
+takedown advertising; when claiming current or accurate, say “as the school
+published it.”
+
+**Not in this deck:** live TSX. Sign the prose, then we implement.
+
+---
+
+## Compare (`/browse`)
+
+**Primary:** counselors and parents building a side-by-side list. IR
+secondary (CSV / filters).
+
+### Now (operator)
+
+- Title: Queryable School Browser
+- Kicker: § BROWSER / 2024-25+ / PRIMARY ROWS
+- H1: Queryable school *browser.*
+- Lede: “Filter the curated 2024-25+ browser rows without losing the source
+  trail. The default view chooses the latest primary row per school…”
+- Stats: Schools in scope / Primary rows / Queryable fields / Data refreshed
+- Error: “Browser query failed”
+- Caption: “Latest primary school-year rows, 2024-25+.”
+
+### Proposed
+
+**Meta**
+
+- Title: Compare schools
+- Description: Compare admissions, cost, and aid across schools. Each row is
+  the latest report the school published that we can put side by side. The
+  original file is one click away.
+
+**Chrome**
+
+- Kicker: § Compare
+- Sub: 2024–25+ · side by side
+
+**H1:** Compare schools, *side by side.*
+
+**Lede** (Newsreader italic, 18 / 1.55):
+
+> Filter admissions, enrollment, cost, and aid. Each row is the latest
+> school report we can compare, as the school published it. Open the
+> original file from the same row.
+
+**Stats** (short labels — `.meta` uppercases them):
+
+| Now | Label | Note |
+|---|---|---|
+| Schools in scope | Schools | In this table |
+| Primary rows | Rows | Latest year per school |
+| Queryable fields | Facts | From current reports |
+| Data refreshed | Refreshed | {date} |
+
+**In-table caption:** Latest reports, 2024–25+. Schools missing a number
+needed for your filters are counted separately. Looking for a match list?
+Use Match.
+
+**Error:** Couldn’t load these schools.
+
+Ban on this page: browser, browser rows, primary row, queryable.
+
+---
+
+## Schools directory (`/schools`)
+
+**Primary:** parents hunting a name. Counselors second.
+
+### Now
+
+- Tailwind `text-2xl font-bold text-gray-900` — not the type system
+- “School Directory”
+- “N schools with archived Common Data Set documents.”
+
+### Proposed
+
+- Title: Schools
+- Description: Find a college and open the reports it published.
+- H1 (serif, display): Schools
+- Lede (italic serif): Every school we have a report for. Search by name.
+- Caption: {n} schools
+
+Keep the table. Restyle onto paper/ink/serif in the same change as the
+prose — the gray heading is the design-system debt on this page.
+
+---
+
+## School page (`/schools/{id}`)
+
+**Primary:** all three. Parents want current numbers and the file.
+Counselors want a URL to send. IR wants the year list and a way to
+contribute.
+
+### Now (operator)
+
+- Title: `{name} Common Data Set (CDS) Archive`
+- Description: “Browse extracted admissions…”
+- Lead: “This page archives N documents… Latest extracted year is…
+  This page is the archive and extract.”
+- JSON-LD: “extracted by collegedata.fyi”
+- Directory-only stub exists (good) but does not say you still get federal
+  numbers
+
+### Proposed meta
+
+- Title: `{name}`
+- Description: `{name} — the report the college publishes, plus federal
+  numbers, in one place. Open the original file.`
+
+### Proposed archive lead
+
+Heading can stay the school name (already the H1). Body:
+
+> This page has {n} reports from {range}. Latest year is {year}.
+> Downloads include {formats}.
+
+If the school’s own page is public:
+
+> The [school’s own page](url) is the publisher. This page is the public
+> copy, with the numbers next to the file.
+
+If the school’s page asks you to email:
+
+> The [school’s own page](url) currently asks you to request the file.
+> The original is here.
+
+Then: What is a [Common Data Set](/about/common-data-set)? Subscribe to
+new reports via [RSS](feed).
+
+Do **not** say extract, extracted, archive and extract, or that a school
+took a file down.
+
+### Directory-only (no CDS on file)
+
+Keep the stub. Add the Wave 1 fallback in product voice:
+
+> We don’t have a report this school published. You still get the federal
+> numbers.
+
+Contribute remains on this page (IR path).
+
+### JSON-LD
+
+Same facts, no “extracted by.” Dataset description: admissions, enrollment,
+cost, and aid as the school published them.
+
+---
+
+## Year page (`/schools/{id}/{year}`)
+
+**Primary:** counselors (the URL they send). Parents opening a year.
+
+### Now
+
+- Description: “official source download plus extracted admissions…”
+- Lead: “archived source file … plus the extracted field tables”
+- Heading: “All extracted fields”
+- Empty: “Structured data coming soon”
+
+### Proposed meta
+
+- Title: `{name}, {year}`
+- Description: `{name} {year} — the report the college published, as it
+  published it. Download the original file.`
+
+### Proposed lead
+
+> This is {name}’s {year} report, as the school published it.
+> [Download the original file](url). See the [school’s own page](url).
+> Subscribe via [RSS](feed).
+
+### Fields heading
+
+**The numbers, as published** — not “All extracted fields.”
+
+Empty (file on disk, numbers not on the page yet):
+
+> The original file is above. The numbers from this report aren’t on the
+> page yet.
+
+Ban: extracted field tables, structured data coming soon (too product-y
+without saying what to do).
+
+---
+
+## Match (`/match`)
+
+**Primary:** parents and students. Counselors second (export).
+
+### Now
+
+- Title: Match List Builder
+- Kicker: Match list builder
+- H1: Build a school list from source-backed admissions data.
+- Lede: “Enter one profile, filter the corpus, and export a
+  counselor-friendly list with academic fit… CDS year, and source PDF.”
+
+### Proposed
+
+- Title: Match
+- Description: Build a college list from the numbers schools publish. On
+  this device. No account. No student profile stored.
+
+**Kicker:** Match
+
+**H1:** Build a list from the *school’s own numbers.*
+
+**Lede** (italic serif):
+
+> Enter a profile on this device. Filter by scores, fit, and admit rate.
+> Export a list with the year and the original file. We don’t store a
+> student profile.
+
+“Corpus” and “source-backed” leave the page. The file link stays — that’s
+the counselor proof.
+
+---
+
+## Coverage (`/coverage`)
+
+**Primary:** counselors and IR. Parents who searched a missing school.
+
+The H1 already works: What we have, *and what we don’t.*
+
+### Tighten
+
+- Title: Coverage (drop “— collegedata.fyi”; the template adds it)
+- Description: Which schools have a current report, which are stale, and
+  which we’ve never found. Filter by state and size.
+- Lede can stay, minus “resolver”:
+
+> Every undergraduate Title-IV school, with whether we have a public
+> report on file. Publishing is voluntary. Some schools post the file,
+> some bury it, some don’t publish one we could find.
+
+**Methodology** (on this page, still English):
+
+- Keep: we look on school sites and known public archives; last-checked
+  date; *No public CDS found* ≠ never publishes; contribute from the
+  school page.
+- Replace “the resolver has not scanned it” with “we haven’t checked this
+  school yet.”
+- Drop the “labeled separately so readers can tell” lecture. One line:
+  federal numbers stay labeled as federal.
+
+---
+
+## Read-aloud checks
+
+- Parent on a school page: “I can see current numbers — the school’s
+  report if they published one, federal if they didn’t — and download the
+  file.”
+- Counselor on a year page: “I can send this URL. The official file is on
+  it.”
+- IR on Compare: “I can filter and export without being taught what a
+  primary row is.”
+
+If any of those fail, the page isn’t done.
+
+---
+
+## Out of Wave 2
+
+Recipes, methodology, API docs — Wave 3/4. Cards on school pages
+(positioning, merit, admission strategy) keep their numbers; only
+operator chrome around them moves if it uses banned words. Do not
+redesign those cards in this wave.

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -176,8 +176,9 @@ because of it.
 1. Draft in a copy deck (`docs/copy/`), not in a 400-line React diff.
 2. Anthony reads as a reader.
 3. Then implement in `web/`.
-4. Small PRs per wave. Wave 1 (front door) shipped 2026-08-27. Wave 2 is
-   the product surfaces: Compare, schools directory, school and year pages,
-   Match, Coverage. Deck: [`docs/copy/wave-2-product-surfaces.md`](../docs/copy/wave-2-product-surfaces.md).
+4. Small PRs per wave. Wave 1 (front door) shipped 2026-08-27. Wave 2
+   product surfaces (Compare, schools directory, school and year pages,
+   Match, Coverage) signed after Fable review 2026-08-27. Deck:
+   [`docs/copy/wave-2-product-surfaces.md`](../docs/copy/wave-2-product-surfaces.md).
 
 Waves 3–4 (methodology, API) wait until Wave 2’s dialect is signed.

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -174,8 +174,8 @@ because of it.
 1. Draft in a copy deck (`docs/copy/`), not in a 400-line React diff.
 2. Anthony reads as a reader.
 3. Then implement in `web/`.
-4. Small PRs per wave. Wave 1 is the front door: homepage, About, CDS
-   explainer, metadata, nav chrome.
+4. Small PRs per wave. Wave 1 (front door) shipped 2026-08-27. Wave 2 is
+   the product surfaces: Compare, schools directory, school and year pages,
+   Match, Coverage. Deck: [`docs/copy/wave-2-product-surfaces.md`](../docs/copy/wave-2-product-surfaces.md).
 
-Waves 2–4 (school pages, methodology, API) wait until Wave 1’s dialect is
-stable.
+Waves 3–4 (methodology, API) wait until Wave 2’s dialect is signed.

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -140,8 +140,10 @@ Product copy prefers the right-hand column. Operator docs may use the left.
 | CDS field IDs in a lede (`C.101`, `AP_RECD_1ST_MEN_N`) | the fact in English, ID only in tables or API docs |
 | “a 47-page PDF is not a database” as the hook | what a family or counselor can *do* with the report |
 
-Keep saying **Common Data Set** on the explainer and in SEO. Define it in
-the first sentence, then talk about the numbers.
+Keep saying **Common Data Set** on the explainer and in SEO. School and
+year pages are a Google door: people search `{name} Common Data Set`.
+Put that phrase in the title, description, and first sentence. H1 can
+be the school name. Define the term once, then talk about the numbers.
 
 When claiming **current** or **accurate**, anchor to “as the school
 published it.” Never imply we verified the school’s math. Parents want

--- a/web/src/app/browse/page.tsx
+++ b/web/src/app/browse/page.tsx
@@ -4,9 +4,9 @@ import { fetchSiteStats, fetchBrandColorIndex } from "@/lib/queries";
 import { formatCount, formatShortDate } from "@/lib/format";
 
 export const metadata: Metadata = {
-  title: "Queryable School Browser",
+  title: "Compare schools",
   description:
-    "Filter the 2024-25+ Common Data Set browser rows by admissions, enrollment, price, and outcome metrics.",
+    "Compare admissions, cost, and aid across schools. Each row is the latest school report we can compare, as the school published it. The original file is one click away.",
   alternates: { canonical: "/browse" },
   openGraph: { url: "/browse" },
 };
@@ -32,9 +32,8 @@ export default async function BrowsePage() {
         className="browser-hero"
       >
         <div className="meta" style={{ paddingTop: 10, lineHeight: 1.8 }}>
-          <div>§ BROWSER</div>
+          <div>§ Compare</div>
           <div>2024-25+</div>
-          <div>PRIMARY ROWS</div>
         </div>
         <div>
           <h1
@@ -47,20 +46,25 @@ export default async function BrowsePage() {
               letterSpacing: "-0.02em",
             }}
           >
-            Queryable school <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>browser.</span>
+            Compare schools,{" "}
+            <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>
+              side by side.
+            </span>
           </h1>
           <p
+            className="serif"
             style={{
               margin: "20px 0 0",
               maxWidth: 720,
               color: "var(--ink-2)",
-              fontSize: 17,
-              lineHeight: 1.6,
+              fontSize: 18,
+              fontStyle: "italic",
+              lineHeight: 1.55,
             }}
           >
-            Filter the curated 2024-25+ browser rows without losing the source trail.
-            The default view chooses the latest primary row per school that can answer
-            the active filters, then reports how many schools were missing values.
+            Filter admissions, cost, and aid. Each row is the latest school report
+            we can compare, as the school published it. Open the original file from
+            the same row.
           </p>
           <div
             className="browser-hero-stats rule-2"
@@ -72,10 +76,25 @@ export default async function BrowsePage() {
               gap: 18,
             }}
           >
-            <BrowserHeroStat label="Schools in scope" value={formatCount(stats.browser_school_count)} />
-            <BrowserHeroStat label="Primary rows" value={formatCount(stats.browser_primary_row_count)} />
-            <BrowserHeroStat label="Queryable fields" value={formatCount(stats.queryable_field_count)} />
-            <BrowserHeroStat label="Data refreshed" value={formatShortDate(stats.browser_updated_at)} />
+            <BrowserHeroStat
+              label="Schools"
+              value={formatCount(stats.browser_school_count)}
+              note="In this table"
+            />
+            <BrowserHeroStat
+              label="Reports"
+              value={formatCount(stats.browser_primary_row_count)}
+              note="2024-25 and newer"
+            />
+            <BrowserHeroStat
+              label="Facts"
+              value={formatCount(stats.queryable_field_count)}
+              note="From the latest reports"
+            />
+            <BrowserHeroStat
+              label="Refreshed"
+              value={formatShortDate(stats.browser_updated_at)}
+            />
           </div>
         </div>
       </section>
@@ -102,11 +121,24 @@ export default async function BrowsePage() {
   );
 }
 
-function BrowserHeroStat({ label, value }: { label: string; value: string }) {
+function BrowserHeroStat({
+  label,
+  value,
+  note,
+}: {
+  label: string;
+  value: string;
+  note?: string;
+}) {
   return (
     <div>
       <div className="meta" style={{ marginBottom: 4 }}>{label}</div>
       <div className="nums" style={{ fontSize: 22, color: "var(--ink)" }}>{value}</div>
+      {note ? (
+        <div style={{ marginTop: 6, fontSize: 13, color: "var(--ink-3)", lineHeight: 1.4 }}>
+          {note}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/app/coverage/page.tsx
+++ b/web/src/app/coverage/page.tsx
@@ -7,9 +7,9 @@ import { CoverageDashboard } from "@/components/CoverageDashboard";
 export const revalidate = 900; // ISR: 15 minutes, matches the refresh-coverage cron
 
 export const metadata: Metadata = {
-  title: "Coverage — collegedata.fyi",
+  title: "Coverage",
   description:
-    "Per-institution Common Data Set coverage status across every active, undergraduate-serving Title-IV institution. Filter by state, enrollment, and the resolver's last attempt to see which schools we have, which we have an older year for, and which haven't yet published one we could find.",
+    "Which schools have a current Common Data Set, which have only older years, and which have none we could find. Filter by state and size.",
   alternates: { canonical: "/coverage" },
 };
 
@@ -42,19 +42,19 @@ export default async function CoveragePage() {
           What we have, <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>and what we don&rsquo;t.</span>
         </h1>
         <p
+          className="serif"
           style={{
             marginTop: 18,
-            fontSize: 16,
+            fontSize: 18,
+            fontStyle: "italic",
             lineHeight: 1.55,
             color: "var(--ink-2)",
             maxWidth: 720,
           }}
         >
-          Every active, undergraduate-serving Title-IV institution in the
-          United States, with our latest verdict on whether we have a public
-          Common Data Set archived. The Common Data Set is voluntary; some
-          schools publish openly, some bury it, and some don&rsquo;t publish
-          at all. This page is an honest accounting of which is which.
+          Every U.S. college that takes federal student aid, and whether we have
+          a public report on file. Publishing is voluntary. Some schools post
+          the file, some bury it, some don&rsquo;t publish one we could find.
         </p>
       </header>
 
@@ -93,17 +93,15 @@ export default async function CoveragePage() {
             usable public source turning up. That is different from saying the
             school never publishes one: CDS files are voluntary, and some are
             posted in places automated discovery cannot reliably reach.
-            <em> Not checked yet</em> means the school is in scope, but the
-            resolver has not scanned it.
+            <em> Not checked yet</em> means we haven&rsquo;t checked this
+            school yet.
           </p>
           <p style={{ margin: 0 }}>
             Coverage refreshes every 15 minutes from{" "}
             <a href="https://collegescorecard.ed.gov/" target="_blank" rel="noopener noreferrer">
               College Scorecard
-            </a>. CDS files are often newer than federal outcome datasets, while
-            NCES/IPEDS and Scorecard provide broader baseline context. We keep
-            those sources labeled separately so readers can tell what came from
-            a school publication and what came from federal data.
+            </a>. CDS files are often newer than federal outcome datasets.
+            Federal numbers stay labeled as federal.
           </p>
           <p style={{ margin: 0 }}>
             Know where one of these is published? Open the school page and{" "}

--- a/web/src/app/match/page.tsx
+++ b/web/src/app/match/page.tsx
@@ -5,9 +5,9 @@ import { fetchMatchBuilderSchools, fetchBrandColorIndex } from "@/lib/queries";
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: "Match List Builder",
+  title: "Match",
   description:
-    "Build a college match list from Common Data Set score bands, academic fit, admit rates, and archived source documents.",
+    "Build a college list from the numbers schools publish. On this device. No account. No student profile stored.",
   alternates: { canonical: "/match" },
 };
 
@@ -25,11 +25,17 @@ export default async function MatchPage({
   return (
     <div className="mx-auto max-w-6xl px-4 sm:px-6 py-8 match-page">
       <header className="match-hero">
-        <div className="meta">Match list builder</div>
-        <h1 className="serif">Build a school list from source-backed admissions data.</h1>
-        <p>
-          Enter one profile, filter the corpus, and export a counselor-friendly list with academic
-          fit, admissions outlook, percentile, admit rate, CDS year, and source PDF.
+        <div className="meta">Match</div>
+        <h1 className="serif">
+          Build a list from the{" "}
+          <span style={{ fontStyle: "italic", color: "var(--forest-ink)" }}>
+            school&apos;s own numbers.
+          </span>
+        </h1>
+        <p className="serif" style={{ fontStyle: "italic", fontSize: 18, lineHeight: 1.55 }}>
+          Enter scores and GPA — they stay on this device. Filter by fit and
+          admit rate. Export a list with the year and the original file. We
+          don&apos;t store a student profile.
         </p>
       </header>
 

--- a/web/src/app/schools/[school_id]/[year]/page.tsx
+++ b/web/src/app/schools/[school_id]/[year]/page.tsx
@@ -42,7 +42,7 @@ export async function generateMetadata({
   const path = `/schools/${resolvedSchoolId}/${year}`;
   const title = `${doc.school_name} Common Data Set ${year}`;
   const description =
-    `View ${doc.school_name} Common Data Set ${year}: official source download plus extracted admissions, enrollment, SAT/ACT, financial aid, and field-level CDS data.`;
+    `${doc.school_name} ${year}: the school’s Common Data Set — admissions, cost, and aid — plus the original file to download.`;
 
   return {
     title,
@@ -99,7 +99,7 @@ export default async function SchoolYearPage({ params }: {
       "@context": "https://schema.org",
       "@type": "Dataset",
       name: `${schoolName} Common Data Set ${year}`,
-      description: `Common Data Set ${year} for ${schoolName}, containing admissions, enrollment, financial aid, and other institutional data.`,
+      description: `Common Data Set ${year} for ${schoolName}: admissions, cost, and aid as the school published them.`,
       url: canonicalUrl,
       creator: { "@type": "Organization", name: schoolName },
       temporalCoverage: year,
@@ -156,7 +156,7 @@ export default async function SchoolYearPage({ params }: {
             {schoolName}
           </h1>
           <h2 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "10px 0 0" }}>
-            {yearLead.heading}
+            {year}
           </h2>
         </div>
       </header>
@@ -273,7 +273,7 @@ async function DocumentVariant({
       {hasValues ? (
         <div style={{ marginTop: 24 }}>
           <h3 className="serif" style={{ fontSize: 22, fontWeight: 400, margin: "0 0 16px" }}>
-            All extracted fields
+            The numbers, as published
           </h3>
           <FieldsView
             schemaVersion={schemaVersion ?? doc.cds_year}
@@ -281,15 +281,12 @@ async function DocumentVariant({
             totalFields={totalFields}
           />
         </div>
-      ) : isExtracted ? (
-        <div className="cd-card" style={{ marginTop: 16, padding: "24px 28px" }}>
-          <p>No structured field values available for this document yet.</p>
-        </div>
       ) : (
         <div className="cd-card" style={{ marginTop: 16, padding: "24px 28px" }}>
           <p>
-            Structured data coming soon. The source document is available for
-            download above.
+            {sourceDownloadUrl
+              ? "The original file is above. The numbers from this report aren&apos;t on the page yet."
+              : "The numbers from this report aren&apos;t on the page yet."}
           </p>
         </div>
       )}

--- a/web/src/app/schools/[school_id]/page.tsx
+++ b/web/src/app/schools/[school_id]/page.tsx
@@ -26,7 +26,7 @@ import { CoverageBadge } from "@/components/CoverageBadge";
 import { SubmissionForm } from "@/components/SubmissionForm";
 import { FederalBaselineTable } from "@/components/FederalBaselineTable";
 import { isCanonicalCdsYear, storageUrl, yearRange } from "@/lib/format";
-import { archiveLead } from "@/lib/archive-lead";
+import { archiveLead, directoryOnlyLead } from "@/lib/archive-lead";
 import { ArchiveLead } from "@/components/ArchiveLead";
 import { SchoolGlyph } from "@/components/SchoolGlyph";
 import type { ManifestRow, InstitutionCoverage } from "@/lib/types";
@@ -48,15 +48,17 @@ export async function generateMetadata({
     const coverage = await fetchInstitutionCoverage(resolvedSchoolId);
     if (coverage) {
       const path = `/schools/${resolvedSchoolId}`;
+      const title = `${coverage.school_name} Common Data Set`;
+      const description = `We haven’t found a Common Data Set from this school. ${coverage.coverage_summary}`;
       return {
-        title: `${coverage.school_name} - ${coverage.coverage_label}`,
-        description: coverage.coverage_summary,
+        title,
+        description,
         alternates: { canonical: path },
         robots: { index: false, follow: true },
         openGraph: {
           url: path,
-          title: coverage.school_name,
-          description: coverage.coverage_summary,
+          title,
+          description,
         },
       };
     }
@@ -64,18 +66,15 @@ export async function generateMetadata({
   }
 
   const name = docs[0].school_name;
-  const coverage = await fetchInstitutionCoverage(resolvedSchoolId);
-  const location = formatLocation(coverage);
   const years = docs
     .map((d) => d.canonical_year)
     .filter(isCanonicalCdsYear)
     .sort();
   const path = `/schools/${resolvedSchoolId}`;
-  const archiveCount = `${docs.length} CDS document${docs.length !== 1 ? "s" : ""}`;
-  const locationLead = location ? ` for ${location}` : "";
+  const yearsOnFile = years.length > 0 ? yearRange(years[0], years[years.length - 1]) : "none";
   const description =
-    `Download ${name} Common Data Set files${locationLead}. Browse extracted admissions, enrollment, financial aid, SAT/ACT, and source links. ${archiveCount}, ${yearRange(years[0], years[years.length - 1])}.`;
-  const title = `${name} Common Data Set (CDS) Archive`;
+    `${name} Common Data Set — the yearly report the college publishes on admissions, cost, and aid, plus federal numbers. Years on file: ${yearsOnFile}. Download the original file.`;
+  const title = `${name} Common Data Set`;
 
   return {
     title,
@@ -228,7 +227,7 @@ export default async function SchoolDetailPage({ params }: {
       "@type": "CollegeOrUniversity",
       name,
       url: schoolUrl,
-      description: `Common Data Set archive for ${name}. ${docs.length} document${docs.length !== 1 ? "s" : ""} archived${years.length > 0 ? `, ${yearRange(years[0], years[years.length - 1])}` : ""}.`,
+      description: `${docs.length} Common Data Set report${docs.length !== 1 ? "s" : ""} for ${name}${years.length > 0 ? `, ${yearRange(years[0], years[years.length - 1])}` : ""}.`,
       ...(coverage?.city || coverage?.state
         ? {
             address: {
@@ -250,9 +249,9 @@ export default async function SchoolDetailPage({ params }: {
     {
       "@context": "https://schema.org",
       "@type": "DataCatalog",
-      name: `${name} Common Data Set archive`,
+      name: `${name} Common Data Set`,
       url: schoolUrl,
-      description: `Every archived Common Data Set year for ${name}, keyed to the canonical 1,105-field schema published by the Common Data Set Initiative.`,
+      description: `Every Common Data Set year we have for ${name}, as the school published it.`,
       creator: { "@type": "Organization", name, url: schoolUrl },
       provider: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
       isAccessibleForFree: true,
@@ -260,7 +259,7 @@ export default async function SchoolDetailPage({ params }: {
       dataset: uniqueYears.map((year) => ({
         "@type": "Dataset",
         name: `${name} Common Data Set ${year}`,
-        description: `Common Data Set ${year} for ${name}, containing admissions, enrollment, financial aid, and other institutional data extracted by collegedata.fyi.`,
+        description: `Common Data Set ${year} for ${name}: admissions, cost, and aid as the school published them.`,
         url: `https://www.collegedata.fyi/schools/${school_id}/${year}`,
         creator: { "@type": "Organization", name },
         provider: { "@type": "Organization", name: "collegedata.fyi", url: "https://www.collegedata.fyi" },
@@ -331,6 +330,9 @@ export default async function SchoolDetailPage({ params }: {
               <span>{name.toUpperCase()}</span>
             </span>
           </div>
+          <div className="meta" style={{ marginBottom: 12 }}>
+            Common Data Set
+          </div>
           <h1
             className="serif"
             style={{
@@ -349,7 +351,7 @@ export default async function SchoolDetailPage({ params }: {
               name
             )}
           </h1>
-          {schoolLead ? <ArchiveLead lead={schoolLead} /> : null}
+          {schoolLead ? <ArchiveLead lead={schoolLead} showHeading={false} /> : null}
           <div
             style={{
               display: "flex",
@@ -401,7 +403,7 @@ export default async function SchoolDetailPage({ params }: {
           <div className="meta cd-school-header__count">
             <span className="cd-school-header__glyph">§</span>
             <span>
-              {docs.length} document{docs.length !== 1 ? "s" : ""} archived
+              {docs.length} report{docs.length !== 1 ? "s" : ""}
             </span>
             {earliestYear && latestYear && earliestYear !== latestYear && (
               <span className="cd-school-header__years">
@@ -498,6 +500,8 @@ async function DirectoryOnlySchoolPage({
         year: "numeric",
       })
     : null;
+  const hasFederal = Boolean(scorecard) || federalFacts.length > 0;
+  const lead = directoryOnlyLead(hasFederal);
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -519,7 +523,7 @@ async function DirectoryOnlySchoolPage({
       <header className="cd-school-header">
         <div>
         <div className="meta" style={{ marginBottom: 16 }}>
-          § Institution directory
+          Common Data Set
         </div>
         <h1
           className="serif"
@@ -590,7 +594,7 @@ async function DirectoryOnlySchoolPage({
             maxWidth: 640,
           }}
         >
-          {coverage.coverage_summary}
+          {lead}
         </p>
         {coverage.website_url && (
           <p
@@ -653,9 +657,9 @@ async function DirectoryOnlySchoolPage({
           maxWidth: 640,
         }}
       >
-        We track every active, undergraduate-serving Title-IV institution
-        and refresh CDS coverage every 15 minutes. Federal data above comes
-        from NCES/IPEDS and College Scorecard when available.{" "}
+        We look for a public report from every U.S. college that takes
+        federal student aid. Federal data above comes from NCES/IPEDS and
+        College Scorecard when we have it.{" "}
         <Link href="/about">Read the method</Link>.
       </p>
     </div>

--- a/web/src/app/schools/page.tsx
+++ b/web/src/app/schools/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { fetchManifest, aggregateSchools, fetchBrandColorIndex } from "@/lib/queries";
 import { SchoolTable } from "@/components/SchoolTable";
 
 export const metadata: Metadata = {
   title: "Schools",
   description:
-    "Browse U.S. colleges with archived Common Data Set documents. Search by name, sort by year or document count.",
+    "Every college with a Common Data Set on file. Open the reports each school published.",
   alternates: { canonical: "/schools" },
   openGraph: { url: "/schools" },
 };
@@ -23,11 +24,39 @@ export default async function SchoolsPage() {
   }));
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-1">School Directory</h1>
-      <p className="text-gray-600 mb-6">
-        {schools.length} schools with archived Common Data Set documents.
-      </p>
+    <div className="mx-auto max-w-5xl" style={{ padding: "52px 24px 72px" }}>
+      <header style={{ marginBottom: 28 }}>
+        <h1
+          className="serif"
+          style={{
+            fontWeight: 400,
+            fontSize: "clamp(42px, 6vw, 68px)",
+            lineHeight: 1,
+            margin: 0,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Schools
+        </h1>
+        <p
+          className="serif"
+          style={{
+            margin: "18px 0 0",
+            maxWidth: 640,
+            fontStyle: "italic",
+            fontSize: 18,
+            lineHeight: 1.55,
+            color: "var(--ink-2)",
+          }}
+        >
+          Every school we have a report from. Don&apos;t see yours? Check{" "}
+          <Link href="/coverage">Coverage</Link> — schools without a report still
+          get a page with the federal numbers.
+        </p>
+        <p className="meta" style={{ marginTop: 16 }}>
+          {schools.length} schools
+        </p>
+      </header>
       <SchoolTable schools={schools} />
     </div>
   );

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -215,7 +215,7 @@ function SubsectionBlock({
         <div style={{ marginTop: reconstructedTables.length > 0 ? 14 : 0 }}>
           {reconstructedTables.length > 0 && (
             <div className="meta" style={{ marginBottom: 6 }}>
-              Other extracted fields
+              Other fields
             </div>
           )}
           <KVRows fields={fallbackFields} schemaVersion={schemaVersion} />

--- a/web/src/components/FieldsView.tsx
+++ b/web/src/components/FieldsView.tsx
@@ -465,7 +465,7 @@ function ProvenanceNote({
       }}
     >
       <span className="meta" style={{ color: "var(--forest)" }}>
-        § Extraction
+        § This report
       </span>
       <span className="serif stat-num" style={{ fontSize: 18 }}>
         {totalExtracted.toLocaleString("en-US")}
@@ -479,7 +479,7 @@ function ProvenanceNote({
         )}
       </span>
       <span style={{ color: "var(--ink-2)" }}>
-        field{totalExtracted === 1 ? "" : "s"} parsed from this CDS.
+        number{totalExtracted === 1 ? "" : "s"} from this report.
       </span>
     </div>
   );

--- a/web/src/components/SchoolBrowser.tsx
+++ b/web/src/components/SchoolBrowser.tsx
@@ -154,7 +154,7 @@ function downloadCsv(rows: BrowserRow[]) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "collegedata-browser-export.csv";
+  a.download = "collegedata-compare.csv";
   document.body.appendChild(a);
   a.click();
   a.remove();
@@ -355,23 +355,23 @@ export function SchoolBrowser({
           }}
           className="browser-meta-grid"
         >
-          <MetaStat label="Schools in scope" value={metadata ? metadata.schools_in_scope.toLocaleString() : "..."} />
-          <MetaStat label="Matching filters" value={metadata ? metadata.total_rows.toLocaleString() : "..."} />
-          <MetaStat label="With required fields" value={metadata ? metadata.schools_with_required_fields.toLocaleString() : "..."} />
-          <MetaStat label="Missing fields" value={metadata ? metadata.schools_missing_required_fields.toLocaleString() : "..."} />
+          <MetaStat label="Schools" value={metadata ? metadata.schools_in_scope.toLocaleString() : "..."} />
+          <MetaStat label="Match your filters" value={metadata ? metadata.total_rows.toLocaleString() : "..."} />
+          <MetaStat label="Have every number" value={metadata ? metadata.schools_with_required_fields.toLocaleString() : "..."} />
+          <MetaStat label="Missing a number" value={metadata ? metadata.schools_missing_required_fields.toLocaleString() : "..."} />
         </div>
         <p className="meta" style={{ marginTop: 14, lineHeight: 1.55 }}>
-          Latest primary school-year rows, 2024-25+. Fields needed for the current filters: {requiredLabels}.
+          Latest reports, 2024-25+. Schools missing a number your filters need are counted above. Fields needed: {requiredLabels}.
           {metadata ? ` Filtered out by your criteria: ${metadata.schools_failing_filters.toLocaleString()}.` : ""}
           {" "}
-          <Link href="/match">Looking for fit ranking? Use Match.</Link>
+          <Link href="/match">Building a list? Use Match.</Link>
         </p>
       </section>
 
       {error && (
         <div className="cd-card" style={{ padding: 16, borderColor: "var(--brick)", marginBottom: 18 }}>
-          <div className="meta" style={{ color: "var(--brick)", marginBottom: 6 }}>Browser query failed</div>
-          <p style={{ margin: 0, color: "var(--ink-2)", fontSize: 14 }}>{error}</p>
+          <div className="meta" style={{ color: "var(--brick)", marginBottom: 6 }}>Couldn&apos;t load</div>
+          <p style={{ margin: 0, color: "var(--ink-2)", fontSize: 14 }}>Try again in a moment.</p>
         </div>
       )}
 

--- a/web/src/components/SchoolTable.tsx
+++ b/web/src/components/SchoolTable.tsx
@@ -43,8 +43,8 @@ export function SchoolTable({ schools }: { schools: SchoolSummary[] }) {
   }
 
   function SortIcon({ col }: { col: SortKey }) {
-    if (sortKey !== col) return <span className="text-gray-300 ml-1">&#x2195;</span>;
-    return <span className="ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
+    if (sortKey !== col) return <span style={{ marginLeft: 6, color: "var(--ink-4)" }}>↕</span>;
+    return <span style={{ marginLeft: 6 }}>{sortDir === "asc" ? "↑" : "↓"}</span>;
   }
 
   return (
@@ -53,57 +53,75 @@ export function SchoolTable({ schools }: { schools: SchoolSummary[] }) {
         type="text"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        placeholder="Filter schools..."
-        className="mb-4 w-full max-w-md rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
+        placeholder="Search by name"
+        aria-label="Search schools by name"
+        style={{
+          marginBottom: 16,
+          width: "100%",
+          maxWidth: 420,
+          height: 36,
+          padding: "0 12px",
+          border: "1px solid var(--rule)",
+          background: "#faf6ec",
+          color: "var(--ink)",
+          fontFamily: "var(--sans)",
+          fontSize: 14,
+          borderRadius: 2,
+          outline: "none",
+        }}
+        onFocus={(e) => {
+          e.currentTarget.style.borderColor = "var(--forest)";
+        }}
+        onBlur={(e) => {
+          e.currentTarget.style.borderColor = "var(--rule)";
+        }}
       />
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", minWidth: 640, borderCollapse: "collapse", fontSize: 14 }}>
           <thead>
-            <tr className="border-b border-gray-200 text-left text-gray-500">
+            <tr className="meta" style={{ textAlign: "left", borderBottom: "1px solid var(--rule-strong)" }}>
               <th
-                className="py-2 pr-4 cursor-pointer select-none"
+                style={{ padding: "9px 16px 9px 0", cursor: "pointer", userSelect: "none" }}
                 onClick={() => toggleSort("name")}
               >
                 School <SortIcon col="name" />
               </th>
               <th
-                className="py-2 pr-4 cursor-pointer select-none text-right"
+                style={{ padding: "9px 16px", cursor: "pointer", userSelect: "none", textAlign: "right" }}
                 onClick={() => toggleSort("docs")}
               >
-                Documents <SortIcon col="docs" />
+                Reports <SortIcon col="docs" />
               </th>
               <th
-                className="py-2 pr-4 cursor-pointer select-none"
+                style={{ padding: "9px 16px", cursor: "pointer", userSelect: "none" }}
                 onClick={() => toggleSort("year")}
               >
-                Latest Year <SortIcon col="year" />
+                Latest year <SortIcon col="year" />
               </th>
-              <th className="py-2">Formats</th>
+              <th style={{ padding: "9px 0" }}>Formats</th>
             </tr>
           </thead>
           <tbody>
             {filtered.map((school) => (
-              <tr
-                key={school.school_id}
-                className="border-b border-gray-100 hover:bg-gray-50"
-              >
-                <td className="py-2.5 pr-4">
+              <tr key={school.school_id} className="rule">
+                <td style={{ padding: "12px 16px 12px 0" }}>
                   <Link
                     href={`/schools/${school.school_id}`}
-                    className="school-name-with-glyph text-blue-600 hover:text-blue-800 font-medium"
+                    className="school-name-with-glyph"
+                    style={{ fontFamily: "var(--serif)", fontSize: 18 }}
                   >
                     <SchoolGlyph size="sm" brandColors={school.brand_colors} />
                     {school.school_name}
                   </Link>
                 </td>
-                <td className="py-2.5 pr-4 text-right text-gray-600">
+                <td className="nums" style={{ padding: "12px 16px", textAlign: "right" }}>
                   {school.doc_count}
                 </td>
-                <td className="py-2.5 pr-4 text-gray-600">
+                <td className="nums" style={{ padding: "12px 16px" }}>
                   {school.latest_year ?? "—"}
                 </td>
-                <td className="py-2.5">
-                  <div className="flex gap-1 flex-wrap">
+                <td style={{ padding: "12px 0" }}>
+                  <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
                     {school.formats.map((f) => (
                       <Badge
                         key={f}
@@ -119,13 +137,11 @@ export function SchoolTable({ schools }: { schools: SchoolSummary[] }) {
         </table>
       </div>
       {filtered.length === 0 && (
-        <p className="mt-8 text-center text-gray-500">
-          No schools found matching &ldquo;{search}&rdquo;
+        <p style={{ marginTop: 28, maxWidth: 520, color: "var(--ink-2)", lineHeight: 1.55 }}>
+          No reports on file match &ldquo;{search}.&rdquo; Try the site search —
+          schools without a report still have a page with the federal numbers.
         </p>
       )}
-      <p className="mt-4 text-xs text-gray-400">
-        {filtered.length} of {schools.length} schools
-      </p>
     </div>
   );
 }

--- a/web/src/components/WhatChangedCard.tsx
+++ b/web/src/components/WhatChangedCard.tsx
@@ -74,7 +74,7 @@ export function WhatChangedCard({ events }: WhatChangedCardProps) {
           <div className="what-changed-card__count">
             <span className="meta">Published signals</span>
             <strong className="serif stat-num">{visibleEvents.length}</strong>
-            <small>Generated from extracted Common Data Set fields.</small>
+            <small>From year-over-year school reports.</small>
           </div>
         </div>
 
@@ -113,7 +113,7 @@ export function WhatChangedCard({ events }: WhatChangedCardProps) {
         </div>
 
         <div className="what-changed-card__source card-source-actions rule mono">
-          <span>§ SOURCE: COMMON DATA SET YEAR-OVER-YEAR FIELD PROJECTION</span>
+          <span>§ SOURCE: COMMON DATA SET YEAR-OVER-YEAR</span>
         </div>
       </div>
     </section>

--- a/web/src/lib/archive-lead.test.ts
+++ b/web/src/lib/archive-lead.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   archiveLead,
+  directoryOnlyLead,
   leadContainsBannedCopy,
   leadPlainText,
   yearArchiveLead,
@@ -30,7 +31,7 @@ describe("archiveLead", () => {
       documents: vtDocs,
     });
     expect(leadPlainText(lead)).toMatchInlineSnapshot(
-      `"Virginia Tech Common Data Set archive, 2011–2025 (3 documents). This page archives 3 documents from 2011–2025. Latest extracted year is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own CDS page currently asks the public to request the file. This page is the archived source plus extract. What is a Common Data Set? Subscribe to school-published files via RSS."`,
+      `"Virginia Tech Common Data Set The Virginia Tech Common Data Set is the yearly report the college publishes about itself. 3 reports on file, 2011–2025; the latest is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own page currently asks you to request the file. The original is here. What is a Common Data Set? Subscribe to new reports via RSS."`,
     );
     expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
   });
@@ -43,7 +44,7 @@ describe("archiveLead", () => {
       documents: hmcDocs,
     });
     expect(leadPlainText(lead)).toMatchInlineSnapshot(
-      `"Harvey Mudd College Common Data Set archive, 2010–2025 (16 documents). This page archives 16 documents from 2010–2025. Latest extracted year is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own CDS page is the publisher; this page is the archive and extract. What is a Common Data Set? Subscribe to school-published files via RSS."`,
+      `"Harvey Mudd College Common Data Set The Harvey Mudd College Common Data Set is the yearly report the college publishes about itself. 16 reports on file, 2010–2025; the latest is 2025-26. Downloads include PDF, XLSX, and CSV. The school's own page is the publisher. This page is the public copy, with the numbers next to the file. What is a Common Data Set? Subscribe to new reports via RSS."`,
     );
     expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
   });
@@ -61,7 +62,7 @@ describe("archiveLead", () => {
       ],
     });
     expect(leadPlainText(lead)).toMatchInlineSnapshot(
-      `"Thin College Common Data Set archive, 2023-24 (1 document). This page archives 1 document from 2023-24. Latest extracted year is 2023-24. Downloads include PDF, XLSX, and CSV. What is a Common Data Set? Subscribe to school-published files via RSS."`,
+      `"Thin College Common Data Set The Thin College Common Data Set is the yearly report the college publishes about itself. 1 report on file, 2023-24; the latest is 2023-24. Downloads include PDF, XLSX, and CSV. What is a Common Data Set? Subscribe to new reports via RSS."`,
     );
   });
 
@@ -76,7 +77,16 @@ describe("archiveLead", () => {
     ).toBeNull();
   });
 
-  it("year-page lead names the school, year, and source file", () => {
+  it("tells the truth on directory-only pages with and without federal numbers", () => {
+    expect(directoryOnlyLead(true)).toBe(
+      "We haven’t found a Common Data Set from this school. The federal numbers are below.",
+    );
+    expect(directoryOnlyLead(false)).toBe(
+      "We haven’t found a Common Data Set from this school, and we don’t have federal numbers for it either.",
+    );
+  });
+
+  it("year-page lead names the school, year, and original file", () => {
     const lead = yearArchiveLead({
       schoolId: "virginia-tech",
       schoolName: "Virginia Tech",
@@ -86,11 +96,23 @@ describe("archiveLead", () => {
       sourceDownloadHref: "https://example.invalid/vt.xlsx",
     });
     expect(lead.heading).toBe("Virginia Tech Common Data Set 2025-26");
-    expect(leadPlainText(lead)).toContain("archived source file");
-    expect(leadPlainText(lead)).toContain("extracted field tables");
-    expect(leadPlainText(lead)).toContain("school's own CDS page");
-    expect(leadPlainText(lead)).toContain("RSS");
-    expect(leadContainsBannedCopy(leadPlainText(lead))).toBe(false);
+    const text = leadPlainText(lead);
+    expect(text).toContain("The 2025-26 Common Data Set for Virginia Tech");
+    expect(text).toContain("as the school published them");
+    expect(text).toContain("Download the original file");
+    expect(text).toContain("school's page for these reports");
+    expect(text).toContain("RSS");
+    expect(text).not.toMatch(/extracted/i);
+    expect(leadContainsBannedCopy(text)).toBe(false);
+  });
+
+  it("omits the download link when there is no stored file", () => {
+    const lead = yearArchiveLead({
+      schoolId: "thin-college",
+      schoolName: "Thin College",
+      year: "2023-24",
+    });
+    expect(leadPlainText(lead)).not.toContain("Download the original file");
   });
 
   it("ignores sentinel CDS years when naming the archive range", () => {
@@ -117,8 +139,9 @@ describe("archiveLead", () => {
     });
     const text = leadPlainText(lead);
     expect(text).toContain("2000–2025");
-    expect(text).toContain("Latest extracted year is 2025-26");
+    expect(text).toContain("the latest is 2025-26");
     expect(text).not.toContain("unknown");
+    expect(text).not.toMatch(/extracted/i);
   });
 
   it("states when a year-page date is only this archive's discovery", () => {

--- a/web/src/lib/archive-lead.ts
+++ b/web/src/lib/archive-lead.ts
@@ -66,6 +66,9 @@ const BANNED_LEAD_WORDS = [
   "top stem",
   "chance me",
   "how to get in",
+  "extracted",
+  "extractor",
+  "archive and extract",
 ];
 
 export function officialPageLabel(url: string): string {
@@ -85,12 +88,6 @@ function uniqueYears(documents: ArchiveDocumentFacts[]): string[] {
         .filter(isCanonicalCdsYear),
     ),
   ).sort();
-}
-
-function extractedYears(documents: ArchiveDocumentFacts[]): string[] {
-  return uniqueYears(
-    documents.filter((doc) => doc.extraction_status === "extracted"),
-  );
 }
 
 function formatLabels(documents: ArchiveDocumentFacts[]): string[] {
@@ -127,28 +124,29 @@ export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
   if (facts.documents.length === 0) return null;
 
   const years = uniqueYears(facts.documents);
-  const extracted = extractedYears(facts.documents);
   const range = years.length > 0 ? yearRange(years[0], years[years.length - 1]) : null;
+  const latest = years.length > 0 ? years[years.length - 1] : null;
   const count = facts.documents.length;
-  const countLabel = `${count} document${count === 1 ? "" : "s"}`;
-  const heading = range
-    ? `${facts.schoolName} Common Data Set archive, ${range} (${countLabel}).`
-    : `${facts.schoolName} Common Data Set archive (${countLabel}).`;
+  const countLabel = `${count} report${count === 1 ? "" : "s"}`;
+  const heading = `${facts.schoolName} Common Data Set`;
 
   const paragraphs: LeadPart[][] = [];
 
   const first: LeadPart[] = [
     {
       type: "text",
-      text: range
-        ? `This page archives ${countLabel} from ${range}.`
-        : `This page archives ${countLabel}.`,
+      text: `The ${facts.schoolName} Common Data Set is the yearly report the college publishes about itself.`,
     },
   ];
-  if (extracted.length > 0) {
+  if (range && latest) {
     first.push({
       type: "text",
-      text: ` Latest extracted year is ${extracted[extracted.length - 1]}.`,
+      text: ` ${countLabel} on file, ${range}; the latest is ${latest}.`,
+    });
+  } else {
+    first.push({
+      type: "text",
+      text: ` ${countLabel} on file.`,
     });
   }
   const formats = formatLabels(facts.documents);
@@ -165,7 +163,7 @@ export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
     const sourceLink: LeadPart = {
       type: "link",
       href: official.url,
-      text: "school's own CDS page",
+      text: "school's own page",
       external: true,
     };
     if (official.access === "request") {
@@ -174,14 +172,17 @@ export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
         sourceLink,
         {
           type: "text",
-          text: " currently asks the public to request the file. This page is the archived source plus extract.",
+          text: " currently asks you to request the file. The original is here.",
         },
       ]);
     } else {
       paragraphs.push([
         { type: "text", text: "The " },
         sourceLink,
-        { type: "text", text: " is the publisher; this page is the archive and extract." },
+        {
+          type: "text",
+          text: " is the publisher. This page is the public copy, with the numbers next to the file.",
+        },
       ]);
     }
   }
@@ -201,7 +202,7 @@ export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
     paragraphs.push([{ type: "text", text: freshness }]);
   }
   paragraphs.push([
-    { type: "text", text: "Subscribe to school-published files via " },
+    { type: "text", text: "Subscribe to new reports via " },
     {
       type: "link",
       href: schoolFeedPath(facts.schoolId),
@@ -213,25 +214,27 @@ export function archiveLead(facts: ArchiveLeadFacts): ArchiveLead | null {
   return { heading, paragraphs };
 }
 
+export function directoryOnlyLead(hasFederal: boolean): string {
+  return hasFederal
+    ? "We haven’t found a Common Data Set from this school. The federal numbers are below."
+    : "We haven’t found a Common Data Set from this school, and we don’t have federal numbers for it either.";
+}
+
 export function yearArchiveLead(facts: YearArchiveLeadFacts): ArchiveLead {
   const official = officialSource(facts.schoolId, facts.ipedsId);
   const parts: LeadPart[] = [
     {
       type: "text",
-      text: `This is the archived source file for ${facts.schoolName} Common Data Set ${facts.year}`,
+      text: `The ${facts.year} Common Data Set for ${facts.schoolName} — admissions, cost, and aid, as the school published them.`,
     },
   ];
-  if (facts.hasExtract) {
-    parts.push({ type: "text", text: " plus the extracted field tables" });
-  }
-  parts.push({ type: "text", text: "." });
 
   if (facts.sourceDownloadHref) {
     parts.push({ type: "text", text: " " });
     parts.push({
       type: "link",
       href: facts.sourceDownloadHref,
-      text: "Download the source",
+      text: "Download the original file",
       external: true,
     });
     parts.push({ type: "text", text: "." });
@@ -242,7 +245,7 @@ export function yearArchiveLead(facts: YearArchiveLeadFacts): ArchiveLead {
     parts.push({
       type: "link",
       href: official.url,
-      text: "school's own CDS page",
+      text: "school's page for these reports",
       external: true,
     });
     parts.push({ type: "text", text: "." });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -55,13 +55,13 @@ export function sourceDownloadLabel(
 export function formatExtractionStatus(status: string): string {
   switch (status) {
     case "extracted":
-      return "Extracted";
+      return "On the page";
     case "extraction_pending":
-      return "Pending";
+      return "Not yet";
     case "failed":
-      return "Failed";
+      return "Couldn't read";
     case "discovered":
-      return "Discovered";
+      return "File only";
     default:
       return status;
   }

--- a/web/src/lib/wave-2-product-copy.test.ts
+++ b/web/src/lib/wave-2-product-copy.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const src = (rel: string) => readFileSync(join(process.cwd(), "src", rel), "utf8");
+
+describe("Wave 2 product copy", () => {
+  it("keeps Compare chrome free of browser/primary/queryable", () => {
+    const browse = src("app/browse/page.tsx");
+    expect(browse).toContain('title: "Compare schools"');
+    expect(browse).toMatch(/as the school published it/);
+    expect(browse).toContain("side by side");
+    expect(browse).toContain('label="Reports"');
+    expect(browse).toContain("2024-25 and newer");
+    expect(browse).not.toMatch(/Queryable/);
+    expect(browse).not.toMatch(/PRIMARY ROWS/);
+    expect(browse).not.toMatch(/§ BROWSER/);
+
+    const browser = src("components/SchoolBrowser.tsx");
+    expect(browser).toContain("Building a list? Use Match.");
+    expect(browser).toContain("Couldn&apos;t load");
+    expect(browser).toContain("Try again in a moment.");
+    expect(browser).not.toMatch(/Browser query failed/);
+    expect(browser).not.toMatch(/Looking for fit ranking/);
+    expect(browser).not.toMatch(/primary school-year rows/);
+  });
+
+  it("points the schools directory at Coverage and restyles off gray/blue", () => {
+    const page = src("app/schools/page.tsx");
+    expect(page).toContain('title: "Schools"');
+    expect(page).toContain("Common Data Set on file");
+    expect(page).toContain("Every school we have a report from");
+    expect(page).toContain('href="/coverage"');
+    expect(page).not.toMatch(/School Directory/);
+    expect(page).not.toMatch(/text-gray-900/);
+
+    const table = src("components/SchoolTable.tsx");
+    expect(table).toContain("Try the site search");
+    expect(table).not.toMatch(/text-blue-600/);
+    expect(table).not.toMatch(/focus:border-blue-500/);
+    expect(table).not.toMatch(/No schools found matching/);
+  });
+
+  it("keeps Common Data Set in school and year SEO without extract language", () => {
+    const school = src("app/schools/[school_id]/page.tsx");
+    expect(school).toContain("${name} Common Data Set");
+    expect(school).not.toMatch(/\(CDS\) Archive/);
+    expect(school).not.toMatch(/extracted by collegedata/);
+    expect(school).not.toMatch(/1,105-field schema/);
+    expect(school).toContain("directoryOnlyLead");
+
+    const year = src("app/schools/[school_id]/[year]/page.tsx");
+    expect(year).toContain("The numbers, as published");
+    expect(year).not.toMatch(/All extracted fields/);
+    expect(year).not.toMatch(/Structured data coming soon/);
+    expect(year).not.toMatch(/plus extracted admissions/);
+  });
+
+  it("rewrites Match and Coverage in product voice", () => {
+    const match = src("app/match/page.tsx");
+    expect(match).toContain('title: "Match"');
+    expect(match).toContain("No student profile stored");
+    expect(match).toContain("school&apos;s own numbers");
+    expect(match).toContain("Enter scores and GPA");
+    expect(match).not.toMatch(/source-backed/);
+    expect(match).not.toMatch(/corpus/);
+
+    const coverage = src("app/coverage/page.tsx");
+    expect(coverage).toContain('title: "Coverage"');
+    expect(coverage).toContain("takes federal student aid");
+    expect(coverage).toContain("haven&rsquo;t checked this");
+    expect(coverage).toContain("Federal numbers stay labeled as federal");
+    expect(coverage).not.toMatch(/Title-IV institution in the/);
+    expect(coverage).not.toMatch(/resolver has not scanned/);
+    expect(coverage).not.toMatch(/labeled separately so readers can tell/);
+    expect(coverage).not.toMatch(/resolver's last attempt/);
+  });
+});

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -51,9 +51,9 @@ test("coverage page renders filterable accountability data", async ({ page }) =>
 test("browser loads live rows and source links resolve", async ({ page, request }) => {
   await page.goto("/browse");
   await expect(
-    page.getByRole("heading", { name: /Queryable school browser/i }),
+    page.getByRole("heading", { name: /Compare schools/i }),
   ).toBeVisible();
-  await expect(page.getByText("Browser query failed")).toHaveCount(0);
+  await expect(page.getByText("Couldn't load")).toHaveCount(0);
   await expect(page.getByText(/Showing 1-/)).toBeVisible();
 
   const source = page.locator('[data-testid="browser-source-link"]:visible').first();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Wave 2 product-surface copy, signed after Fable review and now in the pages.

- Compare (`/browse`): Compare schools, *side by side.* Reports / Facts labels. No browser/primary/queryable.
- Schools directory: serif H1, Coverage pointer, empty state to site search, restyle off gray/blue.
- School page: `{name} Common Data Set` title; H1 is the school name; lead names CDS once. Directory-only tells the truth in two states.
- Year page: `{name} Common Data Set {year}` title; **The numbers, as published**; honest empty state.
- Match: school’s own numbers, scores stay on this device.
- Coverage: no Title-IV in the lede (kept in Methodology), no resolver.

Copy deck: `docs/copy/wave-2-product-surfaces.md`
Fable review: `docs/copy/wave-2-fable-review.md`

[Compare page](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_compare.webp)
[Schools empty state](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_schools_empty.webp)
[Rice school page](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_rice.webp)
[Bowdoin year page](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_bowdoin_year.webp)
[Match](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_match.webp)
[Coverage](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_coverage.webp)
[wave2_product_copy_pages.mp4](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave2_product_copy_pages.mp4)

## Testing

- Vitest: 383 passed, including archive-lead snapshots and Wave 2 copy guards
- Browser walkthrough of Compare, Schools (empty search), Rice, Bowdoin 2024-25, Match, Coverage
- CI green on head

## Locked from Wave 1

Compare (not Browser). No takedown advertising. Accuracy = as the school published it. Federal fallback stays. Common Data Set in school/year SEO.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

