### PR TITLE
Ship Wave 4 methodology and API copy

### DIFF
--- a/docs/copy/wave-4-fable-review.md
+++ b/docs/copy/wave-4-fable-review.md
@@ -1,0 +1,456 @@
+# Wave 4 Fable review
+
+Verdict: **ship with patches**
+
+Patches applied to `wave-4-methodology-api.md` 2026-08-27 (must-fixes 1–7
+and should-fixes 1–8; nits 1–4 applied because they were one-line).
+Independently checked against live TSX and the public API: Bowdoin 2025-26
+SAT 1470/1510/1540, 34.76% submit; `school_merit_profile` 335 of 488 with
+H.2A02 (68.6%) vs the deck’s May 2026 244 of 365; three live “v1”s, not
+one; `/api` leftover chrome is gray, not blue. No school-card TSX this
+wave. The PositioningCard caption “% OF ADMITS SUBMITTED” is logged for a
+later card-copy pass.
+
+Independently checked against live TSX and the live API (2026-08-27). The
+deck's premise holds: the three school-card `.meta` kickers are
+"§ Academic profile," "§ Admission rounds," "§ Merit and need aid," the
+index card titles already match them, and the live detail H1s are still
+"Academic positioning" / "Admission strategy" / "Merit profile" — the
+realignment is real work, correctly aimed. Every "Now" line I checked is
+accurate except two ("blue" on `/api`, and the deck sees only one of the
+three live "v1"s). Live-API checks: Bowdoin 2025-26 verifies exactly
+(SAT 1470/1510/1540, 34.76% submit); `school_browser_rows` has 697 rows;
+`school_merit_profile` has 488 rows with H.2A02 present on 335 (68.6%) —
+verified against the API, not the paragraph. The deck's 244 of 365
+(66.8%) matches only the May 3, 2026 audit note in
+`docs/plans/prd-018-section-h-audit.md`. No TSX in this review.
+
+The structure survives: kickers become H1s, changelog and pipeline lore
+die, metadata moves with the prose. But the deck ships the wrong
+population for C.9 three times on the page whose only job is the trail,
+hardcodes a coverage fraction that is stale on arrival — against its own
+written instruction — welds that fraction to a share rule computed from
+different fields, and, one wave after being burned for it, again leaves
+writer guidance inside a replacement string. Fix the strings; the
+architecture is right.
+
+Read as: counselor off a METHOD link, then IR, then an analyst pointing
+an LLM at `/api`. Locks honored — no parent gloss demanded, no card or
+chart redesign, no new docs layout, API parameters kept as code.
+
+---
+
+## Must-fix
+
+### 1. "Admitted-class bands" — C.9 describes the enrolled class, and the page knows it
+
+Quoted (deck, three separate strings): index card body "Where a student's
+SAT or ACT lands in the published admitted-class bands."; positioning
+description "…a school's published Common Data Set admitted-class bands.";
+positioning lede "Where a student's SAT or ACT would land in the
+admitted-class numbers the school published."
+
+Failure: C.9 reports score bands and submit rates for **enrolled**
+first-time, first-year students — the entering class, not the admitted
+pool. Verified against the canonical schema (C.9 cohort: first-time,
+first-year; "Percent Submitting SAT Scores") and against the page's own
+worked example, which says "34.76% of **enrolled** first-year students
+submitting SAT scores" three lines below a lede that says "admitted-class."
+This is not a labeling nit: admitted-pool bands run higher than
+enrolled-class bands because of yield melt, so the error changes what the
+number means for the exact task the card performs — a student measuring a
+score against a bar. The live page already has the disease ("admitted-class
+numbers," C.8's "all admitted students," and the self-contradicting "only a
+minority of enrolled students submitted… the range describes submitters,
+not the full admitted class"). The deck retitles the page and walks past
+it. Its own read-aloud check — "I know which CDS fields built the card" —
+fails when the counselor learns the field and misreads its population. The
+deck's audience note even names "C.9 submitter-only" as earned jargon; it
+caught the submitter caveat and missed the bigger one standing next to it.
+
+Replacements:
+
+Index card body:
+
+> Where a student's SAT or ACT lands in the score bands the school
+> published for enrolled first-years. Not a chance-me.
+
+Positioning description:
+
+> How collegedata.fyi compares a student's scores to a school's published
+> Common Data Set score bands for enrolled first-years. Not a chance-me.
+
+Positioning lede:
+
+> Where a student's SAT or ACT would land in the numbers the school
+> published for its enrolled first-years — the entering class, not the
+> admitted pool. It is not a chance-me, and it does not predict an
+> admissions decision.
+
+Kept C.8 note, patched in place: "whether score bands describe all
+enrolled first-years or only the subset who submitted scores."
+
+Kept "Why this isn't a chance-me," patched in place: "A position compares
+a student's numbers with the bands the school published for enrolled
+first-years." and "That means the range describes submitters, not the
+full entering class."
+
+Logged, out of this wave: the school-page `PositioningCard` caption reads
+"% OF ADMITS SUBMITTED SAT SCORES" — the same error, on the card the
+counselor came from. Cards are locked this wave; put the caption on the
+next card-copy worklist. Do not ship a methodology page that canonizes
+the caption's mistake in the meantime.
+
+### 2. The merit coverage sentence — stale on arrival, and it counts one field while describing another
+
+Quoted (deck, proposed): "H.2A02 is present for 244 of 365 latest 2024-25+
+primary rows (66.8%). When either field is absent, or the denominator is
+zero, the share is left blank."
+
+Failure: three problems in two sentences. (a) **Stale.** 244 of 365 is
+the May 3, 2026 audit figure. The live `school_merit_profile` view today
+has 488 rows, 335 with H.2A02 present — 68.6% — verified against the
+public API with an exact count, not against any paragraph. The deck's own
+caveat says "If those counts have drifted, use the live view count…
+do not hardcode a stale fraction without checking," and then hardcodes
+May's fraction without checking. (b) **Conflation.** H.2A02 is the
+*average dollar amount* of non-need aid; the blank-share rule the second
+sentence describes is computed from H.2A01 (recipient count) divided by
+H.201 (verified in the `school_merit_profile` migration). Welded into one
+breath, "either field" grammatically points back at H.2A02, which is not
+in the share formula. The one audience this page is for will notice.
+(c) **Duplication.** The share-blank sentence already exists on the page,
+verbatim and attached to the correct fields, in "What H2A does and does
+not mean." Pasting the deck's replacement ships it twice.
+
+Replacement (Missing data policy, final sentence):
+
+> The average no-need grant (H.2A02) is currently reported for 335 of 488
+> schools in the merit view (69%).
+
+Prefer computing both counts live from the view — the API page already
+interpolates its row counts from site stats; same pattern, and it is the
+only durable fix for a number that has now gone stale once. If it must be
+hardcoded, date it. Do not restate the share rule here; it already lives
+in the H2A section.
+
+### 3. The deck bans "v1" and then instructs the implementer to keep two of them
+
+Quoted (deck, ban list): "Ban in prose: … 'v1.'" Quoted (deck,
+positioning): "Replace 'v1 does not score' with 'This card does not
+score.'" Quoted (deck, admission rounds): "Keep: … 'Read ED rates
+carefully'".
+
+Failure: the live pages contain three "v1"s and the deck sees one. The
+positioning C.12 note says "v1 displays the school average beside your
+entered GPA" — untouched by the deck's single replacement. The
+admission-strategy "Read ED rates carefully" section — which the deck
+says to keep — says "We do not estimate a general-pool ED rate in v1
+because CDS does not separate those applicant groups." Both keep
+instructions ship a banned token.
+
+Replacement (C.12): "The card displays the school average beside the
+student's entered GPA; GPA never contributes to academic fit because
+weighted and unweighted scales are not consistently documented."
+
+Replacement (admission rounds): "We do not estimate a general-pool ED
+rate because CDS does not separate those applicant groups."
+
+### 4. The retitled Compare example still opens with "The browser"
+
+Quoted (deck): "'Search the curated school browser' → 'Search
+latest-per-school rows (Compare)'". Quoted (live, unaddressed): "The
+browser uses an Edge Function so latest-per-school ranking can account
+for required fields and null answerability."
+
+Failure: "Browser" is on the deck's own ban list and VOICE fixed the
+public name as Compare. The deck sands the heading and leaves the banned
+name as the first word of the first sentence underneath it. The analyst
+reads the heading, then the sentence, and now has two names for one thing
+— the exact confusion the rename exists to end.
+
+Replacement:
+
+> Compare's latest-per-school ranking runs through an Edge Function so it
+> can account for required fields and null answerability. Percent and
+> rate values are stored as fractions from 0 to 1.
+
+### 5. "Fetch field values for a document" — the curl underneath fetches artifact notes
+
+Quoted (deck): "'Fetch extracted field values for a document' → 'Fetch
+field values for a document'" and the replacement paragraph ending
+"Deterministic values win conflicts."
+
+Failure: the example under that heading is
+`cds_artifacts?document_id=eq.<uuid>&kind=eq.canonical&select=notes` — it
+returns artifact notes, not field values. The old heading was dishonest
+with the Docling context; the new one is dishonest without it. And once
+the LLM-fallback sentence is cut, "Deterministic values win conflicts"
+dangles — deterministic as opposed to *what*? The referent was amputated
+in the same edit; what remains is pipeline lore the reader can no longer
+decode. The deck declared heading-versus-example honesty in scope and
+then created a fresh mismatch.
+
+Replacement heading: "Fetch the canonical artifact for a document."
+
+Replacement paragraph:
+
+> Prefer `cds_fields` for field-level queries. If you need the underlying
+> artifact, fetch `kind=eq.canonical` on `cds_artifacts` — the canonical
+> artifact is the one the site serves.
+
+### 6. Writer guidance inside a replacement string, again
+
+Quoted (deck, resource blurbs): "`school_browser_rows`: Curated serving
+layer for Compare, CSV, and the academic-profile / admission-rounds
+cards. Do not say 'website browser.'"
+
+Failure: "Do not say 'website browser.'" is an instruction to the writer
+sitting inside copy an implementer will paste — the identical failure
+shape as Wave 3 must-fix 1 ("Counselors second."). Every other bullet in
+this list is pure page copy; this one ends in a style memo.
+
+Replacement: end the blurb at "cards." Move the prohibition into the
+deck's ban list where it belongs. (This blurb also silently deletes the
+page's live counts — see Should-fix 4.)
+
+### 7. The missing-value sentence enumerates three causes and omits the most common one
+
+Quoted (deck, proposed): "A missing value is usually one of three things:
+the school has no public CDS, the field is not in the friendly
+dictionary, or the row failed a sanity check and was withheld."
+
+Failure: the most common cause is none of the three — the school filed a
+CDS and left the field blank. The merit methodology page documents this
+at corpus scale: roughly a third of schools in the merit view have a
+filing with no H.2A02 (335 of 488 report it; verified live). An analyst's
+first null will usually be this fourth case, and a sentence that
+enumerates three and hedges with "usually" teaches them to distrust the
+enumeration — on the troubleshooting step, where trust is the product.
+
+Replacement:
+
+> A missing value is usually one of four things: the school has no public
+> CDS, the school's filing leaves the field blank, the field is not in
+> the friendly dictionary, or the row failed a sanity check and was
+> withheld. The sources endpoint shows the document and the federal
+> release behind the page.
+
+---
+
+## Should-fix
+
+### 1. Second person survives the sections the deck keeps
+
+Quoted (live, kept wholesale): "A position compares your numbers with
+published admitted-class bands."
+
+Failure: the deck's own rationale for rewriting the lede is "'Your
+scores' addresses a parent; this page is the trail" — then it keeps "Why
+this isn't a chance-me" untouched, with "your numbers" in the first line
+(and "your entered GPA" in C.12, fixed en passant by must-fix 3). Half a
+pronoun purge reads worse than none.
+
+Replacement: covered by the must-fix 1 patch ("A position compares a
+student's numbers with the bands the school published for enrolled
+first-years.").
+
+### 2. Admission-rounds Sources: "drop PRD 016B and Phase 0" with no replacement strings
+
+Quoted (deck): "Sources — drop PRD 016B and Phase 0. Same serving table,
+same curl."
+
+Failure: the live section is two compound sentences where the condemned
+clauses are structural halves ("…; PRD 016B adds columns to that
+resource, not a new API endpoint." and "Phase 0 measurement results are
+preserved in the repository's PRD findings note; the API page documents
+the public columns exposed by this card."). "Drop X" with no strings is
+how Wave 3 should-fix 8 happened — the implementer improvises and the
+deck stops being checkable.
+
+Replacement:
+
+> Every school card links the archived CDS for the displayed year. The
+> serving table is `school_browser_rows`, documented on the API page.
+
+Both live sentences die; the "public columns" clause is covered by
+"documented on the API page."
+
+### 3. The proposed API lede loses the base URL and the PostgREST link
+
+Quoted (deck, proposed lede): "Two ways in: simple no-auth JSON for
+agents and scripts, and the full PostgREST archive for bulk work."
+
+Failure: the live lede introduces `api.collegedata.fyi` in a code chip
+and links the PostgREST docs. The proposal drops both; the base URL's
+next appearance is buried inside resource-card URLs. For the analyst and
+the LLM alike, the base URL is the single most load-bearing string on the
+page — it belongs in sentence one.
+
+Replacement: "…and the full PostgREST archive at `api.collegedata.fyi`
+for bulk work." — keeping the PostgREST link on the word.
+
+### 4. The blurb rewrites delete the page's live counts
+
+Quoted (live `cds_fields` blurb): "{formatCount(stats.queryable_field_count)}
+normalized field rows…" Quoted (live `school_browser_rows` blurb): "{n}
+primary 2024-25+ rows across {k} schools, refreshed {date}."
+
+Failure: the deck's replacement blurbs are static prose; the live ones
+interpolate counts and a refresh date from site stats. Those
+interpolations are the page's best honesty device — the exact anti-stale
+mechanism must-fix 2 has to retrofit onto the merit page — and the deck
+deletes them without comment.
+
+Replacement (`cds_fields`): "{count} normalized field rows from 2024-25
+and newer filings. Derived metrics such as `acceptance_rate` live on
+`school_browser_rows`." Replacement (`school_browser_rows`): "{n} primary
+2024-25+ rows across {k} schools, refreshed {date}. The curated serving
+layer behind Compare, CSV export, and the academic-profile and
+admission-rounds cards."
+
+### 5. "Pin a snapshot" over three `latest` curls
+
+Quoted (deck): "4. Use snapshots for local work → 4. Pin a snapshot"
+
+Failure: every example under the new heading fetches the `latest` alias —
+the heading commands the one thing no example shows. Curl changes are
+explicitly legal where the heading is dishonest.
+
+Replacement: keep the heading and add one pinned line to the block:
+`curl 'https://www.collegedata.fyi/snapshots/<snapshot-id>/schools.jsonl'`
+(the manifest names the id).
+
+### 6. Two "start here"s
+
+Quoted (live, kept): "Start here for MCP tools, CLIs, notebooks, and
+quick integrations." Quoted (deck): "H2 Runbook → Start here"
+
+Failure: the Simple-endpoints intro opens with "Start here…" and the H2
+two sections later is now titled "Start here." A skimming reader is told
+to start in two places.
+
+Replacement (intro sentence): "The friendly surface for MCP tools, CLIs,
+notebooks, and quick integrations."
+
+### 7. The detail titles lose the word "methodology" entirely
+
+Quoted (deck): "Title: Academic profile" (and "Admission rounds," "Merit
+and need aid").
+
+Failure: the root layout templates titles as `%s | collegedata.fyi`, so
+the proposed strings render as "Academic profile | collegedata.fyi" — in
+a search snippet, indistinguishable from the school-page card it
+documents, and stripped of the one word professionals actually search.
+The H1 is the kicker's job; the title tag can carry both.
+
+Replacement titles: "Academic profile methodology," "Admission rounds
+methodology," "Merit and need aid methodology."
+
+### 8. Merit description drops the federal label
+
+Quoted (deck, proposed): "…with College Scorecard net-price and outcome
+context."
+
+Failure: federal numbers stay labeled federal is a Wave 1 lock, and
+metadata is where search meets the page. The on-page lede keeps "federal
+College Scorecard"; the description should not be the one surface that
+lets Scorecard pass unlabeled.
+
+Replacement: "…with federal College Scorecard net-price and outcome
+context."
+
+---
+
+## Nit
+
+### 1. "If a future card uses" — roadmap voice in kept copy
+
+Quoted (live, kept): "If a future card uses a CDS year more than three
+years old, the scoring result carries a stale-data caveat."
+
+Replacement: "If the newest archived CDS for a school is more than three
+years old, the card carries a stale-data caveat."
+
+### 2. There is no blue on `/api`
+
+Quoted (deck): "restyle `/api` off gray/blue Tailwind onto paper/ink
+tokens."
+
+Failure: the live links already use `--forest`; the leftover chrome is
+gray. The restyle work is real; the diagnosis should be accurate so the
+implementer isn't hunting for blue that isn't there.
+
+### 3. The second live stat dies silently
+
+Quoted (live, unmentioned in the proposal): "effective first-year merit
+answerability was 252 of 365 (69.0%)."
+
+Failure: dropping it is a defensible simplification; not saying so reads
+as oversight. One deck line: "The effective-answerability stat goes too."
+
+### 4. The italic device lands on an acronym
+
+Quoted (deck): "H1: The public *API.*"
+
+Failure: every other Wave 4 H1 italicizes a lowercase noun ("built,"
+"profile," "rounds," "aid"); italicizing a three-letter all-caps acronym
+in the serif face is typographic noise, not emphasis.
+
+Replacement: "The public API." — roman throughout, or italicize
+"public."
+
+---
+
+## What holds
+
+- The spine of the wave: all three H1-to-kicker realignments, verified
+  against the live components. The counselor who leaves "§ Admission
+  rounds" now lands on "Admission rounds." That was the brief, and it's
+  right.
+- Metadata proposed in the same change for every page whose prose changes
+  — the Wave 3 must-fix 7 lesson, learned and applied.
+- The API description fix: "Common Data Set filings and federal data" is
+  the right-size umbrella for the two-of-three source conflation the
+  deck correctly caught in the live meta.
+- The kill list: "now exposes," "Runbook," "projected," "V1 friendly
+  dictionary," "extraction results," the Docling paragraph, PRD 016 /
+  016B / Phase 0. This is the layer discipline the wave exists for.
+- Keeping the Bowdoin worked example — verified accurate against the live
+  API (2025-26; 1470/1510/1540; 34.76% submitting). The one hardcoded
+  worked example on these pages is the one that's still true.
+- "Which rates CDS will not support" in the admission-rounds description;
+  the C.22 EA honesty; "we take no legal position on ED"; NBER as
+  methodological context and D'Amico as a pointer, not a finding.
+- Merit lede kept, and "What H2A does and does not mean" kept — the
+  understates-mixed-packages caveat is the most valuable sentence on the
+  page.
+- `.eq("extraction_status", "extracted")` and query parameters kept as
+  code; field lists keep `extracted_at` / `extraction_status`.
+- Restyle scope: tokens only, forest links, catalog untouched, no new
+  docs layout.
+
+## Do not reopen
+
+- Gloss-first homepage; named sources on About.
+- `/browse` is Compare; API stays in the header.
+- No takedown advertising.
+- "As the school published it"; we never imply we verified the school's
+  math.
+- Federal numbers stay labeled federal.
+- Common Data Set in school/year SEO.
+- Recipes are IR-first (Wave 3, shipped).
+- Analytical jargon that earns the point stays; extractor war stories
+  stay banned on these pages. Field IDs and table names are allowed at
+  this layer; API parameters are code.
+- Harvey Mudd / Docling: `docs/known-issues/` and a methodology
+  *appendix* only. The `/api` Docling cut is correct — don't relitigate
+  it into an appendix demand.
+- No parent gloss on methodology or `/api`.
+- School cards and charts ship as-is this wave. The `PositioningCard`
+  caption ("% OF ADMITS SUBMITTED") is logged under must-fix 1 for a
+  future card-copy pass, not smuggled into this one.
+- URL slugs stay `/methodology/positioning` and
+  `/methodology/admission-strategy` even though the H1s change; slug
+  churn is not copy.
+- Discover stays out.

--- a/docs/copy/wave-4-methodology-api.md
+++ b/docs/copy/wave-4-methodology-api.md
@@ -1,0 +1,400 @@
+# Wave 4 copy deck — Methodology and API
+
+Read this as a counselor who clicked METHOD on a school card, then as IR,
+then as someone pointing an LLM at `/api`. Do not review it as a React
+diff. Waves 1–3 are on `main`. This wave wraps the public-voice project.
+
+**Audience.** Methodology and `/api` are the professional layer: counselors
+who want the trail, IR, researchers, developers. Parents using an LLM are
+welcome on `/api`; they are not the methodology H1. Jargon is fine when it
+names the method (ED residual, H2A, C.9 submitter-only). Extractor war
+stories are not (Docling, AcroForm, drain, “extracted,” Tier 4, how we
+parsed the PDF). Field IDs and table names belong here.
+
+Locked from Waves 1–3 (do not reopen): gloss-first homepage; `/browse` is
+Compare; API in the header; no takedown advertising; “as the school
+published it”; Common Data Set in school/year SEO; Recipes are IR-first;
+Harvey Mudd / Docling stays in `docs/known-issues/` (and may appear in a
+methodology *appendix*, not in card-method prose).
+
+Fable review 2026-08-27: **ship with patches.** Must-fixes and should-fixes
+are applied below. Full write-up:
+[`wave-4-fable-review.md`](wave-4-fable-review.md). Anthony asked to wrap
+the voice project; this deck is the implementable source.
+
+Logged for a later card-copy pass (not this wave): `PositioningCard`
+caption “% OF ADMITS SUBMITTED SAT SCORES” — C.9 is enrolled first-years,
+not admits.
+
+**Not in this deck:** Discover (soft-launch, unindexed). School-card
+redesign. Chart redesign. Changing curl examples except where the heading
+or surrounding sentence is dishonest. API query parameters
+(`extraction_status=eq.extracted`) are code and stay. Do not invent a new
+docs layout.
+
+---
+
+## What these pages are
+
+Methodology: the trail behind three school-page cards. One question per
+page — what the card uses, what it does not, what the number is not.
+
+API: two public surfaces (no-auth JSON for agents; PostgREST for bulk).
+Same archive the site uses. Cite the source next to the number.
+
+Ban in prose: extracted, extractor, Docling, AcroForm, drain, projection
+(the pipeline kind), Browser, “website browser,” runbook, “now exposes,”
+PRD numbers, “v1.”
+
+Keep: field IDs, table names, anon key, PostgREST, `ipeds_id`, release
+type, provisional vs final, H2A, ED residual, submitter-only.
+
+---
+
+## Methodology index (`/methodology`)
+
+**Primary:** counselors off a METHOD link. Secondary: IR.
+
+### Now
+
+- Title: Methodology
+- Description: “How collegedata.fyi turns Common Data Set source documents
+  into academic profile, admission strategy, and merit profile cards.”
+- H1: How the cards are built.
+- Lede: source fields, derivations, caveats; starts from archived CDS.
+- Cards: Academic profile / Admission rounds / Merit and need aid
+- Detail H1s do not match the cards (Academic *positioning* vs Academic
+  *profile*)
+
+### Proposed
+
+**Meta**
+
+- Title: Methodology
+- Description: How the school-page cards read Common Data Set filings —
+  academic profile, admission rounds, merit and need aid. What they use,
+  what they skip, what they do not predict.
+
+**H1:** How the cards are *built.* (keep the sentence; italic the verb)
+
+**Lede** (italic serif, 18/1.55):
+
+> The trail behind the school-page cards. Each note names the CDS fields,
+> the derivation, and the caveat. Nothing here predicts an admissions
+> decision or a financial-aid package.
+
+**Cards** — titles stay (they match the school-page `.meta` kickers).
+Bodies name the method, not the pipeline:
+
+| Card | Body |
+|---|---|
+| Academic profile | Where a student’s SAT or ACT lands in the score bands the school published for enrolled first-years. Not a chance-me. |
+| Admission rounds | ED, EA, wait-list, and yield from Section C — including what CDS will not let you compute. |
+| Merit and need aid | What the school reported in Section H, plus federal net-price and outcome context. Not a package estimate. |
+
+---
+
+## Academic profile (`/methodology/positioning`)
+
+**Primary:** counselor who clicked METHOD on Academic profile.
+
+### Now
+
+- Title: Academic Positioning Methodology
+- H1: Academic positioning
+- Lede: “This page shows where your scores would land…”
+- Field notes say “v1 does not score rank”
+- Sources: `school_browser_rows`; “PRD 016 does not add a new API resource”
+
+The H1 does not match the card the counselor left. “Your scores” addresses
+a parent; this page is the trail. “v1” and “PRD 016” are operator.
+
+### Proposed
+
+**Title:** Academic profile methodology
+
+**Description:** How collegedata.fyi compares a student’s scores to a
+school’s published Common Data Set score bands for enrolled first-years.
+Not a chance-me.
+
+**H1:** Academic *profile.*
+
+**Lede:**
+
+> Where a student’s SAT or ACT would land in the numbers the school
+> published for its enrolled first-years — the entering class, not the
+> admitted pool. It is not a chance-me, and it does not predict an
+> admissions decision.
+
+Keep the C.7–C.12 / C.1 / C.2 field notes. They *are* the method.
+
+C.8 (patched): whether score bands describe all enrolled first-years or
+only the subset who submitted scores.
+
+C.11: “This card does not score rank…”
+
+C.12:
+
+> The card displays the school average beside the student’s entered GPA;
+> GPA never contributes to academic fit because weighted and unweighted
+> scales are not consistently documented.
+
+**Why this isn’t a chance-me** (patched):
+
+> A position compares a student’s numbers with the bands the school
+> published for enrolled first-years.
+
+and
+
+> That means the range describes submitters, not the full entering class.
+
+Stale-data (drop roadmap voice):
+
+> If the newest archived CDS for a school is more than three years old,
+> the card carries a stale-data caveat.
+
+**Sources:**
+
+> Every card links the archived CDS for that school year. The serving
+> table is `school_browser_rows`, documented on the API page.
+
+---
+
+## Admission rounds (`/methodology/admission-strategy`)
+
+**Primary:** same counselor, plus IR checking ED math.
+
+### Now
+
+- Title: Admission Strategy Methodology
+- H1: Admission strategy (card kicker is Admission rounds)
+- Lede is already professional. Keep the spine.
+- “PRD 016B adds columns”; “Phase 0 measurement results are preserved in
+  the repository’s PRD findings note”
+
+### Proposed
+
+**Title:** Admission rounds methodology
+
+**Description:** How collegedata.fyi reads Early Decision, Early Action,
+yield, wait-list, and admission-factor context from Common Data Set
+Section C — and which rates CDS will not support.
+
+**H1:** Admission *rounds.*
+
+**Lede:** keep, one tightness pass:
+
+> The headline admit rate in most college guides averages across rounds.
+> This note says what Section C actually publishes, what we derive, and
+> what those numbers do not prove.
+
+Keep: C.1 / C.21 / C.22 / C.2 / C.7 / C.13; “Why non-early residual”;
+“Read ED rates carefully” with no “v1”:
+
+> We do not estimate a general-pool ED rate because CDS does not
+> separate those applicant groups.
+
+NBER as methodological context (not school-level data); wait-list
+year-to-year noise; “we take no legal position on ED.”
+
+**Sources:**
+
+> Every school card links the archived CDS for the displayed year. The
+> serving table is `school_browser_rows`, documented on the API page.
+
+The D’Amico docket can stay as a pointer for readers who want legal
+context. Do not write it as a finding. If it crowds the method, move it
+below Sources.
+
+---
+
+## Merit and need aid (`/methodology/merit-profile`)
+
+**Primary:** counselor plus IR. Federal numbers stay labeled federal.
+
+### Now
+
+- Title: Merit Profile Methodology
+- H1: Merit profile (card kicker is Merit and need aid)
+- Lede is already the right claim: what the school awarded, not a package.
+- Missing-data paragraph: “After the May 3, 2026 Tier 4 redrain, direct
+  H.2A02 answerability was 244 of 365 latest primary 2024+ schools
+  (66.8%)…”
+
+That coverage count is useful. The redrain is a pipeline story. VOICE
+allows Harvey Mudd / Docling in a methodology *appendix*, not in the
+card-method body.
+
+### Proposed
+
+**Title:** Merit and need aid methodology
+
+**Description:** How collegedata.fyi reads merit-aid and need-aid from
+Common Data Set Section H, with federal College Scorecard net-price and
+outcome context. Not a personalized price estimate.
+
+**H1:** Merit and need *aid.*
+
+**Lede:** keep.
+
+Keep H.2 / H.2A / H.6 / H.14 / Scorecard notes. Keep “What H2A does and
+does not mean” (understates mixed packages). Keep “Missing data policy”:
+missing stays missing; no imputation from peers or marketing copy.
+
+**Coverage sentence** (drop the redrain and the effective-answerability
+stat). Date the live-API count (2026-08-27: 335 of 488, 69%). Do not
+restate the H.2A01/H.201 share-blank rule — it already lives in “What
+H2A does and does not mean.”
+
+> The average no-need grant (H.2A02) is currently reported for 335 of 488
+> schools in the merit view (69%).
+
+**Sources** — keep `school_merit_profile` and the curl. Scorecard is
+federal context joined by IPEDS UNITID; say that once.
+
+---
+
+## API (`/api`)
+
+**Primary:** researchers, IR, developers. Secondary: parents pointing an
+LLM at a public endpoint (why API stays in the header).
+
+### Now
+
+- Title: API
+- Description: “Public REST API for the collegedata.fyi Common Data Set
+  archive and source-labeled NCES/IPEDS federal baseline facts.”
+  (Scorecard is used; the description names two of three sources.)
+- H1: API, `font-bold text-gray-900` — leftover SaaS chrome
+- Lede: “CollegeData.FYI now exposes two public surfaces…”
+- H2: Runbook (smoke-test, CLI, MCP, snapshots, troubleshoot)
+- Troubleshoot: “the projected value failed a sanity check”
+- Example: “Search the curated school browser”
+- Example: “Fetch extracted field values for a document” plus “For Tier 4
+  Docling extracts, the LLM fallback cleaned row…”
+- Resource blurbs: “extraction results,” “website browser”
+- Page is gray-50 / gray-900 / gray-800. Design system: no blue; cards
+  are paper, not Tailwind white/gray.
+
+Code samples and the resource catalog stay. This wave is the sentences
+around them, plus restyle onto tokens.
+
+### Proposed
+
+**Title:** API
+
+**Description:** Public API for Common Data Set filings and federal data —
+no-auth JSON for agents, and the full PostgREST archive. Same sources the
+site uses.
+
+**H1:** The *public* API.
+
+**Lede** (italic serif, 18/1.55):
+
+> Two ways in: simple no-auth JSON for agents and scripts, and the full
+> [PostgREST](https://postgrest.org/) archive at `api.collegedata.fyi`
+> for bulk work. Every page on this site is built from the endpoints
+> below. Keep the source label next to the number.
+
+Drop “now exposes.” This is not a changelog.
+
+Simple-endpoints intro (avoid a second “Start here”):
+
+> The friendly surface for MCP tools, CLIs, notebooks, and quick
+> integrations.
+
+**H2 Runbook → Start here**
+
+Keep the five steps. Relabel:
+
+| Now | Proposed |
+|---|---|
+| Runbook | Start here |
+| 1. Smoke-test the API | 1. Try search, facts, and compare |
+| 2. Run the CLI | 2. Run the CLI |
+| 3. Connect an MCP client | 3. Connect an MCP client |
+| 4. Use snapshots for local work | 4. Pin a snapshot |
+| 5. Troubleshoot source gaps | 5. When a value is missing |
+
+Under “Pin a snapshot,” keep the `latest` curls and add one pinned line
+(`<snapshot-id>` is in the manifest):
+
+`curl 'https://www.collegedata.fyi/snapshots/<snapshot-id>/schools.jsonl'`
+
+**Missing-value sentence:**
+
+> A missing value is usually one of four things: the school has no public
+> CDS, the school’s filing leaves the field blank, the field is not in
+> the friendly dictionary, or the row failed a sanity check and was
+> withheld. The sources endpoint shows the document and the federal
+> release behind the page.
+
+**Resource blurbs** (prose only; keep live interpolated counts; field
+lists stay, including `extracted_at` / `extraction_status`):
+
+- `cds_manifest`: One row per archived CDS document — school, year,
+  source URL, format, `extraction_status`. Carries `ipeds_id` so federal
+  joins are one query.
+- `cds_artifacts`: Raw artifacts keyed by document. Prefer `cds_fields`
+  for field-level queries.
+- `cds_fields`: `{count} normalized field rows from 2024-25 and newer
+  filings. Derived metrics such as acceptance_rate live on
+  school_browser_rows.`
+- `school_browser_rows`: `{n} primary 2024-25+ rows across {k} schools,
+  refreshed {date}. The curated serving layer behind Compare, CSV export,
+  and the academic-profile and admission-rounds cards.`
+
+**Examples to retitle**
+
+- “Search the curated school browser” → “Search latest-per-school rows
+  (Compare)”
+
+  Body:
+
+  > Compare’s latest-per-school ranking runs through an Edge Function so
+  > it can account for required fields and null answerability. Percent
+  > and rate values are stored as fractions from 0 to 1.
+
+- “Fetch extracted field values for a document” → “Fetch the canonical
+  artifact for a document”
+
+  Body:
+
+  > Prefer `cds_fields` for field-level queries. If you need the
+  > underlying artifact, fetch `kind=eq.canonical` on `cds_artifacts` —
+  > the canonical artifact is the one the site serves.
+
+Keep the JavaScript example’s `.eq("extraction_status", "extracted")` —
+that is the published filter name.
+
+Keep: anon-key auth, endowment draw-rate example (already honest),
+federal-baseline example, schema/licensing, GitHub issue footer.
+
+**Restyle:** leftover chrome is gray (`text-gray-900`, `bg-gray-50`), not
+blue — forest links already. Page wrapper, H1, lede, H2, code blocks,
+resource cards onto `--paper` / `--ink` / `--serif` / `--mono`. No
+`text-gray-900`. Do not redesign the catalog.
+
+---
+
+## Read-aloud checks
+
+- Counselor on methodology: “I know which CDS fields built the card, and
+  that it is not a prediction.”
+- IR on merit: “H2A understates mixed packages; missing stays missing;
+  Scorecard is federal.”
+- Analyst on `/api`: “Two surfaces, copy-paste queries, no pipeline
+  lore, table names I can use.”
+
+If the lede could be a changelog (“now exposes”) or a pipeline note
+(“Tier 4 redrain”), it isn’t done.
+
+---
+
+## Out of Wave 4
+
+Discover. School cards (including the PositioningCard admit-submit
+caption). Pipeline observation (operator). GitHub README. Do not add a
+fourth methodology page for extractors — `docs/known-issues/` already
+holds Harvey Mudd / Docling. Slugs stay `/methodology/positioning` and
+`/methodology/admission-strategy`.

--- a/web/VOICE.md
+++ b/web/VOICE.md
@@ -185,8 +185,6 @@ because of it.
 2. Anthony reads as a reader.
 3. Then implement in `web/`.
 4. Small PRs per wave. Wave 1 (front door) shipped 2026-08-27. Wave 2
-   product surfaces shipped 2026-08-27. Wave 3 Recipes (IR and data
-   analysts first) copy is locked in
-   [`docs/copy/wave-3-recipes.md`](../docs/copy/wave-3-recipes.md).
-
-Wave 4 (methodology, API) waits until Wave 3 lands.
+   product surfaces shipped 2026-08-27. Wave 3 Recipes shipped 2026-08-27.
+   Wave 4 (methodology, API) wraps the public-voice project. Deck:
+   [`docs/copy/wave-4-methodology-api.md`](../docs/copy/wave-4-methodology-api.md).

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -8,7 +8,7 @@ import { TrackedLink } from "@/components/TrackedLink";
 export const metadata: Metadata = {
   title: "API",
   description:
-    "Public REST API for the collegedata.fyi Common Data Set archive and source-labeled NCES/IPEDS federal baseline facts.",
+    "Public API for Common Data Set filings and federal data — no-auth JSON for agents, and the full PostgREST archive. Same sources the site uses.",
   alternates: { canonical: "/api" },
   openGraph: { url: "/api" },
 };
@@ -35,7 +35,7 @@ function CodeBlock({ children }: { children: string }) {
           }}
         />
       </div>
-      <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-gray-200 bg-gray-50 px-4 py-3 pr-16 text-xs leading-relaxed text-gray-800">
+      <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-[var(--rule)] bg-[var(--paper-2)] px-4 py-3 pr-16 text-xs leading-relaxed text-[var(--ink)]">
         <code>{children}</code>
       </pre>
     </div>
@@ -47,11 +47,24 @@ export default async function ApiDocsPage() {
   const scorecardVintage = stats.scorecard_data_year ?? "the current published Scorecard vintage";
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 text-gray-800">
-      <h1 className="text-3xl font-bold text-gray-900">API</h1>
-      <p className="mt-3 text-base leading-relaxed text-gray-600">
-        CollegeData.FYI now exposes two public surfaces: simple no-auth JSON
-        endpoints for agents and command-line tools, and the full read-only{" "}
+    <div className="mx-auto max-w-3xl px-4 py-12">
+      <div className="meta">§ API</div>
+      <h1
+        className="serif mt-3 leading-none"
+        style={{ fontSize: "clamp(40px, 6vw, 64px)" }}
+      >
+        The <span style={{ fontStyle: "italic" }}>public</span> API.
+      </h1>
+      <p
+        className="serif mt-5"
+        style={{
+          color: "var(--ink-2)",
+          fontSize: 18,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
+        Two ways in: simple no-auth JSON for agents and scripts, and the full{" "}
         <a
           className={API_LINK_CLASS}
           href="https://postgrest.org/"
@@ -60,19 +73,19 @@ export default async function ApiDocsPage() {
         >
           PostgREST
         </a>{" "}
-        API at{" "}
-        <code className="break-all rounded bg-gray-100 px-1.5 py-0.5 text-sm">{BASE}</code>
-        . Every page on this site is built from the same endpoints documented
-        below: archived Common Data Set documents, structured CDS fields,
-        source-labeled NCES/IPEDS baseline facts, and curated federal Scorecard
-        context.
+        archive at{" "}
+        <code className="break-all rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-sm not-italic">
+          {BASE}
+        </code>{" "}
+        for bulk work. Every page on this site is built from the endpoints
+        below. Keep the source label next to the number.
       </p>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         Simple endpoints
       </h2>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
-        Start here for MCP tools, CLIs, notebooks, and quick integrations. These
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
+        The friendly surface for MCP tools, CLIs, notebooks, and quick integrations. These
         endpoints do not require the Supabase anon key and return source labels
         next to facts so agents can cite values without guessing where they came
         from.
@@ -90,13 +103,13 @@ curl 'https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chi
 curl 'https://www.collegedata.fyi/api/fields'
 
 curl 'https://www.collegedata.fyi/openapi.json'`}</CodeBlock>
-      <p className="mt-4 text-sm leading-relaxed text-gray-700">
+      <p className="mt-4 text-sm leading-relaxed text-[var(--ink-2)]">
         The same simple endpoints from R, with no API key.{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">httr2</code>{" "}
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">httr2</code>{" "}
         and{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">jsonlite</code>{" "}
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">jsonlite</code>{" "}
         are enough. Send{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           X-CollegeData-Client
         </code>{" "}
         so we can tell research scripts apart from other traffic.
@@ -118,43 +131,43 @@ compare <- request("https://www.collegedata.fyi/api/compare") |>
   req_headers(\`X-CollegeData-Client\` = "r-httr2") |>
   req_perform() |>
   resp_body_json()`}</CodeBlock>
-      <p className="mt-3 text-sm leading-relaxed text-gray-700">
+      <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
         The per-school facts endpoint accepts the <code>finance</code> category
         for endowment facts. The fixed-schema compare endpoint does not: a
         compare request containing <code>finance</code> returns <code>400</code>
         instead of substituting unrelated fields. A categories filter with no
         recognized values also returns <code>400</code> on either endpoint.
       </p>
-      <p className="mt-3 text-sm leading-relaxed text-gray-700">
+      <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
         The minimal MCP server and CLI live in the repo under{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           packages/mcp-server
         </code>{" "}
         and{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           packages/cli
         </code>
         . Both wrap the simple endpoints rather than reimplementing query logic.
       </p>
-      <p className="mt-3 text-sm leading-relaxed text-gray-700">
+      <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
         If you build on these endpoints, send a short{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           X-CollegeData-Client
         </code>{" "}
         header such as{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           my-app-name
         </code>
         . It helps us understand API usage and keep the free public surface
         healthy without requiring API keys.
       </p>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
-        Runbook
+      <h2 className="serif mt-10 text-2xl">
+        Start here
       </h2>
-      <div className="mt-4 space-y-6 text-sm leading-relaxed text-gray-700">
+      <div className="mt-4 space-y-6 text-sm leading-relaxed text-[var(--ink-2)]">
         <section>
-          <h3 className="font-semibold text-gray-900">1. Smoke-test the API</h3>
+          <h3 className="serif text-lg">1. Try search, facts, and compare</h3>
           <p className="mt-1">
             Start with search, facts, and compare. If these three work, the
             friendly API surface is healthy enough for most agent and CLI use.
@@ -165,11 +178,11 @@ curl 'https://www.collegedata.fyi/api/compare?schools=mit,yale,university-of-chi
         </section>
 
         <section>
-          <h3 className="font-semibold text-gray-900">2. Run the CLI</h3>
+          <h3 className="serif text-lg">2. Run the CLI</h3>
           <p className="mt-1">
             From a checkout of the repo, the CLI can point at production,
             preview, or localhost with{" "}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
               COLLEGEDATA_API_BASE
             </code>
             .
@@ -180,7 +193,7 @@ COLLEGEDATA_API_BASE=https://www.collegedata.fyi node packages/cli/bin/collegeda
         </section>
 
         <section>
-          <h3 className="font-semibold text-gray-900">3. Connect an MCP client</h3>
+          <h3 className="serif text-lg">3. Connect an MCP client</h3>
           <p className="mt-1">
             The MCP server is read-only and uses the same friendly API. Configure
             a client to run the server command from the repository root.
@@ -199,27 +212,28 @@ COLLEGEDATA_API_BASE=https://www.collegedata.fyi node packages/cli/bin/collegeda
         </section>
 
         <section>
-          <h3 className="font-semibold text-gray-900">4. Use snapshots for local work</h3>
+          <h3 className="serif text-lg">4. Pin a snapshot</h3>
           <p className="mt-1">
             Use pinned snapshot paths for reproducible notebooks and the{" "}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
               latest
             </code>{" "}
-            alias for quick experiments.
+            alias for quick experiments. The manifest names the snapshot id.
           </p>
           <CodeBlock>{`curl 'https://www.collegedata.fyi/snapshots/latest/manifest.json'
 curl 'https://www.collegedata.fyi/snapshots/latest/schools.jsonl'
-curl 'https://www.collegedata.fyi/snapshots/latest/school_facts.jsonl'`}</CodeBlock>
+curl 'https://www.collegedata.fyi/snapshots/latest/school_facts.jsonl'
+curl 'https://www.collegedata.fyi/snapshots/<snapshot-id>/schools.jsonl'`}</CodeBlock>
         </section>
 
         <section>
-          <h3 className="font-semibold text-gray-900">5. Troubleshoot source gaps</h3>
+          <h3 className="serif text-lg">5. When a value is missing</h3>
           <p className="mt-1">
-            A missing value is usually one of three things: the school has no
-            public CDS, the field is not part of the V1 friendly dictionary, or
-            the source row is intentionally withheld because the projected value
-            failed a sanity check. The sources endpoint shows the document and
-            federal release context behind the page.
+            A missing value is usually one of four things: the school has no
+            public CDS, the school&apos;s filing leaves the field blank, the field
+            is not in the friendly dictionary, or the row failed a sanity check
+            and was withheld. The sources endpoint shows the document and the
+            federal release behind the page.
           </p>
           <CodeBlock>{`curl 'https://www.collegedata.fyi/api/schools/mit/sources'
 curl 'https://www.collegedata.fyi/api/fields?category=admissions'
@@ -227,16 +241,16 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         </section>
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         Raw PostgREST authentication
       </h2>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         All requests require a Supabase{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">anon</code>{" "}
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">anon</code>{" "}
         key passed as both an{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">apikey</code>{" "}
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">apikey</code>{" "}
         query parameter and an{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           Authorization
         </code>{" "}
         bearer header. The anon key is public and grants read-only access to
@@ -244,14 +258,14 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
       </p>
       <CodeBlock>{ANON_KEY}</CodeBlock>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         Resources
       </h2>
 
       <div className="mt-4 space-y-6">
         <Resource
           name="cds_manifest"
-          description="One row per archived CDS document. Joins schools, source URLs, format detection, and extraction status. Carries ipeds_id so federal-data joins are one query away."
+          description="One row per archived CDS document — school, year, source URL, format, extraction_status. Carries ipeds_id so federal joins are one query."
           fields={[
             "school_id",
             "school_name",
@@ -309,7 +323,7 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         />
         <Resource
           name="cds_artifacts"
-          description="Raw extraction artifacts keyed by document. Most consumers should prefer cds_fields for field-level queries or the selected-result helper semantics documented below."
+          description="Raw artifacts keyed by document. Prefer cds_fields for field-level queries."
           fields={[
             "document_id",
             "kind",
@@ -332,7 +346,7 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         />
         <Resource
           name="cds_fields"
-          description={`${formatCount(stats.queryable_field_count)} normalized field rows from selected 2024-25+ extraction results. Use this for direct canonical-field queries across schools; derived metrics such as acceptance_rate live in school_browser_rows/browser-search.`}
+          description={`${formatCount(stats.queryable_field_count)} normalized field rows from 2024-25 and newer filings. Derived metrics such as acceptance_rate live on school_browser_rows.`}
           fields={[
             "school_id",
             "school_name",
@@ -370,7 +384,7 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         />
         <Resource
           name="school_browser_rows"
-          description={`${formatCount(stats.browser_primary_row_count)} primary 2024-25+ rows across ${formatCount(stats.browser_school_count)} schools, refreshed ${formatShortDate(stats.browser_updated_at)}. This is the curated serving layer for the website browser, CSV exports, and the per-school academic positioning and admission strategy cards.`}
+          description={`${formatCount(stats.browser_primary_row_count)} primary 2024-25+ rows across ${formatCount(stats.browser_school_count)} schools, refreshed ${formatShortDate(stats.browser_updated_at)}. The curated serving layer behind Compare, CSV export, and the academic-profile and admission-rounds cards.`}
           fields={[
             "school_id",
             "school_name",
@@ -928,12 +942,12 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
         />
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">Examples</h2>
+      <h2 className="serif mt-10 text-2xl">Examples</h2>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         Fetch federal baseline facts for a no-CDS school
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Federal baseline facts come from <code>school_facts_unified</code>. Keep
         the release type, source table/variable, quality flag, and definition
         alignment visible if you reuse these values; they are NCES/IPEDS facts,
@@ -943,10 +957,10 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         Fetch a historical IPEDS time series
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Historical IPEDS queries are fastest when they use the public{" "}
         <code>ipeds_id</code> key, one or more <code>field_key</code> values, and
         a bounded <code>data_year</code> range. Avoid filtering raw{" "}
@@ -956,10 +970,10 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         Compute an endowment draw-rate series
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Finance Part H reports beginning and ending endowment values plus the
         components of change from fiscal year 2020 onward. A sign-normalized
         spending rate is <code>abs(F2H03C) / F2H01</code>. Keep the quality and
@@ -973,13 +987,13 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
-        Search the curated school browser
+      <h3 className="serif mt-6 text-lg">
+        Search latest-per-school rows (Compare)
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
-        The browser uses an Edge Function so latest-per-school ranking can account
-        for required fields and null answerability. Percent and rate values are
-        stored as fractions from <code>0</code> to <code>1</code>.
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
+        Compare&apos;s latest-per-school ranking runs through an Edge Function so it
+        can account for required fields and null answerability. Percent and
+        rate values are stored as fractions from <code>0</code> to <code>1</code>.
       </p>
       <CodeBlock>{`curl '${BASE}/functions/v1/browser-search' \\
   -H 'apikey: <anon key>' \\
@@ -987,11 +1001,11 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'content-type: application/json' \\
   --data '{"mode":"latest_per_school","variant_scope":"primary_only","min_year_start":2024,"filters":[{"field":"acceptance_rate","op":"<=","value":0.1}],"page_size":10}'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
-        Fetch academic positioning data for one school
+      <h3 className="serif mt-6 text-lg">
+        Fetch academic-profile data for one school
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
-        The academic positioning card reads the already-public{" "}
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
+        The academic-profile card reads the already-public{" "}
         <code>school_browser_rows</code> resource. SAT/ACT submit rates are stored
         as fractions, and the card links to{" "}
         <Link href="/methodology/positioning" className={API_LINK_CLASS}>
@@ -1003,11 +1017,11 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
-        Fetch admission strategy data for one school
+      <h3 className="serif mt-6 text-lg">
+        Fetch admission-rounds data for one school
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
-        Admission strategy fields are also served from{" "}
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
+        Admission-rounds fields are also served from{" "}
         <code>school_browser_rows</code>. ED counts are published when the CDS reports
         them; EA is limited to offered/restrictive flags because CDS C.22 does not
         include EA applicant or admit counts. The card methodology is documented at{" "}
@@ -1020,10 +1034,10 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         Fetch merit-aid context for one school
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Merit profile data comes from <code>school_merit_profile</code>, a latest
         primary CDS Section H view joined to Scorecard affordability and outcome
         fields. H2A non-need award values are source-reported institutional facts,
@@ -1037,42 +1051,37 @@ curl 'https://www.collegedata.fyi/llms.txt'`}</CodeBlock>
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         List the most recent year for every school
       </h3>
       <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?removed_at=is.null&select=school_id,school_name,canonical_year&order=canonical_year.desc&limit=10' \\
   -H 'apikey: ${ANON_KEY.slice(0, 24)}…' \\
   -H 'Authorization: Bearer ${ANON_KEY.slice(0, 24)}…'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
+      <h3 className="serif mt-6 text-lg">
         Fetch all archived years for one school
       </h3>
       <CodeBlock>{`curl '${BASE}/rest/v1/cds_manifest?school_id=eq.harvard-university&removed_at=is.null&select=canonical_year,source_format,extraction_status' \\
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h3 className="mt-6 text-base font-semibold text-gray-900">
-        Fetch extracted field values for a document
+      <h3 className="serif mt-6 text-lg">
+        Fetch the canonical artifact for a document
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
-        The selected extraction contract chooses the deterministic canonical
-        artifact first. For Tier 4 Docling extracts, the LLM fallback cleaned row
-        can fill gaps, but deterministic values win conflicts. Raw consumers can
-        reproduce that behavior by fetching <code>kind=eq.canonical</code> plus
-        rows with{" "}
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
-          producer=eq.tier4_llm_fallback
-        </code>{" "}
-        and overlaying the canonical values on top.
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
+        Prefer <code>cds_fields</code> for field-level queries. If you need the
+        underlying artifact, fetch <code>kind=eq.canonical</code> on{" "}
+        <code>cds_artifacts</code> — the canonical artifact is the one the site
+        serves.
       </p>
       <CodeBlock>{`curl '${BASE}/rest/v1/cds_artifacts?document_id=eq.<uuid>&kind=eq.canonical&select=notes' \\
   -H 'apikey: <anon key>' \\
   -H 'Authorization: Bearer <anon key>'`}</CodeBlock>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         JavaScript client
       </h2>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         The same{" "}
         <a
           className={API_LINK_CLASS}
@@ -1098,22 +1107,22 @@ const { data } = await supabase
   .is("removed_at", null)
   .limit(20);`}</CodeBlock>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         Source documents
       </h2>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Original CDS files are hosted on Supabase Storage. Once you have a
         manifest row, build the public URL as{" "}
-        <code className="break-all rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+        <code className="break-all rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
           {BASE}/storage/v1/object/public/sources/&lt;source_storage_path&gt;
         </code>
         . Every file is content-addressed by SHA-256.
       </p>
 
-      <h2 className="mt-10 text-xl font-semibold text-gray-900">
+      <h2 className="serif mt-10 text-2xl">
         Schema and licensing
       </h2>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         Field IDs follow the canonical 1,105-field schema derived from the CDS
         Initiative&apos;s 2025-26 XLSX template. The full schema is checked
         into the repo at{" "}
@@ -1130,7 +1139,7 @@ const { data } = await supabase
         public-document status.
       </p>
 
-      <div className="mt-10 border-t border-gray-200 pt-6 text-sm text-gray-500">
+      <div className="mt-10 border-t border-[var(--rule)] pt-6 text-sm text-[var(--ink-3)]">
         Found something missing or wrong? Open an issue on{" "}
         <a
           className={API_LINK_CLASS}
@@ -1148,7 +1157,7 @@ const { data } = await supabase
 
 function FieldChip({ name }: { name: string }) {
   return (
-    <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+    <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs text-[var(--ink-2)]">
       {name}
     </code>
   );
@@ -1172,9 +1181,9 @@ function Resource({
   const highlighted = new Set(fields);
   const extras = allFields?.filter((f) => !highlighted.has(f)) ?? [];
   return (
-    <div className="rounded border border-gray-200 p-4">
+    <div className="rounded border border-[var(--rule)] p-4">
       <div className="flex flex-wrap items-baseline justify-between gap-3">
-        <code className="min-w-0 break-all text-sm font-semibold text-gray-900">
+        <code className="min-w-0 break-all text-sm font-semibold text-[var(--ink)]">
           GET /rest/v1/{name}
         </code>
         <TrackedLink
@@ -1192,7 +1201,7 @@ function Resource({
           try it →
         </TrackedLink>
       </div>
-      <p className="mt-2 text-sm leading-relaxed text-gray-700">
+      <p className="mt-2 text-sm leading-relaxed text-[var(--ink-2)]">
         {description}
       </p>
       <div className="mt-2 flex flex-wrap gap-1.5">

--- a/web/src/app/methodology/admission-strategy/page.tsx
+++ b/web/src/app/methodology/admission-strategy/page.tsx
@@ -7,9 +7,9 @@ const ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzZHV3bXlndm1kb3pocHZ6YWl4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxMDk3NTksImV4cCI6MjA5MTY4NTc1OX0.fYZOIHyrOWzidgc-CVxWCY5Fe9pQk12-6YjDIS6y9qs";
 
 export const metadata: Metadata = {
-  title: "Admission Strategy Methodology",
+  title: "Admission rounds methodology",
   description:
-    "How collegedata.fyi derives Early Decision, Early Action, yield, wait-list, and admission-factor context from Common Data Set fields.",
+    "How collegedata.fyi reads Early Decision, Early Action, yield, wait-list, and admission-factor context from Common Data Set Section C — and which rates CDS will not support.",
   alternates: { canonical: "/methodology/admission-strategy" },
   openGraph: { url: "/methodology/admission-strategy" },
 };
@@ -44,11 +44,21 @@ export default function AdmissionStrategyMethodologyPage() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
       <div className="meta">§ Methodology</div>
-      <h1 className="serif mt-3 text-5xl leading-none">Admission strategy</h1>
-      <p className="mt-5 text-lg leading-relaxed text-[var(--ink-2)]">
-        The headline admit rate in most college guides is a weighted average across
-        application rounds. This page explains what we surface from the Common Data Set,
-        what those numbers mean, and what they do not prove.
+      <h1 className="serif mt-3 text-5xl leading-none">
+        Admission <span style={{ fontStyle: "italic" }}>rounds.</span>
+      </h1>
+      <p
+        className="serif mt-5"
+        style={{
+          color: "var(--ink-2)",
+          fontSize: 18,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
+        The headline admit rate in most college guides averages across rounds.
+        This note says what Section C actually publishes, what we derive, and
+        what those numbers do not prove.
       </p>
 
       <section className="mt-10">
@@ -105,7 +115,7 @@ export default function AdmissionStrategyMethodologyPage() {
         <p className="mt-4 text-sm leading-relaxed text-[var(--ink-2)]">
           Published ED rates include recruited athletes, legacy applicants, and other
           institutional-priority applicants. We do not estimate a general-pool ED rate
-          in v1 because CDS does not separate those applicant groups.
+          because CDS does not separate those applicant groups.
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
           For context, the NBER paper{" "}
@@ -166,16 +176,12 @@ export default function AdmissionStrategyMethodologyPage() {
         <h2 className="serif text-3xl">Sources and audit trail</h2>
         <p className="mt-4 text-sm leading-relaxed text-[var(--ink-2)]">
           Every school card links to the archived CDS source for the displayed year.
-          The public serving table is <code>school_browser_rows</code>; PRD 016B adds
-          columns to that resource, not a new API endpoint.
+          The serving table is <code>school_browser_rows</code>, documented on the{" "}
+          <Link href="/api">API page</Link>.
         </p>
         <CodeBlock>{`curl '${BASE}/rest/v1/school_browser_rows?school_id=eq.bowdoin&select=school_id,school_name,canonical_year,applied,admitted,ed_offered,ed_applicants,ed_admitted,ea_offered,ea_restrictive,wait_list_offered,wait_list_accepted,wait_list_admitted,admission_strategy_card_quality' \\
   -H 'apikey: ${ANON_KEY.slice(0, 24)}...' \\
   -H 'Authorization: Bearer ${ANON_KEY.slice(0, 24)}...'`}</CodeBlock>
-        <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
-          Phase 0 measurement results are preserved in the repository&apos;s PRD
-          findings note; the API page documents the public columns exposed by this card.
-        </p>
       </section>
     </main>
   );

--- a/web/src/app/methodology/merit-profile/page.tsx
+++ b/web/src/app/methodology/merit-profile/page.tsx
@@ -7,9 +7,9 @@ const ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzZHV3bXlndm1kb3pocHZ6YWl4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxMDk3NTksImV4cCI6MjA5MTY4NTc1OX0.fYZOIHyrOWzidgc-CVxWCY5Fe9pQk12-6YjDIS6y9qs";
 
 export const metadata: Metadata = {
-  title: "Merit Profile Methodology",
+  title: "Merit and need aid methodology",
   description:
-    "How collegedata.fyi derives merit-aid, need-aid, net-price, and outcome context from Common Data Set Section H and College Scorecard data.",
+    "How collegedata.fyi reads merit-aid and need-aid from Common Data Set Section H, with federal College Scorecard net-price and outcome context. Not a personalized price estimate.",
   alternates: { canonical: "/methodology/merit-profile" },
   openGraph: { url: "/methodology/merit-profile" },
 };
@@ -44,8 +44,18 @@ export default function MeritProfileMethodologyPage() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
       <div className="meta">§ Methodology</div>
-      <h1 className="serif mt-3 text-5xl leading-none">Merit profile</h1>
-      <p className="mt-5 text-lg leading-relaxed text-[var(--ink-2)]">
+      <h1 className="serif mt-3 text-5xl leading-none">
+        Merit and need <span style={{ fontStyle: "italic" }}>aid.</span>
+      </h1>
+      <p
+        className="serif mt-5"
+        style={{
+          color: "var(--ink-2)",
+          fontSize: 18,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
         The merit profile combines source-reported CDS Section H aid facts with
         federal College Scorecard affordability and outcome context. It is built
         to answer what a school says it awarded, not to predict any applicant&apos;s
@@ -106,10 +116,9 @@ export default function MeritProfileMethodologyPage() {
         <h2 className="serif text-3xl">Missing data policy</h2>
         <p className="mt-4 text-sm leading-relaxed text-[var(--ink-2)]">
           Missing CDS fields stay missing. We do not impute merit awards from peer
-          schools, marketing copy, or third-party scholarship pages. After the
-          May 3, 2026 Tier 4 redrain, direct H.2A02 answerability was 244 of 365
-          latest primary 2024+ schools (66.8%), and effective first-year merit
-          answerability was 252 of 365 (69.0%).
+          schools, marketing copy, or third-party scholarship pages. The average
+          no-need grant (H.2A02) is currently reported for 335 of 488 schools in
+          the merit view (69%).
         </p>
       </section>
 

--- a/web/src/app/methodology/page.tsx
+++ b/web/src/app/methodology/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Methodology",
   description:
-    "How collegedata.fyi turns Common Data Set source documents into academic profile, admission strategy, and merit profile cards.",
+    "How the school-page cards read Common Data Set filings — academic profile, admission rounds, merit and need aid. What they use, what they skip, what they do not predict.",
   alternates: { canonical: "/methodology" },
   openGraph: { url: "/methodology" },
 };
@@ -13,17 +13,17 @@ const METHODS = [
   {
     href: "/methodology/positioning",
     title: "Academic profile",
-    body: "How SAT and ACT bands are read from the CDS and compared against a student-entered score.",
+    body: "Where a student’s SAT or ACT lands in the score bands the school published for enrolled first-years. Not a chance-me.",
   },
   {
     href: "/methodology/admission-strategy",
     title: "Admission rounds",
-    body: "How ED, EA, wait-list, yield, fee, and admissions-factor fields are derived from Section C.",
+    body: "ED, EA, wait-list, and yield from Section C — including what CDS will not let you compute.",
   },
   {
     href: "/methodology/merit-profile",
     title: "Merit and need aid",
-    body: "How Section H merit-aid facts are combined with federal affordability and outcome context.",
+    body: "What the school reported in Section H, plus federal net-price and outcome context. Not a package estimate.",
   },
 ];
 
@@ -32,12 +32,20 @@ export default function MethodologyIndexPage() {
     <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6">
       <div className="meta">§ Methodology</div>
       <h1 className="serif mt-3 leading-none" style={{ fontSize: "clamp(40px, 6vw, 64px)" }}>
-        How the cards are built.
+        How the cards are <span style={{ fontStyle: "italic" }}>built.</span>
       </h1>
-      <p className="mt-5 max-w-2xl text-[17px] leading-relaxed text-[var(--ink-2)]">
-        These notes explain the source fields, derivations, and caveats behind
-        the public cards on each school page. Every method starts from archived
-        Common Data Set documents and keeps the source trail visible.
+      <p
+        className="serif mt-5 max-w-2xl"
+        style={{
+          color: "var(--ink-2)",
+          fontSize: 18,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
+        The trail behind the school-page cards. Each note names the CDS fields,
+        the derivation, and the caveat. Nothing here predicts an admissions
+        decision or a financial-aid package.
       </p>
 
       <div className="mt-10 grid gap-4 sm:grid-cols-3">

--- a/web/src/app/methodology/positioning/page.tsx
+++ b/web/src/app/methodology/positioning/page.tsx
@@ -7,9 +7,9 @@ const ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzZHV3bXlndm1kb3pocHZ6YWl4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxMDk3NTksImV4cCI6MjA5MTY4NTc1OX0.fYZOIHyrOWzidgc-CVxWCY5Fe9pQk12-6YjDIS6y9qs";
 
 export const metadata: Metadata = {
-  title: "Academic Positioning Methodology",
+  title: "Academic profile methodology",
   description:
-    "How collegedata.fyi compares student scores to a school's published Common Data Set admitted-class bands.",
+    "How collegedata.fyi compares a student's scores to a school's published Common Data Set score bands for enrolled first-years. Not a chance-me.",
   alternates: { canonical: "/methodology/positioning" },
   openGraph: { url: "/methodology/positioning" },
 };
@@ -44,10 +44,22 @@ export default function PositioningMethodologyPage() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
       <div className="meta">§ Methodology</div>
-      <h1 className="serif mt-3 text-5xl leading-none">Academic positioning</h1>
-      <p className="mt-5 text-lg leading-relaxed text-[var(--ink-2)]">
-        This page shows where your scores would land in a school&apos;s admitted-class
-        numbers. It is not a chance-me, and it does not predict admissions decisions.
+      <h1 className="serif mt-3 text-5xl leading-none">
+        Academic <span style={{ fontStyle: "italic" }}>profile.</span>
+      </h1>
+      <p
+        className="serif mt-5"
+        style={{
+          color: "var(--ink-2)",
+          fontSize: 18,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
+        Where a student&apos;s SAT or ACT would land in the numbers the school
+        published for its enrolled first-years — the entering class, not the
+        admitted pool. It is not a chance-me, and it does not predict an
+        admissions decision.
       </p>
 
       <section className="mt-10">
@@ -59,9 +71,10 @@ export default function PositioningMethodologyPage() {
             but the methodology treats them as descriptive data rather than decision weights.
           </FieldUse>
           <FieldUse field="C.8" title="Test policies and score-use context">
-            We use C.8 to frame whether score bands represent all admitted students or only
-            the subset who submitted scores. At test-optional schools, the card repeats the
-            submitter-only caveat inline with the SAT and ACT ranges.
+            We use C.8 to frame whether score bands describe all enrolled
+            first-years or only the subset who submitted scores. At test-optional
+            schools, the card repeats the submitter-only caveat inline with the SAT
+            and ACT ranges.
           </FieldUse>
           <FieldUse field="C.9" title="SAT and ACT score bands">
             C.9 provides the 25th, 50th, and 75th percentile anchors. For Bowdoin College,
@@ -71,14 +84,15 @@ export default function PositioningMethodologyPage() {
             admission.
           </FieldUse>
           <FieldUse field="C.11" title="High-school class rank">
-            C.11 can describe class-rank distribution where schools publish it. v1 does not
-            score rank because many schools omit rank or receive it from too small a subset
+            C.11 can describe class-rank distribution where schools publish it. This card
+            does not score rank because many schools omit rank or receive it from too small a subset
             of applicants to compare responsibly across institutions.
           </FieldUse>
           <FieldUse field="C.12" title="High-school GPA">
-            C.12 provides average high-school GPA and the percent submitting GPA. v1 displays
-            the school average beside your entered GPA, but GPA never contributes to academic
-            fit because weighted and unweighted scales are not consistently documented.
+            C.12 provides average high-school GPA and the percent submitting GPA. The card
+            displays the school average beside the student&apos;s entered GPA; GPA never
+            contributes to academic fit because weighted and unweighted scales are not
+            consistently documented.
           </FieldUse>
           <FieldUse field="C.1 / C.2" title="Applicant, admitted, and enrolled counts">
             C.1 and C.2 supply applicant and admit counts. The serving layer derives admit
@@ -104,15 +118,15 @@ export default function PositioningMethodologyPage() {
       <section className="mt-10 border-t border-[var(--rule-strong)] pt-6">
         <h2 className="serif text-3xl">Why this isn&apos;t a chance-me</h2>
         <p className="mt-4 text-sm leading-relaxed text-[var(--ink-2)]">
-          A position compares your numbers with published admitted-class bands. A
-          prediction estimates the probability that an applicant with many hidden traits
-          will be admitted. The Common Data Set supports the first task and does not
-          support the second.
+          A position compares a student&apos;s numbers with the bands the school
+          published for enrolled first-years. A prediction estimates the probability
+          that an applicant with many hidden traits will be admitted. The Common Data
+          Set supports the first task and does not support the second.
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
           Test-optional reporting makes the distinction sharper. A school can publish a
           high SAT middle 50% while only a minority of enrolled students submitted SAT
-          scores. That means the range describes submitters, not the full admitted class.
+          scores. That means the range describes submitters, not the full entering class.
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
           Selective admissions also include institutional priorities that are absent from
@@ -121,8 +135,8 @@ export default function PositioningMethodologyPage() {
           admit rate.
         </p>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
-          Current cards read 2024-25 or newer CDS rows. If a future card uses a CDS
-          year more than three years old, the scoring result carries a stale-data caveat.
+          If the newest archived CDS for a school is more than three years old, the
+          card carries a stale-data caveat.
         </p>
       </section>
 
@@ -138,8 +152,8 @@ export default function PositioningMethodologyPage() {
   -H 'apikey: ${ANON_KEY.slice(0, 24)}...' \\
   -H 'Authorization: Bearer ${ANON_KEY.slice(0, 24)}...'`}</CodeBlock>
         <p className="mt-3 text-sm leading-relaxed text-[var(--ink-2)]">
-          The endpoint is the same public PostgREST resource documented on the{" "}
-          <Link href="/api">API page</Link>; PRD 016 does not add a new API resource.
+          The serving table is documented on the{" "}
+          <Link href="/api">API page</Link>.
         </p>
       </section>
     </main>

--- a/web/src/lib/wave-4-copy.test.ts
+++ b/web/src/lib/wave-4-copy.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const src = (rel: string) => readFileSync(join(process.cwd(), "src", rel), "utf8");
+
+describe("Wave 4 methodology and API copy", () => {
+  it("aligns the methodology index with school-card kickers", () => {
+    const page = src("app/methodology/page.tsx");
+    expect(page).toContain("How the school-page cards read Common Data Set filings");
+    expect(page).toContain("How the cards are");
+    expect(page).toContain("The trail behind the school-page cards");
+    expect(page).toContain("enrolled first-years. Not a chance-me.");
+    expect(page).toContain("what CDS will not let you compute");
+    expect(page).toContain("federal net-price and outcome context");
+    expect(page).not.toMatch(/admitted-class bands/);
+    expect(page).not.toMatch(/turns Common Data Set source documents into/);
+  });
+
+  it("writes academic profile as enrolled first-years, not admits", () => {
+    const page = src("app/methodology/positioning/page.tsx");
+    expect(page).toContain('title: "Academic profile methodology"');
+    expect(page).toContain("Academic");
+    expect(page).toContain("profile.");
+    expect(page).toContain("enrolled first-years — the entering class, not the");
+    expect(page).toContain("score bands describe all enrolled");
+    expect(page).toContain("not the full entering class");
+    expect(page).toContain("does not score rank");
+    expect(page).toContain("the student&apos;s entered GPA");
+    expect(page).not.toMatch(/PRD 016/);
+    expect(page).not.toMatch(/your scores/);
+    expect(page).not.toMatch(/admitted-class/);
+    expect(page).not.toMatch(/v1 does not/);
+    expect(page).not.toMatch(/v1 displays/);
+  });
+
+  it("renames admission strategy to admission rounds and drops operator notes", () => {
+    const page = src("app/methodology/admission-strategy/page.tsx");
+    expect(page).toContain('title: "Admission rounds methodology"');
+    expect(page).toContain("Admission");
+    expect(page).toContain("rounds.");
+    expect(page).toContain("what Section C actually publishes");
+    expect(page).toContain("We do not estimate a general-pool ED rate");
+    expect(page).toContain("documented on the");
+    expect(page).not.toMatch(/in v1 because/);
+    expect(page).not.toMatch(/PRD 016B/);
+    expect(page).not.toMatch(/Phase 0/);
+  });
+
+  it("keeps H2A caveats and drops the Tier 4 redrain coverage story", () => {
+    const page = src("app/methodology/merit-profile/page.tsx");
+    expect(page).toContain('title: "Merit and need aid methodology"');
+    expect(page).toContain("federal College Scorecard");
+    expect(page).toContain("335 of 488");
+    expect(page).toContain("H.2A02");
+    expect(page).not.toMatch(/Tier 4/);
+    expect(page).not.toMatch(/redrain/);
+    expect(page).not.toMatch(/effective first-year merit answerability/);
+  });
+
+  it("rewrites API docs off changelog, runbook, and extractor lore", () => {
+    const page = src("app/api/page.tsx");
+    expect(page).toContain("The ");
+    expect(page).toContain("public");
+    expect(page).toContain("API.");
+    expect(page).toContain("Two ways in");
+    expect(page).toContain("api.collegedata.fyi");
+    expect(page).toContain("Start here");
+    expect(page).toContain("When a value is missing");
+    expect(page).toContain("the school&apos;s filing leaves the field blank");
+    expect(page).toContain("Search latest-per-school rows (Compare)");
+    expect(page).toContain("Compare&apos;s latest-per-school ranking");
+    expect(page).toContain("Fetch the canonical artifact for a document");
+    expect(page).toContain("the canonical artifact is the one the site");
+    expect(page).toContain("The curated serving layer behind Compare");
+    expect(page).toContain(".eq(\"extraction_status\", \"extracted\")");
+    expect(page).not.toMatch(/now exposes/);
+    expect(page).not.toMatch(/Runbook/);
+    expect(page).not.toMatch(/Smoke-test/);
+    expect(page).not.toMatch(/Docling/);
+    expect(page).not.toMatch(/Tier 4/);
+    expect(page).not.toMatch(/website browser/);
+    expect(page).not.toMatch(/text-gray-900/);
+    expect(page).not.toMatch(/projected value/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Wrap the public-voice project. Wave 4 is methodology and `/api`.

Fable: **ship with patches.** Applied. Biggest catch: C.9 describes **enrolled first-years**, not the admitted pool — the live methodology page (and the school-page caption) had been saying admitted-class. Cards stay as-is this wave; the `PositioningCard` caption “% OF ADMITS SUBMITTED SAT SCORES” is logged for a later pass.

- Methodology H1s match the school-card kickers: Academic *profile.* / Admission *rounds.* / Merit and need *aid.*
- Merit coverage uses the live-API count (335 of 488, 69%), not the May 2026 Tier 4 redrain note
- `/api`: Start here, not Runbook; Compare, not Browser; canonical artifact, not Docling; restyle off gray Tailwind onto paper/ink
- Missing-value copy names four causes, including “the school’s filing leaves the field blank”

Discover stays out. School cards unchanged. Query parameters (`extraction_status=eq.extracted`) stay as code.

Deck: `docs/copy/wave-4-methodology-api.md`. Fable write-up: `docs/copy/wave-4-fable-review.md`.

## Testing

- Vitest: `web/src/lib/wave-4-copy.test.ts` plus full suite (394 tests, 44 files)
- Browser: `/methodology`, `/methodology/positioning`, `/methodology/admission-strategy`, `/methodology/merit-profile`, `/api` — desktop and iPhone XR. H1s wrap; no overflow; no leftover Runbook / Docling / admitted-class / v1 in prose.

[wave_4_methodology_api_desktop_mobile_demo.mp4](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave_4_methodology_api_desktop_mobile_demo.mp4)

[Methodology index — How the cards are built](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmethodology_index_desktop.webp)
[Academic profile methodology — enrolled first-years, not admits](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Facademic_profile_methodology.webp)
[Admission rounds — ED residual, no general-pool estimate](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmission_rounds_ed_residual.webp)
[Merit coverage — H.2A02 on 335 of 488 schools](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmerit_aid_h2a02_coverage.webp)
[The public API — paper/ink, forest links](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_public_hero.webp)
[Methodology index on iPhone XR](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmethodology_index_mobile.webp)

## Review as a reader

Read `/methodology` as a counselor who clicked METHOD, then `/api` as IR.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

