### PR TITLE
Fix extraction pipeline correctness and finder recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Lint GHA run-script heredocs
         run: python tools/ops/lint_gha_heredocs.py
       - name: Run ops tests
-        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_collegedata_ops_bundle tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit tools.ops.test_enqueue_changed_seeds tools.ops.test_top100_coverage tools.ops.test_lint_gha_heredocs
+        run: python -m unittest tools.ops.test_automation_health tools.ops.test_record_heartbeat tools.ops.test_pipeline_writers tools.ops.test_collegedata_ops_bundle tools.ops.test_directory_enqueue_autopilot tools.ops.test_directory_enqueue_batches tools.ops.test_extraction_backlog_audit tools.ops.test_enqueue_changed_seeds tools.ops.test_upsert_pipeline_alert_issue tools.ops.test_top100_coverage tools.ops.test_lint_gha_heredocs
       - name: Run data-integrity audit support tests
         run: python -m unittest tools.data_quality.test_audit_support
 

--- a/.github/workflows/ops-finder-probe.yml
+++ b/.github/workflows/ops-finder-probe.yml
@@ -133,46 +133,6 @@ jobs:
             --summary-json finder-probe/stuck-probe-summary.json \
             2>&1 | tee finder-probe/stuck-probe.log
 
-      - name: Heartbeat finder_stuck_pdf finish
-        if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf')
-        env:
-          STEP_OUTCOME: ${{ steps.re_probe_stuck.outcome }}
-        run: |
-          stuck=0
-          if [[ -f finder-probe/stuck-ids.txt ]]; then
-            stuck=$(grep -cve '^[[:space:]]*$' finder-probe/stuck-ids.txt || true)
-          fi
-          python -c '
-          import json, os, sys
-          from pathlib import Path
-          stuck = int(sys.argv[1])
-          path = Path("finder-probe/stuck-probe-summary.json")
-          summary = {"probed": 0, "found": 0, "replaced": 0, "still_stuck": 0}
-          if path.exists():
-              summary.update(json.loads(path.read_text()))
-          Path("finder-probe/stuck-heartbeat.json").write_text(json.dumps({
-              "stuck": stuck,
-              "reprobed": summary.get("probed", 0),
-              "still_stuck": summary.get(
-                  "still_stuck",
-                  max(0, summary.get("probed", 0) - summary.get("found", 0)),
-              ),
-          }) + "\n")
-          ' "$stuck"
-          status=ok
-          error=none
-          if [[ "$STEP_OUTCOME" == "failure" ]]; then
-            status=error
-            error=job_failed
-          fi
-          python tools/ops/record_heartbeat.py \
-            --station finder_stuck_pdf \
-            --status "$status" \
-            --trigger "${PIPELINE_TRIGGER}" \
-            --summary-json finder-probe/stuck-heartbeat.json \
-            --error-code "$error" \
-            --run-url "${PIPELINE_RUN_URL}"
-
       - name: Open issue when stuck-PDF re-probe fails
         if: failure() && steps.re_probe_stuck.outcome == 'failure'
         env:
@@ -207,6 +167,8 @@ jobs:
           set -euo pipefail
           PYTHONUNBUFFERED=1 python tools/finder/probe_urls.py \
             --brave-fallback \
+            --audit-active-html \
+            --audit-report-json finder-probe/active-html-audit.json \
             --include-active-no-hint \
             --cooldown-days "${INPUT_COOLDOWN_DAYS}" \
             --brave-budget "${INPUT_BRAVE_BUDGET}" \
@@ -287,6 +249,49 @@ jobs:
             --out-json finder-probe/stuck-after.json \
             --out-md finder-probe/stuck-after.md \
             --out-ids finder-probe/stuck-ids-after.txt
+
+      - name: Heartbeat finder_stuck_pdf finish
+        if: always() && (env.INPUT_MODE == 'both' || env.INPUT_MODE == 'stuck-pdf')
+        env:
+          STEP_OUTCOME: ${{ steps.re_probe_stuck.outcome }}
+        run: |
+          python -c '
+          import json
+          from pathlib import Path
+
+          def count_ids(path):
+              return sum(1 for line in path.read_text().splitlines() if line.strip())
+
+          initial_path = Path("finder-probe/stuck-ids.txt")
+          after_path = Path("finder-probe/stuck-ids-after.txt")
+          initial_stuck = count_ids(initial_path) if initial_path.exists() else 0
+          summary_path = Path("finder-probe/stuck-probe-summary.json")
+          summary = {"probed": 0, "replaced": 0}
+          if summary_path.exists():
+              summary.update(json.loads(summary_path.read_text()))
+          if after_path.exists():
+              still_stuck = count_ids(after_path)
+          else:
+              still_stuck = max(0, initial_stuck - int(summary.get("replaced", 0)))
+          Path("finder-probe/stuck-heartbeat.json").write_text(json.dumps({
+              "stuck": initial_stuck,
+              "reprobed": summary.get("probed", 0),
+              "still_stuck": still_stuck,
+          }) + "\n")
+          '
+          status=ok
+          error=none
+          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+            status=error
+            error=job_failed
+          fi
+          python tools/ops/record_heartbeat.py \
+            --station finder_stuck_pdf \
+            --status "$status" \
+            --trigger "${PIPELINE_TRIGGER}" \
+            --summary-json finder-probe/stuck-heartbeat.json \
+            --error-code "$error" \
+            --run-url "${PIPELINE_RUN_URL}"
 
       - name: Add run summary
         if: always()

--- a/supabase/functions/_shared/archive.test.ts
+++ b/supabase/functions/_shared/archive.test.ts
@@ -1,0 +1,89 @@
+import { assertEquals, assertFalse, assertRejects } from "jsr:@std/assert";
+import { PDFDocument } from "npm:pdf-lib@1.17.1";
+import { buildPdfBundle, PermanentError } from "./archive.ts";
+
+async function pdfWithPageSizes(
+  sizes: [number, number][],
+): Promise<Uint8Array> {
+  const pdf = await PDFDocument.create({ updateMetadata: false });
+  for (const [width, height] of sizes) {
+    pdf.addPage([width, height]);
+  }
+  return await pdf.save();
+}
+
+async function bundleParts() {
+  return [
+    {
+      section: "A",
+      final_url: "https://example.edu/a.pdf",
+      bytes: await pdfWithPageSizes([[101, 201], [102, 202]]),
+    },
+    {
+      section: "B",
+      final_url: "https://example.edu/b.pdf",
+      bytes: await pdfWithPageSizes([[301, 401]]),
+    },
+  ];
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    copy.buffer as ArrayBuffer,
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+Deno.test("section package bundling produces repeatable bytes and SHA", async () => {
+  const parts = await bundleParts();
+  const first = await buildPdfBundle(parts);
+
+  // pdf-lib metadata timestamps have one-second precision. Crossing that
+  // boundary ensures this catches accidental metadata generation.
+  await new Promise((resolve) => setTimeout(resolve, 1_100));
+  const second = await buildPdfBundle(parts);
+
+  assertEquals(second, first);
+  assertEquals(await sha256Hex(second), await sha256Hex(first));
+});
+
+Deno.test("section package bundling preserves page order and count", async () => {
+  const bundled = await buildPdfBundle(await bundleParts());
+  const pdf = await PDFDocument.load(bundled, { updateMetadata: false });
+
+  assertEquals(pdf.getPageCount(), 3);
+  assertEquals(
+    pdf.getPages().map((page) => [page.getWidth(), page.getHeight()]),
+    [[101, 201], [102, 202], [301, 401]],
+  );
+});
+
+Deno.test("section package bundle omits generated PDF dates", async () => {
+  const bundled = await buildPdfBundle(await bundleParts());
+  const pdf = await PDFDocument.load(bundled, { updateMetadata: false });
+  const raw = new TextDecoder().decode(bundled);
+
+  assertEquals(pdf.getCreationDate(), undefined);
+  assertEquals(pdf.getModificationDate(), undefined);
+  assertFalse(raw.includes("CreationDate"));
+  assertFalse(raw.includes("ModDate"));
+});
+
+Deno.test("invalid section input maps to wrong_content_type", async () => {
+  const error = await assertRejects(
+    () =>
+      buildPdfBundle([{
+        section: "A",
+        final_url: "https://example.edu/not-a-pdf.pdf",
+        bytes: new TextEncoder().encode("not a PDF"),
+      }]),
+    PermanentError,
+  );
+
+  assertEquals(error.category, "wrong_content_type");
+});

--- a/supabase/functions/_shared/archive.ts
+++ b/supabase/functions/_shared/archive.ts
@@ -547,12 +547,14 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
     .join("");
 }
 
