### PR TITLE
Fix 2024-25 B1 gender map that mislabeled enrollment sex ratios

### DIFF
--- a/tools/extraction_worker/test_tier4_cleaner_b1.py
+++ b/tools/extraction_worker/test_tier4_cleaner_b1.py
@@ -155,6 +155,61 @@ B2 Enrollment by Racial/Ethnic Category
         self.assertEqual(values["B.177"]["value"], "11090")
         self.assertEqual(values["B.178"]["value"], "54384")
 
+    def test_b1_2024_25_interleaved_gender_columns(self):
+        """2024-25 schemas interleave Men/Women/Another/Unknown per row.
+
+        The 2025-26 hand-coded B1 map must not run here: it would write
+        all-other men into B.102/B.103 (women / another-gender FY) and park
+        real women counts on B.126. Empty Another Gender cells must not shift
+        Unknown left.
+        """
+        from pathlib import Path
+
+        from tier4_cleaner import SchemaIndex
+
+        markdown = """
+## B1 Institutional Enrollment - Men and Women
+
+| Undergraduate Students: Full-Time              | Men    | Women   | Another Gender   | Unknown   |
+|------------------------------------------------|--------|---------|------------------|-----------|
+| Degree-seeking, first-time first-year students | 1,089  | 1,667   |                  | 3         |
+| Other first-year, degree-seeking               |        |         |                  |           |
+| All other degree-seeking                       | 8,571  | 11,216  |                  | 43        |
+| Total degree-seeking                           | 9,660  | 12,883  | 0                | 46        |
+| All other undergraduates enrolled in credit    | 26     | 49      |                  |           |
+| Total undergraduate Full-Time Students         | 9,686  | 12,932  | 0                | 46        |
+| Undergraduate Students: Part-Time              | Men    | Women   | Another Gender   | Unknown   |
+| Total degree-seeking                           | 0      | 0       | 0                | 0         |
+| All other undergraduates enrolled in credit    | 19     | 12      |                  |           |
+| Total undergraduate Part-Time Students         | 19     | 12      | 0                | 0         |
+| Undergraduate Students: All                    | Men    | Women   | Another Gender   | Unknown   |
+| Total undergraduate Students                   | 9,705  | 12,944  |                  | 46        |
+| Total all undergraduates                       | 22,695 |         |                  |           |
+| Total all graduate                             | 17,079 |         |                  |           |
+| GRAND TOTAL ALL STUDENTS                       | 39,774 |         |                  |           |
+
+## B2 Enrollment by Racial/Ethnic Category
+"""
+        schema = SchemaIndex(Path("schemas/cds_schema_2024_25.json"))
+        values = clean(markdown, schema=schema, canonical_year="2024-25")
+
+        self.assertEqual(values["B.101"]["value"], "1089")
+        self.assertEqual(values["B.102"]["value"], "1667")
+        self.assertNotIn("B.103", values)
+        self.assertEqual(values["B.104"]["value"], "3")
+        self.assertEqual(values["B.109"]["value"], "8571")
+        self.assertEqual(values["B.110"]["value"], "11216")
+        self.assertEqual(values["B.112"]["value"], "43")
+        self.assertEqual(values["B.149"]["value"], "9705")
+        self.assertEqual(values["B.150"]["value"], "12944")
+        self.assertEqual(values["B.152"]["value"], "46")
+        self.assertEqual(values["B.193"]["value"], "22695")
+        self.assertEqual(values["B.194"]["value"], "17079")
+        self.assertEqual(values["B.195"]["value"], "39774")
+        # Pre-fix symptom: women FY parked on B.126, all-other men on B.102.
+        self.assertNotIn("B.126", values)
+        self.assertNotEqual(values.get("B.102", {}).get("value"), "8571")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -467,6 +467,39 @@ _SCHEMA_FIXED_C1_FIELD_MAP_QNS = {
     f"C.{n:03d}" for n in range(101, 119)
 }
 
