### PR TITLE
fix: stop silent finder-probe stalls from indented heredocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
         run: python -m unittest discover -s tools/change_intelligence -p "test_*.py"
       - name: Run discovery policy and engine tests
         run: python -m pytest tools/discovery -q
+      - name: Lint GHA run-script heredocs
+        run: python tools/ops/lint_gha_heredocs.py
       - name: Run ops tests
-        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_collegedata_ops_bundle tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit tools.ops.test_enqueue_changed_seeds tools.ops.test_top100_coverage
+        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_collegedata_ops_bundle tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit tools.ops.test_enqueue_changed_seeds tools.ops.test_top100_coverage tools.ops.test_lint_gha_heredocs
       - name: Run data-integrity audit support tests
         run: python -m unittest tools.data_quality.test_audit_support
 

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -114,15 +114,14 @@ jobs:
         name: Re-probe stuck PDF seeds
         if: env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf'
         run: |
+          set -euo pipefail
+          # No nested bash heredocs in this step. GHA keeps relative indent, so
+          # an indented terminator never closes and bash fails at parse time
+          # even on the empty-ids branch (2026-09-02: 110 stuck, 0 re-probed).
           if [[ ! -s finder-probe/stuck-ids.txt ]]; then
             echo "No stuck PDF seeds to re-probe."
-            python - <<'PY'
-            import json
-            from pathlib import Path
-            Path("finder-probe/stuck-probe-summary.json").write_text(json.dumps({
-                "probed": 0, "found": 0, "replaced": 0, "budget_remaining": 0, "still_stuck": 0,
-            }) + "\n")
-            PY
+            printf '%s\n' '{"probed":0,"found":0,"replaced":0,"budget_remaining":0,"still_stuck":0}' \
+              > finder-probe/stuck-probe-summary.json
             exit 0
           fi
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
@@ -143,11 +142,10 @@ jobs:
           if [[ -f finder-probe/stuck-ids.txt ]]; then
             stuck=$(grep -cve '^[[:space:]]*$' finder-probe/stuck-ids.txt || true)
           fi
-          python - "$stuck" "$STEP_OUTCOME" <<'PY'
-          import json, sys
+          python -c '
+          import json, os, sys
           from pathlib import Path
           stuck = int(sys.argv[1])
-          outcome = sys.argv[2]
           path = Path("finder-probe/stuck-probe-summary.json")
           summary = {"probed": 0, "found": 0, "replaced": 0, "still_stuck": 0}
           if path.exists():
@@ -155,10 +153,12 @@ jobs:
           Path("finder-probe/stuck-heartbeat.json").write_text(json.dumps({
               "stuck": stuck,
               "reprobed": summary.get("probed", 0),
-              "still_stuck": summary.get("still_stuck", max(0, summary.get("probed", 0) - summary.get("found", 0))),
+              "still_stuck": summary.get(
+                  "still_stuck",
+                  max(0, summary.get("probed", 0) - summary.get("found", 0)),
+              ),
           }) + "\n")
-          print(outcome)
-          PY
+          ' "$stuck"
           status=ok
           error=none
           if [[ "$STEP_OUTCOME" == "failure" ]]; then
@@ -173,6 +173,24 @@ jobs:
             --error-code "$error" \
             --run-url "${PIPELINE_RUN_URL}"
 