-async function buildPdfBundle(parts: DownloadedSectionPart[]): Promise<Uint8Array> {
-  const merged = await PDFDocument.create();
+export async function buildPdfBundle(
+  parts: Pick<DownloadedSectionPart, "section" | "final_url" | "bytes">[],
+): Promise<Uint8Array> {
+  const merged = await PDFDocument.create({ updateMetadata: false });
   for (const part of parts) {
     let pdf: PDFDocument;
     try {
-      pdf = await PDFDocument.load(part.bytes);
+      pdf = await PDFDocument.load(part.bytes, { updateMetadata: false });
     } catch (e) {
       throw new PermanentError(
         `section ${part.section} is not a mergeable PDF (${part.final_url}): ${(e as Error).message}`,

--- a/supabase/migrations/20260912143000_latest_archive_terminal_seed.sql
+++ b/supabase/migrations/20260912143000_latest_archive_terminal_seed.sql
@@ -1,0 +1,55 @@
+-- Bind finder seed demotion to the exact URL and terminal row that failed.
+-- The finder audit must not delete a newer schools.yaml seed because an older
+-- archive attempt for the same school ended in no_pdfs_found.
+
+begin;
+
+drop function public.latest_archive_terminal_rows(timestamptz, text[]);
+
+create function public.latest_archive_terminal_rows(
+  p_since timestamptz,
+  p_school_ids text[]
+)
+returns table (
+  school_id text,
+  processed_at timestamptz,
+  last_outcome text,
+  cds_url_hint text,
+  status text,
+  active_work boolean
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select distinct on (q.school_id)
+    q.school_id,
+    q.processed_at,
+    q.last_outcome,
+    q.cds_url_hint,
+    q.status,
+    exists (
+      select 1
+      from public.archive_queue active
+      where active.school_id = q.school_id
+        and active.status in ('ready', 'processing')
+    ) as active_work
+  from public.archive_queue q
+  where q.status in ('done', 'failed_permanent')
+    and q.last_outcome is not null
+    and q.processed_at is not null
+    and q.processed_at >= p_since
+    and q.school_id = any(p_school_ids)
+  order by q.school_id, q.processed_at desc, q.id desc;
+$$;
+
+comment on function public.latest_archive_terminal_rows(timestamptz, text[]) is
+  'Returns each requested school latest terminal archive outcome, attempted seed URL, and status at or after p_since.';
+
+revoke all on function public.latest_archive_terminal_rows(timestamptz, text[])
+  from public, anon, authenticated;
+grant execute on function public.latest_archive_terminal_rows(timestamptz, text[])
+  to service_role;
+
+commit;

--- a/tools/finder/apply_probe_log.py
+++ b/tools/finder/apply_probe_log.py
@@ -168,7 +168,11 @@ def write_school_updates(schools_yaml: Path, schools: list[dict], changed_ids: s
         if current_sid not in changed_ids or wrote_seed:
             return
         school = by_id.get(current_sid or "")
-        url = school.get("discovery_seed_url") if school else None
+        url = (
+            school.get("discovery_seed_url") or school.get("cds_url_hint")
+            if school
+            else None
+        )
         if not url:
             return
         out.append(f"  discovery_seed_url: {url}\n")
@@ -190,12 +194,17 @@ def write_school_updates(schools_yaml: Path, schools: list[dict], changed_ids: s
 
         seed_match = SEED_RE.match(line)
         if seed_match:
-            url = school.get("discovery_seed_url")
+            url = school.get("discovery_seed_url") or school.get("cds_url_hint")
             if url:
                 out.append(f"{seed_match.group(1)}discovery_seed_url{seed_match.group(2)}{url}\n")
                 wrote_seed = True
                 applied += 1
                 continue
+            # The in-memory school intentionally removed its seed. Do not
+            # append the original line below or a merge/replay resurrects it.
+            wrote_seed = True
+            applied += 1
+            continue
 
         policy_match = POLICY_RE.match(line)
         if policy_match and school.get("scrape_policy"):

--- a/tools/finder/merge_schools_yaml.py
+++ b/tools/finder/merge_schools_yaml.py
@@ -62,9 +62,10 @@ def overlay_seed_fields(target: dict, source: dict) -> dict:
     for field in SEED_FIELDS:
         if field in source:
             merged[field] = source[field]
-        elif field in merged and field not in source:
-            if field == "cds_url_hint":
-                continue
+        elif field in {"discovery_seed_url", "cds_url_hint"}:
+            # Absence is meaningful for a demotion. Keeping main's value here
+            # resurrects a seed that the probe explicitly deleted.
+            merged.pop(field, None)
     return merged
 
 

--- a/tools/finder/probe_urls.py
+++ b/tools/finder/probe_urls.py
@@ -43,10 +43,11 @@ import urllib.request
 import urllib.error
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
 from collections import defaultdict
+from typing import Callable
 
 import yaml
 
@@ -148,6 +149,21 @@ DEFAULT_COOLDOWN_DAYS = 30
 # while keeping monthly cron runtime bounded at 2400 schools × 60s / workers.
 DEFAULT_SCHOOL_BUDGET_SEC = 60.0
 
+# Search hits and active HTML seeds are untrusted URLs. One MiB is enough to
+# inspect a landing page and document magic without downloading a whole CDS.
+MAX_VALIDATION_BYTES = 1024 * 1024
+VALIDATION_VALID = "valid"
+VALIDATION_INVALID = "invalid"
+VALIDATION_UNVERIFIABLE = "unverifiable"
+TERMINAL_ARCHIVE_STATUSES = {"done", "failed_permanent"}
+AUDITABLE_ARCHIVE_OUTCOMES = {
+    "dead_url",
+    "marked_removed",
+    "no_pdfs_found",
+    "wrong_content_type",
+}
+ACTIVE_HTML_AUDIT_LOOKBACK_DAYS = 180
+
 
 # ── HTTP helpers ────────────────────────────────────────────────────────────
 
@@ -206,6 +222,175 @@ def _head(url: str, timeout: int = 10) -> tuple[int, dict]:
             return resp.status, headers
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
         return -1, {}
+
+
+def _get_bounded(
+    url: str,
+    timeout: int = 15,
+    max_bytes: int = MAX_VALIDATION_BYTES,
+) -> tuple[int, dict, bytes, str, bool]:
+    """Fetch at most max_bytes for content validation.
+
+    Unlike `_get`, HTTP status is preserved. Callers must distinguish a
+    definitive miss (404/410 or successful non-CDS content) from a transient
+    or access-controlled response that cannot safely demote an existing seed.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    deadline = time.monotonic() + timeout
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_SSL_CTX) as resp:
+            status = resp.status
+            headers = {k.lower(): v for k, v in resp.getheaders()}
+            content = bytearray()
+            read = getattr(resp, "read1", resp.read)
+            while len(content) <= max_bytes:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("validation fetch deadline exceeded")
+                try:
+                    resp.fp.raw._sock.settimeout(remaining)
+                except (AttributeError, OSError):
+                    pass
+                chunk = read(min(64 * 1024, max_bytes + 1 - len(content)))
+                if not chunk:
+                    break
+                content.extend(chunk)
+            return (
+                status,
+                headers,
+                bytes(content[:max_bytes]),
+                resp.geturl(),
+                len(content) > max_bytes,
+            )
+    except urllib.error.HTTPError as exc:
+        headers = {k.lower(): v for k, v in exc.headers.items()} if exc.headers else {}
+        return exc.code, headers, b"", exc.geturl() or url, False
+    except (urllib.error.URLError, OSError, ValueError):
+        return -1, {}, b"", url, False
+
+
+class _CdsContentParser(html.parser.HTMLParser):
+    """Collect link targets and text without executing untrusted HTML."""
+
+    def __init__(self):
+        super().__init__()
+        self.links: list[tuple[str, str]] = []
+        self._current_link: int | None = None
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        target = ""
+        if tag == "a":
+            target = values.get("href", "")
+        elif tag in {"embed", "iframe", "source"}:
+            target = values.get("src", "")
+        elif tag == "object":
+            target = values.get("data", "")
+        if target:
+            self.links.append((target, ""))
+            self._current_link = len(self.links) - 1 if tag == "a" else None
+
+    def handle_endtag(self, tag):
+        if tag == "a":
+            self._current_link = None
+
+    def handle_data(self, data):
+        if self._current_link is None:
+            return
+        target, text = self.links[self._current_link]
+        self.links[self._current_link] = (target, text + " " + data)
+
+
+def html_has_cds_content_or_anchors(content: bytes) -> bool:
+    """Require real CDS content or a CDS/document link, not snippet text."""
+    text = content.decode("utf-8", errors="ignore")
+    normalized = re.sub(r"\s+", " ", text).lower()
+    has_cds_phrase = bool(re.search(r"common\s+data\s+set", normalized))
+
+    parser = _CdsContentParser()
+    try:
+        parser.feed(text)
+    except (AssertionError, ValueError):
+        return False
+
+    for target, label in parser.links:
+        combined = urllib.parse.unquote(f"{target} {label}").lower()
+        path = urllib.parse.unquote(urllib.parse.urlparse(target).path).lower()
+        is_document = bool(re.search(r"\.(pdf|xlsx|docx)(?:$|[?#])", path))
+        cds_signal = bool(re.search(r"(?:\bcds\b|common[-_\s]*data[-_\s]*set)", combined))
+        year_signal = bool(re.search(r"20\d{2}\s*[-–_]\s*(?:20)?\d{2}", combined))
+        contextual_target = bool(
+            re.search(
+                (
+                    r"(?:\bcds\b|common[-_]?data[-_]?set)"
+                    r"[-_/\s]*(?:committee|definition|faq|glossary|overview|policy)"
+                    r"(?:[-_/\s]|$)"
+                ),
+                combined,
+            )
+        )
+        if (
+            cds_signal
+            and not contextual_target
+            and target
+            and not target.startswith("#")
+        ):
+            return True
+        if is_document:
+            if has_cds_phrase and year_signal:
+                return True
+
+    # A CDS can itself be HTML rather than a landing page. Require multiple
+    # canonical form signals so an IR mission page mentioning CDS in navigation
+    # does not qualify as the dataset.
+    form_signals = sum(
+        marker in normalized
+        for marker in (
+            "first-time, first-year",
+            "first time, first year",
+            "applicants",
+            "enrolled",
+            "tuition",
+            "degrees conferred",
+        )
+    )
+    return has_cds_phrase and form_signals >= 3
+
+
+def validate_cds_url(url: str) -> tuple[str, str]:
+    """Return (valid|invalid|unverifiable, reason) for a fetched URL."""
+    status, headers, body, final_url, truncated = _get_bounded(url)
+    if status < 0:
+        return VALIDATION_UNVERIFIABLE, "network_error"
+    if status in {401, 403, 405, 408, 425, 429} or status >= 500:
+        return VALIDATION_UNVERIFIABLE, f"http_{status}"
+    if status < 200 or status >= 300:
+        return VALIDATION_INVALID, f"http_{status}"
+
+    content_type = headers.get("content-type", "").lower()
+    stripped = body.lstrip()
+    final_path = urllib.parse.urlparse(final_url).path.lower()
+    if stripped.startswith(b"%PDF-"):
+        return VALIDATION_VALID, "pdf_magic"
+    if stripped.startswith(b"PK\x03\x04") and (
+        re.search(r"\.(xlsx|docx)$", final_path)
+        or "spreadsheet" in content_type
+        or "wordprocessingml" in content_type
+    ):
+        return VALIDATION_VALID, "office_magic"
+
+    looks_html = "html" in content_type or bool(
+        re.search(br"(?is)<!doctype\s+html|<html(?:\s|>)", body[:4096])
+    )
+    if looks_html:
+        if looks_like_news_or_blog(final_url):
+            return VALIDATION_INVALID, "contextual_page_path"
+        if html_has_cds_content_or_anchors(body):
+            return VALIDATION_VALID, "html_cds"
+        if truncated:
+            return VALIDATION_UNVERIFIABLE, "html_validation_window_exhausted"
+        return VALIDATION_INVALID, "html_without_cds_content_or_anchors"
+    return VALIDATION_INVALID, "unsupported_content"
 
 
 def is_cds_page(content: bytes, content_type: str) -> bool:
@@ -539,7 +724,11 @@ def brave_search(domain: str, api_key: str, tracker: dict | None = None) -> str 
         return None
 
     results = data.get("web", {}).get("results", [])
-    return select_brave_cds_url(results, domain)
+    for candidate in brave_cds_candidates(results, domain):
+        validation, _reason = validate_cds_url(candidate)
+        if validation == VALIDATION_VALID:
+            return candidate
+    return None
 
 
 def host_belongs_to_domain(url: str, domain: str) -> bool:
@@ -594,7 +783,12 @@ def may_mark_active(
 def looks_like_news_or_blog(url: str) -> bool:
     parsed = urllib.parse.urlparse(url)
     path = (parsed.path or "").lower()
-    if re.search(r"/(news|blog|stories|noteworthy)(/|$)", path):
+    if re.search(
+        r"/(news|blog|stories|noteworthy|careers?|jobs?|oldstudents)(?:[-_/]|$)",
+        path,
+    ):
+        return True
+    if re.search(r"(?:^|[-_/])thesis(?:[-_./]|$)", path):
         return True
     return "page=" in (parsed.query or "").lower()
 
@@ -607,8 +801,8 @@ def looks_like_non_cds_document(url: str) -> bool:
     return not re.search(r"cds|common[-_]?data", path)
 
 
-def select_brave_cds_url(results: list[dict], domain: str | None = None) -> str | None:
-    """Pick a discovery seed from Brave web results.
+def brave_cds_candidates(results: list[dict], domain: str | None = None) -> list[str]:
+    """Return plausible Brave candidates in listing-before-document order.
 
     Prefer an HTML listing over a year-specific PDF. A PDF seed locks the
     archive resolver onto one file — OU's 2023-24 Combined.pdf instead of
@@ -628,11 +822,12 @@ def select_brave_cds_url(results: list[dict], domain: str | None = None) -> str 
         p = url_str.lower()
         return any(kw in p for kw in bad_keywords)
 
-    landing = None
-    pdf = None
+    landing: list[str] = []
+    documents: list[str] = []
+    seen: set[str] = set()
     for r in results:
         link = r.get("url", "")
-        if not link or looks_like_template(link):
+        if not link or link in seen or looks_like_template(link):
             continue
         if looks_like_search_junk(link):
             continue
@@ -642,16 +837,26 @@ def select_brave_cds_url(results: list[dict], domain: str | None = None) -> str 
             continue
         if domain and not host_belongs_to_domain(link, domain):
             continue
+        seen.add(link)
         if link.lower().endswith(".pdf"):
-            if pdf is None:
-                pdf = link
+            documents.append(link)
             continue
         desc = r.get("description", "").lower()
         title = r.get("title", "").lower()
         if "common data set" in desc or "common data set" in title:
-            if landing is None:
-                landing = link
-    return landing or pdf
+            landing.append(link)
+    return landing + documents
+
+
+def select_brave_cds_url(results: list[dict], domain: str | None = None) -> str | None:
+    """Return the first syntactically plausible Brave candidate.
+
+    Production discovery uses `brave_search`, which bounded-fetches every
+    candidate and continues through alternatives. This helper stays useful for
+    diagnostics that only inspect Brave ranking.
+    """
+    candidates = brave_cds_candidates(results, domain)
+    return candidates[0] if candidates else None
 
 
 def google_dork(domain: str, api_key: str, cx: str) -> str | None:
@@ -769,6 +974,190 @@ def process_school(school: dict, args: argparse.Namespace,
     }
 
 
+def _chunks(values: list[str], size: int = 100) -> list[list[str]]:
+    return [values[i:i + size] for i in range(0, len(values), size)]
+
+
+def fetch_latest_terminal_archive_rows(
+    schools: list[dict],
+    *,
+    supabase_url: str,
+    service_role_key: str,
+) -> list[dict]:
+    """Read bounded latest terminal outcomes for active HTML seeds.
+
+    The existing RPC is index-backed and returns one terminal row per school.
+    Active queue rows are excluded so an old terminal result cannot demote a
+    seed while a newer attempt is ready or processing.
+    """
+    try:
+        from supabase import create_client
+    except ImportError as exc:
+        raise RuntimeError("supabase package is required for --audit-active-html") from exc
+
+    school_ids = [
+        str(school.get("id"))
+        for school in schools
+        if school.get("id")
+        and school.get("scrape_policy") == "active"
+        and (school.get("discovery_seed_url") or school.get("cds_url_hint"))
+        and not is_direct_doc_seed(
+            school.get("discovery_seed_url") or school.get("cds_url_hint")
+        )
+    ]
+    if not school_ids:
+        return []
+
+    sb = create_client(supabase_url, service_role_key)
+    since = (
+        datetime.now(timezone.utc)
+        - timedelta(days=ACTIVE_HTML_AUDIT_LOOKBACK_DAYS)
+    ).isoformat()
+    terminal_rows: list[dict] = []
+    for ids in _chunks(school_ids):
+        terminal = sb.rpc(
+            "latest_archive_terminal_rows",
+            {
+                "p_since": since,
+                "p_school_ids": ids,
+            },
+        ).execute()
+        for row in terminal.data or []:
+            terminal_rows.append(dict(row))
+
+    return [
+        row
+        for row in terminal_rows
+        if not row.get("active_work")
+        and row.get("last_outcome") in AUDITABLE_ARCHIVE_OUTCOMES
+        and row.get("status") in TERMINAL_ARCHIVE_STATUSES
+        and row.get("cds_url_hint")
+    ]
+
+
+def fetch_active_archive_school_ids(
+    school_ids: list[str],
+    *,
+    supabase_url: str,
+    service_role_key: str,
+) -> set[str]:
+    """Recheck active work in bulk immediately before seed mutation."""
+    if not school_ids:
+        return set()
+    try:
+        from supabase import create_client
+    except ImportError as exc:
+        raise RuntimeError("supabase package is required for active-work recheck") from exc
+
+    sb = create_client(supabase_url, service_role_key)
+    active_ids: set[str] = set()
+    for ids in _chunks(list(dict.fromkeys(school_ids))):
+        active = (
+            sb.table("archive_queue")
+            .select("school_id")
+            .in_("school_id", ids)
+            .in_("status", ["ready", "processing"])
+            .execute()
+        )
+        active_ids.update(
+            str(row.get("school_id"))
+            for row in active.data or []
+            if row.get("school_id")
+        )
+    return active_ids
+
+
+def audit_active_html_seeds(
+    schools: list[dict],
+    archive_rows: list[dict],
+    *,
+    dry_run: bool = False,
+    workers: int = 8,
+    active_recheck: Callable[[list[str]], set[str]] | None = None,
+) -> list[dict]:
+    """Demote definitively invalid active HTML seeds after archive failure.
+
+    Network errors, 403/405, rate limits, and 5xx responses are unverifiable
+    and never remove a seed. The latest archive result is a second independent
+    gate, limiting the monthly audit to seeds the archive pipeline already
+    classified as a terminal URL/content miss.
+    """
+    latest: dict[str, dict] = {}
+    for row in archive_rows:
+        sid = str(row.get("school_id") or "")
+        if not sid:
+            continue
+        previous = latest.get(sid)
+        if previous is None or str(row.get("processed_at") or "") > str(
+            previous.get("processed_at") or ""
+        ):
+            latest[sid] = row
+
+    candidates: list[tuple[dict, str, str, dict]] = []
+    for school in schools:
+        sid = str(school.get("id") or "")
+        seed = school.get("discovery_seed_url") or school.get("cds_url_hint") or ""
+        row = latest.get(sid)
+        if (
+            school.get("scrape_policy") != "active"
+            or not seed
+            or is_direct_doc_seed(seed)
+            or row is None
+            or row.get("status") not in TERMINAL_ARCHIVE_STATUSES
+            or row.get("last_outcome") not in AUDITABLE_ARCHIVE_OUTCOMES
+            or str(row.get("cds_url_hint") or "").strip() != seed.strip()
+        ):
+            continue
+        candidates.append((school, sid, seed, row))
+
+    if not candidates:
+        return []
+
+    # Each validation has a bounded network timeout. Parallel validation keeps
+    # the monthly audit's worst case below the workflow deadline even if every
+    # active school is slow, while mutation remains serial and deterministic.
+    with ThreadPoolExecutor(
+        max_workers=max(1, min(workers, len(candidates)))
+    ) as executor:
+        validations = executor.map(
+            validate_cds_url,
+            (seed for _school, _sid, seed, _row in candidates),
+        )
+
+    audited: list[tuple[dict, dict]] = []
+    for (school, sid, seed, row), (validation, reason) in zip(
+        candidates,
+        validations,
+    ):
+        result = {
+            "school_id": sid,
+            "url": seed,
+            "archive_outcome": row.get("last_outcome"),
+            "validation": validation,
+            "reason": reason,
+            "demoted": validation == VALIDATION_INVALID,
+        }
+        audited.append((school, result))
+
+    invalid_ids = [
+        str(result["school_id"])
+        for _school, result in audited
+        if result["demoted"]
+    ]
+    active_ids = active_recheck(invalid_ids) if active_recheck else set()
+    for school, result in audited:
+        if str(result["school_id"]) in active_ids:
+            result["demoted"] = False
+            result["reason"] = "active_work_started"
+        if not result["demoted"] or dry_run:
+            continue
+        school.pop("discovery_seed_url", None)
+        school.pop("cds_url_hint", None)
+        school["scrape_policy"] = "unknown"
+        record_probe(school, "not_found", "active_html_audit", 0, False)
+    return [result for _school, result in audited]
+
+
 def write_probe_summary(
     path: Path | None,
     *,
@@ -777,6 +1166,8 @@ def write_probe_summary(
     replaced: int,
     budget_remaining: int | None,
     still_stuck: int | None = None,
+    audited: int = 0,
+    demoted: int = 0,
 ) -> None:
     if path is None:
         return
@@ -786,6 +1177,8 @@ def write_probe_summary(
         "replaced": replaced,
         "budget_remaining": budget_remaining,
         "still_stuck": still_stuck if still_stuck is not None else max(0, probed - found),
+        "audited": audited,
+        "demoted": demoted,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
@@ -866,6 +1259,18 @@ def main():
                          f"× year combinations.")
     ap.add_argument("--summary-json", type=Path,
                     help="Write probed/found/replaced/budget_remaining for pipeline heartbeats.")
+    ap.add_argument(
+        "--audit-active-html",
+        action="store_true",
+        help="Validate active HTML seeds whose latest archive result is a "
+             "terminal URL/content miss; definitively invalid seeds are "
+             "demoted before normal discovery continues.",
+    )
+    ap.add_argument(
+        "--audit-report-json",
+        type=Path,
+        help="Write per-seed active HTML validation results.",
+    )
     args = ap.parse_args()
 
     data = yaml.safe_load(SCHOOLS_YAML.read_text())
@@ -904,6 +1309,58 @@ def main():
     targeted = only_ids is not None
     reprobe_found = targeted or args.reprobe_pdf_seeds
 
+    audited_results: list[dict] = []
+    demoted_ids: set[str] = set()
+    if args.audit_active_html:
+        audit_schools = [
+            school
+            for school in schools
+            if only_ids is None or str(school.get("id") or "") in only_ids
+        ]
+        supabase_url = os.environ.get("SUPABASE_URL")
+        service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        if not supabase_url or not service_role_key:
+            ap.error(
+                "--audit-active-html requires SUPABASE_URL and "
+                "SUPABASE_SERVICE_ROLE_KEY"
+            )
+        archive_rows = fetch_latest_terminal_archive_rows(
+            audit_schools,
+            supabase_url=supabase_url,
+            service_role_key=service_role_key,
+        )
+        active_recheck = lambda ids: fetch_active_archive_school_ids(
+            ids,
+            supabase_url=supabase_url,
+            service_role_key=service_role_key,
+        )
+        audited_results = audit_active_html_seeds(
+            audit_schools,
+            archive_rows,
+            dry_run=args.dry_run,
+            active_recheck=active_recheck,
+        )
+        demoted_ids = {
+            str(result["school_id"])
+            for result in audited_results
+            if result["demoted"] and not args.dry_run
+        }
+        for result in audited_results:
+            print(
+                f"[active-html-audit] {result['school_id']} "
+                f"{result['validation']} ({result['reason']})"
+            )
+        print(
+            f"Active HTML audit: {len(audited_results)} checked, "
+            f"{sum(bool(result['demoted']) for result in audited_results)} "
+            f"{'would be demoted' if args.dry_run else 'demoted'}"
+        )
+        if args.audit_report_json:
+            args.audit_report_json.parent.mkdir(parents=True, exist_ok=True)
+            args.audit_report_json.write_text(
+                json.dumps(audited_results, indent=2, sort_keys=True) + "\n"
+            )
+
     # ── Build candidate list (apply all filters up front) ──
     name_filter = args.name_contains.lower() if args.name_contains else None
     candidates: list[dict] = []
@@ -938,8 +1395,13 @@ def main():
                 continue
         if name_filter and name_filter not in name.lower():
             continue
-        if not targeted and args.cooldown_days > 0 and should_skip(
-            school, args.cooldown_days, reprobe_found=reprobe_found
+        if (
+            sid not in demoted_ids
+            and not targeted
+            and args.cooldown_days > 0
+            and should_skip(
+                school, args.cooldown_days, reprobe_found=reprobe_found
+            )
         ):
             skipped += 1
             continue
@@ -967,7 +1429,12 @@ def main():
             replaced=0,
             budget_remaining=budget_remaining(),
             still_stuck=0,
+            audited=len(audited_results),
+            demoted=len(demoted_ids),
         )
+        if demoted_ids and not args.dry_run:
+            _save_yaml(data)
+            print(f"Updated {SCHOOLS_YAML}")
         return
 
     # ── Threadpool execution ──
@@ -1021,6 +1488,8 @@ def main():
                 found=found,
                 replaced=replaced,
                 budget_remaining=budget_remaining(),
+                audited=len(audited_results),
+                demoted=len(demoted_ids),
             )
             return
 
@@ -1043,6 +1512,8 @@ def main():
         found=found,
         replaced=replaced,
         budget_remaining=budget_remaining(),
+        audited=len(audited_results),
+        demoted=len(demoted_ids),
     )
 
 

--- a/tools/finder/schools.yaml
+++ b/tools/finder/schools.yaml
@@ -2340,14 +2340,13 @@ schools:
   name: Baker University
   domain: bakeru.edu
   ipeds_id: '154688'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.bakeru.edu/about-baker/careers-baker
 - id: bakersfield-college
   name: Bakersfield College
   domain: bakersfieldcollege.edu
@@ -5990,14 +5989,13 @@ schools:
   name: Cornell College
   domain: cornellcollege.edu
   ipeds_id: '153162'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.cornellcollege.edu/institutional-research/institutional-profile/common-data-sets.shtml
 - id: cornerstone-university
   name: Cornerstone University
   domain: cornerstone.edu
@@ -6428,14 +6426,13 @@ schools:
   name: Dalton State College
   domain: daltonstate.edu
   ipeds_id: '139463'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-09-02T17:56:48Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.daltonstate.edu/about/roadrunner-spotlight-archive.cms?contentType=textonly
 - id: davenport-university
   name: Davenport University
   domain: davenport.edu
@@ -6691,14 +6688,13 @@ schools:
   name: Dickinson State University
   domain: dickinsonstate.edu
   ipeds_id: '200059'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.dickinsonstate.edu/about/institutional-research/
 - id: dillard-university
   name: Dillard University
   domain: dillard.edu
@@ -7094,14 +7090,13 @@ schools:
   name: Eastern New Mexico University-Main Campus
   domain: enmu.edu
   ipeds_id: '187648'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://my.enmu.edu/web/institutional-research/common-data-set
 - id: eastern-oregon-university
   name: Eastern Oregon University
   domain: eou.edu
@@ -10434,14 +10429,13 @@ schools:
   name: Johnson & Wales University-Charlotte
   domain: jwu.edu
   ipeds_id: '445708'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.jwu.edu/about-jwu/terms-of-use.html
 - id: johnson-and-wales-university-online
   name: Johnson & Wales University-Online
   domain: online.jwu.edu
@@ -10464,7 +10458,6 @@ schools:
     last_method: shared_parent
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www.jwu.edu/about-jwu/terms-of-use.html
 - id: johnson-c-smith-university
   name: Johnson C Smith University
   domain: jcsu.edu
@@ -14091,14 +14084,13 @@ schools:
   name: Naval Postgraduate School
   domain: nps.edu
   ipeds_id: '119678'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://faculty.nps.edu/ncrowe/oldstudents/jshaver_thesis.htm
 - id: navarro-college
   name: Navarro College
   domain: navarrocollege.edu
@@ -16142,7 +16134,6 @@ schools:
     last_method: shared_parent
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://sites.sju.edu/academicadmin/files/2017/01/SJU-Common-Data-Set-2015-2016-Part-One.pdf
 - id: pennsylvania-college-of-technology
   name: Pennsylvania College of Technology
   domain: pct.edu
@@ -24711,14 +24702,13 @@ schools:
   name: University of Valley Forge
   domain: valleyforge.edu
   ipeds_id: '216542'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://valleyforge.edu/careers-at-uvf/director-of-financial-services/
 - id: university-of-vermont
   name: University of Vermont
   domain: uvm.edu
@@ -24927,14 +24917,13 @@ schools:
   name: University of Wisconsin-Stevens Point
   domain: uwsp.edu
   ipeds_id: '240480'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-08-21T22:51:00Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://www3.uwsp.edu/oire/Pages/accountability-effectiveness.aspx
 - id: university-of-wisconsin-stout
   name: University of Wisconsin-Stout
   domain: uwstout.edu
@@ -26000,14 +25989,13 @@ schools:
   name: West Virginia State University
   domain: wvstateu.edu
   ipeds_id: '237899'
-  scrape_policy: active
+  scrape_policy: unknown
   probe_state:
-    last_probed_at: '2026-09-02T18:00:10Z'
-    last_result: found
-    last_method: brave
+    last_probed_at: '2026-09-12T13:59:42Z'
+    last_result: not_found
+    last_method: active_html_audit
     patterns_tried: 0
     search_fallback_tried: true
-  discovery_seed_url: https://wvstateu.edu/administration/institutional-research/irae-mission/
 - id: west-virginia-university
   name: West Virginia University
   domain: wvu.edu

--- a/tools/finder/test_apply_probe_log.py
+++ b/tools/finder/test_apply_probe_log.py
@@ -10,6 +10,7 @@ from tools.finder.apply_probe_log import (
     apply_hit,
     apply_logs,
     parse_probe_log,
+    write_school_updates,
 )
 from tools.finder.merge_schools_yaml import merge_school_lists
 
@@ -143,6 +144,30 @@ class WriteYamlTests(unittest.TestCase):
         self.assertIn("last_probed_at: '2026-08-21T22:51:00Z'", text)
         self.assertIn("scrape_policy: unknown", text)
 
+    def test_explicit_seed_deletion_removes_existing_yaml_line(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schools.yaml"
+            path.write_text(YAML_FIXTURE)
+            schools = [
+                {
+                    "id": "albion-college",
+                    "name": "Albion College",
+                    "domain": "albion.edu",
+                    "scrape_policy": "unknown",
+                    "probe_state": {
+                        "last_probed_at": "2026-09-12T00:00:00Z",
+                        "last_result": "not_found",
+                        "last_method": "active_html_audit",
+                    },
+                }
+            ]
+            write_school_updates(path, schools, {"albion-college"})
+            text = path.read_text()
+        self.assertNotIn("https://www.albion.edu/wp-content/uploads/cds-2023.pdf", text)
+        self.assertNotIn("discovery_seed_url:", text.split("- id: elms-college")[0])
+        self.assertIn("scrape_policy: unknown", text)
+        self.assertIn("last_method: active_html_audit", text)
+
 
 class MergeListsTests(unittest.TestCase):
     def test_overlays_only_schools_the_probe_changed(self) -> None:
@@ -201,6 +226,42 @@ class MergeListsTests(unittest.TestCase):
         )
         self.assertEqual(merged[0]["probe_state"]["last_result"], "not_found")
         self.assertEqual(merged[0]["probe_state"]["last_probed_at"], "2026-09-02T14:18:00Z")
+
+    def test_probe_seed_deletion_wins_over_current_main(self) -> None:
+        base = [
+            {
+                "id": "bad-seed",
+                "discovery_seed_url": "https://example.edu/mission",
+                "cds_url_hint": "https://example.edu/legacy-mission",
+                "scrape_policy": "active",
+            }
+        ]
+        main = [
+            {
+                "id": "bad-seed",
+                "discovery_seed_url": "https://example.edu/mission",
+                "cds_url_hint": "https://example.edu/legacy-mission",
+                "scrape_policy": "active",
+                "notes": "preserve me",
+            }
+        ]
+        probed = [
+            {
+                "id": "bad-seed",
+                "scrape_policy": "unknown",
+                "probe_state": {
+                    "last_result": "not_found",
+                    "last_probed_at": "2026-09-12T00:00:00Z",
+                    "last_method": "active_html_audit",
+                },
+            }
+        ]
+        merged, changed = merge_school_lists(base, main, probed)
+        self.assertEqual(changed, ["bad-seed"])
+        self.assertNotIn("discovery_seed_url", merged[0])
+        self.assertNotIn("cds_url_hint", merged[0])
+        self.assertEqual(merged[0]["scrape_policy"], "unknown")
+        self.assertEqual(merged[0]["notes"], "preserve me")
 
 
 if __name__ == "__main__":

--- a/tools/finder/test_finder_workflows.py
+++ b/tools/finder/test_finder_workflows.py
@@ -38,6 +38,27 @@ class FinderProbeWorkflowTests(unittest.TestCase):
         self.assertNotIn("<<", run)
         self.assertIn("printf", run)
 
+    def test_stuck_heartbeat_prefers_post_run_classifier_count(self) -> None:
+        refresh_at = FINDER.index("- name: Refresh stuck report after seed rewrites")
+        heartbeat_at = FINDER.index("- name: Heartbeat finder_stuck_pdf finish")
+        self.assertLess(refresh_at, heartbeat_at)
+        heartbeat = FINDER[heartbeat_at:].split("\n      - name:", 1)[0]
+        self.assertIn('after_path = Path("finder-probe/stuck-ids-after.txt")', heartbeat)
+        self.assertIn("still_stuck = count_ids(after_path)", heartbeat)
+        self.assertIn(
+            'initial_stuck - int(summary.get("replaced", 0))',
+            heartbeat,
+        )
+
+    def test_unknown_probe_audits_failed_active_html_seeds(self) -> None:
+        _, step = FINDER.split("id: probe_unknown", 1)
+        run = step.split("- name:", 1)[0]
+        self.assertIn("--audit-active-html", run)
+        self.assertIn(
+            "--audit-report-json finder-probe/active-html-audit.json",
+            run,
+        )
+
     def test_failures_open_pipeline_alert_issues(self) -> None:
         self.assertIn("upsert_pipeline_alert_issue.py", FINDER)
         self.assertIn("--component", FINDER)

--- a/tools/finder/test_probe_urls.py
+++ b/tools/finder/test_probe_urls.py
@@ -2,19 +2,38 @@
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import yaml
 
 from tools.finder.probe_urls import (
+    _get_bounded,
     _save_yaml,
+    AUDITABLE_ARCHIVE_OUTCOMES,
+    VALIDATION_INVALID,
+    VALIDATION_UNVERIFIABLE,
+    VALIDATION_VALID,
+    SCHOOLS_YAML,
+    audit_active_html_seeds,
+    brave_cds_candidates,
+    brave_search,
+    fetch_latest_terminal_archive_rows,
     host_belongs_to_domain,
+    html_has_cds_content_or_anchors,
     is_cds_page,
     looks_like_search_junk,
     may_mark_active,
+    process_school,
     select_brave_cds_url,
     should_replace_seed,
     should_skip,
     dedupe_identical_seeds,
+    validate_cds_url,
     write_probe_summary,
 )
 
@@ -141,6 +160,16 @@ class SelectBraveCdsUrlTests(unittest.TestCase):
             looks_like_news_or_blog("https://www.widener.edu/news/noteworthy?page=2")
         )
         self.assertTrue(
+            looks_like_news_or_blog(
+                "https://www.bakeru.edu/about-baker/careers-baker"
+            )
+        )
+        self.assertTrue(
+            looks_like_news_or_blog(
+                "https://faculty.nps.edu/ncrowe/oldstudents/jshaver_thesis.htm"
+            )
+        )
+        self.assertTrue(
             looks_like_non_cds_document(
                 "https://www.csuci.edu/budget/documents/otp-budget-presentation-fy17-18.pdf"
             )
@@ -151,12 +180,574 @@ class SelectBraveCdsUrlTests(unittest.TestCase):
             )
         )
 
+    def test_candidate_order_keeps_all_listings_before_pdf_fallback(self) -> None:
+        results = [
+            {
+                "url": "https://example.edu/ir/cds-2024.pdf",
+                "title": "Common Data Set 2024",
+                "description": "Common Data Set",
+            },
+            {
+                "url": "https://example.edu/mission",
+                "title": "Common Data Set",
+                "description": "Institutional research",
+            },
+            {
+                "url": "https://example.edu/ir/reports",
+                "title": "Reports",
+                "description": "Common Data Set reports",
+            },
+        ]
+        self.assertEqual(
+            brave_cds_candidates(results, "example.edu"),
+            [
+                "https://example.edu/mission",
+                "https://example.edu/ir/reports",
+                "https://example.edu/ir/cds-2024.pdf",
+            ],
+        )
+
+    def test_brave_fetch_validation_continues_to_pdf_fallback(self) -> None:
+        results = {
+            "web": {
+                "results": [
+                    {
+                        "url": "https://example.edu/mission",
+                        "title": "Common Data Set",
+                        "description": "Common Data Set",
+                    },
+                    {
+                        "url": "https://example.edu/ir/cds-2024.pdf",
+                        "title": "CDS 2024",
+                        "description": "Common Data Set",
+                    },
+                ]
+            }
+        }
+        with (
+            mock.patch(
+                "tools.finder.probe_urls._get_full",
+                return_value=(200, {}, json.dumps(results).encode()),
+            ),
+            mock.patch(
+                "tools.finder.probe_urls.validate_cds_url",
+                side_effect=[
+                    (VALIDATION_INVALID, "html_without_cds_content_or_anchors"),
+                    (VALIDATION_VALID, "pdf_magic"),
+                ],
+            ) as validate,
+        ):
+            selected = brave_search("example.edu", "test-key")
+        self.assertEqual(selected, "https://example.edu/ir/cds-2024.pdf")
+        self.assertEqual(validate.call_count, 2)
+
+    def test_brave_returns_none_when_unique_candidates_are_not_valid(self) -> None:
+        results = {
+            "web": {
+                "results": [
+                    {
+                        "url": "https://example.edu/mission",
+                        "title": "Common Data Set",
+                        "description": "Common Data Set",
+                    },
+                    {
+                        "url": "https://example.edu/mission",
+                        "title": "Duplicate",
+                        "description": "Common Data Set",
+                    },
+                    {
+                        "url": "https://example.edu/cds.pdf",
+                        "title": "CDS",
+                        "description": "Common Data Set",
+                    },
+                ]
+            }
+        }
+        with (
+            mock.patch(
+                "tools.finder.probe_urls._get_full",
+                return_value=(200, {}, json.dumps(results).encode()),
+            ),
+            mock.patch(
+                "tools.finder.probe_urls.validate_cds_url",
+                side_effect=[
+                    (VALIDATION_INVALID, "html_without_cds_content_or_anchors"),
+                    (VALIDATION_UNVERIFIABLE, "http_403"),
+                ],
+            ) as validate,
+        ):
+            self.assertIsNone(brave_search("example.edu", "test-key"))
+        self.assertEqual(validate.call_count, 2)
+
 
 class IsCdsPageTests(unittest.TestCase):
     def test_mixed_ir_hub_cds_heading_below_5kb_still_matches(self) -> None:
         prefix = ("x" * 6000).encode()
         body = prefix + b"<h2>Common Data Set (CDS)</h2>"
         self.assertTrue(is_cds_page(body, "text/html; charset=utf-8"))
+
+
+class FetchedCandidateValidationTests(unittest.TestCase):
+    def test_validation_fetch_is_bounded(self) -> None:
+        class FakeResponse(io.BytesIO):
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def getheaders(self):
+                return [("Content-Type", "text/html")]
+
+            def geturl(self):
+                return "https://example.edu/cds"
+
+        response = FakeResponse(b"x" * 100)
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            status, _headers, body, _final_url, truncated = _get_bounded(
+                "https://example.edu/cds",
+                max_bytes=16,
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body), 16)
+        self.assertTrue(truncated)
+
+    def test_validation_fetch_enforces_wall_clock_deadline(self) -> None:
+        class SlowResponse:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def getheaders(self):
+                return [("Content-Type", "text/html")]
+
+            def geturl(self):
+                return "https://example.edu/cds"
+
+            def read1(self, _size):
+                return b"x"
+
+            def read(self, _size):
+                return b"x"
+
+        with (
+            mock.patch("urllib.request.urlopen", return_value=SlowResponse()),
+            mock.patch(
+                "tools.finder.probe_urls.time.monotonic",
+                side_effect=[0.0, 0.0, 16.0],
+            ),
+        ):
+            status, _headers, body, _final_url, truncated = _get_bounded(
+                "https://example.edu/cds",
+                timeout=15,
+            )
+        self.assertEqual(status, -1)
+        self.assertEqual(body, b"")
+        self.assertFalse(truncated)
+
+    def test_html_requires_real_cds_anchor(self) -> None:
+        valid = b"""
+        <html><h1>Common Data Set</h1>
+        <a href="/files/CDS_2024-2025.pdf">2024-25 Common Data Set</a></html>
+        """
+        false_page = b"""
+        <html><h1>IRAE Mission</h1>
+        <nav>Common Data Set</nav><p>Our mission is institutional excellence.</p></html>
+        """
+        self.assertTrue(html_has_cds_content_or_anchors(valid))
+        self.assertFalse(html_has_cds_content_or_anchors(false_page))
+
+    def test_navigation_only_cds_committee_link_is_not_content(self) -> None:
+        false_page = b"""
+        <html><nav>
+        <a href="/about/cds-committee">CDS committee</a>
+        <a href="/common-data-set-faq">Common Data Set FAQ</a>
+        <a href="/about/committee">CDS committee</a>
+        <a href="/about?topic=common-data-set-faq">FAQ</a>
+        </nav>
+        <p>Institutional research home page.</p></html>
+        """
+        self.assertFalse(html_has_cds_content_or_anchors(false_page))
+
+    def test_policy_directory_can_contain_legitimate_cds_landing_link(self) -> None:
+        valid = b"""
+        <html><nav>
+        <a href="/institutional-policy/common-data-set/">Common Data Set</a>
+        </nav></html>
+        """
+        self.assertTrue(html_has_cds_content_or_anchors(valid))
+
+    def test_common_data_phrase_plus_unrelated_documents_is_not_enough(self) -> None:
+        false_page = b"""
+        <html><p>A Common Data Set was cited in this article.</p>
+        <a href="/jobs/application.pdf">Application</a>
+        <a href="/research/thesis.pdf">Thesis</a></html>
+        """
+        self.assertFalse(html_has_cds_content_or_anchors(false_page))
+
+    def test_pdf_magic_is_valid_even_for_opaque_url(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(
+                200,
+                {"content-type": "application/octet-stream"},
+                b"%PDF-1.7\n...",
+                "https://example.edu/download?id=123",
+                False,
+            ),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/download?id=123"),
+                (VALIDATION_VALID, "pdf_magic"),
+            )
+
+    def test_successful_false_html_is_definitively_invalid(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(
+                200,
+                {"content-type": "text/html"},
+                b"<html><h1>IRAE Mission</h1><p>Common Data Set</p></html>",
+                "https://example.edu/mission",
+                False,
+            ),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/mission"),
+                (
+                    VALIDATION_INVALID,
+                    "html_without_cds_content_or_anchors",
+                ),
+            )
+
+    def test_truncated_html_without_early_cds_anchor_is_unverifiable(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(
+                200,
+                {"content-type": "text/html"},
+                b"<html><h1>Institutional research</h1>",
+                "https://example.edu/reports",
+                True,
+            ),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/reports"),
+                (
+                    VALIDATION_UNVERIFIABLE,
+                    "html_validation_window_exhausted",
+                ),
+            )
+
+    def test_contextual_page_path_is_invalid_even_with_form_terms(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(
+                200,
+                {"content-type": "text/html"},
+                (
+                    b"<html>Common Data Set applicants enrolled tuition "
+                    b"degrees conferred</html>"
+                ),
+                "https://example.edu/careers-baker",
+                False,
+            ),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/careers-baker"),
+                (VALIDATION_INVALID, "contextual_page_path"),
+            )
+
+    def test_office_magic_with_spreadsheet_content_type_is_valid(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(
+                200,
+                {
+                    "content-type": (
+                        "application/vnd.openxmlformats-officedocument."
+                        "spreadsheetml.sheet"
+                    )
+                },
+                b"PK\x03\x04...",
+                "https://example.edu/download?id=123",
+                False,
+            ),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/download?id=123"),
+                (VALIDATION_VALID, "office_magic"),
+            )
+
+    def test_transient_and_access_failures_are_unverifiable(self) -> None:
+        for status in (-1, 403, 405, 429, 500, 503):
+            with self.subTest(status=status), mock.patch(
+                "tools.finder.probe_urls._get_bounded",
+                return_value=(status, {}, b"", "https://example.edu/cds", False),
+            ):
+                validation, _reason = validate_cds_url("https://example.edu/cds")
+                self.assertEqual(validation, VALIDATION_UNVERIFIABLE)
+
+    def test_404_is_definitively_invalid(self) -> None:
+        with mock.patch(
+            "tools.finder.probe_urls._get_bounded",
+            return_value=(404, {}, b"", "https://example.edu/missing", False),
+        ):
+            self.assertEqual(
+                validate_cds_url("https://example.edu/missing"),
+                (VALIDATION_INVALID, "http_404"),
+            )
+
+
+class ActiveHtmlAuditTests(unittest.TestCase):
+    def test_archive_lookup_excludes_school_with_newer_active_queue_row(self) -> None:
+        terminal_rows = [
+            {
+                "school_id": "eligible",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "last_outcome": "no_pdfs_found",
+                "cds_url_hint": "https://eligible.edu/cds/",
+                "status": "done",
+                "active_work": False,
+            },
+            {
+                "school_id": "processing",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "last_outcome": "wrong_content_type",
+                "cds_url_hint": "https://processing.edu/cds/",
+                "status": "done",
+                "active_work": True,
+            },
+        ]
+
+        class FakeCommand:
+            def __init__(self, data):
+                self.data = data
+
+            def execute(self):
+                return SimpleNamespace(data=self.data)
+
+        class FakeClient:
+            def rpc(self, _name, _params):
+                return FakeCommand(terminal_rows)
+
+            def table(self, _name):
+                raise AssertionError("active-work check must stay inside the RPC")
+
+        schools = [
+            {
+                "id": "eligible",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://eligible.edu/cds/",
+            },
+            {
+                "id": "processing",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://processing.edu/cds/",
+            },
+            {
+                "id": "direct-document",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://example.edu/CDS_2024.pdf",
+            },
+        ]
+        fake_module = SimpleNamespace(create_client=lambda _url, _key: FakeClient())
+        with mock.patch.dict(sys.modules, {"supabase": fake_module}):
+            rows = fetch_latest_terminal_archive_rows(
+                schools,
+                supabase_url="https://example.supabase.co",
+                service_role_key="test-key",
+            )
+        self.assertEqual([row["school_id"] for row in rows], ["eligible"])
+        self.assertEqual(rows[0]["status"], "done")
+
+    def test_terminal_content_failure_and_invalid_live_page_demotes(self) -> None:
+        school = {
+            "id": "west-virginia-state-university",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://wvstateu.edu/mission/",
+            "probe_state": {"last_result": "found"},
+        }
+        rows = [
+            {
+                "school_id": school["id"],
+                "status": "failed_permanent",
+                "last_outcome": "no_pdfs_found",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "cds_url_hint": school["discovery_seed_url"],
+            }
+        ]
+        with mock.patch(
+            "tools.finder.probe_urls.validate_cds_url",
+            return_value=(
+                VALIDATION_INVALID,
+                "html_without_cds_content_or_anchors",
+            ),
+        ):
+            results = audit_active_html_seeds([school], rows)
+        self.assertTrue(results[0]["demoted"])
+        self.assertEqual(school["scrape_policy"], "unknown")
+        self.assertNotIn("discovery_seed_url", school)
+        self.assertEqual(school["probe_state"]["last_method"], "active_html_audit")
+
+    def test_403_does_not_demote_existing_seed(self) -> None:
+        school = {
+            "id": "blocked-school",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://blocked.edu/common-data-set/",
+        }
+        rows = [
+            {
+                "school_id": school["id"],
+                "status": "failed_permanent",
+                "last_outcome": "no_pdfs_found",
+                "cds_url_hint": school["discovery_seed_url"],
+            }
+        ]
+        with mock.patch(
+            "tools.finder.probe_urls.validate_cds_url",
+            return_value=(VALIDATION_UNVERIFIABLE, "http_403"),
+        ):
+            results = audit_active_html_seeds([school], rows)
+        self.assertFalse(results[0]["demoted"])
+        self.assertEqual(school["scrape_policy"], "active")
+        self.assertIn("discovery_seed_url", school)
+
+    def test_failure_for_obsolete_seed_cannot_demote_current_seed(self) -> None:
+        school = {
+            "id": "changed-school",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://example.edu/new-common-data-set/",
+        }
+        rows = [
+            {
+                "school_id": school["id"],
+                "status": "done",
+                "last_outcome": "no_pdfs_found",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "cds_url_hint": "https://example.edu/old-mission/",
+            }
+        ]
+        with mock.patch("tools.finder.probe_urls.validate_cds_url") as validate:
+            self.assertEqual(audit_active_html_seeds([school], rows), [])
+        validate.assert_not_called()
+        self.assertEqual(school["scrape_policy"], "active")
+        self.assertEqual(
+            school["discovery_seed_url"],
+            "https://example.edu/new-common-data-set/",
+        )
+
+    def test_active_work_started_during_validation_blocks_demotion(self) -> None:
+        school = {
+            "id": "racing-school",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://example.edu/mission/",
+        }
+        rows = [
+            {
+                "school_id": school["id"],
+                "status": "done",
+                "last_outcome": "no_pdfs_found",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "cds_url_hint": school["discovery_seed_url"],
+            }
+        ]
+        with mock.patch(
+            "tools.finder.probe_urls.validate_cds_url",
+            return_value=(VALIDATION_INVALID, "http_404"),
+        ):
+            results = audit_active_html_seeds(
+                [school],
+                rows,
+                active_recheck=lambda ids: set(ids),
+            )
+        self.assertFalse(results[0]["demoted"])
+        self.assertEqual(results[0]["reason"], "active_work_started")
+        self.assertEqual(school["scrape_policy"], "active")
+        self.assertIn("discovery_seed_url", school)
+
+    def test_nonterminal_or_transient_archive_result_is_not_audited(self) -> None:
+        base = {
+            "id": "example",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://example.edu/common-data-set/",
+        }
+        rows = [
+            {
+                "school_id": "example",
+                "status": "processing",
+                "last_outcome": "no_pdfs_found",
+                "processed_at": "2026-09-11T00:00:00Z",
+                "cds_url_hint": base["discovery_seed_url"],
+            }
+        ]
+        with mock.patch("tools.finder.probe_urls.validate_cds_url") as validate:
+            self.assertEqual(audit_active_html_seeds([dict(base)], rows), [])
+            rows[0]["status"] = "failed_permanent"
+            rows[0]["last_outcome"] = "transient"
+            self.assertEqual(audit_active_html_seeds([dict(base)], rows), [])
+        validate.assert_not_called()
+        self.assertNotIn("transient", AUDITABLE_ARCHIVE_OUTCOMES)
+
+    def test_direct_document_seeds_are_out_of_scope(self) -> None:
+        school = {
+            "id": "example",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://example.edu/CDS_2024.pdf",
+        }
+        rows = [
+            {
+                "school_id": "example",
+                "status": "failed_permanent",
+                "last_outcome": "wrong_content_type",
+                "cds_url_hint": school["discovery_seed_url"],
+            }
+        ]
+        with mock.patch("tools.finder.probe_urls.validate_cds_url") as validate:
+            self.assertEqual(audit_active_html_seeds([school], rows), [])
+        validate.assert_not_called()
+
+    def test_newest_terminal_row_controls_audit_and_dry_run_preserves_seed(self) -> None:
+        school = {
+            "id": "example",
+            "scrape_policy": "active",
+            "discovery_seed_url": "https://example.edu/mission",
+        }
+        rows = [
+            {
+                "school_id": "example",
+                "status": "done",
+                "last_outcome": "no_pdfs_found",
+                "processed_at": "2026-09-10T00:00:00Z",
+                "cds_url_hint": school["discovery_seed_url"],
+            },
+            {
+                "school_id": "example",
+                "status": "done",
+                "last_outcome": "transient",
+                "processed_at": "2026-09-11T00:00:00Z",
+                "cds_url_hint": school["discovery_seed_url"],
+            },
+        ]
+        with mock.patch("tools.finder.probe_urls.validate_cds_url") as validate:
+            self.assertEqual(audit_active_html_seeds([school], rows), [])
+            validate.assert_not_called()
+
+        rows[1]["last_outcome"] = "dead_url"
+        with mock.patch(
+            "tools.finder.probe_urls.validate_cds_url",
+            return_value=(VALIDATION_INVALID, "http_404"),
+        ):
+            results = audit_active_html_seeds([school], rows, dry_run=True)
+        self.assertTrue(results[0]["demoted"])
+        self.assertEqual(school["scrape_policy"], "active")
+        self.assertIn("discovery_seed_url", school)
 
 
 class SeedReplaceTests(unittest.TestCase):
@@ -248,6 +839,33 @@ class CheckpointHelpersTests(unittest.TestCase):
         self.assertIn("Xavier", text)
 
 
+class SeedRepairTests(unittest.TestCase):
+    def test_confirmed_contextual_false_positive_seeds_stay_demoted(self) -> None:
+        schools = {
+            school["id"]: school
+            for school in yaml.safe_load(SCHOOLS_YAML.read_text())["schools"]
+        }
+        repaired_ids = {
+            "baker-university",
+            "cornell-college",
+            "dalton-state-college",
+            "dickinson-state-university",
+            "eastern-new-mexico-university-main-campus",
+            "johnson-and-wales-university-charlotte",
+            "johnson-and-wales-university-providence",
+            "naval-postgraduate-school",
+            "pennsylvania-college-of-health-sciences",
+            "university-of-valley-forge",
+            "university-of-wisconsin-stevens-point",
+            "west-virginia-state-university",
+        }
+        for school_id in repaired_ids:
+            with self.subTest(school_id=school_id):
+                school = schools[school_id]
+                self.assertEqual(school["scrape_policy"], "unknown")
+                self.assertNotIn("discovery_seed_url", school)
+
+
 class IdentityActivateTests(unittest.TestCase):
     def test_missing_official_record_cannot_become_active(self) -> None:
         school = {
@@ -263,6 +881,35 @@ class IdentityActivateTests(unittest.TestCase):
             )
         )
         self.assertTrue(may_mark_active(school, None))
+
+    def test_process_school_rejects_candidate_missing_from_identity_snapshot(
+        self,
+    ) -> None:
+        school = {
+            "id": "missing-school",
+            "name": "Missing School",
+            "domain": "missing.edu",
+            "ipeds_id": "999999",
+            "scrape_policy": "unknown",
+        }
+        args = SimpleNamespace(
+            search_only=False,
+            rps=1,
+            school_budget_sec=1,
+            bing_fallback=False,
+            brave_fallback=False,
+            google_fallback=False,
+            dry_run=False,
+        )
+        with mock.patch(
+            "tools.finder.probe_urls.probe_school",
+            return_value=("https://missing.edu/common-data-set/", 1),
+        ):
+            result = process_school(school, args, {"official_records": {}})
+        self.assertIsNone(result["url"])
+        self.assertEqual(school["scrape_policy"], "unknown")
+        self.assertEqual(school["probe_state"]["last_result"], "not_found")
+        self.assertNotIn("discovery_seed_url", school)
 
 
 if __name__ == "__main__":

--- a/tools/ops/enqueue_changed_seeds.py
+++ b/tools/ops/enqueue_changed_seeds.py
@@ -8,6 +8,7 @@ months, new listings should be fetched the same day they land on main.
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import sys
 import uuid
@@ -32,19 +33,41 @@ def seed_of(school: dict) -> str:
     return str(school.get("discovery_seed_url") or school.get("cds_url_hint") or "")
 
 
+def institution_identity(school: dict) -> tuple[str, str] | None:
+    """Return the stable comparison key for one institution."""
+    ipeds_id = str(school.get("ipeds_id") or "").strip()
+    if ipeds_id:
+        return ("ipeds_id", ipeds_id)
+    school_id = str(school.get("id") or "").strip()
+    if school_id:
+        return ("id", school_id)
+    return None
+
+
 def changed_seed_ids(before: list[dict], after: list[dict]) -> list[str]:
-    before_map = {str(row.get("id")): row for row in before if row.get("id")}
+    before_map = {
+        identity: row
+        for row in before
+        if (identity := institution_identity(row)) is not None
+    }
     changed: list[str] = []
     for row in after:
         sid = str(row.get("id") or "")
         if not sid:
             continue
-        prev = before_map.get(sid)
+        identity = institution_identity(row)
+        prev = before_map.get(identity) if identity is not None else None
         if prev is None:
             if seed_of(row) and row.get("scrape_policy") == "active":
                 changed.append(sid)
             continue
-        if seed_of(row) and seed_of(row) != seed_of(prev):
+        if (
+            seed_of(row)
+            and row.get("scrape_policy") == "active"
+            and sid != str(prev.get("id") or "")
+        ):
+            changed.append(sid)
+        elif seed_of(row) and seed_of(row) != seed_of(prev):
             changed.append(sid)
         elif (
             prev.get("scrape_policy") != "active"
@@ -52,7 +75,9 @@ def changed_seed_ids(before: list[dict], after: list[dict]) -> list[str]:
             and seed_of(row)
         ):
             changed.append(sid)
-    return changed
+    # The archive API filters by school slug, so duplicate-IPEDs rows with the
+    # same slug must produce one request token even when both seeds changed.
+    return list(dict.fromkeys(changed))
 
 
 def load_schools(path: Path) -> list[dict]:
@@ -87,19 +112,28 @@ def canary_filter_error(result: dict) -> str | None:
     return None
 
 
-def chunk_filter_error(result: dict, group: list[str]) -> str | None:
+def chunk_filter_error(
+    result: dict,
+    group: list[str],
+    *,
+    expected_matches: int | None = None,
+) -> str | None:
     requested = result.get("school_ids_requested")
     matched = result.get("school_ids_matched")
     enqueued = int(result.get("enqueued") or 0)
+    maximum_matches = expected_matches if expected_matches is not None else len(group)
     if requested != len(group):
         return (
             f"school_ids_requested={requested!r}, expected {len(group)} "
             "(filter did not echo this chunk)"
         )
-    if matched is None or int(matched) > len(group):
-        return f"school_ids_matched={matched!r} exceeds chunk of {len(group)}"
-    if enqueued > len(group):
-        return f"enqueued={enqueued} exceeds chunk of {len(group)}"
+    if matched is None or int(matched) > maximum_matches:
+        return (
+            f"school_ids_matched={matched!r} exceeds expected school rows "
+            f"{maximum_matches}"
+        )
+    if enqueued > maximum_matches:
+        return f"enqueued={enqueued} exceeds expected school rows {maximum_matches}"
     return None
 
 
@@ -129,7 +163,14 @@ def main() -> int:
         help="Do not ping archive-enqueue with a fake school_id first.",
     )
     args = ap.parse_args()
-    ids = changed_seed_ids(load_schools(args.before), load_schools(args.after))
+    before_schools = load_schools(args.before)
+    after_schools = load_schools(args.after)
+    ids = changed_seed_ids(before_schools, after_schools)
+    active_seed_counts = collections.Counter(
+        str(row.get("id") or "")
+        for row in after_schools
+        if row.get("scrape_policy") == "active" and seed_of(row)
+    )
     print(json.dumps({"changed": len(ids), "ids": ids}, indent=2))
     if not ids:
         print("No seed changes; skipping enqueue.", file=sys.stderr)
@@ -153,7 +194,11 @@ def main() -> int:
                 "run_id": run_id,
             },
         )
-        error = chunk_filter_error(result, group)
+        error = chunk_filter_error(
+            result,
+            group,
+            expected_matches=sum(active_seed_counts[sid] for sid in group),
+        )
         if error:
             raise OpsError(error)
         enqueued += int(result.get("enqueued") or 0)

--- a/tools/ops/test_enqueue_changed_seeds.py
+++ b/tools/ops/test_enqueue_changed_seeds.py
@@ -27,6 +27,107 @@ class ChangedSeedIdsTests(unittest.TestCase):
         ]
         self.assertEqual(changed_seed_ids(before, after), ["a", "b"])
 
+    def test_duplicate_slugs_compare_by_ipeds_identity(self) -> None:
+        before = [
+            {
+                "id": "bethel-university",
+                "ipeds_id": "173160",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.bethel.edu/cds/",
+            },
+            {
+                "id": "bethel-university",
+                "ipeds_id": "219718",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.bethelu.edu/cds/",
+            },
+        ]
+        after = [
+            {
+                "id": "bethel-university",
+                "ipeds_id": "173160",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.bethel.edu/cds/",
+            },
+            {
+                "id": "bethel-university",
+                "ipeds_id": "219718",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.bethelu.edu/cds/",
+            },
+        ]
+        self.assertEqual(changed_seed_ids(before, after), [])
+
+    def test_duplicate_slugs_still_detect_actual_institution_change(self) -> None:
+        before = [
+            {
+                "id": "westminster-college",
+                "ipeds_id": "179946",
+                "scrape_policy": "unknown",
+            },
+            {
+                "id": "westminster-college",
+                "ipeds_id": "216807",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.westminster.edu/old.pdf",
+            },
+        ]
+        after = [
+            {
+                "id": "westminster-college",
+                "ipeds_id": "179946",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.wcmo.edu/cds/",
+            },
+            {
+                "id": "westminster-college",
+                "ipeds_id": "216807",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://www.westminster.edu/old.pdf",
+            },
+        ]
+        self.assertEqual(changed_seed_ids(before, after), ["westminster-college"])
+
+    def test_duplicate_slug_changes_emit_one_archive_filter_token(self) -> None:
+        before = [
+            {
+                "id": "bethel-university",
+                "ipeds_id": ipeds_id,
+                "scrape_policy": "active",
+                "discovery_seed_url": f"https://old-{ipeds_id}.edu/cds/",
+            }
+            for ipeds_id in ("173160", "219718")
+        ]
+        after = [
+            {
+                "id": "bethel-university",
+                "ipeds_id": ipeds_id,
+                "scrape_policy": "active",
+                "discovery_seed_url": f"https://new-{ipeds_id}.edu/cds/",
+            }
+            for ipeds_id in ("173160", "219718")
+        ]
+        self.assertEqual(changed_seed_ids(before, after), ["bethel-university"])
+
+    def test_slug_change_enqueues_new_archive_filter_id(self) -> None:
+        before = [
+            {
+                "id": "old-school-slug",
+                "ipeds_id": "123456",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://example.edu/cds/",
+            }
+        ]
+        after = [
+            {
+                "id": "new-school-slug",
+                "ipeds_id": "123456",
+                "scrape_policy": "active",
+                "discovery_seed_url": "https://example.edu/cds/",
+            }
+        ]
+        self.assertEqual(changed_seed_ids(before, after), ["new-school-slug"])
+
     def test_chunks_ids(self) -> None:
         self.assertEqual(chunked(["a", "b", "c", "d"], 2), [["a", "b"], ["c", "d"]])
 
@@ -88,6 +189,31 @@ class SchoolIdsCanaryTests(unittest.TestCase):
             )
         )
         self.assertEqual(CANARY_SCHOOL_ID, "__finder_seed_catchup_canary__")
+
+    def test_chunk_allows_duplicate_slug_to_match_multiple_school_rows(self) -> None:
+        group = ["bethel-university"]
+        self.assertIsNone(
+            chunk_filter_error(
+                {
+                    "enqueued": 2,
+                    "school_ids_requested": 1,
+                    "school_ids_matched": 2,
+                },
+                group,
+                expected_matches=2,
+            )
+        )
+        self.assertIsNotNone(
+            chunk_filter_error(
+                {
+                    "enqueued": 3,
+                    "school_ids_requested": 1,
+                    "school_ids_matched": 3,
+                },
+                group,
+                expected_matches=2,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tools/ops/test_upsert_pipeline_alert_issue.py
+++ b/tools/ops/test_upsert_pipeline_alert_issue.py
@@ -1,0 +1,121 @@
+"""Tests for pipeline alert issue upserts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from tools.ops import upsert_pipeline_alert_issue
+
+
+def gh_result(
+    returncode: int = 0,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class UpsertPipelineAlertIssueTests(unittest.TestCase):
+    def run_main(
+        self,
+        results: list[subprocess.CompletedProcess[str]],
+        *,
+        token: bool = True,
+    ) -> tuple[int, int]:
+        argv = [
+            "upsert_pipeline_alert_issue.py",
+            "--repo",
+            "owner/repo",
+            "--component",
+            "finder",
+            "--title",
+            "Pipeline alert",
+            "--body",
+            "Something failed.",
+        ]
+        env = {"GH_TOKEN": "test-token"} if token else {}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.argv", argv),
+            patch.object(
+                upsert_pipeline_alert_issue,
+                "run_gh",
+                side_effect=results,
+            ) as run_gh,
+        ):
+            return upsert_pipeline_alert_issue.main(), run_gh.call_count
+
+    def test_missing_token_returns_nonzero(self) -> None:
+        returncode, calls = self.run_main([], token=False)
+        self.assertNotEqual(returncode, 0)
+        self.assertEqual(calls, 0)
+
+    def test_issue_list_failure_returns_nonzero(self) -> None:
+        returncode, calls = self.run_main([gh_result(1, stderr="list denied")])
+        self.assertNotEqual(returncode, 0)
+        self.assertEqual(calls, 1)
+
+    def test_comment_failure_returns_nonzero(self) -> None:
+        returncode, calls = self.run_main(
+            [
+                gh_result(stdout='[{"number": 42, "title": "Pipeline alert"}]'),
+                gh_result(1, stderr="comment denied"),
+            ]
+        )
+        self.assertNotEqual(returncode, 0)
+        self.assertEqual(calls, 2)
+
+    def test_existing_alert_comment_returns_zero(self) -> None:
+        returncode, calls = self.run_main(
+            [
+                gh_result(stdout='[{"number": 42, "title": "Pipeline alert"}]'),
+                gh_result(),
+            ]
+        )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(calls, 2)
+
+    def test_successful_labeled_create_returns_zero(self) -> None:
+        returncode, calls = self.run_main(
+            [
+                gh_result(stdout="[]"),
+                gh_result(stdout="https://github.com/owner/repo/issues/42\n"),
+            ]
+        )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(calls, 2)
+
+    def test_successful_bare_create_retry_returns_zero(self) -> None:
+        returncode, calls = self.run_main(
+            [
+                gh_result(stdout="[]"),
+                gh_result(1, stderr="label missing"),
+                gh_result(stdout="https://github.com/owner/repo/issues/42\n"),
+            ]
+        )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(calls, 3)
+
+    def test_terminal_create_failure_returns_nonzero(self) -> None:
+        returncode, calls = self.run_main(
+            [
+                gh_result(stdout="[]"),
+                gh_result(1, stderr="label missing"),
+                gh_result(1, stderr="create denied"),
+            ]
+        )
+        self.assertNotEqual(returncode, 0)
+        self.assertEqual(calls, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ops/upsert_pipeline_alert_issue.py
+++ b/tools/ops/upsert_pipeline_alert_issue.py
@@ -35,8 +35,8 @@ def main() -> int:
     args = parser.parse_args()
 
     if not os.environ.get("GH_TOKEN") and not os.environ.get("GITHUB_TOKEN"):
-        print("::warning::no GH_TOKEN; skipping pipeline alert issue", file=sys.stderr)
-        return 0
+        print("::error::no GH_TOKEN; cannot upsert pipeline alert issue", file=sys.stderr)
+        return 1
 
     labels = ["pipeline-alert", f"component:{args.component}"]
     body = args.body.strip() + "\n"
@@ -58,8 +58,8 @@ def main() -> int:
         ]
     )
     if listed.returncode != 0:
-        print(f"::warning::gh issue list failed: {listed.stderr.strip()}", file=sys.stderr)
-        return 0
+        print(f"::error::gh issue list failed: {listed.stderr.strip()}", file=sys.stderr)
+        return 1
 
     rows = json.loads(listed.stdout or "[]")
     match = next((row for row in rows if row.get("title") == args.title), None)
@@ -77,10 +77,10 @@ def main() -> int:
         )
         if commented.returncode != 0:
             print(
-                f"::warning::gh issue comment failed: {commented.stderr.strip()}",
+                f"::error::gh issue comment failed: {commented.stderr.strip()}",
                 file=sys.stderr,
             )
-            return 0
+            return 1
         print(f"Commented on alert issue #{match['number']}")
         return 0
 
@@ -117,10 +117,10 @@ def main() -> int:
         )
         if created.returncode != 0:
             print(
-                f"::warning::gh issue create failed: {created.stderr.strip()}",
+                f"::error::gh issue create failed: {created.stderr.strip()}",
                 file=sys.stderr,
             )
-            return 0
+            return 1
     print(f"Opened alert issue: {created.stdout.strip()}")
     return 0
 


### PR DESCRIPTION
## Summary
- make section-package PDF bytes and SHA deterministic by disabling generated metadata
- correct stuck-PDF accounting, finder alert failure exits, and IPEDS-aware seed catch-up identity handling
- validate Brave candidates before activation and safely demote confirmed false HTML seeds only when the exact archived seed failed and no active work remains
- repair the known contextual false-positive seeds and preserve seed deletions through probe-log merges
- extend the latest-terminal archive RPC with attempted seed, status, and active-work state

## Safety
- HTML validation is byte-bounded, wall-clock checked during reads, and treats truncation/access failures as unverifiable
- mutating audits require live service-role access, recheck active work after validation, and skip stale archive failures
- changed-seed catch-up keeps the whole-corpus canary and allows only the expected number of duplicate-slug rows

## Tests
- complete Python CI command set passed
- Supabase/Deno suites: 228 passed
- finder identity guard: 0 errors (26 existing warnings)
- retired redirect guard passed
- migration filename hygiene passed
- AI-assessed changed-path coverage: 88%
- independent testing and adversarial re-reviews found no remaining concrete correctness defects

## Rollout
After merge, apply migrations from a fresh clean `main` checkout before the next finder audit.

Made with [Cursor](https://cursor.com)