+# B1 hand-coded map entries use 2025-26 question numbers (all-males block
+# then all-females block: B.101 men FY, B.102 other-FY men, B.126 women FY).
+# 2023-24 / 2024-25 interleave Men/Women/Another Gender[/Unknown] per row
+# (B.101 men FY, B.102 women FY, B.103 another gender FY). Applying the
+# 2025-26 map against those schemas writes all-other men into B.102/B.103
+# and parks real women counts on B.126 — the Northeastern 2024-25 failure.
+_SCHEMA_FIXED_B1_FIELD_MAP_QNS = {
+    "B.101",
+    "B.102",
+    "B.103",
+    "B.104",
+    "B.106",
+    "B.126",
+    "B.127",
+    "B.128",
+    "B.129",
+    "B.131",
+    "B.151",
+}
+
+# Schema years that use the interleaved Men/Women/Another Gender layout.
+_B1_INTERLEAVED_GENDER_YEARS = frozenset({"2023-24", "2024-25"})
+
+_GENDER_ALIASES: dict[str, frozenset[str]] = {
+    "Males": frozenset({"Males", "Men"}),
+    "Men": frozenset({"Males", "Men"}),
+    "Females": frozenset({"Females", "Women"}),
+    "Women": frozenset({"Females", "Women"}),
+    "Another Gender": frozenset({"Another Gender"}),
+    "Unknown": frozenset({"Unknown"}),
+    "All": frozenset({"All"}),
+}
+
 # C9 percentile tables normally use 25th/50th/75th columns, but some schools
 # publish 25th/75th/50th/mean. Keep row matching by assessment label while
 # mapping columns by header role whenever Docling preserves the headers.
@@ -556,8 +589,10 @@ class SchemaIndex:
                 continue
             if question_norm is not None and f["_q_norm"] != question_norm:
                 continue
-            if gender is not None and f["gender"] != gender:
-                continue
+            if gender is not None:
+                allowed = _GENDER_ALIASES.get(gender, frozenset({gender}))
+                if f["gender"] not in allowed:
+                    continue
             if cohort is not None and f["cohort"] != cohort:
                 continue
             if unit_load is not None and f["unit_load"] != unit_load:
