### PR TITLE
Fix Claude Desktop MCP connect (NDJSON + absolute path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,17 @@ jobs:
       - name: Run data-integrity resolver support tests
         run: deno test tools/data_quality/reprobe_resolver_cohort.test.ts
 
+  mcp:
+    name: MCP stdio handshake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Run MCP stdio tests
+        run: node --test packages/mcp-server/collegedata-mcp.test.js
+
   web:
     name: Next.js build
     runs-on: ubuntu-latest

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,10 +1,33 @@
 # CollegeData.FYI MCP server
 
-Read-only MCP wrapper for the public CollegeData.FYI friendly API.
+Read-only MCP wrapper for the public CollegeData.FYI friendly API. One Node
+file, no install, no API key. Stdio is newline-delimited JSON-RPC — the
+framing Claude Desktop and other MCP clients speak.
 
 ```bash
-COLLEGEDATA_API_BASE=https://www.collegedata.fyi node packages/mcp-server/bin/collegedata-mcp.js
+node packages/mcp-server/bin/collegedata-mcp.js
 ```
+
+Claude Desktop does not run from this repository. Put an **absolute path**
+in `claude_desktop_config.json` (macOS:
+`~/Library/Application Support/Claude/claude_desktop_config.json`; Windows:
+`%APPDATA%\Claude\claude_desktop_config.json`), then fully quit and reopen
+Claude:
+
+```json
+{
+  "mcpServers": {
+    "collegedata": {
+      "command": "node",
+      "args": ["/absolute/path/to/collegedata-fyi/packages/mcp-server/bin/collegedata-mcp.js"]
+    }
+  }
+}
+```
+
+If Claude reports `spawn node ENOENT`, set `command` to the full path from
+`which node`. Node 20 or newer. `COLLEGEDATA_API_BASE` is optional and
+defaults to `https://www.collegedata.fyi`.
 
 Tools:
 
@@ -15,4 +38,3 @@ Tools:
 - `get_field_dictionary`
 
 The server does not use a service-role key and exposes no write tools.
-

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -25,8 +25,8 @@ Claude:
 }
 ```
 
-If Claude reports `spawn node ENOENT`, set `command` to the full path from
-`which node`. Node 20 or newer. `COLLEGEDATA_API_BASE` is optional and
+If Claude reports `spawn node ENOENT`, set `command` to the path that
+`which node` prints. Node 20 or newer. `COLLEGEDATA_API_BASE` is optional and
 defaults to `https://www.collegedata.fyi`.
 
 Tools:

--- a/packages/mcp-server/bin/collegedata-mcp.js
+++ b/packages/mcp-server/bin/collegedata-mcp.js
@@ -2,7 +2,7 @@
 
 const API_BASE = (process.env.COLLEGEDATA_API_BASE ?? "https://www.collegedata.fyi").replace(/\/$/, "");
 const CLIENT_NAME = "mcp";
-const CLIENT_VERSION = "0.1.1";
+const CLIENT_VERSION = "0.1.2";
 
 const FACT_CATEGORIES = "identity, admissions, enrollment, cost, aid, finance, outcomes, sources";
 const COMPARE_CATEGORIES = "identity, admissions, enrollment, cost, aid, outcomes, sources";
@@ -125,59 +125,89 @@ async function callTool(name, args) {
   throw new Error(`Unknown tool: ${name}`);
 }
 
-function send(id, result) {
-  const body = JSON.stringify({ jsonrpc: "2.0", id, result });
-  process.stdout.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`);
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
-function sendError(id, error) {
-  const body = JSON.stringify({
+function sendResult(id, result) {
+  writeMessage({ jsonrpc: "2.0", id, result });
+}
+
+function sendError(id, error, code = -32000) {
+  writeMessage({
     jsonrpc: "2.0",
-    id,
-    error: { code: -32000, message: error.message },
+    id: id ?? null,
+    error: { code, message: error.message ?? String(error) },
   });
-  process.stdout.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`);
+}
+
+async function handleMessage(message) {
+  if (message.method === "initialize") {
+    const requested = message.params?.protocolVersion;
+    sendResult(message.id, {
+      protocolVersion: requested || "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "collegedata-fyi", version: CLIENT_VERSION },
+    });
+    return;
+  }
+  if (message.method === "notifications/initialized" || message.method === "notifications/cancelled") {
+    return;
+  }
+  if (message.method === "ping") {
+    sendResult(message.id, {});
+    return;
+  }
+  if (message.method === "tools/list") {
+    sendResult(message.id, { tools });
+    return;
+  }
+  if (message.method === "tools/call") {
+    try {
+      const payload = await callTool(message.params?.name, message.params?.arguments ?? {});
+      sendResult(message.id, {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+      });
+    } catch (error) {
+      sendResult(message.id, {
+        content: [{ type: "text", text: error.message ?? String(error) }],
+        isError: true,
+      });
+    }
+    return;
+  }
+  if (message.id != null) {
+    sendError(message.id, new Error(`Method not found: ${message.method}`), -32601);
+  }
 }
 
 let buffer = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", async (chunk) => {
