### PR TITLE
Rewrite alignment-gap copy and keep hover boxes off the pointer

### DIFF
--- a/docs/recipes/alignment-gap.md
+++ b/docs/recipes/alignment-gap.md
@@ -1,17 +1,17 @@
 # Alignment gap
 
-**Question:** Of schools whose graduates carry an above-median debt burden,
-how many are already spending more per first-year student on non-need merit
-aid than it would take to close that gap?
+**Question:** How does graduate debt burden compare with non-need merit aid
+and with an institution's financial resources when College Scorecard, CDS
+H2A, and IPEDS are joined?
 
 Open [`/recipes/alignment-gap`](https://www.collegedata.fyi/recipes/alignment-gap)
-for two interactive scatters. Panel A is the CDS join: merit spend per
-first-year (H2A) against the alignment gap (Scorecard), colored by endowment
-per undergraduate (IPEDS). Schools that award no merit aid sit on a dedicated
-`$0` rail, off the log scale. Panel B keeps the endowment scatter so Bard,
-Grinnell, Bennington, Sarah Lawrence, Oberlin, and Earlham — no usable H2A —
-stay on the page. Both panels measure the gap against the same 375-school
-median burden. Hover any dot for the school name.
+for two interactive scatters. Panel A plots the alignment gap (Scorecard)
+against estimated non-need merit aid per first-year student (CDS H2A),
+colored by endowment per undergraduate (IPEDS). Schools that award no
+non-need merit aid sit on a dedicated `$0` rail, off the log scale. Panel B
+keeps a broader endowment comparison so schools without a usable H2A row —
+including Bard and Grinnell — stay on the page. Both panels measure the gap
+against the same 375-school median burden. Hover any dot for the school name.
 
 ## What the recipe computes
 
@@ -22,16 +22,16 @@ earnings:
 burden = median_debt_monthly_payment × 12 / earnings_10yr_median
 ```
 
-The **alignment gap** is the completer debt that would have to be shed to reach
-the 375-school corpus median burden at that school's own earnings, expressed
-per year of enrollment:
+The **alignment gap** estimates how much lower median completer debt would
+need to be for the school to reach the 375-school median burden at its
+existing earnings, expressed per year of enrollment:
 
 ```text
 gap = median_debt_completers × (1 − median_burden / burden) / 4
 ```
 
-**Merit spend per first-year** is the discount a school chooses to hand to
-students who did not demonstrate need:
+**Merit aid per first-year student** is the H2A non-need share times the
+average non-need grant:
 
 ```text
 merit_per_fy = non_need_aid_share_first_year_ft × avg_non_need_grant_first_year_ft
@@ -80,16 +80,17 @@ python3 tools/scorecard/build_alignment_gap_recipe.py
 
 ## How to read the panels
 
-- **Already spending it** — positive gap, merit spend ≥ gap.
-- **Genuinely constrained** — positive gap, merit spend below it. Control
-  group, not a target list. Includes schools that award $0 merit aid and
-  still have a gap.
-- **Gap ≤ 0** — burden at or below the corpus median.
-- Panel B quadrants split the same gap against endowment per undergraduate.
-  “High endowment” on both panels means at or above the 375-school median.
+- **Merit aid is larger than the gap** — positive gap, merit spend ≥ gap.
+- **Merit aid is smaller than the gap** — positive gap, merit spend below it.
+  Includes schools that award $0 merit aid and still have a gap.
+- **Debt burden is at or below the median** — no positive alignment gap under
+  this definition.
+- Panel B quadrants split the same gap against endowment per undergraduate:
+  higher/lower debt burden × higher/lower endowment. “High endowment” on both
+  panels means at or above the 375-school median.
 
-CDS H2A excludes some mixed-need merit awards and covers first-year full-time
-students only, so it describes the recruiting discount, not the whole aid
-budget. Scorecard earnings cover federally aided students and describe a
-cohort that enrolled about a decade before the CDS row. The join is
-institutional, not longitudinal.
+CDS H2A covers first-year full-time students and specifically reports
+non-need aid. Some awards that combine need and merit may not appear. Scorecard
+earnings cover federally aided students and describe a cohort that enrolled
+about a decade before the CDS row. The join is institutional, not longitudinal.
+The gap is a comparison measure, not a recommended tuition price.

--- a/web/src/app/recipes/alignment-gap/page.tsx
+++ b/web/src/app/recipes/alignment-gap/page.tsx
@@ -5,20 +5,21 @@ import { AlignmentGapMeritChart } from "@/components/AlignmentGapMeritChart";
 import { TrackedLink } from "@/components/TrackedLink";
 import { formatRecipeShare } from "@/lib/format";
 import {
-  formatEndowmentPerStudent,
   formatUsd,
   type AlignmentGapMeritRow,
+  type AlignmentGapRow,
 } from "@/lib/alignment-gap-recipe-analysis";
 import {
   ALIGNMENT_GAP_MERIT_META,
   ALIGNMENT_GAP_MERIT_SCHOOLS,
   ALIGNMENT_GAP_META,
+  ALIGNMENT_GAP_SCHOOLS,
 } from "@/lib/alignment-gap-recipe-data";
 
 export const metadata: Metadata = {
   title: "Alignment gap",
   description:
-    "Whether a school is already spending its alignment gap on non-need merit aid, plotted against College Scorecard debt burden and IPEDS endowment.",
+    "Debt burden, aid, and financial resources — College Scorecard, CDS H2A merit aid, and IPEDS endowment in one comparison.",
   alternates: { canonical: "/recipes/alignment-gap" },
   openGraph: { url: "/recipes/alignment-gap" },
 };
@@ -45,6 +46,9 @@ const TRAPPED_EXAMPLE_IDS = [
 const meritById = new Map(
   ALIGNMENT_GAP_MERIT_SCHOOLS.map((row) => [row.schoolId, row]),
 );
+const endowmentById = new Map(
+  ALIGNMENT_GAP_SCHOOLS.map((row) => [row.schoolId, row]),
+);
 
 function requireMerit(id: string): AlignmentGapMeritRow {
   const row = meritById.get(id);
@@ -52,56 +56,78 @@ function requireMerit(id: string): AlignmentGapMeritRow {
   return row;
 }
 
+function requireEndowment(id: string): AlignmentGapRow {
+  const row = endowmentById.get(id);
+  if (!row) throw new Error(`endowment join missing ${id}`);
+  return row;
+}
+
+function roundUsd(value: number, step: number): string {
+  return formatUsd(Math.round(value / step) * step);
+}
+
 const COVERS_EXAMPLES = COVERS_EXAMPLE_IDS.map(requireMerit);
 const TRAPPED_EXAMPLES = TRAPPED_EXAMPLE_IDS.map(requireMerit);
+const quincy = requireMerit("quincy-university");
+const hollins = requireEndowment("hollins-university");
+const bennington = requireEndowment("bennington-college");
+const bard = requireEndowment("bard-college");
+const grinnell = requireEndowment("grinnell-college");
 const ex = ALIGNMENT_GAP_MERIT_META.exclusions;
-const coversPct = formatRecipeShare(ALIGNMENT_GAP_MERIT_META.coversShare, 0);
+const medianEndowmentUsd = roundUsd(
+  ALIGNMENT_GAP_META.medianEndowmentPerStudent,
+  1000,
+);
+const hollinsEndowmentUsd = roundUsd(hollins.endowmentPerStudent, 1000);
+const bardEndowmentUsd = roundUsd(bard.endowmentPerStudent, 100);
+const grinnellEndowmentMillions = (grinnell.endowmentPerStudent / 1_000_000).toFixed(2);
+const benningtonInstructionPct = Math.round(bennington.instructionShare * 100);
 
 const REGIONS = [
   {
     num: "A",
-    head: "Already spending it",
+    head: "Merit aid is larger than the gap",
     count: ALIGNMENT_GAP_MERIT_META.regions.covers,
-    body: `${ALIGNMENT_GAP_MERIT_META.regions.covers} of ${ALIGNMENT_GAP_MERIT_META.positiveGap} — ${coversPct} — spend more per first-year student on non-need merit aid than their entire annual alignment gap. Quincy is the discounting model in one row: every first-year gets merit aid averaging $27,587 against a $20,359 net price.`,
+    body: `Among the ${ALIGNMENT_GAP_MERIT_META.positiveGap} schools in this view with above-median debt burden, ${ALIGNMENT_GAP_MERIT_META.regions.covers} report average non-need merit aid per first-year student that is larger than their annual alignment gap. Quincy University is an especially visible example. It reports non-need merit aid for every full-time first-year student, averaging ${formatUsd(quincy.avgMeritGrant)}, compared with an average net price of ${formatUsd(quincy.avgNetPrice)} and an alignment gap of ${formatUsd(quincy.gap)} per year. That does not mean Quincy could simply move ${formatUsd(quincy.gap)} from one budget line to another. It does show that the scale of its existing merit discount is large relative to the debt adjustment represented by the gap.`,
   },
   {
     num: "B",
-    head: "Genuinely constrained",
+    head: "Merit aid is smaller than the gap",
     count: ALIGNMENT_GAP_MERIT_META.regions.constrained,
-    body: "Positive gap, merit spend below it. This list is mostly regional publics and HBCUs. Incarnate Word sits on the $0 rail: it awards no non-need aid and still has a gap to close. Control group, not a target list — schools whose discount is already spoken for, or was never large enough to close the gap.",
+    body: "These schools also have above-median debt burden, but their reported non-need merit aid per first-year student is smaller than the alignment gap. Some award very little non-need merit aid at all. The University of the Incarnate Word, for example, reports $0 in this CDS measure while still showing a positive alignment gap. For these schools, Panel A provides less evidence that a large non-need merit program is part of the affordability picture. Other factors—price, need-based aid, student borrowing, graduate earnings, and the institution's broader finances—matter more.",
   },
   {
     num: "C",
-    head: "No gap to close",
+    head: "Debt burden is at or below the median",
     count: ALIGNMENT_GAP_MERIT_META.regions.none,
-    body: "Burden at or below the 375-school corpus median. The money question does not arise. They stay on the chart so the diagonal has a below as well as an above.",
+    body: `These schools have no positive alignment gap under this definition because their debt burden is already at or below the ${formatRecipeShare(ALIGNMENT_GAP_META.medianBurden, 2)} median used for the comparison. They remain on the chart so the relationship between merit aid and debt burden can be seen across the full sample.`,
   },
 ];
 
 const QUADRANTS = [
   {
     num: "I",
-    head: "Capacity exists",
+    head: "Higher debt burden · higher endowment",
     count: ALIGNMENT_GAP_META.quadrants.capacity,
-    body: "Burden above the median, and endowment above it too. If price and outcome are out of line here, the money to close the gap is on the balance sheet. Hollins sits furthest out: an 8.6% burden against about $457k per student.",
+    body: `These schools have debt burden above the sample median and endowment per undergraduate above the sample median. That combination does not tell us what a school should charge or how much of its endowment could be used for financial aid. It does tell us that the institution has relatively greater financial resources while its graduates still carry a relatively high federal-loan burden. Hollins University is near the outer edge of this group, with a ${formatRecipeShare(hollins.burden, 1)} debt burden and roughly ${hollinsEndowmentUsd} in endowment per undergraduate.`,
   },
   {
     num: "II",
-    head: "Constrained",
+    head: "Higher debt burden · lower endowment",
     count: ALIGNMENT_GAP_META.quadrants.constrained,
-    body: "The same elevated burden, without the endowment to buy the price down. Bennington lives here — high burden on a modest per-student endowment, and the lowest instruction-to-net-price ratio of its peer group at 0.76.",
+    body: `These schools also have above-median debt burden, but their endowment per undergraduate is below the median. That is an important distinction. Two colleges can produce a similar debt burden for graduates while having very different financial resources available to support students or subsidize the cost of instruction. Bennington College is one example: relatively high debt burden, a more modest endowment per student, and instructional spending equal to about ${benningtonInstructionPct}% of its average net price.`,
   },
   {
     num: "III",
-    head: "Endowment absorbs it",
+    head: "Lower debt burden · higher endowment",
     count: ALIGNMENT_GAP_META.quadrants.absorbs,
-    body: "Grinnell, Princeton, Stanford, Wellesley — low burden next to large per-student wealth. Instruction often exceeds net price — at these endowment levels, tuition is not what pays for the classroom.",
+    body: "These schools combine debt burden at or below the median with above-median endowment per undergraduate. This group includes Grinnell, Princeton, Stanford, and Wellesley. At a number of highly endowed colleges, reported instructional spending per student exceeds average net price. In other words, tuition and other payments from students are only part of what funds the educational program.",
   },
   {
     num: "IV",
-    head: "Earnings do the work",
+    head: "Lower debt burden · lower endowment",
     count: ALIGNMENT_GAP_META.quadrants.earnings,
-    body: "No unusual wealth, low burden anyway, because graduates earn enough to carry the debt. Bentley, Babson, and Santa Clara sit here.",
+    body: "These schools keep debt burden at or below the median without an unusually large endowment per student. Graduate earnings can be an important part of that result because earnings are the denominator in the debt-burden calculation. Debt levels matter too. Bentley, Babson, and Santa Clara are examples in this part of the chart.",
   },
 ];
 
@@ -113,9 +139,6 @@ export default function AlignmentGapPage() {
   const sampleMedianBurden = formatRecipeShare(
     ALIGNMENT_GAP_MERIT_META.sampleMedianBurden,
     2,
-  );
-  const medianEndowment = formatEndowmentPerStudent(
-    ALIGNMENT_GAP_META.medianEndowmentPerStudent,
   );
 
   return (
@@ -153,81 +176,86 @@ export default function AlignmentGapPage() {
               fontSize: "clamp(36px, 5.5vw, 52px)",
               margin: "12px 0 0",
               letterSpacing: "-0.02em",
-              lineHeight: 1,
+              lineHeight: 1.05,
             }}
           >
-            What a school charges, against what it{" "}
-            <span style={{ fontStyle: "italic" }}>delivers.</span>
+            Debt burden, aid, and{" "}
+            <span style={{ fontStyle: "italic" }}>financial resources</span>
           </h1>
-          <p
-            className="serif"
-            style={{
-              maxWidth: 740,
-              marginTop: 12,
-              color: "var(--ink-2)",
-              fontSize: 18,
-              fontStyle: "italic",
-              lineHeight: 1.55,
-            }}
-          >
-            Debt burden is the share of median 10-year earnings that goes to
-            federal loan payments each year. The alignment gap is the completer
-            debt a school would have to shed to reach the corpus median burden
-            at its own earnings, expressed per year of enrollment. Panel A asks
-            whether the school is already spending that money on students who
-            did not demonstrate need. Panel B asks whether the endowment could
-            close it.
-          </p>
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
           <span className="cd-chip">CDS H2A</span>
-          <span className="cd-chip">Scorecard</span>
+          <span className="cd-chip">College Scorecard</span>
           <span className="cd-chip">IPEDS</span>
         </div>
       </header>
+
+      <div style={{ maxWidth: 760, marginTop: 16 }}>
+        <p
+          className="serif"
+          style={{
+            margin: 0,
+            color: "var(--ink-2)",
+            fontSize: 18,
+            fontStyle: "italic",
+            lineHeight: 1.55,
+          }}
+        >
+          College affordability data lives in several different places.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The College Scorecard tells us about student debt, loan payments,
+          earnings, and net price. The Common Data Set tells us how colleges
+          use non-need merit aid. IPEDS tells us about institutional finances,
+          including endowment and instructional spending.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          This page joins those sources to look at them together.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The starting point is <strong>debt burden</strong>: the share of
+          median earnings that would go toward federal student-loan payments
+          each year. We then calculate an <strong>alignment gap</strong> for
+          each school: roughly how much less debt its graduates would need to
+          carry, expressed per year of college, to reach the median debt burden
+          in this group of schools.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The gap is not a recommended tuition price or a claim that lowering
+          price by exactly that amount would produce the same reduction in
+          borrowing. It is a common yardstick that lets us compare the size of
+          the debt burden with other financial measures from the college.
+        </p>
+      </div>
 
       <section
         className="endowment-recipe-ledger rule-2"
         style={{ marginTop: 28 }}
       >
         <div>
-          <span className="meta">Merit join</span>
           <strong>{ALIGNMENT_GAP_MERIT_META.schoolCount.toLocaleString("en-US")}</strong>
-          <small>CDS H2A × Scorecard × IPEDS, after range guards</small>
+          <small>Schools with usable merit-aid, debt, earnings, price, and endowment data</small>
         </div>
         <div>
-          <span className="meta">Already spending it</span>
+          <strong>{ALIGNMENT_GAP_MERIT_META.positiveGap.toLocaleString("en-US")}</strong>
+          <small>
+            Debt burden above the {corpusMedianBurden} median used on this page
+          </small>
+        </div>
+        <div>
           <strong>
             {ALIGNMENT_GAP_MERIT_META.regions.covers} of {ALIGNMENT_GAP_MERIT_META.positiveGap}
           </strong>
           <small>
-            {coversPct} of schools with a positive gap — merit sample
+            Schools where estimated non-need merit aid per first-year student is
+            larger than the annual alignment gap
           </small>
         </div>
         <div>
-          <span className="meta">Genuinely constrained</span>
-          <strong>{ALIGNMENT_GAP_MERIT_META.regions.constrained.toLocaleString("en-US")}</strong>
-          <small>Positive gap, merit spend below it — merit sample</small>
-        </div>
-        <div>
-          <span className="meta">$0 merit aid</span>
           <strong>{ALIGNMENT_GAP_MERIT_META.zeroMeritCount.toLocaleString("en-US")}</strong>
-          <small>Need-only schools, plotted on the left rail</small>
+          <small>Schools in this sample reporting no non-need merit aid</small>
         </div>
       </section>
-
-      <p
-        className="serif"
-        style={{
-          maxWidth: 760,
-          marginTop: 28,
-          fontSize: 20,
-          lineHeight: 1.45,
-          color: "var(--ink)",
-        }}
-      >
-        {ALIGNMENT_GAP_MERIT_META.regions.covers} of {ALIGNMENT_GAP_MERIT_META.positiveGap} — {coversPct} — spend more per first-year student on non-need merit aid than their entire annual alignment gap. For those schools, the money to close that gap is already leaving the building. It is going to students who don&apos;t need it.
-      </p>
 
       <section style={{ marginTop: 28 }}>
         <AlignmentGapMeritChart />
@@ -272,7 +300,7 @@ export default function AlignmentGapPage() {
 
       <section style={{ marginTop: 36, overflowX: "auto" }}>
         <div className="meta" style={{ marginBottom: 10 }}>
-          Worked examples · already spending it
+          Worked examples · merit aid larger than the gap
         </div>
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
           <thead>
@@ -302,7 +330,7 @@ export default function AlignmentGapPage() {
 
       <section style={{ marginTop: 28, overflowX: "auto" }}>
         <div className="meta" style={{ marginBottom: 10 }}>
-          Worked examples · genuinely constrained
+          Worked examples · merit aid smaller than the gap
         </div>
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
           <thead>
@@ -324,26 +352,39 @@ export default function AlignmentGapPage() {
         </table>
       </section>
 
-      <section className="endowment-recipe-ledger rule-2" style={{ marginTop: 48 }}>
+      <section style={{ marginTop: 48, maxWidth: 760 }}>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          Now add financial resources
+        </h2>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
+          The merit-aid comparison only works for schools with usable CDS H2A
+          data. Many colleges do not publish that field consistently.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          A second view uses a larger group of {ALIGNMENT_GAP_META.schoolCount}{" "}
+          schools and asks a different question: <strong>how does graduate
+          debt burden compare with the financial resources of the
+          institution?</strong> Here we plot the same alignment gap against
+          endowment per undergraduate.
+        </p>
+      </section>
+
+      <section className="endowment-recipe-ledger rule-2" style={{ marginTop: 28 }}>
         <div>
-          <span className="meta">Endowment join</span>
           <strong>{ALIGNMENT_GAP_META.schoolCount.toLocaleString("en-US")}</strong>
-          <small>SAT midpoint, Scorecard, net price, endowment — Panel B</small>
+          <small>Schools in the endowment comparison</small>
         </div>
         <div>
-          <span className="meta">Median debt burden</span>
           <strong>{corpusMedianBurden}</strong>
-          <small>375-school endowment join — both panels</small>
+          <small>Median debt burden in this group</small>
         </div>
         <div>
-          <span className="meta">Above that burden</span>
           <strong>{ALIGNMENT_GAP_META.aboveMedianBurden.toLocaleString("en-US")}</strong>
-          <small>Schools whose graduates carry more than the Panel B median</small>
+          <small>Debt burden above the median</small>
         </div>
         <div>
-          <span className="meta">Median endowment</span>
-          <strong>{medianEndowment}</strong>
-          <small>Per undergraduate — the vertical divider</small>
+          <strong>{medianEndowmentUsd}</strong>
+          <small>Median endowment per undergraduate</small>
         </div>
       </section>
 
@@ -389,101 +430,219 @@ export default function AlignmentGapPage() {
       </section>
 
       <section style={{ marginTop: 48, maxWidth: 760 }}>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          An example: Bard and Grinnell
+        </h2>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
-          Bard and Grinnell enroll students with almost identical median SATs — 1510
-          and 1490. Grinnell charges $17,648 net; Bard charges $34,649. Grinnell&apos;s graduates
-          carry a 3.5% debt burden, Bard&apos;s 6.6%. Grinnell also holds $1.54M in
-          endowment per undergraduate against Bard&apos;s $69.5k — 22 times as much.
-          Same students, same outcomes, opposite prices, and the reason is on the
-          balance sheet rather than in the admissions office.
+          Bard and Grinnell illustrate why putting these datasets together can
+          be useful.
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          The pair shows the mechanism, not the choice set. Grinnell admitted 14.5%
-          of applicants in 2024–25 — 1,416 of 9,758 — so most students choosing Bard
-          were never choosing between the two. Neither school appears in Panel A:
-          they file no usable H2A row. That is why Panel B stays.
+          Their published median SAT scores are similar: {bard.satCompositeP50}{" "}
+          for Bard and {grinnell.satCompositeP50} for Grinnell. But the financial
+          picture in the joined data is very different.
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          A 17-year-old comparing these two schools is choosing between a 3.5% debt
-          burden and a 6.6% one. Neither school publishes that number. Both publish a
-          sticker price. Whether a school <em>should</em> price to its outcomes is
-          arguable — whether an applicant should be able to see both numbers before
-          signing is not.
+          Grinnell&apos;s average net price is {formatUsd(grinnell.avgNetPrice)},
+          compared with {formatUsd(bard.avgNetPrice)} at Bard. Grinnell&apos;s
+          graduate debt burden is {formatRecipeShare(grinnell.burden, 1)},
+          compared with {formatRecipeShare(bard.burden, 1)} at Bard. And Grinnell
+          reports about ${grinnellEndowmentMillions} million in endowment per
+          undergraduate, compared with about {bardEndowmentUsd} at Bard.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Those numbers do <strong>not</strong> make Bard and Grinnell equivalent
+          colleges, nor do they prove that the difference in endowment caused
+          the difference in price or debt. Admissions alone make that clear:
+          Grinnell admitted 1,416 of 9,758 applicants in 2024–25, or 14.5%.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The comparison simply shows what becomes visible when data that
+          normally sits in separate systems is placed side by side. Two
+          colleges can enroll students with similar published test profiles
+          while having very different prices, graduate debt burdens, and
+          institutional resources.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Neither Bard nor Grinnell appears in the first chart because neither
+          has a usable H2A merit-aid row in this dataset. That is why the
+          second chart uses the broader endowment comparison.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          For a student or family, that is the practical point of the exercise:
+          sticker price, financial aid, debt, earnings, and a college&apos;s
+          financial resources are usually presented separately. Looking at them
+          together gives a more complete picture.
         </p>
       </section>
 
       <section style={{ marginTop: 48, maxWidth: 760 }}>
-        <div className="meta" style={{ marginBottom: 8 }}>
-          § How the gap is computed
-        </div>
         <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
-          Burden first, then a price movement.
+          How the alignment gap is calculated
         </h2>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
-          Burden is <code>median_debt_monthly_payment × 12 ÷ earnings_10yr_median</code>.
-          The alignment gap is the completer debt a school would have to shed to
-          reach the corpus median burden at its own earnings, expressed per year
-          of enrollment:{" "}
-          <code>gap = completer_debt × (1 − median_burden / burden) / 4</code>.
-          Merit spend per first-year is{" "}
-          <code>non_need_aid_share_first_year_ft × avg_non_need_grant_first_year_ft</code>.
-          Both panels measure the gap against the {ALIGNMENT_GAP_META.schoolCount}-school
-          endowment-join median burden, {corpusMedianBurden}. The merit sample&apos;s own
-          median is {sampleMedianBurden}; it stays in this note so a school that
-          appears in both figures is not two numbers. Hover any dot — not only the
-          labeled ones — for the school name.
+          The calculation starts with debt burden.
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          Panel A is the join that makes the eyebrow true. The vertical axis is
-          College Scorecard. The horizontal axis is CDS H2A. Color is IPEDS
-          endowment per undergraduate. Panel B keeps the full corpus — including
-          Bard, Grinnell, Bennington, Sarah Lawrence, Oberlin, and Earlham, which
-          have no usable H2A — with IPEDS endowment on x and instruction ÷ net
-          price in color. Panel A is smaller because it requires usable H2A, not
-          because Panel B is a superset of it. Panel B does not require H2A; it
-          does require a CDS SAT midpoint. The samples overlap, but neither
-          contains the other.
+          <code>debt burden = median monthly federal loan payment × 12 ÷ median earnings 10 years after enrollment</code>
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          n = {ALIGNMENT_GAP_MERIT_META.schoolCount} on Panel A after data guards,
-          from {ex.universe.toLocaleString("en-US")} rows in{" "}
-          <code>school_merit_profile</code>. Dropped: quality limited ({ex.qualityLimited})
-          or missing ({ex.qualityMissing}); missing H2A share or average grant ({ex.missingH2a});
-          share outside 0–100% ({ex.rangeShare}, including Cal State Chico at 12,087%
-          and Dickinson at 104.5%); average grant outside [0, $80,000] ({ex.rangeGrant},
-          Duke at $85,600). A published $0 grant is kept: {ALIGNMENT_GAP_MERIT_META.zeroMeritCount}{" "}
-          schools award no non-need aid, including four with no gap to close and
-          Incarnate Word, which does. Also dropped: rows without Scorecard earnings,
-          debt, net price, and endowment ({ex.missingScorecard}). The quality flag
-          said strong on every range violation. The guards are in the recipe query;
-          they are not optional.
+          A school with annual loan payments of $3,000 and median earnings of
+          $60,000 would therefore have a debt burden of 5%.
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          CDS H2A excludes some mixed-need merit awards and can understate total
-          merit availability. It also covers first-year full-time students only, so
-          it describes the discount a school uses to recruit, not its whole aid
-          budget.
+          The median debt burden in the {ALIGNMENT_GAP_META.schoolCount}-school
+          comparison on this page is <strong>{corpusMedianBurden}</strong>.
         </p>
         <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
-          Median federal debt in the {ALIGNMENT_GAP_META.schoolCount}-school endowment
-          join spans {formatUsd(ALIGNMENT_GAP_META.debtMin)} to {formatUsd(ALIGNMENT_GAP_META.debtMax)},
-          and {formatUsd(ALIGNMENT_GAP_META.debtMode)} — the federal aggregate borrowing
-          limit for dependent undergraduates — is the single most common value,
-          shared by {ALIGNMENT_GAP_META.debtModeCount} schools. Debt cannot measure
-          how expensive a school is. It measures burden. Net price is the price
-          variable. Scorecard earnings cover federally aided students and describe
-          a cohort that enrolled about a decade before the CDS row joined to it.
-          The join is institutional, not longitudinal. Figures here are{" "}
-          {ALIGNMENT_GAP_META.scorecardYears.join(", ")} College Scorecard against
-          2024–26 CDS. Instructional expenditure per FTE and endowment are IPEDS
-          figures surfaced through the Scorecard join.
+          For schools above that level, the alignment gap estimates how much
+          lower median completer debt would need to be for the school to reach
+          a {corpusMedianBurden} burden at its existing earnings level. We
+          divide that amount by four so it can be read as an annual figure.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          <code>alignment gap = completer debt × (1 − median burden ÷ school burden) ÷ 4</code>
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          A positive gap means debt burden is above the sample median. A zero
+          or negative gap means it is at or below the median.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Again, this is a comparison measure. It should not be read as a
+          prediction that reducing annual net price by the same number would
+          reduce student debt one-for-one.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          For the first chart, we also estimate non-need merit aid per
+          full-time first-year student:
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          <code>merit aid per first-year student = share receiving non-need merit aid × average non-need merit grant</code>
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          For example, if 40% of first-year students receive non-need merit aid
+          and the average grant among recipients is $20,000, the measure used
+          here is $8,000 per first-year student.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Both charts use the same {corpusMedianBurden} median debt burden so a
+          school does not have a different benchmark depending on which chart
+          you are viewing. The smaller merit-aid sample has a very similar
+          median of {sampleMedianBurden}.
+        </p>
+      </section>
+
+      <section style={{ marginTop: 48, maxWidth: 760 }}>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          What is being joined
+        </h2>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
+          Panel A combines three sources. College Scorecard supplies debt, loan
+          payments, earnings, and net price. Common Data Set H2A supplies
+          non-need merit-aid information for full-time first-year students.
+          IPEDS supplies endowment information.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          After data-quality checks, {ALIGNMENT_GAP_MERIT_META.schoolCount}{" "}
+          schools have enough usable information for this view.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Panel B does not require H2A merit-aid data, so it can include many
+          schools that are missing from Panel A. It uses College Scorecard
+          debt, earnings, and net price; IPEDS endowment and instructional
+          spending; and a recent CDS SAT midpoint to define the{" "}
+          {ALIGNMENT_GAP_META.schoolCount}-school comparison group.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The two samples overlap, but neither is simply a subset of the other.
+        </p>
+      </section>
+
+      <section style={{ marginTop: 48, maxWidth: 760 }}>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          Data limits
+        </h2>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
+          This page combines institutional data from different systems and
+          different years, so the numbers should not be read as if they
+          describe one group of students moving through college at the same
+          time.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The College Scorecard figures used here are from{" "}
+          {ALIGNMENT_GAP_META.scorecardYears.join(", ")}. Earnings data describe
+          federally aided students from an earlier cohort, roughly a decade
+          after they first enrolled. The CDS data are from 2024–25 or 2025–26.
+          The join is by institution, not by individual student or graduating
+          class.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          CDS H2A also has limits. It covers full-time first-year students and
+          specifically reports non-need aid. Some awards that combine need and
+          merit may not appear in the measure. It is best understood as a view
+          of one part of a school&apos;s recruiting and tuition-discount strategy,
+          not its total financial-aid budget.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Federal student debt has limits as a measure of affordability as
+          well. Median debt in this {ALIGNMENT_GAP_META.schoolCount}-school
+          sample ranges from {formatUsd(ALIGNMENT_GAP_META.debtMin)} to{" "}
+          {formatUsd(ALIGNMENT_GAP_META.debtMax)}, and           {formatUsd(ALIGNMENT_GAP_META.debtMode)}—the
+          federal aggregate borrowing limit for many dependent undergraduates—is
+          the most common value in the sample. Families may
+          pay college costs with income, savings, parent borrowing, private
+          loans, grants, or other resources that are not captured by this debt
+          number.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          That is why this page does not use federal debt as a substitute for
+          price. Net price remains the price measure. Debt burden tells us
+          something different: how large federal loan payments are relative to
+          later earnings.
+        </p>
+      </section>
+
+      <section style={{ marginTop: 48, maxWidth: 760 }}>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          Data-quality checks
+        </h2>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: 0 }}>
+          Panel A begins with {ex.universe.toLocaleString("en-US")} possible
+          merit-profile rows. We keep {ALIGNMENT_GAP_MERIT_META.schoolCount} after
+          requiring usable CDS merit-aid data and the Scorecard and IPEDS
+          fields needed for the comparison.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          Rows are removed when the merit profile is too incomplete, required
+          values are missing, or published values fall outside reasonable
+          ranges. That includes {ex.rangeShare} reported merit-aid shares
+          outside 0–100% and {ex.rangeGrant} average grant above $80,000. A
+          legitimate published value of $0 is kept.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          {ALIGNMENT_GAP_MERIT_META.zeroMeritCount} schools in the final sample
+          report no non-need merit aid. Four already have debt burden at or
+          below the median. The University of the Incarnate Word has a positive
+          alignment gap.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "14px 0 0" }}>
+          The checks matter because joining datasets can make a bad source
+          value look much more meaningful than it really is. The filters used
+          for this page are part of the reproducible recipe rather than manual
+          exclusions made after looking at the chart.
         </p>
       </section>
 
       <section style={{ marginTop: 48 }}>
-        <div className="meta" style={{ marginBottom: 10 }}>
-          § Pull the join yourself
-        </div>
+        <h2 className="serif" style={{ fontSize: 28, margin: "0 0 12px", letterSpacing: "-0.015em" }}>
+          Pull the data yourself
+        </h2>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: "var(--ink-2)", margin: "0 0 16px", maxWidth: 760 }}>
+          The underlying data and calculations are public. The queries below
+          reproduce the source rows used for the two panels. Panel B contains
+          more rows than the API&apos;s 1,000-row response limit, so retrieve it
+          in pages.
+        </p>
         <pre
           style={{
             background: "var(--ink)",
@@ -517,22 +676,40 @@ curl 'https://api.collegedata.fyi/rest/v1/scorecard_summary?select=ipeds_id,earn
   -H 'Authorization: Bearer <anon key>'`}
         </pre>
         <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "16px 0 0" }}>
-          Keep <code>non_need_aid_share_first_year_ft</code> in [0, 1] and{" "}
-          <code>avg_non_need_grant_first_year_ft</code> in [0, 80000]; require{" "}
-          <code>merit_profile_quality</code> in <code>strong</code> or{" "}
-          <code>partial</code>. A published $0 grant is kept. Panel A joins
-          endowment from <code>scorecard_summary</code> and undergraduate
-          enrollment from <code>school_browser_rows.undergrad_enrollment_scorecard</code>.
+          For Panel A, keep non-need aid shares between 0 and 1, average
+          non-need grants between $0 and $80,000, and merit profiles rated{" "}
+          <code>strong</code> or <code>partial</code>. Keep{" "}
+          <code>non_need_aid_share_first_year_ft</code> in [0, 1] and{" "}
+          <code>avg_non_need_grant_first_year_ft</code> in [0, 80000]. A
+          published $0 grant is kept.
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "14px 0 0" }}>
+          Panel A joins endowment from <code>scorecard_summary</code> and
+          undergraduate enrollment from{" "}
+          <code>school_browser_rows.undergrad_enrollment_scorecard</code>.
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "14px 0 0" }}>
           Panel B joins undergraduate enrollment from{" "}
-          <code>institution_directory.undergraduate_enrollment</code>, falling back
-          to <code>scorecard_summary.enrollment</code>, and keeps only rows with a
-          CDS SAT midpoint in <code>school_browser_rows</code>. Then{" "}
-          <code>burden = monthly × 12 / earnings</code>,{" "}
-          <code>gap = completer_debt × (1 − median_burden / burden) / 4</code>, and{" "}
-          <code>merit_per_fy = share × avg_non_need_grant</code>, using the
-          375-school median burden on both panels. The anon key is on the{" "}
-          <Link href="/api">API page</Link>. Rebuild the checked-in dataset with{" "}
-          <code>python3 tools/scorecard/build_alignment_gap_recipe.py</code>.
+          <code>institution_directory.undergraduate_enrollment</code>, using
+          Scorecard enrollment as a fallback, and keeps schools with a recent
+          CDS SAT composite midpoint.
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "14px 0 0" }}>
+          Both panels then use the same calculations:
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "14px 0 0" }}>
+          <code>burden = monthly payment × 12 ÷ earnings</code>
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "8px 0 0" }}>
+          <code>gap = completer debt × (1 − median burden ÷ burden) ÷ 4</code>
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "8px 0 0" }}>
+          <code>merit per first-year = share receiving non-need aid × average non-need grant</code>
+        </p>
+        <p style={{ color: "var(--ink-2)", fontSize: 14, lineHeight: 1.55, margin: "14px 0 0" }}>
+          The anonymous API key is available on the <Link href="/api">API page</Link>.
+          To rebuild the checked-in dataset:{" "}
+          <code>python3 tools/scorecard/build_alignment_gap_recipe.py</code>
         </p>
         <div style={{ marginTop: 14, display: "flex", gap: 16, flexWrap: "wrap", fontSize: 13 }}>
           <TrackedLink

--- a/web/src/app/recipes/page.tsx
+++ b/web/src/app/recipes/page.tsx
@@ -80,7 +80,7 @@ const RECIPES: Recipe[] = [
     slug: "alignment-gap",
     title: "Alignment gap",
     tagline:
-      "Of schools with a positive alignment gap and clean CDS H2A merit data, 61% already spend more per first-year on non-need aid than the annual gap. Two panels: merit spend versus the gap, then endowment. Hover any school.",
+      "Debt burden from College Scorecard, joined to CDS H2A merit aid and IPEDS endowment. Compare the alignment gap with merit aid, then with endowment per student. Hover any school.",
     audience:
       "IR, college-finance reporters, and analysts joining CDS H2A merit aid to Scorecard earnings and debt, and IPEDS endowment.",
     demoPath: "/recipes/alignment-gap",

--- a/web/src/components/AlignmentGapChart.tsx
+++ b/web/src/components/AlignmentGapChart.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { ChartHoverTooltip } from "@/components/ChartHoverTooltip";
 import { formatRecipeShare } from "@/lib/format";
 import {
   bandCircleStyle,
   bandMark,
   formatEndowmentPerStudent,
   formatGapUsd,
+  formatUsd,
   formatInstructionShare,
   instructionShareBand,
   quadrantFor,
@@ -91,10 +93,10 @@ function svgCoords(
 }
 
 const QUADRANT_LABEL: Record<string, string> = {
-  capacity: "capacity exists",
-  constrained: "constrained",
-  absorbs: "endowment absorbs it",
-  earnings: "earnings do the work",
+  capacity: "higher burden · higher endowment",
+  constrained: "higher burden · lower endowment",
+  absorbs: "lower burden · higher endowment",
+  earnings: "lower burden · lower endowment",
 };
 
 function hitRadiusInSvg(svg: SVGSVGElement): number {
@@ -124,6 +126,7 @@ function nearestPoint(
 }
 
 export function AlignmentGapChart() {
+  const wrapRef = useRef<HTMLDivElement>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
@@ -181,13 +184,27 @@ export function AlignmentGapChart() {
         }}
       >
         <div>
-          <div className="meta">Fig. 2 · Could they afford to?</div>
+          <div className="meta">Fig. 2 · Compare debt burden with endowment per student</div>
           <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--ink-2)", maxWidth: 640, lineHeight: 1.5 }}>
-            Vertical axis: alignment gap, dollars per year — College Scorecard.
-            Horizontal axis: endowment per undergraduate, log scale — IPEDS.
-            Color: instructional spending as a share of net price. Dots above the
-            brick line have a heavier graduate debt burden than this 375-school
-            sample&apos;s median. Hover any dot — every school is named.
+            The vertical axis again shows the alignment gap. A value above zero
+            means the school&apos;s debt burden is above the{" "}
+            {formatRecipeShare(ALIGNMENT_GAP_META.medianBurden, 2)} median. A
+            value below zero means it is below the median. The horizontal axis
+            shows endowment per undergraduate on a log scale. The vertical
+            divider marks the sample median of about{" "}
+            {formatUsd(Math.round(ALIGNMENT_GAP_META.medianEndowmentPerStudent / 1000) * 1000)}{" "}
+            per undergraduate.
+          </p>
+          <p style={{ margin: "8px 0 0", fontSize: 13, color: "var(--ink-2)", maxWidth: 640, lineHeight: 1.5 }}>
+            Color shows instructional spending per student as a share of average
+            net price. This adds some context about the relationship between
+            what students pay and what the institution reports spending on
+            instruction. Endowment per student is only a broad measure of
+            financial capacity. Endowments contain restricted funds, and two
+            colleges with the same endowment per student may have very different
+            obligations and spending policies. The chart is intended to show
+            financial context, not available cash. Hover over any dot to see the
+            school.
           </p>
         </div>
         <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, color: "var(--ink-3)" }}>
@@ -215,7 +232,7 @@ export function AlignmentGapChart() {
         </label>
       </div>
 
-      <div style={{ position: "relative" }}>
+      <div ref={wrapRef} style={{ position: "relative" }}>
       <svg
         width={W}
         height={H}
@@ -258,7 +275,7 @@ export function AlignmentGapChart() {
           </text>
         ))}
         <text x={M.l} y={22} fontFamily="var(--mono)" fontSize="10" fill="var(--ink-3)" letterSpacing="0.06em">
-          CONSTRAINED · {ALIGNMENT_GAP_META.quadrants.constrained}
+          II · HIGHER BURDEN, LOWER ENDOWMENT · {ALIGNMENT_GAP_META.quadrants.constrained}
         </text>
         <text
           x={W - M.r}
@@ -269,10 +286,10 @@ export function AlignmentGapChart() {
           fill="var(--ink-3)"
           letterSpacing="0.06em"
         >
-          CAPACITY EXISTS · {ALIGNMENT_GAP_META.quadrants.capacity}
+          I · HIGHER BURDEN, HIGHER ENDOWMENT · {ALIGNMENT_GAP_META.quadrants.capacity}
         </text>
         <text x={M.l} y={H - 8} fontFamily="var(--mono)" fontSize="10" fill="var(--ink-3)" letterSpacing="0.06em">
-          EARNINGS DO THE WORK · {ALIGNMENT_GAP_META.quadrants.earnings}
+          IV · LOWER BURDEN, LOWER ENDOWMENT · {ALIGNMENT_GAP_META.quadrants.earnings}
         </text>
         <text
           x={W - M.r}
@@ -283,7 +300,7 @@ export function AlignmentGapChart() {
           fill="var(--ink-3)"
           letterSpacing="0.06em"
         >
-          ENDOWMENT ABSORBS IT · {ALIGNMENT_GAP_META.quadrants.absorbs}
+          III · LOWER BURDEN, HIGHER ENDOWMENT · {ALIGNMENT_GAP_META.quadrants.absorbs}
         </text>
         <text
           x={W - M.r}
@@ -358,21 +375,14 @@ export function AlignmentGapChart() {
       </svg>
 
       {hover && (
-        <div
-          data-testid="alignment-gap-tooltip"
-          style={{
-            position: "absolute",
-            left: `${Math.min(((hover.cx + 12) / W) * 100, 72)}%`,
-            top: `${Math.max(((hover.cy - 36) / H) * 100, 6)}%`,
-            pointerEvents: "none",
-            background: "var(--ink)",
-            color: "var(--paper)",
-            padding: "10px 12px",
-            fontSize: 13,
-            lineHeight: 1.45,
-            minWidth: 200,
-            zIndex: 2,
-          }}
+        <ChartHoverTooltip
+          wrapRef={wrapRef}
+          viewW={W}
+          viewH={H}
+          cx={hover.cx}
+          cy={hover.cy}
+          placementKey={hover.schoolId}
+          testId="alignment-gap-tooltip"
         >
           <div className="serif" style={{ fontSize: 16 }}>
             {hover.schoolName}
@@ -391,7 +401,7 @@ export function AlignmentGapChart() {
           <div>Endowment {formatEndowmentPerStudent(hover.endowmentPerStudent)}/student</div>
           <div>Instruction {formatInstructionShare(hover.instructionShare)}</div>
           <div>Burden {formatRecipeShare(hover.burden, 1)}</div>
-        </div>
+        </ChartHoverTooltip>
       )}
       </div>
 

--- a/web/src/components/AlignmentGapMeritChart.tsx
+++ b/web/src/components/AlignmentGapMeritChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { ChartHoverTooltip } from "@/components/ChartHoverTooltip";
 import { formatRecipeShare } from "@/lib/format";
 import {
   bandCircleStyle,
@@ -100,9 +101,9 @@ function svgCoords(
 }
 
 const REGION_LABEL: Record<string, string> = {
-  covers: "already spending it",
-  constrained: "genuinely constrained",
-  none: "gap ≤ 0",
+  covers: "merit aid larger than the gap",
+  constrained: "merit aid smaller than the gap",
+  none: "debt burden at or below the median",
 };
 
 function hitRadiusInSvg(svg: SVGSVGElement): number {
@@ -147,6 +148,7 @@ function diagonalPoints(): string {
 }
 
 export function AlignmentGapMeritChart() {
+  const wrapRef = useRef<HTMLDivElement>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
@@ -205,19 +207,27 @@ export function AlignmentGapMeritChart() {
         }}
       >
         <div>
-          <div className="meta">Fig. 1 · Are they already spending it?</div>
+          <div className="meta">Fig. 1 · Compare the debt gap with merit aid</div>
           <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--ink-2)", maxWidth: 640, lineHeight: 1.5 }}>
-            Vertical axis: alignment gap, dollars per year — College Scorecard,
-            against the same {formatRecipeShare(ALIGNMENT_GAP_MERIT_META.medianBurden, 2)}{" "}
-            median as Fig. 2. Horizontal axis: non-need merit spend per
-            first-year student — CDS H2A. Values above $0 use a log scale;{" "}
-            {ALIGNMENT_GAP_MERIT_META.zeroMeritCount} schools that award no
-            merit aid sit on the left rail, off that scale. Color: endowment
-            per undergraduate — IPEDS, with the same{" "}
-            {formatEndowmentPerStudent(HIGH_CUT)} high cut as Fig. 2. The brick
-            diagonal is where merit spend equals the annual gap. Everything to
-            its right is already spending more than it would take to close it.
-            Hover any dot — every school is named.
+            The vertical axis shows the alignment gap in dollars per year. The
+            horizontal axis shows estimated non-need merit aid per full-time
+            first-year student, using the Common Data Set. Because most values
+            are spread over a wide range, the axis uses a log scale. Schools
+            reporting no non-need merit aid are shown separately at $0.
+          </p>
+          <p style={{ margin: "8px 0 0", fontSize: 13, color: "var(--ink-2)", maxWidth: 640, lineHeight: 1.5 }}>
+            The diagonal line is where the two amounts are equal. Schools to the
+            lower-right of the line report more non-need merit aid per first-year
+            student than the size of their alignment gap. Schools to the
+            upper-left report less. Color shows endowment per undergraduate,
+            adding another measure of the institution&apos;s financial resources.
+          </p>
+          <p style={{ margin: "8px 0 0", fontSize: 13, color: "var(--ink-2)", maxWidth: 640, lineHeight: 1.5 }}>
+            These amounts are useful for comparison, but they are not
+            interchangeable dollar for dollar. Merit aid is generally a tuition
+            discount rather than a cash expenditure, and changing a college&apos;s
+            aid policy would not necessarily produce an equal change in student
+            borrowing. Hover over any dot to see the school.
           </p>
         </div>
         <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, color: "var(--ink-3)" }}>
@@ -245,7 +255,7 @@ export function AlignmentGapMeritChart() {
         </label>
       </div>
 
-      <div style={{ position: "relative" }}>
+      <div ref={wrapRef} style={{ position: "relative" }}>
       <svg
         width={W}
         height={H}
@@ -330,7 +340,7 @@ export function AlignmentGapMeritChart() {
           </text>
         ))}
         <text x={LOG_L} y={22} fontFamily="var(--mono)" fontSize="10" fill="var(--ink-3)" letterSpacing="0.06em">
-          GENUINELY CONSTRAINED · {ALIGNMENT_GAP_MERIT_META.regions.constrained}
+          SMALLER THAN THE GAP · {ALIGNMENT_GAP_MERIT_META.regions.constrained}
         </text>
         <text
           x={PLOT_R}
@@ -341,7 +351,7 @@ export function AlignmentGapMeritChart() {
           fill="var(--ink-3)"
           letterSpacing="0.06em"
         >
-          ALREADY SPENDING IT · {ALIGNMENT_GAP_MERIT_META.regions.covers}
+          LARGER THAN THE GAP · {ALIGNMENT_GAP_MERIT_META.regions.covers}
         </text>
         <text
           x={(LOG_L + PLOT_R) / 2}
@@ -352,7 +362,7 @@ export function AlignmentGapMeritChart() {
           fill="var(--ink-3)"
           letterSpacing="0.06em"
         >
-          GAP ≤ 0 · {ALIGNMENT_GAP_MERIT_META.regions.none}
+          AT OR BELOW MEDIAN · {ALIGNMENT_GAP_MERIT_META.regions.none}
         </text>
         <text
           x={PLOT_R}
@@ -438,21 +448,14 @@ export function AlignmentGapMeritChart() {
       </svg>
 
       {hover && (
-        <div
-          data-testid="alignment-gap-merit-tooltip"
-          style={{
-            position: "absolute",
-            left: `${Math.min(((hover.cx + 12) / W) * 100, 72)}%`,
-            top: `${Math.max(((hover.cy - 36) / H) * 100, 6)}%`,
-            pointerEvents: "none",
-            background: "var(--ink)",
-            color: "var(--paper)",
-            padding: "10px 12px",
-            fontSize: 13,
-            lineHeight: 1.45,
-            minWidth: 200,
-            zIndex: 2,
-          }}
+        <ChartHoverTooltip
+          wrapRef={wrapRef}
+          viewW={W}
+          viewH={H}
+          cx={hover.cx}
+          cy={hover.cy}
+          placementKey={hover.schoolId}
+          testId="alignment-gap-merit-tooltip"
         >
           <div className="serif" style={{ fontSize: 16 }}>
             {hover.schoolName}
@@ -471,7 +474,7 @@ export function AlignmentGapMeritChart() {
           )}
           <div>Endowment {formatEndowmentPerStudent(hover.endowmentPerStudent)}/student</div>
           <div>Burden {formatRecipeShare(hover.burden, 1)}</div>
-        </div>
+        </ChartHoverTooltip>
       )}
       </div>
 

--- a/web/src/components/ChartHoverTooltip.tsx
+++ b/web/src/components/ChartHoverTooltip.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import {
+  placeTooltipAwayFromPointer,
+  type TooltipPlacement,
+} from "@/lib/chart-tooltip-placement";
+
+const EST_WIDTH = 260;
+const EST_HEIGHT = 156;
+const GAP = 18;
+
+export function ChartHoverTooltip({
+  wrapRef,
+  viewW,
+  viewH,
+  cx,
+  cy,
+  placementKey,
+  testId,
+  children,
+}: {
+  wrapRef: RefObject<HTMLDivElement | null>;
+  viewW: number;
+  viewH: number;
+  cx: number;
+  cy: number;
+  placementKey: string;
+  testId: string;
+  children: ReactNode;
+}) {
+  const tipRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<TooltipPlacement | null>(null);
+
+  useLayoutEffect(() => {
+    const wrap = wrapRef.current;
+    const svg = wrap?.querySelector("svg");
+    const tip = tipRef.current;
+    if (!wrap || !svg) return;
+
+    const update = () => {
+      const wrapRect = wrap.getBoundingClientRect();
+      const svgRect = svg.getBoundingClientRect();
+      const pointerX =
+        svgRect.left - wrapRect.left + (cx / viewW) * svgRect.width;
+      const pointerY =
+        svgRect.top - wrapRect.top + (cy / viewH) * svgRect.height;
+      const next = placeTooltipAwayFromPointer({
+        pointerX,
+        pointerY,
+        chartLeft: svgRect.left - wrapRect.left,
+        chartTop: svgRect.top - wrapRect.top,
+        chartWidth: svgRect.width,
+        chartHeight: svgRect.height,
+        tooltipWidth: tip?.offsetWidth || EST_WIDTH,
+        tooltipHeight: tip?.offsetHeight || EST_HEIGHT,
+        gap: GAP,
+      });
+      setPos((prev) => {
+        if (
+          prev &&
+          prev.side === next.side &&
+          Math.abs(prev.left - next.left) < 0.5 &&
+          Math.abs(prev.top - next.top) < 0.5
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    };
+
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [wrapRef, viewW, viewH, cx, cy, placementKey]);
+
+  const style: CSSProperties = {
+    position: "absolute",
+    left: pos?.left ?? 0,
+    top: pos?.top ?? 0,
+    visibility: pos ? "visible" : "hidden",
+    pointerEvents: "none",
+    background: "var(--ink)",
+    color: "var(--paper)",
+    padding: "10px 12px",
+    fontSize: 13,
+    lineHeight: 1.45,
+    minWidth: 200,
+    maxWidth: 280,
+    zIndex: 2,
+  };
+
+  return (
+    <div
+      ref={tipRef}
+      data-testid={testId}
+      data-tooltip-side={pos?.side ?? "pending"}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/src/lib/alignment-gap-copy.test.ts
+++ b/web/src/lib/alignment-gap-copy.test.ts
@@ -38,33 +38,40 @@ describe("alignment-gap recipe", () => {
     expect(formatEndowmentPerStudent(4_982_000)).toBe("$4.98M");
   });
 
-  it("writes the lede as burden, then a debt gap, then two panels", () => {
+  it("writes the lede as debt burden, then an alignment gap, then two panels", () => {
     const page = src("app/recipes/alignment-gap/page.tsx");
-    expect(page).toContain("What a school charges, against what it");
-    expect(page).toContain("Debt burden is the share of median 10-year earnings");
-    expect(page).toContain("expressed per year of enrollment");
+    expect(page).toContain("Debt burden, aid, and");
+    expect(page).toContain("financial resources");
+    expect(page).toContain("College affordability data lives in several different places.");
+    expect(page).toContain("The starting point is");
+    expect(page).toContain("debt burden");
+    expect(page).toContain("alignment gap");
+    expect(page).toContain("expressed per year of college");
     expect(page).toContain("completer");
-    expect(page).toContain("corpus median burden");
     expect(page).not.toContain("how much net price would have to fall");
     expect(page).not.toContain("or could rise");
-    expect(page).toContain("Hover any dot");
+    expect(page).not.toContain("already leaving the building");
+    expect(page).not.toContain("students who don");
+    expect(page).not.toContain("What a school charges, against what it");
     expect(page).not.toMatch(/Recipe 1B/);
     expect(page).not.toMatch(/IPERS/);
     expect(page).not.toMatch(/Naming it would be accurate and unfair/);
 
     const chart = src("components/AlignmentGapChart.tsx");
-    expect(chart).toContain("data-testid=\"alignment-gap-tooltip\"");
+    expect(chart).toContain("testId=\"alignment-gap-tooltip\"");
     expect(chart).toContain("{hover.schoolName}");
-    expect(chart).toContain("Could they afford to?");
-    expect(chart).toContain("Hover any dot — every school is named");
+    expect(chart).toContain("Compare debt burden with endowment per student");
+    expect(chart).toContain("Hover over any dot to see the");
     expect(chart).toContain("var(--ochre)");
     expect(chart).toContain("○ 90% and over");
+    expect(chart).toContain("ChartHoverTooltip");
+    expect(chart).not.toContain("Could they afford to?");
     expect(chart).not.toContain("var(--forest-2)");
     expect(chart).not.toContain("var(--forest-ink)");
     expect(chart).not.toMatch(/best\.nm \?/);
 
     const merit = src("components/AlignmentGapMeritChart.tsx");
-    expect(merit).toContain("Are they already spending it?");
+    expect(merit).toContain("Compare the debt gap with merit aid");
     expect(merit).toContain("merit spend = annual gap");
     expect(merit).toContain("{hover.schoolName}");
     expect(merit).toContain("CDS H2A");
@@ -72,11 +79,23 @@ describe("alignment-gap recipe", () => {
     expect(merit).toContain("var(--forest)");
     expect(merit).toContain("○ ");
     expect(merit).toContain("NO MERIT AID");
-    expect(merit).toContain("GAP ≤ 0");
+    expect(merit).toContain("AT OR BELOW MEDIAN");
+    expect(merit).toContain("LARGER THAN THE GAP");
+    expect(merit).toContain("SMALLER THAN THE GAP");
     expect(merit).toContain("alignment-gap-zero-rail");
+    expect(merit).toContain("The vertical axis shows the alignment gap");
+    expect(merit).toContain("ChartHoverTooltip");
+    expect(merit).not.toContain("Are they already spending it?");
     expect(merit).not.toContain("NO GAP TO CLOSE");
+    expect(merit).not.toContain("GENUINELY CONSTRAINED");
+    expect(merit).not.toContain("ALREADY SPENDING IT");
     expect(merit).not.toContain("endowmentTercile");
     expect(merit).not.toContain("var(--forest-ink)");
+
+    const tooltip = src("components/ChartHoverTooltip.tsx");
+    expect(tooltip).toContain("placeTooltipAwayFromPointer");
+    expect(tooltip).toContain("data-tooltip-side");
+    expect(tooltip).toContain("pointerEvents: \"none\"");
 
     const analysis = src("lib/alignment-gap-recipe-analysis.ts");
     expect(analysis).toContain('fill: "none"');
@@ -84,31 +103,35 @@ describe("alignment-gap recipe", () => {
     expect(analysis).toContain('fill: "var(--forest)"');
   });
 
-  it("applies the seven copy fixes", () => {
-    const page = src("app/recipes/alignment-gap/page.tsx");
-    expect(page).toContain(
-      "the lowest instruction-to-net-price ratio of its peer group at 0.76",
-    );
+  it("keeps the method notes and drops the old punchy panel names", () => {
+    const page = src("app/recipes/alignment-gap/page.tsx").replace(/\s+/g, " ");
+    expect(page).toContain("instructional spending equal to about");
+    expect(page).toContain("% of its average net price.");
     expect(page).not.toContain("already spending most of net price on instruction");
     expect(page).toContain(
-      "Instruction often exceeds net price — at these endowment levels, tuition is not what pays for the classroom.",
+      "reported instructional spending per student exceeds average net price",
     );
     expect(page).not.toContain("because the endowment, not tuition, is paying");
     expect(page).toContain("federal aggregate borrowing");
     expect(page).toContain("dependent undergraduates");
-    expect(page).toContain("Bard and Grinnell enroll students with almost identical median SATs");
-    expect(page).toContain("whether an applicant should be able to see both numbers before");
+    expect(page).toContain("An example: Bard and Grinnell");
+    expect(page).toContain("Those numbers do");
+    expect(page).not.toContain("whether an applicant should be able to see both numbers before");
+    expect(page).not.toContain("Same students, same outcomes, opposite prices");
     expect(page).toContain("CDS H2A");
-    expect(page).toContain("The vertical axis is");
     expect(page).toContain("College Scorecard");
-    expect(page).toContain("excludes some mixed-need merit awards");
+    expect(page).toContain("Some awards that combine need and merit may not appear");
     expect(page).toContain("limit=1000&offset=1000");
     expect(page).toContain("limit=1000&offset=2000");
     expect(page).toContain("Content-Range: 0-999/2158");
-    expect(page).toContain("[0, $80,000]");
+    expect(page).toContain("[0, 80000]");
     expect(page).toContain("institution_directory.undergraduate_enrollment");
     expect(page).toContain("undergrad_enrollment_scorecard");
     expect(page).toContain("A published $0 grant is kept");
+    expect(page).toContain("Merit aid is larger than the gap");
+    expect(page).toContain("Merit aid is smaller than the gap");
+    expect(page).not.toContain("Already spending it");
+    expect(page).not.toContain("Genuinely constrained");
     expect(page).not.toContain("which is why its n is larger");
     expect(page).not.toContain("land far below what those scores predict");
     expect(page).not.toContain("Each panel uses the median burden of the sample it plots");
@@ -142,7 +165,10 @@ describe("alignment-gap recipe", () => {
     );
     expect(Math.round(ALIGNMENT_GAP_MERIT_META.coversShare * 100)).toBe(61);
     const recipesIndex = src("app/recipes/page.tsx");
-    expect(recipesIndex).toContain("61% already spend more per first-year");
+    expect(recipesIndex).toContain(
+      "Compare the alignment gap with merit aid, then with endowment per student. Hover any school.",
+    );
+    expect(recipesIndex).not.toContain("61% already spend more per first-year");
     expect(recipesIndex).not.toContain("63% already spend more per first-year");
   });
 

--- a/web/src/lib/chart-tooltip-placement.test.ts
+++ b/web/src/lib/chart-tooltip-placement.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  placeTooltipAwayFromPointer,
+  tooltipCoversPointer,
+} from "./chart-tooltip-placement";
+
+const CHART = {
+  chartLeft: 0,
+  chartTop: 0,
+  chartWidth: 920,
+  chartHeight: 580,
+  tooltipWidth: 260,
+  tooltipHeight: 150,
+  gap: 18,
+};
+
+describe("placeTooltipAwayFromPointer", () => {
+  it("puts a right-side point's box to the left, clear of the pointer", () => {
+    const placed = placeTooltipAwayFromPointer({
+      ...CHART,
+      pointerX: 860,
+      pointerY: 220,
+    });
+    expect(placed.side).toBe("left");
+    expect(placed.left + 260).toBeLessThanOrEqual(860 - 18);
+    expect(
+      tooltipCoversPointer(
+        { left: placed.left, top: placed.top, width: 260, height: 150 },
+        860,
+        220,
+        18,
+      ),
+    ).toBe(false);
+  });
+
+  it("puts a left-side point's box to the right, clear of the pointer", () => {
+    const placed = placeTooltipAwayFromPointer({
+      ...CHART,
+      pointerX: 80,
+      pointerY: 300,
+    });
+    expect(placed.side).toBe("right");
+    expect(placed.left).toBeGreaterThanOrEqual(80 + 18);
+    expect(
+      tooltipCoversPointer(
+        { left: placed.left, top: placed.top, width: 260, height: 150 },
+        80,
+        300,
+        18,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not slide a clamped left-side box back over a far-right point", () => {
+    const placed = placeTooltipAwayFromPointer({
+      ...CHART,
+      pointerX: 900,
+      pointerY: 40,
+      tooltipWidth: 400,
+      tooltipHeight: 180,
+    });
+    expect(
+      tooltipCoversPointer(
+        { left: placed.left, top: placed.top, width: 400, height: 180 },
+        900,
+        40,
+        18,
+      ),
+    ).toBe(false);
+    expect(placed.side).not.toBe("right");
+  });
+
+  it("keeps the box inside the chart", () => {
+    const placed = placeTooltipAwayFromPointer({
+      ...CHART,
+      pointerX: 880,
+      pointerY: 540,
+    });
+    expect(placed.left).toBeGreaterThanOrEqual(0);
+    expect(placed.top).toBeGreaterThanOrEqual(0);
+    expect(placed.left + 260).toBeLessThanOrEqual(920);
+    expect(placed.top + 150).toBeLessThanOrEqual(580);
+  });
+});

--- a/web/src/lib/chart-tooltip-placement.test.ts
+++ b/web/src/lib/chart-tooltip-placement.test.ts
@@ -22,7 +22,9 @@ describe("placeTooltipAwayFromPointer", () => {
       pointerY: 220,
     });
     expect(placed.side).toBe("left");
-    expect(placed.left + 260).toBeLessThanOrEqual(860 - 18);
+    expect(placed.left + 260).toBeCloseTo(860 - 18, 5);
+    expect(placed.top).toBeLessThan(220);
+    expect(placed.top + 150).toBeGreaterThan(220);
     expect(
       tooltipCoversPointer(
         { left: placed.left, top: placed.top, width: 260, height: 150 },
@@ -40,7 +42,7 @@ describe("placeTooltipAwayFromPointer", () => {
       pointerY: 300,
     });
     expect(placed.side).toBe("right");
-    expect(placed.left).toBeGreaterThanOrEqual(80 + 18);
+    expect(placed.left).toBeCloseTo(80 + 18, 5);
     expect(
       tooltipCoversPointer(
         { left: placed.left, top: placed.top, width: 260, height: 150 },

--- a/web/src/lib/chart-tooltip-placement.ts
+++ b/web/src/lib/chart-tooltip-placement.ts
@@ -25,10 +25,10 @@ export function tooltipCoversPointer(
   gap = 0,
 ): boolean {
   return (
-    pointerX >= box.left - gap &&
-    pointerX <= box.left + box.width + gap &&
-    pointerY >= box.top - gap &&
-    pointerY <= box.top + box.height + gap
+    pointerX > box.left - gap &&
+    pointerX < box.left + box.width + gap &&
+    pointerY > box.top - gap &&
+    pointerY < box.top + box.height + gap
   );
 }
 

--- a/web/src/lib/chart-tooltip-placement.ts
+++ b/web/src/lib/chart-tooltip-placement.ts
@@ -1,0 +1,112 @@
+export type TooltipSide = "left" | "right" | "above" | "below";
+
+export type TooltipPlacement = {
+  left: number;
+  top: number;
+  side: TooltipSide;
+};
+
+export type TooltipPlacementInput = {
+  pointerX: number;
+  pointerY: number;
+  chartLeft: number;
+  chartTop: number;
+  chartWidth: number;
+  chartHeight: number;
+  tooltipWidth: number;
+  tooltipHeight: number;
+  gap?: number;
+};
+
+export function tooltipCoversPointer(
+  box: { left: number; top: number; width: number; height: number },
+  pointerX: number,
+  pointerY: number,
+  gap = 0,
+): boolean {
+  return (
+    pointerX >= box.left - gap &&
+    pointerX <= box.left + box.width + gap &&
+    pointerY >= box.top - gap &&
+    pointerY <= box.top + box.height + gap
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.max(min, Math.min(value, max));
+}
+
+/**
+ * Place a hover box so it stays inside the chart and never covers the
+ * pointer. Prefer the opposite horizontal side of a right- or left-edge
+ * point so neighboring dots stay reachable.
+ */
+export function placeTooltipAwayFromPointer(
+  input: TooltipPlacementInput,
+): TooltipPlacement {
+  const gap = input.gap ?? 18;
+  const {
+    pointerX: px,
+    pointerY: py,
+    chartLeft: cl,
+    chartTop: ct,
+    chartWidth: cw,
+    chartHeight: ch,
+    tooltipWidth: tw,
+    tooltipHeight: th,
+  } = input;
+
+  const chartRight = cl + cw;
+  const chartBottom = ct + ch;
+  const maxLeft = chartRight - tw;
+  const maxTop = chartBottom - th;
+
+  const fit = (left: number, top: number) => ({
+    left: clamp(left, cl, maxLeft),
+    top: clamp(top, ct, maxTop),
+  });
+
+  const covers = (left: number, top: number) =>
+    tooltipCoversPointer(
+      { left, top, width: tw, height: th },
+      px,
+      py,
+      gap,
+    );
+
+  const trySide = (side: TooltipSide): TooltipPlacement | null => {
+    let left = 0;
+    let top = 0;
+    if (side === "left") {
+      left = px - gap - tw;
+      top = py - th / 2;
+    } else if (side === "right") {
+      left = px + gap;
+      top = py - th / 2;
+    } else if (side === "above") {
+      left = px - tw / 2;
+      top = py - gap - th;
+    } else {
+      left = px - tw / 2;
+      top = py + gap;
+    }
+    const next = fit(left, top);
+    if (covers(next.left, next.top)) return null;
+    return { ...next, side };
+  };
+
+  const preferLeft = px >= cl + cw / 2;
+  const order: TooltipSide[] = preferLeft
+    ? ["left", "above", "below", "right"]
+    : ["right", "above", "below", "left"];
+
+  for (const side of order) {
+    const hit = trySide(side);
+    if (hit) return hit;
+  }
+
+  const left = preferLeft ? cl : maxLeft;
+  const top = py >= ct + ch / 2 ? ct : maxTop;
+  return { left, top, side: preferLeft ? "left" : "right" };
+}

--- a/web/tests/alignment-gap-recipe.spec.ts
+++ b/web/tests/alignment-gap-recipe.spec.ts
@@ -63,11 +63,13 @@ test("alignment-gap fig 1 tooltip stays off the pointer on the right side", asyn
   const cy = pointer!.y + pointer!.height / 2;
   const pad = 8;
   const coversPointer =
-    cx >= box!.x - pad &&
-    cx <= box!.x + box!.width + pad &&
-    cy >= box!.y - pad &&
-    cy <= box!.y + box!.height + pad;
+    cx > box!.x - pad &&
+    cx < box!.x + box!.width + pad &&
+    cy > box!.y - pad &&
+    cy < box!.y + box!.height + pad;
   expect(coversPointer).toBe(false);
+  expect(box!.x + box!.width).toBeLessThan(cx);
+  expect(Math.abs(box!.y + box!.height / 2 - cy)).toBeLessThan(120);
 });
 
 test("alignment-gap panels share one gap number for Pratt", async ({ page }) => {

--- a/web/tests/alignment-gap-recipe.spec.ts
+++ b/web/tests/alignment-gap-recipe.spec.ts
@@ -4,12 +4,12 @@ test("alignment-gap merit panel names the school on every dot", async ({ page })
   await page.goto("/recipes/alignment-gap");
 
   await expect(
-    page.getByRole("heading", { name: /what a school charges, against what it delivers/i }),
+    page.getByRole("heading", { name: /debt burden, aid, and financial resources/i }),
   ).toBeVisible();
-  await expect(page.locator("header p.serif")).toContainText(
-    /completer debt a school would have to shed/i,
+  await expect(page.locator("header + div p.serif")).toContainText(
+    /college affordability data lives in several different places/i,
   );
-  await expect(page.getByText(/are they already spending it/i)).toBeVisible();
+  await expect(page.getByText(/compare the debt gap with merit aid/i)).toBeVisible();
   await expect(page.getByText(/merit spend = annual gap/i)).toBeVisible();
 
   const meritChart = page.getByTestId("alignment-gap-merit-chart");
@@ -30,16 +30,44 @@ test("alignment-gap merit panel names the school on every dot", async ({ page })
   await page.getByLabel("Find a school in the merit join").fill("University of the Incarnate Word");
   await expect(tooltip).toContainText("University of the Incarnate Word");
   await expect(tooltip).toContainText("$0 · no merit aid");
-  await expect(tooltip).toContainText("genuinely constrained");
+  await expect(tooltip).toContainText("merit aid smaller than the gap");
 
   await page.getByLabel("Find a school in the merit join").fill("Amherst College");
   await expect(tooltip).toContainText("Amherst College");
   await expect(tooltip).toContainText("$0 · no merit aid");
-  await expect(tooltip).toContainText("gap ≤ 0");
+  await expect(tooltip).toContainText("debt burden at or below the median");
 
   await expect(meritChart.getByTestId("alignment-gap-zero-rail")).toBeAttached();
   await expect(meritChart.locator("svg").getByText("NO MERIT AID")).toBeVisible();
-  await expect(meritChart.locator("svg").getByText(/GAP ≤ 0/)).toBeVisible();
+  await expect(meritChart.locator("svg").getByText(/AT OR BELOW MEDIAN/)).toBeVisible();
+});
+
+test("alignment-gap fig 1 tooltip stays off the pointer on the right side", async ({ page }) => {
+  await page.goto("/recipes/alignment-gap");
+
+  const meritChart = page.getByTestId("alignment-gap-merit-chart");
+  const quincy = meritChart.locator("circle[data-school-id='quincy-university']").first();
+  await quincy.scrollIntoViewIfNeeded();
+  await quincy.hover();
+
+  const tooltip = page.getByTestId("alignment-gap-merit-tooltip");
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText("Quincy University");
+  await expect(tooltip).toHaveAttribute("data-tooltip-side", "left");
+
+  const pointer = await quincy.boundingBox();
+  const box = await tooltip.boundingBox();
+  expect(pointer).toBeTruthy();
+  expect(box).toBeTruthy();
+  const cx = pointer!.x + pointer!.width / 2;
+  const cy = pointer!.y + pointer!.height / 2;
+  const pad = 8;
+  const coversPointer =
+    cx >= box!.x - pad &&
+    cx <= box!.x + box!.width + pad &&
+    cy >= box!.y - pad &&
+    cy <= box!.y + box!.height + pad;
+  expect(coversPointer).toBe(false);
 });
 
 test("alignment-gap panels share one gap number for Pratt", async ({ page }) => {
@@ -69,7 +97,7 @@ test("alignment-gap reproducibility curl pages Panel B past the 1,000-row cap", 
 
 test("alignment-gap endowment panel still names Bard and Grinnell", async ({ page }) => {
   await page.goto("/recipes/alignment-gap");
-  await expect(page.getByText(/could they afford to/i)).toBeVisible();
+  await expect(page.getByText(/compare debt burden with endowment per student/i)).toBeVisible();
 
   const endowmentChart = page.getByTestId("alignment-gap-endowment-chart");
   await endowmentChart.locator("circle[data-school-id='bard-college']").hover({ force: true });
@@ -84,7 +112,7 @@ test("recipes index exposes the alignment-gap recipe as a three-source join", as
   await page.goto("/recipes");
   const card = page.locator("article", { hasText: "Alignment gap" });
   await expect(card.getByText("CDS H2A · Scorecard · IPEDS")).toBeVisible();
-  await expect(card.getByText(/already spend more per first-year/i)).toBeVisible();
+  await expect(card.getByText(/compare the alignment gap with merit aid/i)).toBeVisible();
   await expect(card.getByRole("link", { name: "Open demo →" })).toHaveAttribute(
     "href",
     "/recipes/alignment-gap",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `/recipes/alignment-gap` with the revised explanatory copy (debt burden, merit aid, and financial resources) and fixes Fig. 1 hover occlusion on the right side of the chart.

## Copy
- New H1 and lede: debt burden, alignment gap, then the two joins
- Panel A regions: merit aid larger / smaller than the gap, and debt burden at or below the median
- Panel B quadrants: higher/lower debt burden × higher/lower endowment
- Keeps the existing worked-example tables and Panel A/B curl queries
- Recipes index tagline matches the new framing

## Hover
- Shared placement helper puts the tooltip on the opposite side of the pointer, with an 18px gap
- Right-side Fig. 1 dots (e.g. Quincy) open the box immediately to the left of the point so neighboring points stay reachable
- Same behavior on Fig. 2
- Inclusive gap math had been sending the box to the far corner; that is fixed

## Tests
- Unit tests for copy and tooltip placement (box sits beside the point, not in the corner)
- Playwright checks Quincy’s tooltip `data-tooltip-side="left"`, that the box does not cover the pointer, and that it stays vertically near the hovered dot

[New H1 and lede](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falignment_gap_h1_lede.webp)
[Fig. 1 Quincy hover, tooltip to the left of the point](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falignment_gap_fig1_quincy_hover.webp)
[alignment_gap_fig1_right_side_hover.mp4](https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falignment_gap_fig1_right_side_hover.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93cbd8d-16f4-49d5-b095-26a381edd996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93cbd8d-16f4-49d5-b095-26a381edd996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