@@ -1614,11 +1649,62 @@ def resolve_b5_graduation(
 # new `##` headers, so the resolver must track (unit_load, student_group)
 # context as rows are scanned.
 #
-# Column index (0-3) → gender:
-#   0 = Males, 1 = Females, 2 = Unknown (from "Another Gender" column),
-#   3 = ignored (second "Unknown" column duplicates data for Unknown gender
-#       in the 2024-25 template; the schema collapses both into one field).
+# Column index → gender for the 2025-26 (and older non-interleaved) layout:
+#   0 = Males, 1 = Females, 2 = Unknown. SchemaIndex gender aliases map
+#   Males/Females onto Men/Women when a 2023-24/2024-25 schema is loaded.
 _B1_COL_GENDER = ["Males", "Females", "Unknown"]
+
+
+def _b1_col_genders(schema: SchemaIndex) -> list[str]:
+    """Return B1 value-column gender labels for this schema year."""
+    if schema.schema_version == "2024-25":
+        return ["Men", "Women", "Another Gender", "Unknown"]
+    if schema.schema_version == "2023-24":
+        return ["Men", "Women", "Another Gender"]
+    return list(_B1_COL_GENDER)
+
+
+def _b1_grand_total_qn(schema: SchemaIndex) -> str:
+    if schema.schema_version in _B1_INTERLEAVED_GENDER_YEARS:
+        return "B.195"
+    return "B.178"
+
+
+def _b1_line_values(line: str) -> tuple[str, list[str]] | None:
+    """Split a B1 data line into (label, value cells).
+
+    Markdown pipe tables must keep empty cells so a blank Another Gender
+    column does not shift Unknown left. Plain OCR/pypdf lines fall back to
+    regex number extraction (empty cells are already lost in that text).
+    """
+    stripped = line.strip()
+    if stripped.startswith("|") and stripped.count("|") >= 3:
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            return None
+        # Skip separator / header rows.
+        if all(re.fullmatch(r":?-{3,}:?", c) for c in cells[1:] if c):
+            return None
+        headerish = {_normalize_label(c) for c in cells[1:] if c}
+        if headerish and headerish <= {
+            "men",
+            "women",
+            "males",
+            "females",
+            "another gender",
+            "unknown",
+            "total",
+        }:
+            return None
+        return cells[0], cells[1:]
+
+    nums = re.findall(r"\b\d[\d,]*\b", stripped)
+    if not nums:
+        return None
+    first_num = re.search(r"\b\d[\d,]*\b", stripped)
+    if not first_num:
+        return None
+    return stripped[: first_num.start()].strip(), nums
 
 # Context-change patterns. Order matters — longest match first so
 # "undergraduate students full time" takes priority over "undergraduate
@@ -1641,10 +1727,13 @@ _B1_CONTEXT_RULES: list[tuple[str, str, str]] = [
 _B1_ROW_RULES: list[tuple[str, str, str]] = [
     ("degree seeking first time first year", "First-time, first-year", "Degree-seeking"),
     ("other first year degree seeking",       "Other first-year",       "Degree-seeking"),
-    ("all other degree seeking",              "All other",              "Degree-seeking"),
-    ("total degree seeking",                  "Total",                  "Degree-seeking"),
+    # Enrolled-in-credit rows before the broader "all other degree seeking"
+    # rule so Docling-merged labels like "All other degree-seeking All other
+    # graduates enrolled in credit courses" still resolve to credit courses.
     ("all other undergraduates enrolled",     "All other",              "Enrolled in Credit Courses"),
     ("all other graduates enrolled",          "All other",              "Enrolled in Credit Courses"),
+    ("all other degree seeking",              "All other",              "Degree-seeking"),
+    ("total degree seeking",                  "Total",                  "Degree-seeking"),
     ("degree seeking first time",             "First-time",             "Degree-seeking"),  # graduates-only
     # Rollup totals. "Total" sums by unit_load are disambiguated by the
     # current context (FT / PT / All).
@@ -1660,6 +1749,16 @@ _B1_ROW_RULES: list[tuple[str, str, str]] = [
 
 def _match_b1_row(label_norm: str) -> tuple[str, str] | None:
     """Pick the first row rule whose substring matches the label."""
+    # Docling sometimes concatenates an empty row into the next data row
+    # ("Other first-year, degree-seeking All other degree-seeking"). Prefer
+    # the later, data-bearing cohort when both markers are present.
+    if "all other undergraduates enrolled" in label_norm or "all other graduates enrolled" in label_norm:
+        return "All other", "Enrolled in Credit Courses"
+    if (
+        "all other degree seeking" in label_norm
+        and "other first year degree seeking" in label_norm
+    ):
+        return "All other", "Degree-seeking"
     for substr, cohort, category in _B1_ROW_RULES:
         if substr in label_norm:
             return cohort, category
@@ -1674,13 +1773,16 @@ def _match_b1_context(label_norm: str) -> tuple[str, str] | None:
     return None
 
 
-def _b1_rollup_qn(label_norm: str) -> str | None:
+def _b1_rollup_qn(label_norm: str, schema: SchemaIndex | None = None) -> str | None:
+    interleaved = bool(
+        schema and schema.schema_version in _B1_INTERLEAVED_GENDER_YEARS
+    )
     if "grand total all students" in label_norm:
-        return "B.178"
+        return "B.195" if interleaved else "B.178"
     if "total all undergraduates" in label_norm:
-        return "B.176"
+        return "B.193" if interleaved else "B.176"
     if "total all graduate" in label_norm:
-        return "B.177"
+        return "B.194" if interleaved else "B.177"
     return None
 
 
@@ -1797,7 +1899,7 @@ def _resolve_b1_compact_full_part_time_grid(block: str, schema: SchemaIndex) -> 
             pending_label = ""
         label_norm = _normalize_label(label)
 
-        rollup_qn = _b1_rollup_qn(label_norm)
+        rollup_qn = _b1_rollup_qn(label_norm, schema)
         if rollup_qn:
             out[rollup_qn] = {
                 "value": _extract_number(nums[0]),
@@ -1891,8 +1993,8 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
             pending_label = ""
             continue
 
-        nums = re.findall(r"\b\d[\d,]*\b", line)
-        if not nums:
+        parsed = _b1_line_values(line)
+        if not parsed:
             if unit_load is not None and (
                 line_norm.startswith("degree seeking")
                 or line_norm.startswith("all other")
@@ -1903,10 +2005,7 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
                 pending_label = f"{pending_label} {line}".strip()
             continue
 
-        first_num = re.search(r"\b\d[\d,]*\b", line)
-        if not first_num:
-            continue
-        label = line[:first_num.start()].strip()
+        label, nums = parsed
         if pending_label:
             # Blank rows sometimes precede the next total row. If the next
             # numeric row is itself a total, the pending wrapped label had no
@@ -1918,12 +2017,17 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
             pending_label = ""
         label_norm = _normalize_label(label)
 
-        rollup_qn = _b1_rollup_qn(label_norm)
+        rollup_qn = _b1_rollup_qn(label_norm, schema)
         if rollup_qn and nums:
-            out[rollup_qn] = {
-                "value": _extract_number(nums[0]),
-                "source": "tier4_cleaner",
-            }
+            first_num = next(
+                (n for n in nums if _extract_number(n) is not None),
+                None,
+            )
+            if first_num is not None:
+                out[rollup_qn] = {
+                    "value": _extract_number(first_num),
+                    "source": "tier4_cleaner",
+                }
             continue
 
         if unit_load is None or student_group is None:
@@ -1951,16 +2055,11 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
             local_ul, local_sg = "All", "All Students"
 
         col_values: list[tuple[str, str]] = []
-        if len(nums) >= 1:
-            col_values.append(("Males", nums[0]))
-        if len(nums) >= 2:
-            col_values.append(("Females", nums[1]))
-        if len(nums) >= 3:
-            # The 2024-25 table has both Another Gender and Unknown columns,
-            # while the canonical schema has one Unknown bucket. Use the
-            # Another Gender value when present; the fourth PDF column is only
-            # a fallback in templates where the third column is absent.
-            col_values.append(("Unknown", nums[2]))
+        genders = _b1_col_genders(schema)
+        for col_idx, gender in enumerate(genders):
+            if col_idx >= len(nums):
+                break
+            col_values.append((gender, nums[col_idx]))
 
         for gender, raw_value in col_values:
             num = _extract_number(raw_value)
@@ -2045,7 +2144,13 @@ def resolve_b1_enrollment(
     every label and using whichever fires.
     """
     out: dict[str, dict] = _resolve_b1_layout(markdown, schema)
-    if "B.178" in out:
+    # 2025-26 layout text is complete enough to trust alone. Interleaved
+    # 2023-24/2024-25 years still benefit from structured markdown tables,
+    # which preserve empty Another Gender cells that plain number scans lose.
+    if (
+        schema.schema_version not in _B1_INTERLEAVED_GENDER_YEARS
+        and _b1_grand_total_qn(schema) in out
+    ):
         return out
 
     # Detect B1 tables by section name or by gendered column headers.
@@ -2069,6 +2174,7 @@ def resolve_b1_enrollment(
     # ones (e.g. a "Part-Time" fragment) are appended as continuations.
     unit_load: str | None = None
     student_group: str | None = None
+    prefer_table = schema.schema_version in _B1_INTERLEAVED_GENDER_YEARS
 
     for table in b1_tables:
         # Section header or column headers may advertise the (unit_load,
@@ -2124,7 +2230,7 @@ def resolve_b1_enrollment(
             elif "total all students" in label_norm:
                 local_ul, local_sg = "All", "All Students"
 
-            for col_idx, gender in enumerate(_B1_COL_GENDER):
+            for col_idx, gender in enumerate(_b1_col_genders(schema)):
                 if col_idx >= len(row["values"]):
                     continue
                 num = _extract_number(row["values"][col_idx])
@@ -2138,7 +2244,7 @@ def resolve_b1_enrollment(
                     cohort=cohort,
                     category=category,
                 )
-                if qn and qn not in out:
+                if qn and (prefer_table or qn not in out):
                     out[qn] = {"value": num, "source": "tier4_cleaner"}
 
     return out
@@ -6261,6 +6367,11 @@ def clean(
                 if (
                     idx.schema_version != "2025-26"
                     and qnum in _SCHEMA_FIXED_C1_FIELD_MAP_QNS
+                ):
+                    continue
+                if (
+                    idx.schema_version != "2025-26"
+                    and qnum in _SCHEMA_FIXED_B1_FIELD_MAP_QNS
                 ):
                     continue
                 if substr not in label_norm:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Northeastern’s 2024-25 CDS looked badly wrong on B1 (first-year women showed as 8,571 instead of 1,667; total undergrad gender totals were missing). Root cause: Tier 4’s B1 hand-coded field map used **2025-26** question numbers against **2024-25** schemas that interleave Men/Women/Another Gender/Unknown per row.

## Fix

- Skip the 2025-26 B1 `_FIELD_MAP` entries when `schema_version != 2025-26`
- Alias `Males`/`Females` ↔ `Men`/`Women` in schema lookup
- Preserve empty Another Gender cells in markdown pipe tables (so Unknown does not shift left)
- Write rollups to `B.193`–`B.195` for 2023-24/2024-25
- Prefer “enrolled in credit” over merged empty “all other degree-seeking” row labels
- Regression test from the Northeastern Docling table shape

## Evidence

Against Northeastern’s stored Docling markdown, cleaner now yields:

- B.101/B.102 = 1089 / 1667 (was 1089 / 8571)
- B.149/B.150 = 9705 / 12944 (~42.8% men)
- B.193–B.195 rollups correct

## Ops (already applied from this branch against prod artifacts)

Surgical reclean + `cds_fields` reproject for 13 canary docs with the B.102==B.103 symptom, including Northeastern. Live Northeastern fields now show correct FY and total undergrad gender splits.

UPenn’s canary row stayed sparse after reclean (Docling markdown quality), separate from this mapping bug.

## Test plan

- [x] `pytest tools/extraction_worker/test_tier4_cleaner_b1.py`
- [x] Reproduce clean() on Northeastern artifact markdown
- [x] Reclean/project Northeastern + 12 canaries

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b65e9e5-dffa-4bc1-bcc9-a82c3950339c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b65e9e5-dffa-4bc1-bcc9-a82c3950339c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