-  buffer += chunk;
+let queue = Promise.resolve();
+
+function drain() {
   while (true) {
-    const headerEnd = buffer.indexOf("\r\n\r\n");
-    if (headerEnd === -1) return;
-    const header = buffer.slice(0, headerEnd);
-    const match = header.match(/Content-Length:\s*(\d+)/i);
-    if (!match) {
-      buffer = "";
-      return;
-    }
-    const length = Number(match[1]);
-    const bodyStart = headerEnd + 4;
-    if (buffer.length < bodyStart + length) return;
-    const body = buffer.slice(bodyStart, bodyStart + length);
-    buffer = buffer.slice(bodyStart + length);
+    const newline = buffer.indexOf("\n");
+    if (newline === -1) return;
+    const line = buffer.slice(0, newline).replace(/\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
     let message;
     try {
-      message = JSON.parse(body);
-      if (message.method === "initialize") {
-        send(message.id, {
-          protocolVersion: "2024-11-05",
-          capabilities: { tools: {} },
-          serverInfo: { name: "collegedata-fyi", version: "0.1.0" },
-        });
-      } else if (message.method === "tools/list") {
-        send(message.id, { tools });
-      } else if (message.method === "tools/call") {
-        const payload = await callTool(message.params.name, message.params.arguments ?? {});
-        send(message.id, {
-          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
-        });
-      } else if (message.id != null) {
-        send(message.id, {});
-      }
+      message = JSON.parse(line);
     } catch (error) {
-      sendError(message?.id ?? null, error);
+      sendError(null, error, -32700);
+      continue;
     }
+    queue = queue.then(() => handleMessage(message)).catch((error) => {
+      sendError(message?.id ?? null, error);
+    });
   }
+}
+
+process.stderr.write(`collegedata-mcp ${CLIENT_VERSION} ${API_BASE}\n`);
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  drain();
 });
+process.stdin.on("end", drain);

