### PR TITLE
Restore 2024-25 B1 undergrad totals in table parser + audit tool

### DIFF
--- a/tools/data_quality/audit_b1_gender_2024.py
+++ b/tools/data_quality/audit_b1_gender_2024.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Audit 2023-24 / 2024-25 B1 enrollment gender mapping quality.
+
+Compares stored tier4_docling cleaner values against a fresh clean() of the
+artifact markdown using the current Tier 4 cleaner. Useful after schema-year
+B1 mapping fixes (see PR #168).
+
+Examples:
+  python tools/data_quality/audit_b1_gender_2024.py
+  python tools/data_quality/audit_b1_gender_2024.py --apply-improvements
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT / "tools" / "extraction_worker"))
+
+from supabase import create_client  # noqa: E402
+from tier4_cleaner import SchemaIndex, clean  # noqa: E402
+
+
+YEARS = ("2023-24", "2024-25")
+
+
+def is_b1(qn: str) -> bool:
+    if not qn.startswith("B."):
+        return False
+    try:
+        n = int(qn.split(".", 1)[1])
+    except ValueError:
+        return False
+    return 101 <= n <= 195
+
+
+def b1_map(values: dict) -> dict[str, str | None]:
+    out: dict[str, str | None] = {}
+    for k, v in (values or {}).items():
+        if not is_b1(k):
+            continue
+        out[k] = v.get("value") if isinstance(v, dict) else (None if v is None else str(v))
+    return out
+
+
+def classify(old_b1: dict, new_b1: dict) -> str:
+    if not old_b1 and not new_b1:
+        return "no_b1"
+    if old_b1 and not new_b1:
+        return "lose"
+    if old_b1 == new_b1:
+        return "unchanged"
+    gains = False
+    for qn in ("B.149", "B.150", "B.193", "B.194", "B.195"):
+        if new_b1.get(qn) and not old_b1.get(qn):
+            gains = True
+    if old_b1.get("B.102") and new_b1.get("B.102") and old_b1["B.102"] != new_b1["B.102"]:
+        gains = True
+    ratio = len(new_b1) / max(len(old_b1), 1)
+    if ratio < 0.5 and not gains:
+        return "shrink_risky"
+    if gains or ratio >= 1.0 or len(new_b1) >= len(old_b1):
+        return "improve"
+    return "changed_other"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply-improvements", action="store_true")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "scratch" / "b1-wider-audit" / "audit_b1_gender_2024.json",
+    )
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
+
+    client = create_client(url, key)
+    schemas = {
+        year: SchemaIndex(ROOT / "schemas" / f"cds_schema_{year.replace('-', '_')}.json")
+        for year in YEARS
+    }
+
+    doc_ids: set[tuple[str, str, str]] = set()
+    for year in YEARS:
+        offset = 0
+        while True:
+            batch = (
+                client.table("cds_fields")
+                .select("document_id,school_id,canonical_year,field_id")
+                .eq("canonical_year", year)
+                .like("field_id", "B.1%")
+                .range(offset, offset + 999)
+                .execute()
+            ).data or []
+            for row in batch:
+                try:
+                    n = int(row["field_id"].split(".", 1)[1])
+                except Exception:
+                    continue
+                if 101 <= n <= 195:
+                    doc_ids.add(
+                        (row["document_id"], row["school_id"], row["canonical_year"])
+                    )
+            if len(batch) < 1000:
+                break
+            offset += 1000
+
+    decisions: Counter[str] = Counter()
+    plan = []
+    residuals = []
+
+    for doc_id, school, year in sorted(doc_ids, key=lambda x: x[1]):
+        arts = (
+            client.table("cds_artifacts")
+            .select("id,producer,notes")
+            .eq("document_id", doc_id)
+            .eq("kind", "canonical")
+            .execute()
+        ).data or []
+        art = next(
+            (
+                a
+                for a in arts
+                if (a.get("notes") or {}).get("markdown")
+                and a.get("producer") == "tier4_docling"
+            ),
+            None,
+        )
+        if art is None:
+            art = next(
+                (a for a in arts if (a.get("notes") or {}).get("markdown")),
+                None,
+            )
+        if art is None:
+            decisions["no_artifact_markdown"] += 1
+            residuals.append(
+                {
+                    "school_id": school,
+                    "cds_year": year,
+                    "document_id": doc_id,
+                    "reason": "no_artifact_markdown",
+                }
+            )
+            continue
+
+        notes = art["notes"] or {}
+        md = notes.get("markdown") or ""
+        old_b1 = b1_map(notes.get("values") or {})
+        new_values = clean(md, schema=schemas[year], canonical_year=year)
+        new_b1 = b1_map(new_values)
+        decision = classify(old_b1, new_b1)
+        decisions[decision] += 1
+        row = {
+            "document_id": doc_id,
+            "school_id": school,
+            "cds_year": year,
+            "artifact_id": art["id"],
+            "decision": decision,
+            "old_b1_count": len(old_b1),
+            "new_b1_count": len(new_b1),
+            "old_B.102": old_b1.get("B.102"),
+            "new_B.102": new_b1.get("B.102"),
+            "old_B.149": old_b1.get("B.149"),
+            "new_B.149": new_b1.get("B.149"),
+            "old_B.150": old_b1.get("B.150"),
+            "new_B.150": new_b1.get("B.150"),
+        }
+        if decision == "improve":
+            plan.append({**row, "new_values": new_values, "notes": notes})
+        elif decision != "unchanged":
+            residuals.append(row)
+
+    applied = []
+    if args.apply_improvements and plan:
+        from browser_backend.project_browser_data import (  # noqa: WPS433
+            load_schema_definitions,
+            project_document_id,
+        )
+
+        definitions = load_schema_definitions()
+        for row in plan:
+            new_notes = deepcopy(row["notes"])
+            new_notes["values"] = row["new_values"]
+            new_notes["recleaned_at"] = datetime.now(timezone.utc).isoformat()
+            new_notes["reclean_reason"] = "audit_b1_gender_2024"
+            if isinstance(new_notes.get("stats"), dict):
+                new_notes["stats"]["total_fields"] = len(row["new_values"])
+            client.table("cds_artifacts").update({"notes": new_notes}).eq(
+                "id", row["artifact_id"]
+            ).execute()
+            project_document_id(client, row["document_id"], definitions, apply=True)
+            applied.append({k: v for k, v in row.items() if k not in ("new_values", "notes")})
+        try:
+            client.rpc("refresh_public_serving_caches", {}).execute()
+        except Exception:
+            pass
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "decisions": dict(decisions),
+        "plan_count": len(plan),
+        "applied_count": len(applied),
+        "residuals": [
+            {k: v for k, v in r.items() if k not in ("new_values", "notes")}
+            for r in residuals
+        ],
+        "plan": [
+            {k: v for k, v in r.items() if k not in ("new_values", "notes")} for r in plan
+        ],
+        "applied": applied,
+    }
+    args.output.write_text(json.dumps(payload, indent=2))
+    print(json.dumps({"decisions": dict(decisions), "plan_count": len(plan), "applied_count": len(applied), "output": str(args.output)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/extraction_worker/b1_derive_totals.py
+++ b/tools/extraction_worker/b1_derive_totals.py
@@ -1,0 +1,151 @@
+"""Derive CDS B1 All unit_load gender totals from FT + PT components.
+
+2023-24 / 2024-25 (and 2025-26) schemas leave All undergrad/grad gender
+fields without AcroForm pdf_tags, so Tier 2 never reads them. Schools also
+often leave the All XLSX cells blank while FT/PT are filled. CDS defines
+All = FT + PT per gender, so deriving missing All cells is safe.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _as_int(raw: Any) -> int | None:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        raw = raw.get("value")
+    if raw is None:
+        return None
+    try:
+        return int(float(str(raw).replace(",", "").strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _set_derived(values: dict[str, Any], qn: str, total: int) -> None:
+    existing = values.get(qn)
+    if isinstance(existing, dict):
+        values[qn] = {
+            **existing,
+            "value": str(total),
+            "derived_from": "b1_ft_pt_sum",
+        }
+    else:
+        values[qn] = {
+            "value": str(total),
+            "source": "b1_derive_totals",
+            "derived_from": "b1_ft_pt_sum",
+        }
+
+
+def _index_total_fields(schema_fields: list[dict[str, Any]]) -> dict[tuple[str, str, str], str]:
+    """Map (student_group, unit_load, gender) → question_number for Total/All rows."""
+    out: dict[tuple[str, str, str], str] = {}
+    for field in schema_fields:
+        qn = str(field.get("question_number") or "")
+        if not qn.startswith("B."):
+            continue
+        try:
+            n = int(qn.split(".", 1)[1])
+        except ValueError:
+            continue
+        if not (101 <= n <= 195):
+            continue
+        if field.get("category") not in (None, "All"):
+            # Still allow category All only for enrollment totals.
+            if field.get("category") != "All":
+                continue
+        cohort = str(field.get("cohort") or "")
+        if not cohort.startswith("Total"):
+            continue
+        student_group = str(field.get("student_group") or "")
+        unit_load = str(field.get("unit_load") or "")
+        gender = str(field.get("gender") or "")
+        if student_group not in {"Undergraduates", "Graduates", "All Students"}:
+            continue
+        if unit_load not in {"FT", "PT", "All"}:
+            continue
+        if gender in {"", "All"}:
+            continue
+        out[(student_group, unit_load, gender)] = qn
+    return out
+
+
+def apply_b1_derived_all_totals(
+    values: dict[str, Any],
+    schema_fields: list[dict[str, Any]] | None = None,
+) -> int:
+    """Fill missing All gender totals in ``values``. Returns count added.
+
+    Never overwrites an existing All value. When ``schema_fields`` is omitted,
+    uses the 2023-24/2024-25 interleaved question numbers.
+    """
+    added = 0
+    if schema_fields:
+        index = _index_total_fields(schema_fields)
+        genders = sorted({g for (_sg, _ul, g) in index})
+        for student_group in ("Undergraduates", "Graduates"):
+            for gender in genders:
+                all_qn = index.get((student_group, "All", gender))
+                if not all_qn or _as_int(values.get(all_qn)) is not None:
+                    continue
+                ft_n = _as_int(values.get(index.get((student_group, "FT", gender), "")))
+                pt_n = _as_int(values.get(index.get((student_group, "PT", gender), "")))
+                if ft_n is None or pt_n is None:
+                    continue
+                _set_derived(values, all_qn, ft_n + pt_n)
+                added += 1
+
+        for gender in genders:
+            all_qn = index.get(("All Students", "All", gender))
+            if not all_qn or _as_int(values.get(all_qn)) is not None:
+                continue
+            ug_n = _as_int(values.get(index.get(("Undergraduates", "All", gender), "")))
+            gr_n = _as_int(values.get(index.get(("Graduates", "All", gender), "")))
+            if ug_n is None or gr_n is None:
+                continue
+            _set_derived(values, all_qn, ug_n + gr_n)
+            added += 1
+        return added
+
+    # Fallback pairs for 2023-24 / 2024-25 interleaved schemas.
+    pairs = [
+        # undergrad All = FT + PT
+        ("B.149", "B.121", "B.145"),
+        ("B.150", "B.122", "B.146"),
+        ("B.151", "B.123", "B.147"),
+        ("B.152", "B.124", "B.148"),
+        # graduate All = FT + PT
+        ("B.185", "B.165", "B.181"),
+        ("B.186", "B.166", "B.182"),
+        ("B.187", "B.167", "B.183"),
+        ("B.188", "B.168", "B.184"),
+    ]
+    for all_qn, ft_qn, pt_qn in pairs:
+        if _as_int(values.get(all_qn)) is not None:
+            continue
+        ft_n = _as_int(values.get(ft_qn))
+        pt_n = _as_int(values.get(pt_qn))
+        if ft_n is None or pt_n is None:
+            continue
+        _set_derived(values, all_qn, ft_n + pt_n)
+        added += 1
+
+    all_student_pairs = [
+        ("B.189", "B.149", "B.185"),
+        ("B.190", "B.150", "B.186"),
+        ("B.191", "B.151", "B.187"),
+        ("B.192", "B.152", "B.188"),
+    ]
+    for all_qn, ug_qn, gr_qn in all_student_pairs:
+        if _as_int(values.get(all_qn)) is not None:
+            continue
+        ug_n = _as_int(values.get(ug_qn))
+        gr_n = _as_int(values.get(gr_qn))
+        if ug_n is None or gr_n is None:
+            continue
+        _set_derived(values, all_qn, ug_n + gr_n)
+        added += 1
+    return added

--- a/tools/extraction_worker/test_b1_derive_totals.py
+++ b/tools/extraction_worker/test_b1_derive_totals.py
@@ -1,0 +1,60 @@
+"""Unit tests for B1 All-total derivation (FT+PT)."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from b1_derive_totals import apply_b1_derived_all_totals
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class B1DeriveTotalsTest(unittest.TestCase):
+    def test_interleaved_fallback_pairs(self):
+        values = {
+            "B.121": {"value": "100"},
+            "B.145": {"value": "5"},
+            "B.122": {"value": "200"},
+            "B.146": {"value": "10"},
+            "B.165": {"value": "50"},
+            "B.181": {"value": "2"},
+            "B.166": {"value": "60"},
+            "B.182": {"value": "3"},
+        }
+        added = apply_b1_derived_all_totals(values)
+        self.assertGreaterEqual(added, 4)
+        self.assertEqual(values["B.149"]["value"], "105")
+        self.assertEqual(values["B.150"]["value"], "210")
+        self.assertEqual(values["B.185"]["value"], "52")
+        self.assertEqual(values["B.186"]["value"], "63")
+        self.assertEqual(values["B.189"]["value"], "157")
+        self.assertEqual(values["B.190"]["value"], "273")
+
+    def test_does_not_overwrite_existing(self):
+        values = {
+            "B.121": {"value": "100"},
+            "B.145": {"value": "5"},
+            "B.149": {"value": "999"},
+        }
+        apply_b1_derived_all_totals(values)
+        self.assertEqual(values["B.149"]["value"], "999")
+
+    def test_schema_fields_2024_25(self):
+        schema = json.loads((ROOT / "schemas" / "cds_schema_2024_25.json").read_text())
+        values = {
+            "B.121": {"value": "878"},
+            "B.145": {"value": "0"},
+            "B.122": {"value": "991"},
+            "B.146": {"value": "0"},
+        }
+        added = apply_b1_derived_all_totals(values, schema_fields=schema["fields"])
+        self.assertGreaterEqual(added, 2)
+        self.assertEqual(values["B.149"]["value"], "878")
+        self.assertEqual(values["B.150"]["value"], "991")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/extraction_worker/test_tier4_cleaner_b1.py
+++ b/tools/extraction_worker/test_tier4_cleaner_b1.py
@@ -210,6 +210,29 @@ B2 Enrollment by Racial/Ethnic Category
         self.assertNotIn("B.126", values)
         self.assertNotEqual(values.get("B.102", {}).get("value"), "8571")
 
+    def test_b1_2024_25_total_undergrad_uses_schema_cohort_fallback(self):
+        """B.149/B.150 live under cohort 'Total understand' in 2024-25 schema."""
+        from pathlib import Path
+
+        from tier4_cleaner import SchemaIndex
+
+        # Markdown table only (no layout rollup lines) so the table parser
+        # must resolve total undergraduate men/women via the fallback.
+        markdown = """
+## B1 Institutional Enrollment - Men and Women
+
+| Undergraduate Students: All | Men | Women | Another Gender | Unknown |
+|-----------------------------|-----|-------|----------------|---------|
+| Total undergraduate Students | 9,705 | 12,944 | | 46 |
+
+## B2 Enrollment by Racial/Ethnic Category
+"""
+        schema = SchemaIndex(Path("schemas/cds_schema_2024_25.json"))
+        values = clean(markdown, schema=schema, canonical_year="2024-25")
+        self.assertEqual(values["B.149"]["value"], "9705")
+        self.assertEqual(values["B.150"]["value"], "12944")
+        self.assertEqual(values["B.152"]["value"], "46")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/test_tier4_cleaner_b1.py
+++ b/tools/extraction_worker/test_tier4_cleaner_b1.py
@@ -233,6 +233,122 @@ B2 Enrollment by Racial/Ethnic Category
         self.assertEqual(values["B.150"]["value"], "12944")
         self.assertEqual(values["B.152"]["value"], "46")
 
+    def test_b1_2024_25_derives_all_totals_from_ft_pt(self):
+        """When the All sub-table is missing, All gender totals = FT + PT."""
+        from pathlib import Path
+
+        from tier4_cleaner import SchemaIndex
+
+        markdown = """
+## B1 Institutional Enrollment - Men and Women
+
+## Undergraduate Students: Full-Time
+
+| Category | Men | Women | Another Gender | Unknown |
+|----------|-----|-------|----------------|---------|
+| Total Undergraduate Full-time Students | 3234 | 3422 | 97 | 0 |
+
+## Undergraduate Students: Part-Time
+
+| Category | Men | Women | Another Gender | Unknown |
+|----------|-----|-------|----------------|---------|
+| Total Undergraduate Part-time Students 33 |  | 28 | 0 | 0 |
+
+## Graduate Students: Full-Time
+
+| Category | Men | Women | Another Gender | Unknown |
+|----------|-----|-------|----------------|---------|
+| Total Graduate Full-Time Students | 3732 | 4460 | 173 | 3 |
+
+## Graduate Students: Part-Time
+
+| Category | Men | Women | Another Gender | Unknown |
+|----------|-----|-------|----------------|---------|
+| Total Graduate Part-Time Students | 126 | 215 | 6 | 35 |
+
+## Total All Students (Total Undergraduate Students + Total Graduate Students)
+
+| Total All Students | Men | Women | Another Gender | Unknown |
+|--------------------|-----|-------|----------------|---------|
+| Total All Students: Full-time | 6966 | 7882 | 270 | 3 |
+| Total All Students: Part-time | 159 | 243 | 6 | 35 |
+
+Total all undergraduates: 6814
+Total all graduate: 8750
+GRAND TOTAL All STUDENTS: 15564
+
+## B2 Enrollment by Racial/Ethnic Category
+"""
+        schema = SchemaIndex(Path("schemas/cds_schema_2024_25.json"))
+        values = clean(markdown, schema=schema, canonical_year="2024-25")
+
+        self.assertEqual(values["B.145"]["value"], "33")
+        self.assertEqual(values["B.146"]["value"], "28")
+        self.assertEqual(values["B.149"]["value"], "3267")  # 3234+33
+        self.assertEqual(values["B.150"]["value"], "3450")  # 3422+28
+        self.assertEqual(values["B.185"]["value"], "3858")  # 3732+126
+        self.assertEqual(values["B.186"]["value"], "4675")  # 4460+215
+        self.assertEqual(values["B.189"]["value"], "7125")  # 3267+3858
+        self.assertEqual(values["B.190"]["value"], "8125")  # 3450+4675
+        # Must not park FT/PT all-students rows on B.189/B.190.
+        self.assertNotEqual(values["B.189"]["value"], "159")
+        self.assertEqual(values["B.193"]["value"], "6814")
+        self.assertEqual(values["B.195"]["value"], "15564")
+
+    def test_b1_2024_25_parses_gender_prefixed_all_cells(self):
+        """NYU-style packed All row: cell values like 'Men 11,827'."""
+        from pathlib import Path
+
+        from tier4_cleaner import SchemaIndex
+
+        markdown = """
+## B1 Institutional Enrollment - Men and Women
+
+| Undergraduate Students: Full-Time | Men | Women | Another Gender | Unknown |
+|-----------------------------------|-----|-------|----------------|---------|
+| Total undergraduate Full-Time Students | 100 | 200 | 0 | 0 |
+| Undergraduate Students: Part-Time | Men | Women | Another Gender | Unknown |
+| Total undergraduate Part-Time Students | 10 | 20 | 0 | 0 |
+| Undergraduate Students: All Total undergraduate Students | Men 110 | Women 220 | 0 | 0 |
+
+## B2 Enrollment by Racial/Ethnic Category
+"""
+        schema = SchemaIndex(Path("schemas/cds_schema_2024_25.json"))
+        values = clean(markdown, schema=schema, canonical_year="2024-25")
+        self.assertEqual(values["B.149"]["value"], "110")
+        self.assertEqual(values["B.150"]["value"], "220")
+
+    def test_b1_2024_25_field_id_labeled_rows(self):
+        """Butler-style markdown embeds B1xx IDs in the first cell."""
+        from pathlib import Path
+
+        from tier4_cleaner import SchemaIndex
+
+        markdown = """
+B1 Institutional Enrollment
+
+| B121 | Total undergraduate Full-Time Students:men | 1701 |
+| B122 | Total undergraduate Full-Time Students:women | 2581 |
+| B145 | Total undergraduate Part-Time Students:men | 71 |
+| B146 B147 | Total undergraduate Part-Time Students:women Total undergraduate Part-Time Students: another gender | 135 1 |
+| B149 Total | undergraduate students:men | 1772 |
+| B150 Total | undergraduate students:women | 2716 |
+| B193 | Total all undergraduates | 4489 |
+| B195 | Grand Total All Students | 5746 |
+
+## Enrollment by Racial/Ethnic Category.
+"""
+        schema = SchemaIndex(Path("schemas/cds_schema_2024_25.json"))
+        values = clean(markdown, schema=schema, canonical_year="2024-25")
+        self.assertEqual(values["B.121"]["value"], "1701")
+        self.assertEqual(values["B.145"]["value"], "71")
+        self.assertEqual(values["B.146"]["value"], "135")
+        self.assertEqual(values["B.147"]["value"], "1")
+        self.assertEqual(values["B.149"]["value"], "1772")
+        self.assertEqual(values["B.150"]["value"], "2716")
+        self.assertEqual(values["B.193"]["value"], "4489")
+        self.assertEqual(values["B.195"]["value"], "5746")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -2236,8 +2236,10 @@ def resolve_b1_enrollment(
                 num = _extract_number(row["values"][col_idx])
                 if num is None:
                     continue
-                qn = schema.lookup(
-                    subsection="Institutional Enrollment",
+                # Use shared lookup so 2024-25 schema typos/fallbacks
+                # (e.g. cohort "Total understand" for B.149/B.150) apply.
+                qn = _b1_schema_lookup(
+                    schema,
                     gender=gender,
                     unit_load=local_ul,
                     student_group=local_sg,

--- a/tools/extraction_worker/tier4_cleaner.py
+++ b/tools/extraction_worker/tier4_cleaner.py
@@ -1851,6 +1851,190 @@ def _b1_schema_lookup(
     return qn
 
 
+def _b1_extract_cell_number(value_str: str) -> str | None:
+    """Extract a B1 cell number, tolerating Docling gender prefixes.
+
+    Some markdown tables pack the column header into the cell
+    (``Men 11,827``). Plain ``_extract_number`` rejects those; strip a
+    leading gender word and retry.
+    """
+    num = _extract_number(value_str)
+    if num is not None:
+        return num
+    s = value_str.strip()
+    if not s:
+        return None
+    m = re.match(
+        r"(?i)^(?:men|women|males|females|another\s+gender|unknown)\s+"
+        r"([-+]?\d[\d,]*(?:\.\d+)?)\s*$",
+        s,
+    )
+    if m:
+        return _extract_number(m.group(1))
+    return None
+
+
+def _b1_salvage_values_from_label(label: str, values: list[str]) -> tuple[str, list[str]]:
+    """Move a trailing count out of a Total* label into the first empty cell.
+
+    Docling occasionally merges the Men count into the row label, e.g.
+    ``Total Undergraduate Part-time Students 33`` with values
+    ``["", "28", "0", "0"]``.
+    """
+    label_norm = _normalize_label(label)
+    if not label_norm.startswith("total"):
+        return label, values
+    if values and values[0].strip():
+        return label, values
+    m = re.search(r"^(.*?)[\s:]+(\d[\d,]*)\s*$", label.strip())
+    if not m:
+        return label, values
+    clean_label = m.group(1).strip()
+    # Require the cleaned label to still look like a total row.
+    if not _normalize_label(clean_label).startswith("total"):
+        return label, values
+    salvaged = list(values) if values else [""]
+    if not salvaged:
+        salvaged = [m.group(2)]
+    else:
+        salvaged[0] = m.group(2)
+    return clean_label, salvaged
+
+
+def _b1_value_int(entry: dict | None) -> int | None:
+    if not entry or entry.get("value") is None:
+        return None
+    try:
+        return int(float(str(entry["value"]).replace(",", "")))
+    except (TypeError, ValueError):
+        return None
+
+
+def _b1_derive_all_totals_from_ft_pt(
+    out: dict[str, dict], schema: SchemaIndex
+) -> None:
+    """Fill missing All unit_load gender totals from FT + PT (or UG + Grad).
+
+    Many 2023-24/2024-25 Docling extracts keep FT/PT total rows intact but
+    omit or garble the All sub-table. CDS defines All = FT + PT for each
+    gender, so deriving missing All cells is safe when the inputs exist.
+    Never overwrites an All value already present.
+    """
+    genders = _b1_col_genders(schema)
+
+    def _qn(gender: str, unit_load: str, student_group: str) -> str | None:
+        return _b1_schema_lookup(
+            schema,
+            gender=gender,
+            unit_load=unit_load,
+            student_group=student_group,
+            cohort="Total",
+            category="All",
+        )
+
+    for student_group in ("Undergraduates", "Graduates"):
+        for gender in genders:
+            all_qn = _qn(gender, "All", student_group)
+            if not all_qn or all_qn in out:
+                continue
+            ft_qn = _qn(gender, "FT", student_group)
+            pt_qn = _qn(gender, "PT", student_group)
+            ft_n = _b1_value_int(out.get(ft_qn)) if ft_qn else None
+            pt_n = _b1_value_int(out.get(pt_qn)) if pt_qn else None
+            # Require both sides for this gender. Treating a missing PT cell
+            # as 0 is unsafe when Docling dropped that gender's PT total
+            # (Butler-style single-column merges).
+            if ft_n is None or pt_n is None:
+                continue
+            out[all_qn] = {
+                "value": str(ft_n + pt_n),
+                "source": "tier4_cleaner",
+            }
+
+    # All Students gender totals = undergrad All + graduate All.
+    for gender in genders:
+        all_qn = _qn(gender, "All", "All Students")
+        if not all_qn or all_qn in out:
+            continue
+        ug_qn = _qn(gender, "All", "Undergraduates")
+        gr_qn = _qn(gender, "All", "Graduates")
+        ug_n = _b1_value_int(out.get(ug_qn)) if ug_qn else None
+        gr_n = _b1_value_int(out.get(gr_qn)) if gr_qn else None
+        if ug_n is None or gr_n is None:
+            continue
+        out[all_qn] = {
+            "value": str(ug_n + gr_n),
+            "source": "tier4_cleaner",
+        }
+
+
+def _resolve_b1_field_id_rows(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
+    """Parse Docling tables that embed canonical B1xx IDs in the label cell.
+
+    Butler (and similar) fillable-PDF → markdown extracts look like::
+
+        | B149 Total | undergraduate students:men | 1772 |
+        | B146 B147  | ... women ... another     | 135 1 |
+
+    When the template question number is present, map it directly.
+    """
+    block = _section_between(
+        markdown,
+        r"\bB1\b\.?\s*(?:Institutional Enrollment)?",
+        r"\bB2\b\.?\s*Enrollment by Racial/Ethnic Category|"
+        r"\bEnrollment by Racial/Ethnic Category",
+    )
+    if not block:
+        block = markdown
+
+    known = {
+        f["question_number"]
+        for f in schema.filter(subsection="Institutional Enrollment")
+        if str(f.get("question_number", "")).startswith("B.")
+    }
+    # Rollup totals live outside Institutional Enrollment on some years.
+    for qn in ("B.193", "B.194", "B.195", "B.176", "B.177", "B.178"):
+        known.add(qn)
+
+    out: dict[str, dict] = {}
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        id_text = " ".join(cells[:-1])
+        ids = re.findall(r"\bB\.?\s*(\d{3})\b", id_text, flags=re.IGNORECASE)
+        if not ids:
+            continue
+        qns = [f"B.{num}" for num in ids]
+        qns = [qn for qn in qns if qn in known and 101 <= int(qn[2:]) <= 195]
+        if not qns:
+            continue
+        nums = re.findall(r"\d[\d,]*", cells[-1])
+        if not nums:
+            continue
+        if len(qns) == 1:
+            num = _extract_number(nums[0])
+            if num is not None:
+                out[qns[0]] = {"value": num, "source": "tier4_cleaner"}
+            continue
+        # Multiple IDs in one row: zip with trailing numbers when counts match.
+        if len(nums) >= len(qns):
+            paired = list(zip(qns, nums[: len(qns)]))
+        elif len(nums) == 1 and len(qns) > 1:
+            # Ambiguous merge — skip rather than assign one value to many IDs.
+            continue
+        else:
+            paired = list(zip(qns[: len(nums)], nums))
+        for qn, raw in paired:
+            num = _extract_number(raw)
+            if num is not None:
+                out[qn] = {"value": num, "source": "tier4_cleaner"}
+    return out
+
+
 def _resolve_b1_compact_full_part_time_grid(block: str, schema: SchemaIndex) -> dict[str, dict]:
     """Parse OCR layout where FT and PT B1 columns are side-by-side."""
     if "full time part time" not in _normalize_label(block):
@@ -2015,17 +2199,18 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
             else:
                 label = f"{pending_label} {label}".strip()
             pending_label = ""
+        label, nums = _b1_salvage_values_from_label(label, nums)
         label_norm = _normalize_label(label)
 
         rollup_qn = _b1_rollup_qn(label_norm, schema)
         if rollup_qn and nums:
             first_num = next(
-                (n for n in nums if _extract_number(n) is not None),
+                (n for n in nums if _b1_extract_cell_number(n) is not None),
                 None,
             )
             if first_num is not None:
                 out[rollup_qn] = {
-                    "value": _extract_number(first_num),
+                    "value": _b1_extract_cell_number(first_num),
                     "source": "tier4_cleaner",
                 }
             continue
@@ -2052,6 +2237,10 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
         elif "total graduate students" in label_norm:
             local_ul, local_sg = "All", "Graduates"
         elif "total all students" in label_norm:
+            # Yale-style FT/PT "Total All Students" rows are not schema
+            # fields; only the ungated All-by-gender row maps to B.189+.
+            if "full time" in label_norm or "part time" in label_norm:
+                continue
             local_ul, local_sg = "All", "All Students"
 
         col_values: list[tuple[str, str]] = []
@@ -2062,7 +2251,7 @@ def _resolve_b1_layout(markdown: str, schema: SchemaIndex) -> dict[str, dict]:
             col_values.append((gender, nums[col_idx]))
 
         for gender, raw_value in col_values:
-            num = _extract_number(raw_value)
+            num = _b1_extract_cell_number(raw_value)
             if num is None:
                 continue
             qn = schema.lookup(
@@ -2151,6 +2340,9 @@ def resolve_b1_enrollment(
         schema.schema_version not in _B1_INTERLEAVED_GENDER_YEARS
         and _b1_grand_total_qn(schema) in out
     ):
+        for qn, entry in _resolve_b1_field_id_rows(markdown, schema).items():
+            out[qn] = entry
+        _b1_derive_all_totals_from_ft_pt(out, schema)
         return out
 
     # Detect B1 tables by section name or by gendered column headers.
@@ -2168,6 +2360,9 @@ def resolve_b1_enrollment(
             b1_tables.append(t)
 
     if not b1_tables:
+        for qn, entry in _resolve_b1_field_id_rows(markdown, schema).items():
+            out[qn] = entry
+        _b1_derive_all_totals_from_ft_pt(out, schema)
         return out
 
     # The B1 data typically lives in the first qualifying table; subsequent
@@ -2202,6 +2397,26 @@ def resolve_b1_enrollment(
             if ctx:
                 unit_load, student_group = ctx
 
+            # Scalar rollups (Total all undergraduates / graduate / GRAND
+            # TOTAL) must not fall through to gendered All-Students cells —
+            # "grand total all students" contains "total all students".
+            rollup_qn = _b1_rollup_qn(label_norm, schema)
+            if rollup_qn:
+                first_num = next(
+                    (
+                        _b1_extract_cell_number(v)
+                        for v in row["values"]
+                        if _b1_extract_cell_number(v) is not None
+                    ),
+                    None,
+                )
+                if first_num is not None and (prefer_table or rollup_qn not in out):
+                    out[rollup_qn] = {
+                        "value": first_num,
+                        "source": "tier4_cleaner",
+                    }
+                continue
+
             if unit_load is None or student_group is None:
                 continue
 
@@ -2228,12 +2443,27 @@ def resolve_b1_enrollment(
             elif "total graduate students" in label_norm:
                 local_ul, local_sg = "All", "Graduates"
             elif "total all students" in label_norm:
+                if "full time" in label_norm or "part time" in label_norm:
+                    continue
                 local_ul, local_sg = "All", "All Students"
 
+            row_values = list(row["values"])
+            label_for_row = row["label"]
+            label_for_row, row_values = _b1_salvage_values_from_label(
+                label_for_row, row_values
+            )
+            if label_for_row != row["label"]:
+                label_norm = _normalize_label(label_for_row)
+                # Re-apply local_ul after salvage (label lost trailing digits).
+                if "total undergraduate part time" in label_norm:
+                    local_ul, local_sg = "PT", "Undergraduates"
+                elif "total undergraduate full time" in label_norm:
+                    local_ul, local_sg = "FT", "Undergraduates"
+
             for col_idx, gender in enumerate(_b1_col_genders(schema)):
-                if col_idx >= len(row["values"]):
+                if col_idx >= len(row_values):
                     continue
-                num = _extract_number(row["values"][col_idx])
+                num = _b1_extract_cell_number(row_values[col_idx])
                 if num is None:
                     continue
                 # Use shared lookup so 2024-25 schema typos/fallbacks
@@ -2249,6 +2479,12 @@ def resolve_b1_enrollment(
                 if qn and (prefer_table or qn not in out):
                     out[qn] = {"value": num, "source": "tier4_cleaner"}
 
+    # Explicit B1xx IDs in Docling cells are authoritative when present.
+    field_id_vals = _resolve_b1_field_id_rows(markdown, schema)
+    for qn, entry in field_id_vals.items():
+        out[qn] = entry
+
+    _b1_derive_all_totals_from_ft_pt(out, schema)
     return out
 
 

--- a/tools/tier1_extractor/extract.py
+++ b/tools/tier1_extractor/extract.py
@@ -182,6 +182,15 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
 
     wb.close()
 
+    # All undergrad/grad gender totals are often blank in filled workbooks
+    # even when FT/PT are present. Derive missing All cells (CDS: All=FT+PT).
+    sys.path.insert(0, str(_REPO_ROOT / "tools" / "extraction_worker"))
+    from b1_derive_totals import apply_b1_derived_all_totals  # noqa: WPS433
+
+    b1_all_totals_derived = apply_b1_derived_all_totals(
+        values, schema_fields=schema.get("fields") or []
+    )
+
     return {
         "producer": PRODUCER_NAME,
         "producer_version": PRODUCER_VERSION,
@@ -196,6 +205,7 @@ def extract(xlsx_path: Path, schema: dict, cell_map: dict[str, tuple[str, str]])
             "extraction_layout": extraction_layout,
             "academic_profile_fields_recovered": academic_profile_recovered,
             "application_fields_recovered": application_fields_recovered,
+            "b1_all_totals_derived": b1_all_totals_derived,
         },
         "values": values,
     }

--- a/tools/tier2_extractor/extract.py
+++ b/tools/tier2_extractor/extract.py
@@ -113,6 +113,15 @@ def extract(pdf_path: Path, schema: dict) -> dict:
     schema_tags = set(tag_to_field)
     present_tags = set(acroform) & schema_tags
 
+    # 2023-24/2024-25 All gender totals have null pdf_tags, so AcroForm
+    # never populates them. Derive from FT+PT when both sides exist.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "extraction_worker"))
+    from b1_derive_totals import apply_b1_derived_all_totals  # noqa: WPS433
+
+    b1_all_totals_derived = apply_b1_derived_all_totals(
+        values, schema_fields=schema.get("fields") or []
+    )
+
     return {
         "producer": PRODUCER_NAME,
         "producer_version": PRODUCER_VERSION,
@@ -122,8 +131,9 @@ def extract(pdf_path: Path, schema: dict) -> dict:
         "stats": {
             "acroform_fields_total": len(acroform),
             "schema_fields_total": len(tag_to_field),
-            "schema_fields_populated": len(present_tags),
+            "schema_fields_populated": len(present_tags) + b1_all_totals_derived,
             "unmapped_acroform_fields": len(unmapped),
+            "b1_all_totals_derived": b1_all_totals_derived,
         },
         "values": values,
         "unmapped_fields": unmapped,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues the 2024-25 B1 gender-mapping fix (PR #168). Hardens the Tier4 cleaner for residual markdown layouts, and derives missing All undergrad/grad gender totals (CDS: All = FT + PT) for Tier1/Tier2 where those fields have no `pdf_tag`.

## Cleaner (Tier4) changes
- Derive missing All unit_load gender totals as FT + PT (and All-Students as UG All + Grad All)
- Salvage Men counts Docling merges into Total row labels (Yale Part-Time)
- Parse gender-prefixed cells (`Men 11,827`) on packed All rows (NYU)
- Parse Butler-style tables that embed `B1xx` IDs in the label cell
- Keep `GRAND TOTAL ALL STUDENTS` off gendered All-Students fields

## Tier1 / Tier2 changes
- Shared helper `tools/extraction_worker/b1_derive_totals.py`
- Applied at end of Tier1 XLSX and Tier2 AcroForm extract so future drains fill `B.149`/`B.150` (etc.) when FT+PT exist
- Root cause for Tier2 gap: 2023-24/2024-25 schema leaves All gender fields with `pdf_tag: null`

## Ops applied on prod (this agent)
- Bucket 2 (markdown residuals): 29 docs recleaned / reprojected
- Bucket 1 (tier1/tier2, FT+PT present): 68 docs patched with derived All totals + cache refresh
- Spot-checks: Davidson, Baylor, Clemson, NYU, Yale, Butler, Tufts, Northeastern now show `B.149`/`B.150`

## Tests
- `tools/extraction_worker/test_tier4_cleaner_b1.py`
- `tools/extraction_worker/test_b1_derive_totals.py`
- Existing `tools/tier1_extractor/test_extract.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b65e9e5-dffa-4bc1-bcc9-a82c3950339c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b65e9e5-dffa-4bc1-bcc9-a82c3950339c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