+      - name: Open issue when stuck-PDF re-probe fails
+        if: failure() && steps.re_probe_stuck.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python tools/ops/upsert_pipeline_alert_issue.py \
+            --repo "${REPO}" \
+            --component finder_stuck_pdf \
+            --title "Pipeline alert: Stuck PDFs re-probe failed" \
+            --run-url "${PIPELINE_RUN_URL}" \
+            --body "The monthly/dispatch finder step \`Re-probe stuck PDF seeds\` failed.
+
+          When this stays red, archive keeps hitting stale single-year PDF seeds and new CDS years stop arriving.
+
+          Run: ${PIPELINE_RUN_URL}
+          "
+
       - name: Heartbeat finder_brave start
         if: ${{ always() && !cancelled() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown') }}
         run: |
@@ -186,6 +204,7 @@ jobs:
         name: Probe unknown schools
         if: ${{ always() && !cancelled() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'unknown') }}
         run: |
+          set -euo pipefail
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
             --brave-fallback \
             --include-active-no-hint \
@@ -231,6 +250,7 @@ jobs:
         name: Promote high-confidence landing hints
         if: ${{ always() && !cancelled() && env.INPUT_APPLY_LANDING_HINTS == 'true' }}
         run: |
+          set -euo pipefail
           python tools/finder/promote_landing_hints.py \
             --min-confidence medium \
             --ids-file finder-probe/stuck-ids.txt \
@@ -292,39 +312,40 @@ jobs:
       - name: Upsert coverage issue
         if: success()
         run: |
-          python - <<'PY'
+          # Prefer python -c over nested bash heredocs (GHA relative-indent trap).
+          python -c "
           import json, os, subprocess, sys
           from pathlib import Path
-          repo = os.environ["REPO"]
-          path = Path("finder-probe/stuck-after.md")
+          repo = os.environ['REPO']
+          path = Path('finder-probe/stuck-after.md')
           if not path.exists():
-              path = Path("finder-probe/stuck.md")
+              path = Path('finder-probe/stuck.md')
           if not path.exists():
-              print("No stuck report; skipping issue.")
+              print('No stuck report; skipping issue.')
               sys.exit(0)
-          title = "Finder: stuck PDF discovery seeds"
+          title = 'Finder: stuck PDF discovery seeds'
           body = path.read_text()[:60000]
           existing = subprocess.run(
-              ["gh", "issue", "list", "--repo", repo, "--state", "open",
-               "--search", f'in:title "{title}"', "--json", "number,title"],
+              ['gh', 'issue', 'list', '--repo', repo, '--state', 'open',
+               '--search', 'in:title \"' + title + '\"', '--json', 'number,title'],
               check=True, text=True, stdout=subprocess.PIPE,
           )
-          rows = json.loads(existing.stdout or "[]")
-          match = next((r for r in rows if r.get("title") == title), None)
+          rows = json.loads(existing.stdout or '[]')
+          match = next((r for r in rows if r.get('title') == title), None)
           if match:
               subprocess.run(
-                  ["gh", "issue", "comment", str(match["number"]),
-                   "--repo", repo, "--body", body],
+                  ['gh', 'issue', 'comment', str(match['number']),
+                   '--repo', repo, '--body', body],
                   check=True,
               )
-              print(f"Commented on existing issue #{match['number']}")
+              print('Commented on existing issue #%s' % match['number'])
           else:
               subprocess.run(
-                  ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
+                  ['gh', 'issue', 'create', '--repo', repo, '--title', title, '--body', body],
                   check=True,
               )
-              print("Created coverage issue")
-          PY
+              print('Created coverage issue')
+          "
 
       - name: Snapshot probed schools.yaml
         if: always()
@@ -353,6 +374,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       INPUT_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'both' }}
@@ -383,8 +405,13 @@ jobs:
             --probed finder-probe/schools.yaml \
             --out tools/finder/schools.yaml
 
-      - name: Open PR for seed updates
+      - id: open_seed_pr
+        name: Open PR for seed updates
+        env:
+          REPO: ${{ github.repository }}
+          PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- tools/finder/schools.yaml
@@ -400,23 +427,54 @@ jobs:
           fi
           branch="chore/finder-probe-${GITHUB_RUN_ID}"
           git checkout -B "$branch"
-          git commit -m "$(cat <<'EOF'
-          chore: refresh CDS discovery seeds from monthly finder probe
-
-          Re-probe stale PDF seeds and unknowns via the Brave Search API, and
-          promote high-confidence HTML listings so weekly archive is not stuck
-          on a single year file.
-
-          EOF
-          )"
+          # Avoid nested indented heredocs; multi-line -m is enough.
+          git commit -m "$(printf '%s\n' \
+            'chore: refresh CDS discovery seeds from monthly finder probe' \
+            '' \
+            'Re-probe stale PDF seeds and unknowns via the Brave Search API, and' \
+            'promote high-confidence HTML listings so weekly archive is not stuck' \
+            'on a single year file.')"
           git push -u origin HEAD