--- a/packages/mcp-server/collegedata-mcp.test.js
+++ b/packages/mcp-server/collegedata-mcp.test.js
@@ -1,0 +1,96 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const script = join(root, "bin", "collegedata-mcp.js");
+
+function startServer() {
+  const proc = spawn("node", [script], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, COLLEGEDATA_API_BASE: "https://www.collegedata.fyi" },
+  });
+  proc.stdout.setEncoding("utf8");
+  proc.stderr.setEncoding("utf8");
+  let stdout = "";
+  proc.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  let stderr = "";
+  proc.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  async function readJson(timeoutMs = 2000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const nl = stdout.indexOf("\n");
+      if (nl !== -1) {
+        const line = stdout.slice(0, nl);
+        stdout = stdout.slice(nl + 1);
+        if (!line.trim()) continue;
+        assert.doesNotMatch(line, /^Content-Length:/i);
+        return JSON.parse(line);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`No MCP JSON line within ${timeoutMs}ms. stderr=${stderr}`);
+  }
+
+  function send(message) {
+    proc.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  async function close() {
+    proc.kill("SIGTERM");
+    await Promise.race([once(proc, "exit"), new Promise((resolve) => setTimeout(resolve, 500))]);
+  }
+
+  return { proc, send, readJson, close, getStderr: () => stderr };
+}
+
+describe("collegedata MCP stdio", () => {
+  it("handshakes over newline-delimited JSON, not Content-Length", async () => {
+    const server = startServer();
+    try {
+      server.send({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "claude-desktop", version: "test" },
+        },
+      });
+      const init = await server.readJson();
+      assert.equal(init.id, 0);
+      assert.equal(init.result.protocolVersion, "2025-03-26");
+      assert.equal(init.result.serverInfo.name, "collegedata-fyi");
+      assert.ok(init.result.capabilities.tools);
+
+      server.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      server.send({ jsonrpc: "2.0", id: 1, method: "ping" });
+      const ping = await server.readJson();
+      assert.equal(ping.id, 1);
+      assert.deepEqual(ping.result, {});
+
+      server.send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+      const listed = await server.readJson();
+      assert.equal(listed.id, 2);
+      const names = listed.result.tools.map((tool) => tool.name);
+      assert.deepEqual(names, [
+        "search_schools",
+        "get_school_facts",
+        "compare_schools",
+        "get_source_documents",
+        "get_field_dictionary",
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@collegedata-fyi/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "bin": {
     "collegedata-mcp": "./bin/collegedata-mcp.js"

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -228,11 +228,11 @@ COLLEGEDATA_API_BASE=https://www.collegedata.fyi node packages/cli/bin/collegeda
             <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
               command
             </code>{" "}
-            to the full path from{" "}
+            to the path that{" "}
             <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
               which node
-            </code>
-            .{" "}
+            </code>{" "}
+            prints.{" "}
             <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
               COLLEGEDATA_API_BASE
             </code>{" "}

--- a/web/src/app/api/page.tsx
+++ b/web/src/app/api/page.tsx
@@ -195,17 +195,54 @@ COLLEGEDATA_API_BASE=https://www.collegedata.fyi node packages/cli/bin/collegeda
         <section>
           <h3 className="serif text-lg">3. Connect an MCP client</h3>
           <p className="mt-1">
-            The MCP server is read-only and uses the same friendly API. Configure
-            a client to run the server command from the repository root.
+            The MCP server is a single Node file in the repo (
+            <a
+              className={API_LINK_CLASS}
+              href="https://github.com/bolewood/collegedata-fyi/blob/main/packages/mcp-server/bin/collegedata-mcp.js"
+            >
+              packages/mcp-server/bin/collegedata-mcp.js
+            </a>
+            ). It is read-only and uses the same friendly API — no API key.
+            Claude Desktop launches it as a subprocess, so the path in{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              args
+            </code>{" "}
+            must be absolute; a path relative to the git checkout will not
+            connect. Node 20 or newer. After saving, fully quit and reopen
+            Claude Desktop.
+          </p>
+          <p className="mt-2">
+            Config file: macOS{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              ~/Library/Application Support/Claude/claude_desktop_config.json
+            </code>
+            ; Windows{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              %APPDATA%\Claude\claude_desktop_config.json
+            </code>
+            . If Claude reports{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              spawn node ENOENT
+            </code>
+            , set{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              command
+            </code>{" "}
+            to the full path from{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              which node
+            </code>
+            .{" "}
+            <code className="rounded bg-[var(--paper-2)] px-1.5 py-0.5 text-xs">
+              COLLEGEDATA_API_BASE
+            </code>{" "}
+            is optional and defaults to production.
           </p>
           <CodeBlock>{`{
   "mcpServers": {
     "collegedata": {
       "command": "node",
-      "args": ["packages/mcp-server/bin/collegedata-mcp.js"],
-      "env": {
-        "COLLEGEDATA_API_BASE": "https://www.collegedata.fyi"
-      }
+      "args": ["/absolute/path/to/collegedata-fyi/packages/mcp-server/bin/collegedata-mcp.js"]
     }
   }
 }`}</CodeBlock>

--- a/web/src/lib/wave-4-copy.test.ts
+++ b/web/src/lib/wave-4-copy.test.ts
@@ -66,6 +66,12 @@ describe("Wave 4 methodology and API copy", () => {
     expect(page).toContain("Two ways in");
     expect(page).toContain("api.collegedata.fyi");
     expect(page).toContain("Start here");
+    expect(page).toContain("claude_desktop_config.json");
+    expect(page).toContain(
+      "/absolute/path/to/collegedata-fyi/packages/mcp-server/bin/collegedata-mcp.js",
+    );
+    expect(page).not.toMatch(/"args": \["packages\/mcp-server\/bin\/collegedata-mcp\.js"\]/);
+    expect(page).not.toMatch(/from the repository root/);
     expect(page).toContain("When a value is missing");
     expect(page).toContain("the school&apos;s filing leaves the field blank");
     expect(page).toContain("Search latest-per-school rows (Compare)");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Claude Desktop could not connect to the CollegeData MCP server. Two independent problems:

1. **Wrong wire protocol.** The server framed stdio with LSP `Content-Length` headers. MCP stdio is newline-delimited JSON. Claude sends `initialize` as one JSON line, the server waited for headers that never came, and the client timed out.
2. **Wrong config snippet on `/api`.** `args` was a path relative to the git repo, plus “run from the repository root.” Claude Desktop’s cwd is not the checkout. Anthropic’s own docs require **absolute** paths.

## Fix

- NDJSON stdio, protocol-version echo, `ping`, `notifications/initialized`
- `/api` names `claude_desktop_config.json`, requires an absolute path, notes Node 20+ and `spawn node ENOENT`
- Handshake test in CI

`COLLEGEDATA_API_BASE` is optional (defaults to production). No API key.

## Testing

- `node --test packages/mcp-server/collegedata-mcp.test.js` — initialize / ping / tools/list over NDJSON
- Live `search_schools` for `mit` against production after handshake
- Wave 4 copy lock still green
- Browser: `/api` MCP section, desktop and mobile

[api_mcp_claude_desktop_instructions.mp4](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_mcp_claude_desktop_instructions.mp4)
[MCP instructions on /api, desktop](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_mcp_instructions_desktop.webp)
[MCP instructions on /api, mobile](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_mcp_instructions_mobile.webp)

## After merge

Clone (or download the one file), put the **absolute** path in Claude Desktop config, fully quit and reopen Claude. The GitHub blob on `main` is the old Content-Length server until this lands.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

