### PR TITLE
Fix 2025–26 C1 totals taken from in-state instead of Total

### DIFF
--- a/tools/browser_backend/project_browser_data.py
+++ b/tools/browser_backend/project_browser_data.py
@@ -290,6 +290,14 @@ DERIVED_COMPONENT_FALLBACK_FIELDS = {
     ),
 }
 
+# 2025-26 residency block after a Total-last zip: All, In-State, Out-of-State,
+# Nonresidents, Unknown. Used to detect the Issue #159 in-state-as-total shift.
+C1_RESIDENCY_SHIFT_FIELDS = {
+    ("2025-26", "applied"): ("C.116", "C.119", "C.122", "C.125", "C.128"),
+    ("2025-26", "admitted"): ("C.117", "C.120", "C.123", "C.126", "C.129"),
+    ("2025-26", "first_year_enrolled"): ("C.118", "C.121", "C.124", "C.127", "C.130"),
+}
+
 
 def load_env(env_path: Path = REPO_ROOT / ".env") -> dict[str, str]:
     env: dict[str, str] = {}
@@ -1029,8 +1037,14 @@ def evaluate_metric(
                 if fallback_value is not None:
                     return fallback_value
         total = sum(reported_values, Decimal("0"))
-        if total == 0 and component_fallback_value is not None and component_fallback_value > 0:
-            return component_fallback_value
+        if component_fallback_value is not None:
+            if total == 0 and component_fallback_value > 0:
+                return component_fallback_value
+            if _c1_total_impossible_vs_gender(total, selected, schema_defs, metric):
+                return component_fallback_value
+            shifted_total = _c1_residency_shift_total(selected, schema_defs, metric)
+            if shifted_total is not None:
+                return shifted_total
         return total
     if any(value is None for value in values):
         return None
@@ -1055,6 +1069,72 @@ def evaluate_component_fallback_metric(
         reported_values = [value for value in values if value is not None]
         if reported_values:
             return sum(reported_values, Decimal("0"))
+    return None
+
+
+def _c1_gender_component_values(
+    metric: MetricDefinition,
+    selected: SelectedExtractionResult,
+    schema_defs: dict[str, FieldDefinition],
+) -> list[Decimal]:
+    fallback_groups = DERIVED_COMPONENT_FALLBACK_FIELDS.get(
+        (selected.schema_version, metric.canonical_metric)
+    )
+    if not fallback_groups:
+        return []
+    values = [
+        parse_metric_component(field_id, selected, schema_defs, metric)
+        for field_id in fallback_groups[0]
+    ]
+    return [value for value in values if value is not None]
+
+
+def _c1_total_impossible_vs_gender(
+    total: Decimal,
+    selected: SelectedExtractionResult,
+    schema_defs: dict[str, FieldDefinition],
+    metric: MetricDefinition,
+) -> bool:
+    """A published total cannot be smaller than any gender component."""
+    components = _c1_gender_component_values(metric, selected, schema_defs)
+    return any(total < component for component in components)
+
+
+def _c1_residency_shift_total(
+    selected: SelectedExtractionResult,
+    schema_defs: dict[str, FieldDefinition],
+    metric: MetricDefinition,
+) -> Optional[Decimal]:
+    """Detect the 2025-26 Total-last residency zip that lands the college total in Nonresidents or Unknown."""
+    field_ids = C1_RESIDENCY_SHIFT_FIELDS.get((selected.schema_version, metric.canonical_metric))
+    if not field_ids:
+        return None
+    parsed = [
+        parse_metric_component(field_id, selected, schema_defs, metric)
+        for field_id in field_ids
+    ]
+    total, in_state, out_of_state, nonresidents, unknown = parsed
+    gender_values = _c1_gender_component_values(metric, selected, schema_defs)
+    gender_sum = sum(gender_values, Decimal("0")) if gender_values else None
+    if (
+        total is not None
+        and in_state is not None
+        and out_of_state is not None
+        and nonresidents is not None
+        and abs((total + in_state + out_of_state) - nonresidents) <= 1
+        and gender_sum is not None
+        and abs(nonresidents - gender_sum) <= 1
+        and abs(total - nonresidents) > 1
+    ):
+        return gender_sum
+    if (
+        unknown is not None
+        and gender_sum is not None
+        and abs(unknown - gender_sum) <= 1
+        and total is not None
+        and total < unknown
+    ):
+        return gender_sum
     return None
 
 

--- a/tools/browser_backend/project_browser_data_test.py
+++ b/tools/browser_backend/project_browser_data_test.py
@@ -76,6 +76,18 @@ def defs():
             "C.116": FieldDefinition("2025-26", "C.116", "Applied", "Admission", "Applications", "Number"),
             "C.117": FieldDefinition("2025-26", "C.117", "Admitted", "Admission", "Applications", "Number"),
             "C.118": FieldDefinition("2025-26", "C.118", "Enrolled", "Admission", "Applications", "Number"),
+            "C.119": FieldDefinition("2025-26", "C.119", "Applied in-state", "Admission", "Applications", "Number"),
+            "C.120": FieldDefinition("2025-26", "C.120", "Admitted in-state", "Admission", "Applications", "Number"),
+            "C.121": FieldDefinition("2025-26", "C.121", "Enrolled in-state", "Admission", "Applications", "Number"),
+            "C.122": FieldDefinition("2025-26", "C.122", "Applied out-of-state", "Admission", "Applications", "Number"),
+            "C.123": FieldDefinition("2025-26", "C.123", "Admitted out-of-state", "Admission", "Applications", "Number"),
+            "C.124": FieldDefinition("2025-26", "C.124", "Enrolled out-of-state", "Admission", "Applications", "Number"),
+            "C.125": FieldDefinition("2025-26", "C.125", "Applied international", "Admission", "Applications", "Number"),
+            "C.126": FieldDefinition("2025-26", "C.126", "Admitted international", "Admission", "Applications", "Number"),
+            "C.127": FieldDefinition("2025-26", "C.127", "Enrolled international", "Admission", "Applications", "Number"),
+            "C.128": FieldDefinition("2025-26", "C.128", "Applied unknown residency", "Admission", "Applications", "Number"),
+            "C.129": FieldDefinition("2025-26", "C.129", "Admitted unknown residency", "Admission", "Applications", "Number"),
+            "C.130": FieldDefinition("2025-26", "C.130", "Enrolled unknown residency", "Admission", "Applications", "Number"),
             "C.201": FieldDefinition("2025-26", "C.201", "Wait list policy", "Admission", "Wait List", "YesNo"),
             "C.202": FieldDefinition("2025-26", "C.202", "Wait list offered", "Admission", "Wait List", "Number"),
             "C.203": FieldDefinition("2025-26", "C.203", "Wait list accepted", "Admission", "Wait List", "Number"),
@@ -279,6 +291,81 @@ class BrowserProjectionTests(unittest.TestCase):
         self.assertEqual(browser["applied"], 220)
         self.assertEqual(browser["admitted"], 22)
         self.assertEqual(browser["acceptance_rate"], "0.100000")
+
+    def test_2025_total_smaller_than_gender_component_uses_gender_sum(self):
+        _fields, browser = build_projection_rows(
+            doc(canonical_year="2025-26"),
+            [
+                artifact(values={
+                    "C.101": {"value": "2496"},
+                    "C.104": {"value": "1424"},
+                    "C.107": {"value": "264"},
+                    "C.116": {"value": "911"},
+                    "C.117": {"value": "657"},
+                    "C.118": {"value": "185"},
+                    "C.119": {"value": "741"},
+                    "C.120": {"value": "519"},
+                    "C.121": {"value": "56"},
+                    "C.122": {"value": "844"},
+                    "C.123": {"value": "248"},
+                    "C.124": {"value": "23"},
+                    "C.125": {"value": "2496"},
+                    "C.126": {"value": "1424"},
+                    "C.127": {"value": "264"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 2496)
+        self.assertEqual(browser["admitted"], 1424)
+        self.assertEqual(browser["enrolled_first_year"], 264)
+        self.assertEqual(browser["acceptance_rate"], "0.570513")
+        self.assertEqual(browser["yield_rate"], "0.185393")
+
+    def test_2025_residency_shift_fingerprint_uses_gender_sum(self):
+        _fields, browser = build_projection_rows(
+            doc(canonical_year="2025-26"),
+            [
+                artifact(values={
+                    "C.101": {"value": "5000"},
+                    "C.102": {"value": "4958"},
+                    "C.104": {"value": "2000"},
+                    "C.105": {"value": "1900"},
+                    "C.116": {"value": "8120"},
+                    "C.117": {"value": "2500"},
+                    "C.119": {"value": "1688"},
+                    "C.120": {"value": "900"},
+                    "C.122": {"value": "150"},
+                    "C.123": {"value": "500"},
+                    "C.125": {"value": "9958"},
+                    "C.126": {"value": "3900"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 9958)
+        self.assertEqual(browser["admitted"], 3900)
+
+    def test_2025_duplicate_gender_counts_do_not_replace_matching_total(self):
+        _fields, browser = build_projection_rows(
+            doc(canonical_year="2025-26"),
+            [
+                artifact(values={
+                    "C.101": {"value": "2070"},
+                    "C.102": {"value": "2070"},
+                    "C.104": {"value": "500"},
+                    "C.105": {"value": "500"},
+                    "C.116": {"value": "2070"},
+                    "C.117": {"value": "500"},
+                })
+            ],
+            defs(),
+        )
+
+        self.assertEqual(browser["applied"], 2070)
+        self.assertEqual(browser["admitted"], 500)
 
     def test_sat_act_promoted_fields_project_to_browser_columns(self):
         fields, browser = build_projection_rows(

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -48,7 +48,7 @@ from openpyxl.utils import get_column_letter
 
 
 PRODUCER_NAME = "tier1_xlsx"
-PRODUCER_VERSION = "0.2.2"
+PRODUCER_VERSION = "0.2.3"
 MIN_TEMPLATE_FIELDS_BEFORE_FALLBACK = 25
 
 # Default template path relative to the repo root.
@@ -370,8 +370,12 @@ def recover_c1_application_values(
 
     Several schools publish the standard 2024-25 workbook with C1 answers in
     the visible table's Total / residency columns instead of the template's
-    mapped answer cells. The row labels and section-C column order are stable
-    enough to recover the C1 values deterministically.
+    mapped answer cells. The 2025-26 template keeps those residency columns
+    but puts Total last (In-State, Out-of-State, International, Unknown,
+    Total). Compacting non-empty numbers left-to-right and zipping them onto
+    All-first slots therefore treats in-state as the college total — Issue
+    #159, Wabash 911 vs 2,496. Map by header when the residency block is
+    present, and never publish a total smaller than a gender component.
     """
     available_sheets = set(wb.sheetnames)
     sheet_name = "CDS-C" if "CDS-C" in available_sheets else build_sheet_aliases(available_sheets).get("CDS-C")
@@ -379,6 +383,7 @@ def recover_c1_application_values(
         return 0
     ws = wb[sheet_name]
     recovered: dict[str, object] = {}
+    residency_columns: dict[int, str] | None = None
 
     def lookup(gender: str, residency: str, action: str, unit_load: str = "All") -> str | None:
         target_gender_aliases = {
@@ -421,8 +426,33 @@ def recover_c1_application_values(
                 return value
         return None
 
+    def gender_sum_for_action(action: str) -> float | None:
+        total = 0.0
+        found = False
+        for gender in ("Males", "Females", "Another Gender", "Unknown"):
+            qnum = lookup(gender, "All", action)
+            raw = recovered.get(qnum) if qnum else None
+            if raw is None and qnum:
+                raw = values.get(qnum, {}).get("value")
+            parsed = _parse_number_like(raw)
+            if parsed is None:
+                continue
+            total += parsed
+            found = True
+        return total if found else None
+
+    def assign_residency(action: str, residency: str, raw_value) -> None:
+        qnum = lookup("All", residency, action)
+        if qnum and _is_number_like(raw_value):
+            recovered[qnum] = raw_value
+
     for row in ws.iter_rows(max_col=12):
         row_values = [cell.value for cell in row]
+        header_columns = _c1_residency_header_columns(row_values)
+        if header_columns:
+            residency_columns = header_columns
+            continue
+
         label_col = None
         label = ""
         for idx, value in enumerate(row_values):
@@ -449,9 +479,9 @@ def recover_c1_application_values(
             continue
 
         gender = None
-        if " men " in f" {label} ":
+        if " men " in f" {label} " or " males " in f" {label} ":
             gender = "Males"
-        elif " women " in f" {label} ":
+        elif " women " in f" {label} " or " females " in f" {label} ":
             gender = "Females"
         elif "another gender" in label:
             gender = "Another Gender"
@@ -475,27 +505,143 @@ def recover_c1_application_values(
         if " who " not in label:
             continue
 
+        if residency_columns:
+            for col_idx, residency in residency_columns.items():
+                assign_residency(action, residency, _row_value(row_values, col_idx))
+            continue
+
         numeric_values = [value for value in row_values[label_col + 1:] if _is_number_like(value)]
         if not numeric_values:
+            continue
+        gender_total = gender_sum_for_action(action)
+        last_number = _parse_number_like(numeric_values[-1])
+        if (
+            len(numeric_values) >= 2
+            and gender_total is not None
+            and last_number is not None
+            and abs(last_number - gender_total) <= 1
+        ):
+            assign_residency(action, "All", numeric_values[-1])
+            for residency, value in zip(
+                ("In-State", "Out-of-State", "Nonresidents", "Unknown"),
+                numeric_values[:-1],
+            ):
+                assign_residency(action, residency, value)
             continue
         for residency, value in zip(
             ("All", "In-State", "Out-of-State", "Nonresidents", "Unknown"),
             numeric_values,
         ):
-            qnum = lookup("All", residency, action)
-            if qnum:
-                recovered[qnum] = value
+            assign_residency(action, residency, value)
 
     count = 0
     for qnum, raw_value in recovered.items():
         if qnum not in qnum_to_field:
             continue
-        value = str(raw_value).strip()
+        value = _format_recovered_number(raw_value)
         if not value:
             continue
         if values.get(qnum, {}).get("value") == value:
             continue
         values[qnum] = _field_record(qnum, value, qnum_to_field)
+        count += 1
+    count += _restore_incoherent_c1_totals(values, qnum_to_field)
+    return count
+
+
+def _c1_header_residency(normalized: str) -> str | None:
+    if normalized in {"total", "all", "grand total"}:
+        return "All"
+    if "out of state" in normalized:
+        return "Out-of-State"
+    if normalized in {"in state", "instate"} or normalized.startswith("in state"):
+        return "In-State"
+    if "international" in normalized or "nonresident" in normalized:
+        return "Nonresidents"
+    if normalized in {"unknown", "unknown residency"}:
+        return "Unknown"
+    return None
+
+
+def _c1_residency_header_columns(row_values: list) -> dict[int, str] | None:
+    found: dict[int, str] = {}
+    for idx, value in enumerate(row_values):
+        residency = _c1_header_residency(_norm_label(value))
+        if residency:
+            found[idx] = residency
+    labels = set(found.values())
+    if "In-State" in labels and ("All" in labels or "Out-of-State" in labels):
+        return found
+    return None
+
+
+def _parse_number_like(value) -> float | None:
+    if not _is_number_like(value):
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value).replace(",", "").strip())
+    except ValueError:
+        return None
+
+
+def _format_recovered_number(value) -> str:
+    parsed = _parse_number_like(value)
+    if parsed is None:
+        return str(value).strip() if value is not None else ""
+    if parsed.is_integer():
+        return str(int(parsed))
+    return str(value).strip()
+
+
+def _restore_incoherent_c1_totals(values: dict, qnum_to_field: dict[str, dict]) -> int:
+    """Replace a published C1 total that is smaller than a gender component."""
+    count = 0
+    for action in ("applied", "admitted", "enrolled"):
+        total_qnum = None
+        gender_qnums: list[str] = []
+        for qnum, field in qnum_to_field.items():
+            if not str(qnum).startswith("C.1"):
+                continue
+            if str(field.get("residency") or "All") != "All":
+                continue
+            question = _norm_label(field.get("question"))
+            if action == "admitted":
+                if "admitted" not in question:
+                    continue
+            elif action == "applied":
+                if "applied" not in question:
+                    continue
+            elif action == "enrolled":
+                if "enrolled" not in question:
+                    continue
+                if "full time" in question or "part time" in question:
+                    continue
+            gender = _norm_label(field.get("gender"))
+            if gender == "all":
+                total_qnum = qnum
+            elif gender in {"men", "male", "males", "women", "female", "females", "another gender", "unknown", "students of unknown sex", "unknown gender"}:
+                gender_qnums.append(qnum)
+        if not total_qnum or not gender_qnums:
+            continue
+        gender_values = [
+            parsed
+            for parsed in (_parse_number_like(values.get(qnum, {}).get("value")) for qnum in gender_qnums)
+            if parsed is not None
+        ]
+        if not gender_values:
+            continue
+        total_value = _parse_number_like(values.get(total_qnum, {}).get("value"))
+        gender_sum = sum(gender_values)
+        if total_value is not None and total_value + 0.5 >= max(gender_values):
+            continue
+        restored = _format_recovered_number(gender_sum)
+        if values.get(total_qnum, {}).get("value") == restored:
+            continue
+        values[total_qnum] = _field_record(total_qnum, restored, qnum_to_field)
         count += 1
     return count
 

--- a/tools/tier1_extractor/test_extract.py
+++ b/tools/tier1_extractor/test_extract.py
@@ -11,6 +11,63 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from extract import extract
 
 
+def _c1_field(
+    qnum: str,
+    question: str,
+    *,
+    gender: str = "All",
+    residency: str = "All",
+    unit_load: str = "All",
+) -> dict:
+    return {
+        "question_number": qnum,
+        "word_tag": None,
+        "question": question,
+        "section": "First-Time, First-Year Admission",
+        "subsection": "Applications",
+        "value_type": "Number",
+        "gender": gender,
+        "residency": residency,
+        "unit_load": unit_load,
+    }
+
+
+def _schema_2025_c1() -> dict:
+    fields = [
+        _c1_field("C.101", "Total first-time, first-year males who applied", gender="Males"),
+        _c1_field("C.102", "Total first-time, first-year females who applied", gender="Females"),
+        _c1_field("C.103", "Total first-time, first-year students of unknown sex who applied", gender="Unknown"),
+        _c1_field("C.104", "Total first-time, first-year males who were admitted", gender="Males"),
+        _c1_field("C.105", "Total first-time, first-year females who were admitted", gender="Females"),
+        _c1_field("C.106", "Total first-time, first-year students of unknown sex who were admitted", gender="Unknown"),
+        _c1_field("C.107", "Total first-time, first-year males who enrolled", gender="Males"),
+        _c1_field("C.108", "Total first-time, first-year females who enrolled", gender="Females"),
+        _c1_field("C.109", "Total first-time, first-year students of unknown sex who enrolled", gender="Unknown"),
+        _c1_field(
+            "C.110",
+            "Total full-time, first-time, first-year males who enrolled",
+            gender="Males",
+            unit_load="FT",
+        ),
+        _c1_field("C.116", "Total first-time, first-year students who applied"),
+        _c1_field("C.117", "Total first-time, first-year students who were admitted"),
+        _c1_field("C.118", "Total first-time, first-year students who enrolled"),
+        _c1_field("C.119", "Total first-time, first-year who applied", residency="In-State"),
+        _c1_field("C.120", "Total first-time, first-year who were admitted", residency="In-State"),
+        _c1_field("C.121", "Total first-time, first-year who enrolled", residency="In-State"),
+        _c1_field("C.122", "Total first-time, first-year who applied", residency="Out-of-State"),
+        _c1_field("C.123", "Total first-time, first-year who were admitted", residency="Out-of-State"),
+        _c1_field("C.124", "Total first-time, first-year who enrolled", residency="Out-of-State"),
+        _c1_field("C.125", "Total first-time, first-year who applied", residency="Nonresidents"),
+        _c1_field("C.126", "Total first-time, first-year who were admitted", residency="Nonresidents"),
+        _c1_field("C.127", "Total first-time, first-year who enrolled", residency="Nonresidents"),
+        _c1_field("C.128", "Total first-time, first-year who applied", residency="Unknown"),
+        _c1_field("C.129", "Total first-time, first-year who were admitted", residency="Unknown"),
+        _c1_field("C.130", "Total first-time, first-year who enrolled", residency="Unknown"),
+    ]
+    return {"schema_version": "2025-26", "fields": fields}
+
+
 class Tier1ExtractTests(unittest.TestCase):
     def test_uses_short_section_tab_aliases_for_template_cell_map(self):
         wb = openpyxl.Workbook()
@@ -251,6 +308,102 @@ class Tier1ExtractTests(unittest.TestCase):
         self.assertEqual(result["values"]["C.118"]["value"], "23446")
         self.assertEqual(result["values"]["C.119"]["value"], "6218")
         self.assertEqual(result["stats"]["application_fields_recovered"], 11)
+
+    def test_maps_2025_residency_block_total_last_not_in_state_as_all(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "CDS-C"
+        ws["B11"] = "Total first-time, first-year males who applied"
+        ws["E11"] = 2496
+        ws["B16"] = "Total first-time, first-year males who were admitted"
+        ws["E16"] = 1424
+        ws["B21"] = "Total first-time, first-year males who enrolled"
+        ws["E21"] = 264
+        ws["B26"] = "Total full-time, first-time, first-year males who enrolled"
+        ws["E26"] = 264
+        ws["E36"] = "In-State"
+        ws["F36"] = "Out-of-State"
+        ws["G36"] = "International"
+        ws["H36"] = "Unknown"
+        ws["I36"] = "Total"
+        ws["B37"] = "Total first-time, first-year (degree-seeking) who applied"
+        ws["E37"] = 911
+        ws["F37"] = 741
+        ws["G37"] = 844
+        ws["I37"] = 2496
+        ws["B38"] = "Total first-time, first-year (degree-seeking) who were admitted"
+        ws["E38"] = 657
+        ws["F38"] = 519
+        ws["G38"] = 248
+        ws["I38"] = 1424
+        ws["B39"] = "Total first-time, first-year (degree-seeking) who enrolled"
+        ws["E39"] = 185
+        ws["F39"] = 56
+        ws["G39"] = 23
+        ws["I39"] = 264
+
+        schema = _schema_2025_c1()
+        # Template map already has the correct Total cells; recovery must
+        # not zip the in-state column onto C.116/C.117/C.118.
+        cell_map = {
+            "C.101": ("CDS-C", "E11"),
+            "C.104": ("CDS-C", "E16"),
+            "C.107": ("CDS-C", "E21"),
+            "C.116": ("CDS-C", "I37"),
+            "C.117": ("CDS-C", "I38"),
+            "C.118": ("CDS-C", "I39"),
+            "C.119": ("CDS-C", "E37"),
+            "C.122": ("CDS-C", "F37"),
+            "C.125": ("CDS-C", "G37"),
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(Path(tmp.name), schema, cell_map)
+
+        self.assertEqual(result["values"]["C.101"]["value"], "2496")
+        self.assertEqual(result["values"]["C.116"]["value"], "2496")
+        self.assertEqual(result["values"]["C.117"]["value"], "1424")
+        self.assertEqual(result["values"]["C.118"]["value"], "264")
+        self.assertEqual(result["values"]["C.119"]["value"], "911")
+        self.assertEqual(result["values"]["C.122"]["value"], "741")
+        self.assertEqual(result["values"]["C.125"]["value"], "844")
+        self.assertEqual(result["values"]["C.120"]["value"], "657")
+        self.assertEqual(result["values"]["C.123"]["value"], "519")
+        self.assertEqual(result["values"]["C.126"]["value"], "248")
+
+    def test_maps_2025_residency_block_when_unknown_column_is_filled(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "CDS-C"
+        ws["B11"] = "Total first-time, first-year males who applied"
+        ws["E11"] = 1000
+        ws["B12"] = "Total first-time, first-year females who applied"
+        ws["E12"] = 2000
+        ws["E36"] = "In-State"
+        ws["F36"] = "Out-of-State"
+        ws["G36"] = "International"
+        ws["H36"] = "Unknown"
+        ws["I36"] = "Total"
+        ws["B37"] = "Total first-time, first-year (degree-seeking) who applied"
+        ws["E37"] = 1100
+        ws["F37"] = 1200
+        ws["G37"] = 400
+        ws["H37"] = 300
+        ws["I37"] = 3000
+
+        schema = _schema_2025_c1()
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            wb.save(tmp.name)
+            result = extract(Path(tmp.name), schema, {"C.101": ("CDS-C", "Z99")})
+
+        self.assertEqual(result["values"]["C.101"]["value"], "1000")
+        self.assertEqual(result["values"]["C.102"]["value"], "2000")
+        self.assertEqual(result["values"]["C.116"]["value"], "3000")
+        self.assertEqual(result["values"]["C.119"]["value"], "1100")
+        self.assertEqual(result["values"]["C.122"]["value"], "1200")
+        self.assertEqual(result["values"]["C.125"]["value"], "400")
+        self.assertEqual(result["values"]["C.128"]["value"], "300")
 
     def test_recovers_freshman_c9_header_and_clears_blank_visible_rows(self):
         wb = openpyxl.Workbook()

--- a/web/src/app/schools/[school_id]/[year]/opengraph-image.tsx
+++ b/web/src/app/schools/[school_id]/[year]/opengraph-image.tsx
@@ -4,6 +4,7 @@ import {
   fetchDocumentsBySchoolAndYear,
   fetchExtract,
 } from "@/lib/queries";
+import { c1HeadlineTotals, fieldNumber } from "@/lib/c1-headline-totals";
 import type { FieldValue } from "@/lib/types";
 import { cachedSchoolInks, schoolOgColors } from "@/lib/school-inks";
 
@@ -18,27 +19,7 @@ function getNum(
   values: Record<string, FieldValue>,
   id: string
 ): number | null {
-  const field = values[id];
-  if (!field) return null;
-  const v = field.value_decoded ?? field.value;
-  const n = parseFloat(v.replace(/,/g, ""));
-  return isNaN(n) ? null : n;
-}
-
-function sumFields(
-  values: Record<string, FieldValue>,
-  ...ids: string[]
-): number | null {
-  let total = 0;
-  let found = false;
-  for (const id of ids) {
-    const n = getNum(values, id);
-    if (n != null) {
-      total += n;
-      found = true;
-    }
-  }
-  return found ? total : null;
+  return fieldNumber(values, id);
 }
 
 export default async function Image({
@@ -81,9 +62,11 @@ export default async function Image({
   const doc = docs[0];
   if (doc.extraction_status === "extracted" && doc.document_id) {
     const { mergedValues: values } = await fetchExtract(doc.document_id);
-
-    const totalApplied = sumFields(values, "C.101", "C.102", "C.103");
-    const totalAdmitted = sumFields(values, "C.104", "C.105", "C.106");
+    const schemaVersion = doc.canonical_year ?? doc.cds_year;
+    const { applied: totalApplied, admitted: totalAdmitted } = c1HeadlineTotals(
+      values,
+      schemaVersion,
+    );
 
     if (totalApplied && totalAdmitted && totalApplied > 0) {
       stats.push({

--- a/web/src/components/KeyStats.tsx
+++ b/web/src/components/KeyStats.tsx
@@ -1,4 +1,5 @@
 import type { FieldValue } from "@/lib/types";
+import { c1HeadlineTotals } from "@/lib/c1-headline-totals";
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
@@ -17,50 +18,6 @@ function getNum(values: Record<string, FieldValue>, id: string): number | null {
   return isNaN(n) ? null : n;
 }
 
-function sumFields(
-  values: Record<string, FieldValue>,
-  ...ids: string[]
-): number | null {
-  let total = 0;
-  let found = false;
-  for (const id of ids) {
-    const n = getNum(values, id);
-    if (n != null) {
-      total += n;
-      found = true;
-    }
-  }
-  return found ? total : null;
-}
-
-function c1TotalsForSchema(schemaVersion: string | undefined): {
-  applied: string[];
-  admitted: string[];
-  enrolled: string[];
-} {
-  if (schemaVersion === "2024-25") {
-    return {
-      applied: ["C.117"],
-      admitted: ["C.118"],
-      enrolled: ["C.119"],
-    };
-  }
-
-  if (schemaVersion === "2025-26") {
-    return {
-      applied: ["C.116"],
-      admitted: ["C.117"],
-      enrolled: ["C.118"],
-    };
-  }
-
-  return {
-    applied: ["C.101", "C.102", "C.103"],
-    admitted: ["C.104", "C.105", "C.106"],
-    enrolled: ["C.107", "C.108", "C.109"],
-  };
-}
-
 export function KeyStats({
   schemaVersion,
   values,
@@ -70,10 +27,8 @@ export function KeyStats({
 }) {
   const stats: { label: string; value: string }[] = [];
 
-  const c1Totals = c1TotalsForSchema(schemaVersion);
-  const totalApplied = sumFields(values, ...c1Totals.applied);
-  const totalAdmitted = sumFields(values, ...c1Totals.admitted);
-  const totalEnrolled = sumFields(values, ...c1Totals.enrolled);
+  const { applied: totalApplied, admitted: totalAdmitted, enrolled: totalEnrolled } =
+    c1HeadlineTotals(values, schemaVersion);
 
   // Acceptance rate
   if (totalApplied && totalAdmitted && totalApplied > 0) {

--- a/web/src/lib/c1-headline-totals.test.ts
+++ b/web/src/lib/c1-headline-totals.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { c1HeadlineTotals } from "./c1-headline-totals";
+import type { FieldValue } from "./types";
+
+function field(value: string): FieldValue {
+  return { value, value_type: "Number" };
+}
+
+describe("c1HeadlineTotals", () => {
+  it("keeps a coherent 2025-26 total", () => {
+    const totals = c1HeadlineTotals(
+      {
+        "C.101": field("1200"),
+        "C.102": field("1300"),
+        "C.116": field("2500"),
+        "C.104": field("100"),
+        "C.105": field("200"),
+        "C.117": field("300"),
+      },
+      "2025-26",
+    );
+    expect(totals.applied).toBe(2500);
+    expect(totals.admitted).toBe(300);
+  });
+
+  it("does not treat in-state as the college total when it is smaller than males", () => {
+    const totals = c1HeadlineTotals(
+      {
+        "C.101": field("2496"),
+        "C.104": field("1424"),
+        "C.107": field("264"),
+        "C.116": field("911"),
+        "C.117": field("657"),
+        "C.118": field("185"),
+        "C.119": field("741"),
+        "C.120": field("519"),
+        "C.121": field("56"),
+        "C.122": field("844"),
+        "C.123": field("248"),
+        "C.124": field("23"),
+        "C.125": field("2496"),
+        "C.126": field("1424"),
+        "C.127": field("264"),
+      },
+      "2025-26",
+    );
+    expect(totals.applied).toBe(2496);
+    expect(totals.admitted).toBe(1424);
+    expect(totals.enrolled).toBe(264);
+  });
+
+  it("detects a Total-last zip when the published total is still larger than each gender", () => {
+    const totals = c1HeadlineTotals(
+      {
+        "C.101": field("5000"),
+        "C.102": field("4958"),
+        "C.116": field("8120"),
+        "C.119": field("1688"),
+        "C.122": field("150"),
+        "C.125": field("9958"),
+      },
+      "2025-26",
+    );
+    expect(totals.applied).toBe(9958);
+  });
+
+  it("does not replace a women's-college total that matches each gender column", () => {
+    const totals = c1HeadlineTotals(
+      {
+        "C.101": field("2070"),
+        "C.102": field("2070"),
+        "C.116": field("2070"),
+      },
+      "2025-26",
+    );
+    expect(totals.applied).toBe(2070);
+  });
+
+  it("uses gender components when the published total is zero", () => {
+    const totals = c1HeadlineTotals(
+      {
+        "C.101": field("100"),
+        "C.102": field("120"),
+        "C.116": field("0"),
+      },
+      "2025-26",
+    );
+    expect(totals.applied).toBe(220);
+  });
+});

--- a/web/src/lib/c1-headline-totals.ts
+++ b/web/src/lib/c1-headline-totals.ts
@@ -1,0 +1,171 @@
+import type { FieldValue } from "@/lib/types";
+
+export type C1HeadlineTotals = {
+  applied: number | null;
+  admitted: number | null;
+  enrolled: number | null;
+};
+
+type HeadlineSpec = {
+  total: string;
+  gender: string[];
+  residency?: {
+    inState: string;
+    outOfState: string;
+    nonresidents: string;
+    unknown: string;
+  };
+};
+
+function headlineSpecs(schemaVersion?: string | null): {
+  applied: HeadlineSpec;
+  admitted: HeadlineSpec;
+  enrolled: HeadlineSpec;
+} {
+  if (schemaVersion === "2024-25") {
+    return {
+      applied: {
+        total: "C.117",
+        gender: ["C.101", "C.102", "C.103", "C.104"],
+      },
+      admitted: {
+        total: "C.118",
+        gender: ["C.105", "C.106", "C.107", "C.108"],
+      },
+      enrolled: {
+        total: "C.119",
+        gender: ["C.109", "C.110", "C.111", "C.112", "C.113", "C.114", "C.115", "C.116"],
+      },
+    };
+  }
+
+  if (schemaVersion === "2025-26") {
+    return {
+      applied: {
+        total: "C.116",
+        gender: ["C.101", "C.102", "C.103"],
+        residency: {
+          inState: "C.119",
+          outOfState: "C.122",
+          nonresidents: "C.125",
+          unknown: "C.128",
+        },
+      },
+      admitted: {
+        total: "C.117",
+        gender: ["C.104", "C.105", "C.106"],
+        residency: {
+          inState: "C.120",
+          outOfState: "C.123",
+          nonresidents: "C.126",
+          unknown: "C.129",
+        },
+      },
+      enrolled: {
+        total: "C.118",
+        gender: ["C.107", "C.108", "C.109"],
+        residency: {
+          inState: "C.121",
+          outOfState: "C.124",
+          nonresidents: "C.127",
+          unknown: "C.130",
+        },
+      },
+    };
+  }
+
+  return {
+    applied: { total: "C.101", gender: ["C.101", "C.102", "C.103"] },
+    admitted: { total: "C.104", gender: ["C.104", "C.105", "C.106"] },
+    enrolled: { total: "C.107", gender: ["C.107", "C.108", "C.109"] },
+  };
+}
+
+export function fieldNumber(
+  values: Record<string, FieldValue>,
+  id: string,
+): number | null {
+  const field = values[id];
+  if (!field) return null;
+  const raw = field.value_decoded ?? field.value;
+  if (raw == null || raw === "") return null;
+  const n = parseFloat(String(raw).replace(/,/g, ""));
+  return Number.isNaN(n) ? null : n;
+}
+
+function sumPresent(
+  values: Record<string, FieldValue>,
+  ids: string[],
+): { sum: number; max: number; count: number } | null {
+  let sum = 0;
+  let max = -Infinity;
+  let count = 0;
+  for (const id of ids) {
+    const n = fieldNumber(values, id);
+    if (n == null) continue;
+    sum += n;
+    if (n > max) max = n;
+    count += 1;
+  }
+  if (count === 0) return null;
+  return { sum, max, count };
+}
+
+function preferCoherentTotal(
+  values: Record<string, FieldValue>,
+  spec: HeadlineSpec,
+): number | null {
+  const gender = sumPresent(values, spec.gender);
+  const total = fieldNumber(values, spec.total);
+
+  if (total != null && total === 0 && gender && gender.sum > 0) {
+    return gender.sum;
+  }
+
+  if (gender && total != null && total < gender.max) {
+    return gender.sum;
+  }
+
+  const residency = spec.residency;
+  if (residency && gender) {
+    const inState = fieldNumber(values, residency.inState);
+    const outOfState = fieldNumber(values, residency.outOfState);
+    const nonresidents = fieldNumber(values, residency.nonresidents);
+    const unknown = fieldNumber(values, residency.unknown);
+    if (
+      total != null &&
+      inState != null &&
+      outOfState != null &&
+      nonresidents != null &&
+      Math.abs(total + inState + outOfState - nonresidents) <= 1 &&
+      Math.abs(nonresidents - gender.sum) <= 1 &&
+      Math.abs(total - nonresidents) > 1
+    ) {
+      return gender.sum;
+    }
+    if (
+      unknown != null &&
+      Math.abs(unknown - gender.sum) <= 1 &&
+      total != null &&
+      total < unknown
+    ) {
+      return gender.sum;
+    }
+  }
+
+  if (total != null && total > 0) return total;
+  if (gender) return gender.sum;
+  return total;
+}
+
+export function c1HeadlineTotals(
+  values: Record<string, FieldValue>,
+  schemaVersion?: string | null,
+): C1HeadlineTotals {
+  const specs = headlineSpecs(schemaVersion);
+  return {
+    applied: preferCoherentTotal(values, specs.applied),
+    admitted: preferCoherentTotal(values, specs.admitted),
+    enrolled: preferCoherentTotal(values, specs.enrolled),
+  };
+}

--- a/web/src/lib/reconstructed-tables.test.ts
+++ b/web/src/lib/reconstructed-tables.test.ts
@@ -205,6 +205,32 @@ describe("buildReconstructedTables", () => {
     expect(c1?.usedFieldIds).toContain("C.117");
   });
 
+  it("does not display an in-state C1 total that is smaller than the male count", () => {
+    const tables = buildReconstructedTables(
+      {
+        "C.101": field("2496", "Total first-time, first-year males who applied"),
+        "C.104": field("1424", "Total first-time, first-year males who were admitted"),
+        "C.116": field("911", "Total first-time, first-year students who applied"),
+        "C.117": field("657", "Total first-time, first-year students who were admitted"),
+      },
+      "2025-26",
+    );
+
+    const c1 = tables.find((table) => table.key === "c1-admissions");
+    expect(c1?.rows[0].cells.map((cell) => cell.display)).toEqual([
+      "2,496",
+      "Not reported",
+      "Not reported",
+      "2,496",
+    ]);
+    expect(c1?.rows[1].cells.map((cell) => cell.display)).toEqual([
+      "1,424",
+      "Not reported",
+      "Not reported",
+      "1,424",
+    ]);
+  });
+
   it("uses the 2024 C1 layout when the question text exposes another gender fields", () => {
     const tables = buildReconstructedTables({
       "C.101": field("1200", "Total first-time, first-year men who applied"),

--- a/web/src/lib/reconstructed-tables.ts
+++ b/web/src/lib/reconstructed-tables.ts
@@ -1,3 +1,4 @@
+import { c1HeadlineTotals } from "./c1-headline-totals";
 import { formatFieldValue } from "./format";
 import { isSchema2024_25 } from "./schema-labels";
 import type { FieldValue } from "./types";
@@ -456,39 +457,72 @@ function isC12024Layout(values: Record<string, FieldValue>): boolean {
 }
 
 function c1Table2025(values: Record<string, FieldValue>): ReconstructedTable {
-  return makeTable({
-    key: "c1-admissions",
-    title: "C1 first-year admissions",
-    caption:
-      "First-time, first-year applicants, admits, and enrolled students by sex or status.",
-    columns: ["Males", "Females", "Unknown sex", "Total"],
-    rows: [
-      ["applied", "Applied", ["C.101", "C.102", "C.103", "C.116"]],
-      ["admitted", "Admitted", ["C.104", "C.105", "C.106", "C.117"]],
-      ["enrolled", "Enrolled", ["C.107", "C.108", "C.109", "C.118"]],
-      ["enrolled-ft", "Enrolled full-time", ["C.110", "C.112", "C.114", null]],
-      ["enrolled-pt", "Enrolled part-time", ["C.111", "C.113", "C.115", null]],
-    ],
+  return patchC1HeadlineTotals(
+    makeTable({
+      key: "c1-admissions",
+      title: "C1 first-year admissions",
+      caption:
+        "First-time, first-year applicants, admits, and enrolled students by sex or status.",
+      columns: ["Males", "Females", "Unknown sex", "Total"],
+      rows: [
+        ["applied", "Applied", ["C.101", "C.102", "C.103", "C.116"]],
+        ["admitted", "Admitted", ["C.104", "C.105", "C.106", "C.117"]],
+        ["enrolled", "Enrolled", ["C.107", "C.108", "C.109", "C.118"]],
+        ["enrolled-ft", "Enrolled full-time", ["C.110", "C.112", "C.114", null]],
+        ["enrolled-pt", "Enrolled part-time", ["C.111", "C.113", "C.115", null]],
+      ],
+      values,
+    }),
     values,
-  });
+    "2025-26",
+  );
 }
 
 function c1Table2024(values: Record<string, FieldValue>): ReconstructedTable {
-  return makeTable({
-    key: "c1-admissions",
-    title: "C1 first-year admissions",
-    caption:
-      "First-time, first-year applicants, admits, and enrolled students by gender or status.",
-    columns: ["Men", "Women", "Another gender", "Unknown gender", "Total"],
-    rows: [
-      ["applied", "Applied", ["C.101", "C.102", "C.103", "C.104", "C.117"]],
-      ["admitted", "Admitted", ["C.105", "C.106", "C.107", "C.108", "C.118"]],
-      ["enrolled-ft", "Enrolled full-time", ["C.109", "C.111", "C.113", "C.115", null]],
-      ["enrolled-pt", "Enrolled part-time", ["C.110", "C.112", "C.114", "C.116", null]],
-      ["enrolled-total", "Enrolled total", [null, null, null, null, "C.119"]],
-    ],
+  return patchC1HeadlineTotals(
+    makeTable({
+      key: "c1-admissions",
+      title: "C1 first-year admissions",
+      caption:
+        "First-time, first-year applicants, admits, and enrolled students by gender or status.",
+      columns: ["Men", "Women", "Another gender", "Unknown gender", "Total"],
+      rows: [
+        ["applied", "Applied", ["C.101", "C.102", "C.103", "C.104", "C.117"]],
+        ["admitted", "Admitted", ["C.105", "C.106", "C.107", "C.108", "C.118"]],
+        ["enrolled-ft", "Enrolled full-time", ["C.109", "C.111", "C.113", "C.115", null]],
+        ["enrolled-pt", "Enrolled part-time", ["C.110", "C.112", "C.114", "C.116", null]],
+        ["enrolled-total", "Enrolled total", [null, null, null, null, "C.119"]],
+      ],
+      values,
+    }),
     values,
-  });
+    "2024-25",
+  );
+}
+
+function patchC1HeadlineTotals(
+  table: ReconstructedTable,
+  values: Record<string, FieldValue>,
+  schemaVersion: string,
+): ReconstructedTable {
+  const headlines = c1HeadlineTotals(values, schemaVersion);
+  const byRow: Record<string, number | null> = {
+    applied: headlines.applied,
+    admitted: headlines.admitted,
+    enrolled: headlines.enrolled,
+    "enrolled-total": headlines.enrolled,
+  };
+  for (const row of table.rows) {
+    const coherent = byRow[row.key];
+    if (coherent == null) continue;
+    const cell = row.cells.at(-1);
+    if (!cell) continue;
+    const display = formatFieldValue(String(coherent), "Number");
+    if (cell.display === display) continue;
+    cell.display = display;
+    cell.missing = false;
+  }
+  return table;
 }
 
 function buildC7Tables(values: Record<string, FieldValue>): ReconstructedTable[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses [#159](https://github.com/bolewood/collegedata-fyi/issues/159) (user-submitted): Wabash College 2025–26 hero shows Applications 911 / Admitted 657 / Enrolled 185, while the official CDS totals are 2,496 / 1,424 / 264.

## What was wrong

Not a KeyStats-only display bug. Stored `cds_fields` and `school_browser_rows` both have `applied=911`. Producer is `tier1_xlsx` 0.2.2. The official workbook is a filled 2025–26 template:

| | In-State | Out-of-State | International | Unknown | Total |
|---|---|---|---|---|---|
| Applied | **911** | 741 | 844 | (empty) | **2496** |

Gender totals in column E are already correct (males applied 2,496). Template cell map reads Total from column I (`C.116` = I37, cached as 2496). `recover_c1_application_values` then compacted non-empty numbers left-to-right and zipped them onto `(All, In-State, Out-of-State, Nonresidents, Unknown)`. Empty Unknown was skipped, so All became 911 and Nonresidents became 2496. That overwrite is why “Other fields” still showed 2,496: it is `C.125` wearing the generic residency question text.

Local re-extract of the official XLSX with current `main` reproduced 911/657/185 exactly (`application_fields_recovered: 12`). After this change the same file yields 2496/1424/264, with in-state 911 and international 844.

## Same class on the live corpus (2025–26)

Invariant: published total smaller than a gender component (`C.116 < max(C.101, C.102, C.103)`), plus the zip fingerprint `C.116 + C.119 + C.122 == C.125 == gender sum`.

- 31 schools fail the hard invariant (applied 30, admitted 26, enrolled 22)
- 5 XLSX schools match the exact Wabash zip: Wabash, Allegheny, Augustana University, Michigan Tech, Southern Connecticut
- 16 of the hard applied rows are `tier1_xlsx` (the extractor bug)
- 9 `tier4_docling` and 6 `tier2_acroform` rows are a sibling class (wrong column / zero total), not the XLSX zip
- 2024–25 browser metrics already sum gender fields, so this headline bug is new with the 2025–26 `C.116` total field. 2024–25 still has zero/subset `C.117` values on some school pages; KeyStats now uses the same gender guard there

Do not use “total < gender sum” as the only heal. Agnes Scott / Spelman look like doubled gender columns (`C.116` equals each gender component). Replacing those totals with the gender sum would double-count.

## What this PR changes

1. **Extractor (`tier1_xlsx` 0.2.3)** — map 2025–26 residency rows by header (In-State … Total last). Compact zip remains for 2024–25 Total-first sheets, with a Total-last fallback when the last number equals the gender sum. Never keep a total smaller than a gender component. Also recognize 2025–26 “males” / “females” labels.
2. **Browser projection** — if `C.116` is smaller than a gender component, or the residency zip fingerprint matches, use the gender sum for `applied` / `admitted` / `enrolled_first_year` (same zero-total fallback as today).
3. **School page** — KeyStats, reconstructed C1 Total column, and the year OG image share `c1HeadlineTotals` so the hero can be correct on deploy even before a redrain.

## After merge (ops, not this PR)

Frontend deploy heals the school-page hero and C1 table from existing `cds_fields`. Stored totals and residency columns stay shifted until:

1. Redrain 2025–26 XLSX documents with `tier1_xlsx` 0.2.3 (at least the five fingerprint schools; all 35 `xlsx` rows in 2025–26 are in scope)
2. Refresh `school_browser_rows` so browse / compare / recipes / the public API stop serving 911 as Wabash applied

PDF C1 compact zips (Baldwin Wallace, BYU, Loyola Chicago, etc.) are a related column-mapping class in `resolve_c1_applications`. The serving-layer gender guard will correct those headlines; the PDF cleaner is not changed here.

## Tests

- Fixture matching Wabash R36–R39: `C.116=2496`, `C.119=911`, `C.125=844`
- Unknown column filled: Total still maps to All
- Existing 2024–25 single-column recovery still passes
- Projector: Wabash-shaped row, fingerprint row (Southern Connecticut shape), Agnes Scott double-count left alone
- Local re-extract of https://www.wabash.edu/institutional_research/docs/cds-2025-2026.xlsx → 2496 / 1424 / 264

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