-          gh pr create --title "chore: refresh CDS discovery seeds from monthly finder probe" --body "$(cat <<EOF
-          ## Summary
-          - Monthly finder probe (\`${INPUT_MODE}\`) updated \`tools/finder/schools.yaml\`.
-          - Stuck PDF-seed report is in the workflow artifacts / coverage issue.
+          body="$(printf '%s\n' \
+            '## Summary' \
+            "- Monthly finder probe (\`${INPUT_MODE}\`) updated \`tools/finder/schools.yaml\`." \
+            '- Stuck PDF-seed report is in the workflow artifacts / coverage issue.' \
+            '' \
+            '## Test plan' \
+            '- [ ] Skim the PR diff for accidental satellite-campus seed copies' \
+            '- [ ] Merging this PR auto-enqueues changed seeds via \`ops-archive-seed-catchup\`')"
+          if gh pr create \
+            --title "chore: refresh CDS discovery seeds from monthly finder probe" \
+            --body "$body"; then
+            exit 0
+          fi
+          # Repo setting "Allow GitHub Actions to create and approve pull
+          # requests" may be off — branch is still on origin; surface an issue
+          # with a one-click compare link instead of silently stranding seeds
+          # (2026-09-02 left chore/finder-probe-33664025899 with no PR).
+          compare="https://github.com/${REPO}/compare/main...${branch}?quick_pull=1"
+          echo "::error::gh pr create failed after pushing ${branch}. Open ${compare}"
+          printf '%s\n' "$branch" > finder-probe-seed-branch.txt
+          printf '%s\n' "$compare" > finder-probe-seed-compare.txt
+          exit 1
 
-          ## Test plan
-          - [ ] Skim the PR diff for accidental satellite-campus seed copies
-          - [ ] Merging this PR auto-enqueues changed seeds via \`ops-archive-seed-catchup\`
-          EOF
-          )"
+      - name: Open issue when seed PR publish fails
+        if: failure() && steps.open_seed_pr.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PIPELINE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          branch="chore/finder-probe-${GITHUB_RUN_ID}"
+          compare="https://github.com/${REPO}/compare/main...${branch}?quick_pull=1"
+          python tools/ops/upsert_pipeline_alert_issue.py \
+            --repo "${REPO}" \
+            --component finder_seed_publish \
+            --title "Pipeline alert: Finder seed branch needs PR" \
+            --run-url "${PIPELINE_RUN_URL}" \
+            --body "Finder probe pushed \`${branch}\` but could not open the PR (often: Actions is not permitted to create pull requests).
+
+          One-click PR: ${compare}
+
+          Merge that PR so \`ops-archive-seed-catchup\` enqueues the new seeds. Without it, archive keeps using stale URLs and intake stalls.
+          "

--- a/tools/finder/README.md
+++ b/tools/finder/README.md
@@ -266,6 +266,13 @@ The guard catches all three at build time before they ship.
 
 **SIGINT saves partial progress.** `Ctrl-C` triggers a finally-block save in `probe_urls.py`, so the fraction of schools probed before interrupt get committed to `schools.yaml`. Tested via an 11-minute wedge + SIGINT during the elite-seed pattern run.
 
+## Silent-failure guards
+
+The monthly Action used to die quietly in two ways:
+
+1. **Indented bash heredocs inside `run: |`** — GHA keeps relative indent, so a nested terminator never closes and bash fails at *parse* time (even on the empty-ids branch). CI now runs `tools/ops/lint_gha_heredocs.py` on every workflow.
+2. **Seed PR create blocked** — if the repo setting "Allow GitHub Actions to create and approve pull requests" is off, the publish job still pushes `chore/finder-probe-<run_id>` and opens a **Pipeline alert** issue with a one-click compare link. Stuck-PDF re-probe failures also open a Pipeline alert issue so a red observation lamp is not the only signal.
+
 ## Recommended monthly cron
 
 GitHub Actions runs this on the 2nd of each month (`ops-finder-probe.yml`). It needs the `BRAVE_API_KEY` repository secret — the finder talks to `api.search.brave.com`, not public brave.com. Manual dispatch:

--- a/tools/finder/test_finder_workflows.py
+++ b/tools/finder/test_finder_workflows.py
@@ -30,6 +30,23 @@ class FinderProbeWorkflowTests(unittest.TestCase):
             FINDER,
         )
 
+    
+    def test_stuck_reprobe_avoids_nested_heredocs_and_uses_pipefail(self) -> None:
+        _, step = FINDER.split("id: re_probe_stuck", 1)
+        run = step.split("- name:", 1)[0]
+        self.assertIn("set -euo pipefail", run)
+        self.assertNotIn("<<", run)
+        self.assertIn("printf", run)
+
+    def test_failures_open_pipeline_alert_issues(self) -> None:
+        self.assertIn("upsert_pipeline_alert_issue.py", FINDER)
+        self.assertIn("--component", FINDER)
+        self.assertIn("Pipeline alert: Stuck PDFs re-probe failed", FINDER)
+        self.assertIn("Pipeline alert: Finder seed branch needs PR", FINDER)
+        _, publish = FINDER.split("publish-seeds:", 1)
+        self.assertIn("issues: write", publish.split("steps:", 1)[0])
+        self.assertIn("id: open_seed_pr", publish)
+
     def test_probe_always_snapshots_yaml_into_the_artifact(self) -> None:
         self.assertIn("cp tools/finder/schools.yaml finder-probe/schools.yaml", FINDER)
         self.assertIn("cp tools/finder/schools.yaml finder-probe/schools-base.yaml", FINDER)

--- a/tools/ops/lint_gha_heredocs.py
+++ b/tools/ops/lint_gha_heredocs.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fail if GitHub Actions `run: |` blocks contain indented bash heredoc terminators.
+
+GHA YAML keeps relative indentation inside `run: |`. A nested:
+
+    python - <<'PY'
+        ...
+        PY
+
+becomes a script whose terminator is indented, so bash never closes the
+heredoc and the step fails at parse time — even on the branch that does
+not execute the heredoc body. That silently broke the monthly stuck-PDF
+re-probe on 2026-09-02.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HEREDOC_START = re.compile(r"""<<(-)?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)(\2)""")
+RUN_HEADER = re.compile(r"^(\s*)run:\s*\|\s*$")
+
+
+def extract_run_scripts(text: str) -> list[tuple[int, str]]:
+    """Return (start_line_1based, dedented_script) for each `run: |` block."""
+    lines = text.splitlines()
+    out: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        match = RUN_HEADER.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        indent = len(match.group(1))
+        start = i + 1
+        i += 1
+        body: list[str] = []
+        while i < len(lines):
+            line = lines[i]
+            if line.strip() == "":
+                body.append("")
+                i += 1
+                continue
+            cur = len(line) - len(line.lstrip(" "))
+            if cur <= indent:
+                break
+            body.append(line)
+            i += 1
+        nonempty = [line for line in body if line.strip()]
+        if not nonempty:
+            continue
+        mind = min(len(line) - len(line.lstrip(" ")) for line in nonempty)
+        script = "\n".join(line[mind:] if len(line) >= mind else line for line in body) + "\n"
+        out.append((start, script))
+    return out
+
+
+def _active_code(line: str) -> str:
+    """Strip a trailing `#` comment, respecting quotes."""
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if ch == "\\" and (in_single or in_double):
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            return line[:i]
+        i += 1
+    return line
+
+
+def find_indented_terminators(script: str) -> list[str]:
+    problems: list[str] = []
+    lines = script.splitlines()
+    for lineno, line in enumerate(lines):
+        code = _active_code(line)
+        for match in HEREDOC_START.finditer(code):
+            strip_tabs = match.group(1) == "-"
+            delim = match.group(3)
+            for term_line in lines[lineno + 1 :]:
+                if strip_tabs:
+                    candidate = term_line.lstrip("\t")
+                else:
+                    candidate = term_line
+                if candidate == delim:
+                    break
+                if candidate.strip() == delim and candidate != delim:
+                    problems.append(
+                        f"heredoc terminator {delim!r} is indented "
+                        f"(line content {term_line!r})"
+                    )
+                    break
+            else:
+                problems.append(
+                    f"heredoc terminator {delim!r} never appears unindented"
+                )
+    return problems
+
+
+def lint_file(path: Path, *, bash_n: bool = True) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for start_line, script in extract_run_scripts(text):
+        for problem in find_indented_terminators(script):
+            errors.append(f"{path}:{start_line}: {problem}")
+        if bash_n:
+            result = subprocess.run(
+                ["bash", "-n"],
+                input=script,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "bash -n failed").strip()
+                errors.append(f"{path}:{start_line}: bash -n: {detail}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=list(Path(".github/workflows").glob("*.yml")),
+    )
+    parser.add_argument("--no-bash-n", action="store_true")
+    args = parser.parse_args()
+    errors: list[str] = []
+    for path in args.paths:
+        if not path.exists():
+            errors.append(f"missing {path}")
+            continue
+        errors.extend(lint_file(path, bash_n=not args.no_bash_n))
+    if errors:
+        print("GHA run-script heredoc lint failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    print(f"ok: linted {len(args.paths)} workflow file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ops/test_lint_gha_heredocs.py
+++ b/tools/ops/test_lint_gha_heredocs.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import textwrap
+import unittest
+from pathlib import Path
+
+from tools.ops.lint_gha_heredocs import (
+    extract_run_scripts,
+    find_indented_terminators,
+    lint_file,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FINDER = ROOT / ".github/workflows/ops-finder-probe.yml"
+
+
+class LintGhaHeredocsTests(unittest.TestCase):
+    def test_detects_indented_terminator(self) -> None:
+        script = textwrap.dedent(
+            """\
+            if true; then
+              python - <<'PY'
+              print(1)
+              PY
+            fi
+            """
+        )
+        # After the outer dedent above, PY is still indented relative to python? 
+        # Reconstruct the exact failure shape GHA produces.
+        script = (
+            "if true; then\n"
+            "  python - <<'PY'\n"
+            "  print(1)\n"
+            "  PY\n"
+            "fi\n"
+        )
+        problems = find_indented_terminators(script)
+        self.assertTrue(problems)
+        self.assertIn("PY", problems[0])
+
+    def test_accepts_column_zero_terminator(self) -> None:
+        script = (
+            "if true; then\n"
+            "  python - <<'PY'\n"
+            "print(1)\n"
+            "PY\n"
+            "fi\n"
+        )
+        self.assertEqual(find_indented_terminators(script), [])
+
+    def test_finder_workflow_run_blocks_are_clean(self) -> None:
+        self.assertTrue(FINDER.exists())
+        errors = lint_file(FINDER, bash_n=True)
+        self.assertEqual(errors, [])
+
+    def test_extract_finds_run_blocks(self) -> None:
+        yaml = textwrap.dedent(
+            """\
+            jobs:
+              probe:
+                steps:
+                  - name: demo
+                    run: |
+                      echo hi
+                      printf '%s\\n' ok
+            """
+        )
+        blocks = extract_run_scripts(yaml)
+        self.assertEqual(len(blocks), 1)
+        self.assertIn("echo hi", blocks[0][1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/upsert_pipeline_alert_issue.py
+++ b/tools/ops/upsert_pipeline_alert_issue.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Upsert a GitHub issue for a red pipeline station.
+
+Designed for Actions: opens an issue when a scheduled/dispatch station fails
+so a silent red lamp is not the only signal. Reuses an open issue with the
+same title (comment) instead of spamming.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--component", required=True, help="Alert component label (not a heartbeat station id)")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--body", required=True)
+    parser.add_argument("--run-url", default="")
+    args = parser.parse_args()
+
+    if not os.environ.get("GH_TOKEN") and not os.environ.get("GITHUB_TOKEN"):
+        print("::warning::no GH_TOKEN; skipping pipeline alert issue", file=sys.stderr)
+        return 0
+
+    labels = ["pipeline-alert", f"component:{args.component}"]
+    body = args.body.strip() + "\n"
+    if args.run_url:
+        body += f"\nRun: {args.run_url}\n"
+
+    listed = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            args.repo,
+            "--state",
+            "open",
+            "--search",
+            f'in:title "{args.title}"',
+            "--json",
+            "number,title",
+        ]
+    )
+    if listed.returncode != 0:
+        print(f"::warning::gh issue list failed: {listed.stderr.strip()}", file=sys.stderr)
+        return 0
+
+    rows = json.loads(listed.stdout or "[]")
+    match = next((row for row in rows if row.get("title") == args.title), None)
+    if match:
+        commented = run_gh(
+            [
+                "issue",
+                "comment",
+                str(match["number"]),
+                "--repo",
+                args.repo,
+                "--body",
+                body,
+            ]
+        )
+        if commented.returncode != 0:
+            print(
+                f"::warning::gh issue comment failed: {commented.stderr.strip()}",
+                file=sys.stderr,
+            )
+            return 0
+        print(f"Commented on alert issue #{match['number']}")
+        return 0
+
+    create_args = [
+        "issue",
+        "create",
+        "--repo",
+        args.repo,
+        "--title",
+        args.title,
+        "--body",
+        body,
+    ]
+    for label in labels:
+        create_args.extend(["--label", label])
+    created = run_gh(create_args)
+    if created.returncode != 0:
+        # Labels may not exist yet — retry without them.
+        print(
+            f"::warning::gh issue create with labels failed ({created.stderr.strip()}); retrying bare",
+            file=sys.stderr,
+        )
+        created = run_gh(
+            [
+                "issue",
+                "create",
+                "--repo",
+                args.repo,
+                "--title",
+                args.title,
+                "--body",
+                body,
+            ]
+        )
+        if created.returncode != 0:
+            print(
+                f"::warning::gh issue create failed: {created.stderr.strip()}",
+                file=sys.stderr,
+            )
+            return 0
+    print(f"Opened alert issue: {created.stdout.strip()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Replace nested GHA run-script heredocs that fail at bash parse time, fail the stuck/unknown probe pipes with pipefail, and open GitHub issues when stuck re-probe or seed-PR publish fails so a red lamp is not the only signal. CI now lints workflow run blocks for this class of bug.