### PR TITLE
fix: keep finder seed PRs green when Brave hits a missing UNITID

### DIFF
--- a/tools/finder/apply_probe_log.py
+++ b/tools/finder/apply_probe_log.py
@@ -32,8 +32,13 @@ from tools.finder.probe_urls import (  # noqa: E402
     looks_like_news_or_blog,
     looks_like_non_cds_document,
     looks_like_search_junk,
+    may_mark_active,
     record_probe,
     should_replace_seed,
+)
+from tools.finder.identity_guard import (  # noqa: E402
+    DEFAULT_SNAPSHOT,
+    load_identity_snapshot,
 )
 
 FOUND_RE = re.compile(
@@ -122,7 +127,12 @@ def url_is_usable(url: str, domain: str | None) -> bool:
     return True
 
 
-def apply_hit(school: dict, hit: ProbeHit, probed_at: str) -> str:
+def apply_hit(
+    school: dict,
+    hit: ProbeHit,
+    probed_at: str,
+    official_records: dict[str, dict[str, str]] | None = None,
+) -> str:
     """Mutate school. Returns action: replaced, found_kept, not_found, skipped_junk."""
     if hit.found:
         url = hit.url or ""
@@ -131,7 +141,8 @@ def apply_hit(school: dict, hit: ProbeHit, probed_at: str) -> str:
         existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
         if should_replace_seed(existing, url):
             school["discovery_seed_url"] = url
-            school["scrape_policy"] = "active"
+            if may_mark_active(school, official_records):
+                school["scrape_policy"] = "active"
             record_probe(school, "found", hit.method, 0, hit.method != "pattern")
             school["probe_state"]["last_probed_at"] = probed_at
             return "replaced"
@@ -228,6 +239,10 @@ def apply_logs(
     data = yaml.safe_load(schools_yaml.read_text())
     schools = data.get("schools") or []
     by_key = index_schools(schools)
+    try:
+        _, official_records = load_identity_snapshot(DEFAULT_SNAPSHOT)
+    except (OSError, ValueError):
+        official_records = {}
     counts = {
         "hits": 0,
         "unmatched": 0,
@@ -245,7 +260,7 @@ def apply_logs(
                 counts["unmatched"] += 1
                 print(f"unmatched: {hit.name} ({hit.domain})", file=sys.stderr)
                 continue
-            action = apply_hit(school, hit, probed_at)
+            action = apply_hit(school, hit, probed_at, official_records)
             counts[action] = counts.get(action, 0) + 1
             sid = str(school.get("id") or "")
             if sid and action != "skipped_junk":

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -3,7 +3,8 @@
 
 For each school in schools.yaml with scrape_policy == "unknown", tries the
 URL pattern ladder against the school's domain. On a hit, updates the entry
-with discovery_seed_url and flips scrape_policy to "active".
+with discovery_seed_url and flips scrape_policy to "active" only when the
+UNITID exists in the IPEDS identity snapshot (otherwise CI fails closed).
 
 Records probe_state per school so we don't re-query paid search APIs for
 schools that genuinely don't publish.
@@ -52,6 +53,11 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+from tools.finder.identity_guard import (  # noqa: E402
+    DEFAULT_SNAPSHOT,
+    load_identity_snapshot,
+    normalize_ipeds,
+)
 from tools.finder.stuck_pdf_seeds import (  # noqa: E402
     choose_canonical_school,
     is_direct_doc_seed,
@@ -555,13 +561,34 @@ def looks_like_search_junk(url: str) -> bool:
 
 def looks_like_article_slug(url: str) -> bool:
     """Drop SEO/blog slugs that matched 'Common Data Set' in a snippet."""
-    last = (urllib.parse.urlparse(url).path or "").rstrip("/").split("/")[-1]
-    last = last.lower()
+    parts = [p for p in (urllib.parse.urlparse(url).path or "").lower().split("/") if p]
+    # Brave hits often append a page index ("/does-harvard-accept-2-9-gpa/5/").
+    while parts and re.fullmatch(r"\d+", parts[-1]):
+        parts.pop()
+    if not parts:
+        return False
+    last = parts[-1]
     if re.search(r"cds|common[-_]?data", last):
         return False
     if re.match(r"^(does|what|why|how|should|is|can|will)-", last):
         return True
     return last.count("-") >= 5
+
+
+def may_mark_active(
+    school: dict,
+    official_records: dict[str, dict[str, str]] | None,
+) -> bool:
+    """Refuse scrape_policy=active when identity_guard would fail CI.
+
+    Missing UNITIDs are warnings while the school stays unknown. Flipping
+    them to active (the Sept 2 Continents States Brave miss) turns the
+    next seed PR red.
+    """
+    if official_records is None:
+        return True
+    ipeds_id = normalize_ipeds(school.get("ipeds_id"))
+    return bool(ipeds_id and ipeds_id in official_records)
 
 
 def looks_like_news_or_blog(url: str) -> bool:
@@ -709,6 +736,15 @@ def process_school(school: dict, args: argparse.Namespace,
         method = last_attempted_method
 
     replaced = False
+    official_records = env.get("official_records")
+    if url and not may_mark_active(school, official_records):
+        print(
+            f"  skip activate {school.get('id')}: UNITID "
+            f"{school.get('ipeds_id')} is not in the IPEDS identity snapshot",
+            file=sys.stderr,
+        )
+        url = None
+        method = last_attempted_method if search_tried else method
     if url:
         existing = school.get("discovery_seed_url") or school.get("cds_url_hint")
         if should_replace_seed(existing, url):
@@ -835,10 +871,16 @@ def main():
     data = yaml.safe_load(SCHOOLS_YAML.read_text())
     schools = data.get("schools", [])
 
+    try:
+        _, official_records = load_identity_snapshot(DEFAULT_SNAPSHOT)
+    except (OSError, ValueError) as exc:
+        print(f"identity snapshot unavailable ({exc}); will not flip scrape_policy", file=sys.stderr)
+        official_records = {}
     env = {
         "google_api_key": os.environ.get("GOOGLE_API_KEY"),
         "google_cx": os.environ.get("GOOGLE_CX"),
         "brave_api_key": os.environ.get("BRAVE_API_KEY"),
+        "official_records": official_records,
         "brave_tracker": {
             "calls": 0,
             "budget": None if args.brave_budget == 0 else args.brave_budget,

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -21114,14 +21114,13 @@ schools:
   name: The Continents States University
   domain: continents.us
   ipeds_id: '492087'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
     last_probed_at: '2026-09-02T17:59:07Z'
-    last_result: found
+    last_result: not_found
     last_method: brave
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.continents.us/does-harvard-accept-2-9-gpa/5/
 - id: the-cooper-union-for-the-advancement-of-science-and-art
   name: The Cooper Union for the Advancement of Science and Art
   domain: cooper.edu

--- a/tools/finder/test_apply_probe_log.py
+++ b/tools/finder/test_apply_probe_log.py
@@ -85,6 +85,39 @@ class ApplyHitTests(unittest.TestCase):
         self.assertEqual(apply_hit(school, hit, "2026-08-21T22:51:00Z"), "skipped_junk")
         self.assertEqual(school["discovery_seed_url"], "https://www.elms.edu/old.pdf")
 
+    def test_paginated_blog_slug_is_skipped_junk(self) -> None:
+        school = {
+            "id": "the-continents-states-university",
+            "domain": "continents.us",
+            "ipeds_id": "492087",
+            "scrape_policy": "unknown",
+        }
+        hit = parse_probe_log(
+            "[    1/1] The Continents States University (continents.us) ... "
+            "[brave] FOUND: https://www.continents.us/does-harvard-accept-2-9-gpa/5/\n"
+        )[0]
+        self.assertEqual(apply_hit(school, hit, "2026-09-02T17:59:07Z"), "skipped_junk")
+        self.assertNotIn("discovery_seed_url", school)
+        self.assertEqual(school["scrape_policy"], "unknown")
+
+    def test_missing_official_record_does_not_flip_active(self) -> None:
+        school = {
+            "id": "the-continents-states-university",
+            "domain": "continents.us",
+            "ipeds_id": "492087",
+            "scrape_policy": "unknown",
+        }
+        hit = parse_probe_log(
+            "[    1/1] The Continents States University (continents.us) ... "
+            "[brave] FOUND: https://www.continents.us/institutional-research/common-data-set/\n"
+        )[0]
+        self.assertEqual(
+            apply_hit(school, hit, "2026-09-02T17:59:07Z", official_records={}),
+            "replaced",
+        )
+        self.assertEqual(school["scrape_policy"], "unknown")
+        self.assertTrue(school["discovery_seed_url"].endswith("common-data-set/"))
+
 
 class WriteYamlTests(unittest.TestCase):
     def test_rewrites_seed_policy_and_probe_state(self) -> None:

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -10,6 +10,7 @@ from tools.finder.probe_urls import (
     host_belongs_to_domain,
     is_cds_page,
     looks_like_search_junk,
+    may_mark_active,
     select_brave_cds_url,
     should_replace_seed,
     should_skip,
@@ -104,11 +105,31 @@ class SelectBraveCdsUrlTests(unittest.TestCase):
                 "https://www.continents.us/does-harvard-accept-2-9-gpa/"
             )
         )
+        self.assertTrue(
+            looks_like_article_slug(
+                "https://www.continents.us/does-harvard-accept-2-9-gpa/5/"
+            )
+        )
         self.assertFalse(
             looks_like_article_slug(
                 "https://www.albion.edu/offices/registrar/institutional-data/"
             )
         )
+        self.assertFalse(
+            looks_like_article_slug(
+                "https://provost.tufts.edu/institutionalresearch/wp-content/uploads/sites/5/CDS_2024-2025-1.pdf"
+            )
+        )
+
+    def test_select_brave_rejects_paginated_blog_slug(self) -> None:
+        results = [
+            {
+                "url": "https://www.continents.us/does-harvard-accept-2-9-gpa/5/",
+                "title": "Common Data Set",
+                "description": "Common Data Set",
+            }
+        ]
+        self.assertIsNone(select_brave_cds_url(results, "continents.us"))
 
     def test_rejects_news_pages_and_non_cds_pdfs(self) -> None:
         from tools.finder.probe_urls import (
@@ -225,6 +246,23 @@ class CheckpointHelpersTests(unittest.TestCase):
             text = path.read_text()
         self.assertIn("id: x", text)
         self.assertIn("Xavier", text)
+
+
+class IdentityActivateTests(unittest.TestCase):
+    def test_missing_official_record_cannot_become_active(self) -> None:
+        school = {
+            "id": "the-continents-states-university",
+            "ipeds_id": "492087",
+            "scrape_policy": "unknown",
+        }
+        self.assertFalse(may_mark_active(school, {}))
+        self.assertTrue(
+            may_mark_active(
+                {**school, "ipeds_id": "168148"},
+                {"168148": {"official_name": "Tufts University"}},
+            )
+        )
+        self.assertTrue(may_mark_active(school, None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Revert `the-continents-states-university` (IPEDS `492087`) to `scrape_policy: unknown` and drop the paginated blog slug seed that made #172 CI fail `identity_guard` (`missing_official_record` is an error only while the school is `active`).
- Treat trailing numeric path segments as pagination in `looks_like_article_slug`, so `.../does-harvard-accept-2-9-gpa/5/` is rejected the same way as the unpaginated slug.
- Do not flip `scrape_policy` to `active` unless the UNITID exists in the checked-in HD2024 identity snapshot, so the next monthly seed PR cannot go red the same way.

## Test plan

- [x] `python tools/finder/identity_guard.py` → 0 errors (26 warnings, including Continents States as unknown)
- [x] `python -m unittest tools.finder.test_identity_guard tools.finder.test_probe_urls tools.finder.test_apply_probe_log tools.finder.test_finder_workflows tools.ops.test_lint_gha_heredocs`
- [ ] CI Python unit tests / identity audit on this PR

## Context

#171 and #172 are on `main`. Archive catchup from #172 already inserted Randolph-Macon 2023-24 (`cds_documents.created_at` 2026-09-11T18:31Z). This agent cannot `workflow_dispatch` Ops finder probe (`gh` GitHub App token: 403 Resource not accessible by integration). Stuck PDFs stays scheduled-error until a **scheduled** probe finish succeeds (dispatch would not copy into `last_scheduled_*`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87cf0ac3-fb96-4e00-bc38-4fb487db55c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87cf0ac3-fb96-4e00-bc38-4fb487db55c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

